### PR TITLE
feat: on-chain token operations (CRIT-01 fix)

### DIFF
--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tower_http::cors::{CorsLayer, Any};
 use crate::core::blockchain::Blockchain;
-use crate::core::transaction::Transaction;
+use crate::core::transaction::{Transaction, TokenOp, TOKEN_OP_ADDRESS};
 use crate::wallet::wallet::Wallet;
 use crate::api::jsonrpc::rpc_dispatcher;
 use crate::api::explorer;
@@ -395,29 +395,40 @@ async fn deploy_token(
     State(state): State<SharedState>,
     Json(req): Json<DeployTokenRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    // C-03 FIX: Derive deployer address from private key
     let wallet = Wallet::from_private_key(&req.from_key)
-        .map_err(|_| (StatusCode::BAD_REQUEST, Json(serde_json::json!({"success": false, "error": "invalid private key"}))))?;
-    let deployer = wallet.address.clone();
+        .map_err(|_| api_err("invalid private key"))?;
+    let sk = wallet.get_secret_key().map_err(|_| api_err("invalid key"))?;
+    let pk = wallet.get_public_key().map_err(|_| api_err("invalid key"))?;
+
+    let token_op = TokenOp::Deploy {
+        name: req.name.clone(),
+        symbol: req.symbol.clone(),
+        decimals: req.decimals,
+        supply: req.total_supply,
+    };
 
     let mut bc = state.write().await;
-    match bc.deploy_token(
-        &deployer, req.name.clone(), req.symbol.clone(),
-        req.decimals, req.total_supply, req.deploy_fee,
-    ) {
-        Ok(addr) => Ok(Json(serde_json::json!({
-            "success": true,
-            "contract_address": addr,
-            "deployer": deployer,
-            "name": req.name,
-            "symbol": req.symbol,
-            "total_supply": req.total_supply,
-        }))),
-        Err(e) => Err((StatusCode::BAD_REQUEST, Json(serde_json::json!({
-            "success": false,
-            "error": e.to_string(),
-        })))),
-    }
+    let nonce = bc.accounts.get_nonce(&wallet.address);
+    let chain_id = bc.chain_id;
+    let data = token_op.encode().map_err(|e| api_err(&e.to_string()))?;
+
+    let tx = Transaction::new(
+        wallet.address.clone(), TOKEN_OP_ADDRESS.to_string(),
+        0, req.deploy_fee, nonce, data, chain_id, &sk, &pk,
+    ).map_err(|e| api_err(&e.to_string()))?;
+
+    let txid = tx.txid.clone();
+    bc.add_to_mempool(tx).map_err(|e| api_err(&e.to_string()))?;
+
+    Ok(Json(serde_json::json!({
+        "success": true,
+        "txid": txid,
+        "deployer": wallet.address,
+        "name": req.name,
+        "symbol": req.symbol,
+        "total_supply": req.total_supply,
+        "status": "pending_in_mempool",
+    })))
 }
 
 async fn token_transfer(
@@ -425,25 +436,39 @@ async fn token_transfer(
     Path(contract): Path<String>,
     Json(req): Json<TokenTransferRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    // C-03 FIX: Derive caller address from private key
     let wallet = Wallet::from_private_key(&req.from_key)
-        .map_err(|_| (StatusCode::BAD_REQUEST, Json(serde_json::json!({"success": false, "error": "invalid private key"}))))?;
-    let caller = wallet.address.clone();
+        .map_err(|_| api_err("invalid private key"))?;
+    let sk = wallet.get_secret_key().map_err(|_| api_err("invalid key"))?;
+    let pk = wallet.get_public_key().map_err(|_| api_err("invalid key"))?;
+
+    let token_op = TokenOp::Transfer {
+        contract: contract.clone(),
+        to: req.to.clone(),
+        amount: req.amount,
+    };
 
     let mut bc = state.write().await;
-    match bc.token_transfer(&contract, &caller, &req.to, req.amount, req.gas_fee) {
-        Ok(()) => Ok(Json(serde_json::json!({
-            "success": true,
-            "contract": contract,
-            "from": caller,
-            "to": req.to,
-            "amount": req.amount,
-        }))),
-        Err(e) => Err((StatusCode::BAD_REQUEST, Json(serde_json::json!({
-            "success": false,
-            "error": e.to_string(),
-        })))),
-    }
+    let nonce = bc.accounts.get_nonce(&wallet.address);
+    let chain_id = bc.chain_id;
+    let data = token_op.encode().map_err(|e| api_err(&e.to_string()))?;
+
+    let tx = Transaction::new(
+        wallet.address.clone(), TOKEN_OP_ADDRESS.to_string(),
+        0, req.gas_fee, nonce, data, chain_id, &sk, &pk,
+    ).map_err(|e| api_err(&e.to_string()))?;
+
+    let txid = tx.txid.clone();
+    bc.add_to_mempool(tx).map_err(|e| api_err(&e.to_string()))?;
+
+    Ok(Json(serde_json::json!({
+        "success": true,
+        "txid": txid,
+        "contract": contract,
+        "from": wallet.address,
+        "to": req.to,
+        "amount": req.amount,
+        "status": "pending_in_mempool",
+    })))
 }
 
 async fn token_burn(
@@ -451,24 +476,42 @@ async fn token_burn(
     Path(contract): Path<String>,
     Json(req): Json<TokenBurnRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    // C-03 FIX: Derive caller address from private key
     let wallet = Wallet::from_private_key(&req.from_key)
-        .map_err(|_| (StatusCode::BAD_REQUEST, Json(serde_json::json!({"success": false, "error": "invalid private key"}))))?;
-    let caller = wallet.address.clone();
+        .map_err(|_| api_err("invalid private key"))?;
+    let sk = wallet.get_secret_key().map_err(|_| api_err("invalid key"))?;
+    let pk = wallet.get_public_key().map_err(|_| api_err("invalid key"))?;
+
+    let token_op = TokenOp::Burn {
+        contract: contract.clone(),
+        amount: req.amount,
+    };
 
     let mut bc = state.write().await;
-    match bc.token_burn(&contract, &caller, req.amount, req.gas_fee) {
-        Ok(()) => Ok(Json(serde_json::json!({
-            "success": true,
-            "contract": contract,
-            "burned_by": caller,
-            "amount": req.amount,
-        }))),
-        Err(e) => Err((StatusCode::BAD_REQUEST, Json(serde_json::json!({
-            "success": false,
-            "error": e.to_string(),
-        })))),
-    }
+    let nonce = bc.accounts.get_nonce(&wallet.address);
+    let chain_id = bc.chain_id;
+    let data = token_op.encode().map_err(|e| api_err(&e.to_string()))?;
+
+    let tx = Transaction::new(
+        wallet.address.clone(), TOKEN_OP_ADDRESS.to_string(),
+        0, req.gas_fee, nonce, data, chain_id, &sk, &pk,
+    ).map_err(|e| api_err(&e.to_string()))?;
+
+    let txid = tx.txid.clone();
+    bc.add_to_mempool(tx).map_err(|e| api_err(&e.to_string()))?;
+
+    Ok(Json(serde_json::json!({
+        "success": true,
+        "txid": txid,
+        "contract": contract,
+        "burned_by": wallet.address,
+        "amount": req.amount,
+        "status": "pending_in_mempool",
+    })))
+}
+
+// Helper for API error responses
+fn api_err(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::BAD_REQUEST, Json(serde_json::json!({"success": false, "error": msg})))
 }
 
 // ── Address history handlers ─────────────────────────────

--- a/src/core/blockchain.rs
+++ b/src/core/blockchain.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use crate::core::block::Block;
-use crate::core::transaction::Transaction;
+use crate::core::transaction::{Transaction, TokenOp};
 use crate::core::account::AccountDB;
 use crate::core::authority::AuthorityManager;
 use crate::core::merkle::merkle_root;
@@ -309,6 +309,49 @@ impl Blockchain {
                 });
             }
 
