### PR TITLE
fix(p2p): increase MAX_CONNECTIONS_PER_IP to 100 for multi-validator setups

### DIFF
--- a/src/network/node.rs
+++ b/src/network/node.rs
@@ -17,7 +17,7 @@ pub const DEFAULT_PORT: u16 = 30303;
 pub const MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024; // 10MB
 
 // M-02 FIX: rate limiting and peer cap constants
-pub const MAX_CONNECTIONS_PER_IP: u32 = 5;
+pub const MAX_CONNECTIONS_PER_IP: u32 = 100;
 pub const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
 pub const MAX_PEERS: usize = 50;
 
@@ -468,7 +468,7 @@ mod tests {
     #[test]
     fn test_m02_max_peers_constant() {
         assert_eq!(MAX_PEERS, 50);
-        assert_eq!(MAX_CONNECTIONS_PER_IP, 5);
+        assert_eq!(MAX_CONNECTIONS_PER_IP, 100);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Raises `MAX_CONNECTIONS_PER_IP` from 5 to 100 in `node.rs`
- Updates the corresponding test assertion

## Fix

With 4 VPS2 validators each creating a new TCP connection per block broadcast, Node 1 was receiving 4+ connections per block from the same IP (103.175.219.233). The old limit of 5 connections/60s was exceeded immediately, causing Node 1 to drop all subsequent VPS2 block broadcasts and stall the chain.

With 5 validators at ~2s block time, each validator produces 1 block every 10s → 6 blocks/60s per validator → 24 connections/60s from VPS2 IP. The new limit of 100 handles this with plenty of headroom.