### PR TITLE
fix: replace placeholder genesis addresses with real wallet addresses

### DIFF
--- a/src/api/explorer.rs
+++ b/src/api/explorer.rs
@@ -375,8 +375,8 @@ mod tests {
             "&amp;amp; already escaped"
         );
         assert_eq!(
-            html_escape("0x89639929a133562d871dd47304ad3ff597908b79"),
-            "0x89639929a133562d871dd47304ad3ff597908b79"
+            html_escape("0x4f3319a747fd564136209cd5d9e7d1a1e4d142be"),
+            "0x4f3319a747fd564136209cd5d9e7d1a1e4d142be"
         );
     }
 }

--- a/src/core/blockchain.rs
+++ b/src/core/blockchain.rs
@@ -18,11 +18,11 @@ pub const BLOCK_TIME_SECS: u64    = 3;
 pub const MAX_TX_PER_BLOCK: usize = 100;
 pub const CHAIN_ID: u64           = 7119;
 
-// ── Genesis addresses (placeholder — replace before mainnet) ──
-pub const FOUNDER_ADDRESS:         &str = "0x89639929a133562d871dd47304ad3ff597908b79";
-pub const ECOSYSTEM_FUND_ADDRESS:  &str = "0x840a2e3ef9433811fc345bcd90e3586a7fc56287";
-pub const EARLY_VALIDATOR_ADDRESS: &str = "0xc556cb23a35ecdb6c22e94ec57789bdbf19da05e";
-pub const RESERVE_ADDRESS:         &str = "0x5d1206cef9461da934eecc4f04743a46a62d3d40";
+// ── Genesis addresses (from genesis_wallets.json — private keys secured) ──
+pub const FOUNDER_ADDRESS:         &str = "0x4f3319a747fd564136209cd5d9e7d1a1e4d142be";
+pub const ECOSYSTEM_FUND_ADDRESS:  &str = "0xeb70fdefd00fdb768dec06c478f450c351499f14";
+pub const EARLY_VALIDATOR_ADDRESS: &str = "0xa7fc67af1ba0c664d859f4c1bcd2eb1f7211f112";
+pub const RESERVE_ADDRESS:         &str = "0x2578cad17e3e56c2970a5b5eab45952439f5ba97";
 
 pub const GENESIS_ALLOCATIONS: &[(&str, u64)] = &[
     (FOUNDER_ADDRESS,         21_000_000 * 100_000_000),


### PR DESCRIPTION
## Summary
- Replace 4 hardcoded placeholder genesis addresses in `blockchain.rs` with real addresses from `genesis_wallets.json`
- Old addresses had no matching private keys — SRX was locked and inaccessible
- Update test sample address in `explorer.rs` for consistency

## Addresses updated
| Role | Old | New |
|---|---|---|
| Founder | `0x8963...08b79` | `0x4f33...142be` |
| Ecosystem | `0x840a...56287` | `0xeb70...9f14` |
| Early Validator | `0xc556...a05e` | `0xa7fc...f112` |
| Reserve | `0x5d12...ba40` | `0x2578...ba97` |

## Test plan
- [x] `cargo build --release` — clean
- [x] `cargo test` — 86/86 passed
- [ ] After merge: reset chain data on VPS, verify genesis allocations go to correct addresses