+            // Validate token operation if present
+            if let Some(token_op) = TokenOp::decode(&tx.data) {
+                match &token_op {
+                    TokenOp::Transfer { contract, amount, .. } => {
+                        if !self.contracts.exists(contract) {
+                            return Err(SentrixError::InvalidTransaction(
+                                format!("token contract {} not found", contract)
+                            ));
+                        }
+                        let token_bal = self.contracts.get_token_balance(contract, &tx.from_address);
+                        if token_bal < *amount {
+                            return Err(SentrixError::InsufficientBalance { have: token_bal, need: *amount });
+                        }
+                    }
+                    TokenOp::Burn { contract, amount } => {
+                        if !self.contracts.exists(contract) {
+                            return Err(SentrixError::InvalidTransaction(
+                                format!("token contract {} not found", contract)
+                            ));
+                        }
+                        let token_bal = self.contracts.get_token_balance(contract, &tx.from_address);
+                        if token_bal < *amount {
+                            return Err(SentrixError::InsufficientBalance { have: token_bal, need: *amount });
+                        }
+                    }
+                    TokenOp::Mint { contract, .. } => {
+                        if !self.contracts.exists(contract) {
+                            return Err(SentrixError::InvalidTransaction(
+                                format!("token contract {} not found", contract)
+                            ));
+                        }
+                    }
+                    TokenOp::Approve { contract, .. } => {
+                        if !self.contracts.exists(contract) {
+                            return Err(SentrixError::InvalidTransaction(
+                                format!("token contract {} not found", contract)
+                            ));
+                        }
+                    }
+                    TokenOp::Deploy { .. } => {} // deploy creates new contract, no pre-check needed
+                }
+            }
+
             // Update working state
             *working_balances.entry(tx.from_address.clone()).or_insert(balance) -= needed;
             *working_nonces.entry(tx.from_address.clone()).or_insert(nonce) += 1;
@@ -329,6 +372,27 @@ impl Blockchain {
                 tx.fee,
             )?;
             total_fee += tx.fee;
+
+            // Execute token operation if present in data field
+            if let Some(token_op) = TokenOp::decode(&tx.data) {
+                match token_op {
+                    TokenOp::Deploy { name, symbol, decimals, supply } => {
+                        self.contracts.deploy(&tx.from_address, &name, &symbol, decimals, supply)?;
+                    }
+                    TokenOp::Transfer { contract, to, amount } => {
+                        self.contracts.execute_transfer(&contract, &tx.from_address, &to, amount)?;
+                    }
+                    TokenOp::Burn { contract, amount } => {
+                        self.contracts.execute_burn(&contract, &tx.from_address, amount)?;
+                    }
+                    TokenOp::Mint { contract, to, amount } => {
+                        self.contracts.execute_mint(&contract, &tx.from_address, &to, amount)?;
+                    }
+                    TokenOp::Approve { contract, spender, amount } => {
+                        self.contracts.execute_approve(&contract, &tx.from_address, &spender, amount)?;
+                    }
+                }
+            }
         }
 
         // Validator gets 50% of fees (other 50% already burned in transfer)
@@ -927,5 +991,147 @@ mod tests {
         // Offset past end: empty
         let empty = bc.get_address_history("validator1", 2, 100);
         assert_eq!(empty.len(), 0);
+    }
+
+    // ── CRIT-01 FIX: On-chain token operation tests ─────
+
+    #[test]
+    fn test_onchain_token_deploy_via_block() {
+        use crate::core::transaction::{TokenOp, TOKEN_OP_ADDRESS};
+
+        let mut bc = setup_chain();
+        let (sk, pk) = make_keypair();
+        let deployer = derive_addr(&pk);
+        bc.accounts.credit(&deployer, 10_000_000).unwrap();
+
+        // Create token deploy transaction
+        let token_op = TokenOp::Deploy {
+            name: "TestToken".to_string(),
+            symbol: "TT".to_string(),
+            decimals: 8,
+            supply: 1_000_000,
+        };
+
+        let tx = Transaction::new(
+            deployer.clone(), TOKEN_OP_ADDRESS.to_string(),
+            0, MIN_TX_FEE, 0, token_op.encode().unwrap(),
+            CHAIN_ID, &sk, &pk,
+        ).unwrap();
+        bc.add_to_mempool(tx).unwrap();
+
+        // Mine block
+        let block = bc.create_block("validator1").unwrap();
+        assert_eq!(block.tx_count(), 2); // coinbase + token deploy
+        bc.add_block(block).unwrap();
+
+        // Token should now be deployed
+        assert_eq!(bc.contracts.contract_count(), 1);
+        let tokens = bc.list_tokens();
+        assert_eq!(tokens[0]["symbol"], "TT");
+        assert_eq!(tokens[0]["total_supply"], 1_000_000);
+    }
+
+    #[test]
+    fn test_onchain_token_transfer_via_block() {
+        use crate::core::transaction::{TokenOp, TOKEN_OP_ADDRESS};
+
+        let mut bc = setup_chain();
+        let (sk, pk) = make_keypair();
+        let alice = derive_addr(&pk);
+        bc.accounts.credit(&alice, 10_000_000).unwrap();
+
+        // Deploy token first (old method for setup)
+        let contract = bc.deploy_token(
+            &alice, "Coin".to_string(), "CN".to_string(), 8, 500_000, 0,
+        ).unwrap();
+
+        // Create transfer transaction
+        let token_op = TokenOp::Transfer {
+            contract: contract.clone(),
+            to: "bob".to_string(),
+            amount: 100_000,
+        };
+        let tx = Transaction::new(
+            alice.clone(), TOKEN_OP_ADDRESS.to_string(),
+            0, MIN_TX_FEE, 0, token_op.encode().unwrap(),
+            CHAIN_ID, &sk, &pk,
+        ).unwrap();
+        bc.add_to_mempool(tx).unwrap();
+
+        // Mine block
+        let block = bc.create_block("validator1").unwrap();
+        bc.add_block(block).unwrap();
+
+        // Verify token balances
+        assert_eq!(bc.token_balance(&contract, &alice), 400_000);
+        assert_eq!(bc.token_balance(&contract, "bob"), 100_000);
+    }
+
+    #[test]
+    fn test_onchain_token_op_recorded_in_block() {
+        use crate::core::transaction::{TokenOp, TOKEN_OP_ADDRESS};
+
+        let mut bc = setup_chain();
+        let (sk, pk) = make_keypair();
+        let deployer = derive_addr(&pk);
+        bc.accounts.credit(&deployer, 10_000_000).unwrap();
+
+        let token_op = TokenOp::Deploy {
+            name: "OnChain".to_string(),
+            symbol: "OC".to_string(),
+            decimals: 8,
+            supply: 999,
+        };
+        let tx = Transaction::new(
+            deployer.clone(), TOKEN_OP_ADDRESS.to_string(),
+            0, MIN_TX_FEE, 0, token_op.encode().unwrap(),
+            CHAIN_ID, &sk, &pk,
+        ).unwrap();
+        let txid = tx.txid.clone();
+        bc.add_to_mempool(tx).unwrap();
+
+        let block = bc.create_block("validator1").unwrap();
+        bc.add_block(block).unwrap();
+
+        // Transaction should be findable in chain
+        let found = bc.get_transaction(&txid);
+        assert!(found.is_some());
+        // Data field should contain the token op
+        let tx_data = found.unwrap();
+        let block_idx = tx_data["block_index"].as_u64().unwrap();
+        assert_eq!(block_idx, 1);
+    }
+
+    #[test]
+    fn test_onchain_token_transfer_insufficient_rejected() {
+        use crate::core::transaction::{TokenOp, TOKEN_OP_ADDRESS};
+
+        let mut bc = setup_chain();
+        let (sk, pk) = make_keypair();
+        let alice = derive_addr(&pk);
+        bc.accounts.credit(&alice, 10_000_000).unwrap();
+
+        let contract = bc.deploy_token(
+            &alice, "Coin".to_string(), "CN".to_string(), 8, 100, 0,
+        ).unwrap();
+
+        // Try to transfer more than token balance
+        let token_op = TokenOp::Transfer {
+            contract: contract.clone(),
+            to: "bob".to_string(),
+            amount: 999, // alice only has 100
+        };
+        let tx = Transaction::new(
+            alice.clone(), TOKEN_OP_ADDRESS.to_string(),
+            0, MIN_TX_FEE, 0, token_op.encode().unwrap(),
+            CHAIN_ID, &sk, &pk,
+        ).unwrap();
+
+        // Should be rejected at mempool (or add_block validation)
+        // add_to_mempool doesn't validate token ops, but add_block Pass 1 does
+        bc.add_to_mempool(tx).unwrap();
+        let block = bc.create_block("validator1").unwrap();
+        let result = bc.add_block(block);
+        assert!(result.is_err());
     }
 }

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -8,6 +8,33 @@ use crate::types::error::{SentrixError, SentrixResult};
 
 pub const MIN_TX_FEE: u64 = 10_000; // 0.0001 SRX in sentri
 pub const COINBASE_ADDRESS: &str = "COINBASE";
+pub const TOKEN_OP_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+
+// ── Token operation types (encoded in Transaction.data field) ──
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum TokenOp {
+    Deploy { name: String, symbol: String, decimals: u8, supply: u64 },
+    Transfer { contract: String, to: String, amount: u64 },
+    Burn { contract: String, amount: u64 },
+    Mint { contract: String, to: String, amount: u64 },
+    Approve { contract: String, spender: String, amount: u64 },
+}
+
+impl TokenOp {
+    pub fn encode(&self) -> SentrixResult<String> {
+        serde_json::to_string(self)
+            .map_err(|e| SentrixError::InvalidTransaction(e.to_string()))
+    }
+
+    pub fn decode(data: &str) -> Option<Self> {
+        serde_json::from_str(data).ok()
+    }
+
+    pub fn is_token_op(data: &str) -> bool {
+        data.contains("\"op\":")
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Transaction {
@@ -169,9 +196,10 @@ impl Transaction {
             ));
         }
 
-        if self.amount == 0 {
+        // amount=0 is allowed for token operations (data field carries the op)
+        if self.amount == 0 && !TokenOp::is_token_op(&self.data) {
             return Err(SentrixError::InvalidTransaction(
-                "amount must be > 0".to_string()
+                "amount must be > 0 (unless token operation)".to_string()
             ));
         }
 

--- a/src/core/vm.rs
+++ b/src/core/vm.rs
@@ -267,6 +267,45 @@ impl ContractRegistry {
         self.contracts.len()
     }
 
+    pub fn exists(&self, address: &str) -> bool {
+        self.contracts.contains_key(address)
+    }
+
+    pub fn get_token_balance(&self, contract: &str, address: &str) -> u64 {
+        self.contracts.get(contract)
+            .map(|c| c.balance_of(address))
+            .unwrap_or(0)
+    }
+
+    // ── On-chain token op helpers (called from add_block) ──
+
+    pub fn execute_transfer(&mut self, contract: &str, from: &str, to: &str, amount: u64) -> SentrixResult<()> {
+        let c = self.contracts.get_mut(contract)
+            .ok_or_else(|| SentrixError::NotFound(format!("contract {}", contract)))?;
+        c.transfer(from, to, amount)
+    }
+
+    pub fn execute_burn(&mut self, contract: &str, from: &str, amount: u64) -> SentrixResult<()> {
+        let c = self.contracts.get_mut(contract)
+            .ok_or_else(|| SentrixError::NotFound(format!("contract {}", contract)))?;
+        c.burn(from, amount)
+    }
+
+    pub fn execute_mint(&mut self, contract: &str, caller: &str, to: &str, amount: u64) -> SentrixResult<()> {
+        let c = self.contracts.get_mut(contract)
+            .ok_or_else(|| SentrixError::NotFound(format!("contract {}", contract)))?;
+        if caller != c.owner {
+            return Err(SentrixError::UnauthorizedValidator("only owner can mint".to_string()));
+        }
+        c.mint(to, amount)
+    }
+
+    pub fn execute_approve(&mut self, contract: &str, owner: &str, spender: &str, amount: u64) -> SentrixResult<()> {
+        let c = self.contracts.get_mut(contract)
+            .ok_or_else(|| SentrixError::NotFound(format!("contract {}", contract)))?;
+        c.approve(owner, spender, amount)
+    }
+
     // ── Dispatch ─────────────────────────────────────────
     pub fn call(
         &mut self,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use clap::{Parser, Subcommand};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use sentrix::core::blockchain::Blockchain;
+use sentrix::core::transaction::{Transaction, TokenOp, TOKEN_OP_ADDRESS};
 use sentrix::wallet::wallet::Wallet;
 use sentrix::wallet::keystore::Keystore;
 use sentrix::storage::db::Storage;
@@ -618,20 +619,34 @@ fn cmd_history(address: &str) -> anyhow::Result<()> {
 
 // ── Token commands ───────────────────────────────────────
 
+fn cli_create_token_tx(bc: &mut Blockchain, wallet: &Wallet, token_op: TokenOp, fee: u64) -> anyhow::Result<String> {
+    let sk = wallet.get_secret_key()?;
+    let pk = wallet.get_public_key()?;
+    let nonce = bc.accounts.get_nonce(&wallet.address);
+    let data = token_op.encode()?;
+    let tx = Transaction::new(
+        wallet.address.clone(), TOKEN_OP_ADDRESS.to_string(),
+        0, fee, nonce, data, bc.chain_id, &sk, &pk,
+    )?;
+    let txid = tx.txid.clone();
+    bc.add_to_mempool(tx)?;
+    Ok(txid)
+}
+
 fn cmd_token_deploy(name: &str, symbol: &str, decimals: u8, supply: u64, deployer_key: &str, fee: u64) -> anyhow::Result<()> {
     let storage = Storage::open(&get_db_path())?;
     let mut bc = storage.load_blockchain()?
         .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
     let wallet = Wallet::from_private_key(deployer_key)?;
-    let contract_address = bc.deploy_token(&wallet.address, name.to_string(), symbol.to_string(), decimals, supply, fee)?;
+    let token_op = TokenOp::Deploy { name: name.to_string(), symbol: symbol.to_string(), decimals, supply };
+    let txid = cli_create_token_tx(&mut bc, &wallet, token_op, fee)?;
     storage.save_blockchain(&bc)?;
-    println!("Token deployed successfully!");
-    println!("  Name:             {}", name);
-    println!("  Symbol:           {}", symbol);
-    println!("  Decimals:         {}", decimals);
-    println!("  Supply:           {}", supply);
-    println!("  Contract address: {}", contract_address);
-    println!("  Deploy fee paid:  {} sentri", fee);
+    println!("Token deploy transaction submitted to mempool!");
+    println!("  TxID:     {}", txid);
+    println!("  Name:     {}", name);
+    println!("  Symbol:   {}", symbol);
+    println!("  Supply:   {}", supply);
+    println!("  Status:   pending (will execute when block is mined)");
     Ok(())
 }
 
@@ -640,13 +655,16 @@ fn cmd_token_transfer(contract: &str, to: &str, amount: u64, from_key: &str, gas
     let mut bc = storage.load_blockchain()?
         .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
     let wallet = Wallet::from_private_key(from_key)?;
-    bc.token_transfer(contract, &wallet.address, to, amount, gas)?;
+    let token_op = TokenOp::Transfer { contract: contract.to_string(), to: to.to_string(), amount };
+    let txid = cli_create_token_tx(&mut bc, &wallet, token_op, gas)?;
     storage.save_blockchain(&bc)?;
-    println!("Token transfer successful!");
+    println!("Token transfer transaction submitted to mempool!");
+    println!("  TxID:     {}", txid);
     println!("  From:     {}", wallet.address);
     println!("  To:       {}", to);
     println!("  Amount:   {}", amount);
     println!("  Contract: {}", contract);
+    println!("  Status:   pending (will execute when block is mined)");
     Ok(())
 }
 
@@ -655,12 +673,15 @@ fn cmd_token_burn(contract: &str, amount: u64, from_key: &str, gas: u64) -> anyh
     let mut bc = storage.load_blockchain()?
         .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
     let wallet = Wallet::from_private_key(from_key)?;
-    bc.token_burn(contract, &wallet.address, amount, gas)?;
+    let token_op = TokenOp::Burn { contract: contract.to_string(), amount };
+    let txid = cli_create_token_tx(&mut bc, &wallet, token_op, gas)?;
     storage.save_blockchain(&bc)?;
-    println!("Tokens burned successfully!");
+    println!("Token burn transaction submitted to mempool!");
+    println!("  TxID:     {}", txid);
     println!("  From:     {}", wallet.address);
     println!("  Amount:   {} burned", amount);
     println!("  Contract: {}", contract);
+    println!("  Status:   pending (will execute when block is mined)");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- **CRIT-01 FIX:** All token operations are now recorded as on-chain transactions
- Token ops encoded in `Transaction.data` field via `TokenOp` enum
- `add_block()` validates and dispatches token ops during block processing
- API endpoints now create signed transactions → mempool → block (no more direct state mutation)
- Token state is now reproducible from block history and syncs across nodes via P2P

## Files changed (5)
- `transaction.rs` — TokenOp enum, encode/decode, allow amount=0 for token ops
- `blockchain.rs` — add_block() token validation (Pass 1) + dispatch (Pass 2), 4 new tests
- `vm.rs` — ContractRegistry helper methods (exists, execute_transfer, etc.)
- `routes.rs` — Token API endpoints create transactions instead of direct mutation
- `main.rs` — CLI token commands create transactions

## Test plan
- [x] `cargo build --release` — clean
- [x] `cargo test` — 109/109 passed (4 new on-chain token tests)
- [ ] After deploy: verify token deploy/transfer via API goes through mempool → block

## Breaking changes
- Token API responses now include `"status": "pending_in_mempool"` and `txid` instead of immediate execution
- Token operations execute when the next block is mined, not immediately on API call