### PR TITLE
fix(sync): proactive block sync on handshake when peer height > local height

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use sentrix::wallet::keystore::Keystore;
 use sentrix::storage::db::Storage;
 use sentrix::api::routes::{create_router, SharedState};
 use sentrix::network::node::{DEFAULT_PORT, Node, NodeEvent};
+use sentrix::network::sync::ChainSync;
 
 const API_PORT: u16 = 8545;
 
@@ -486,7 +487,8 @@ async fn cmd_start(
         });
     }
 
-    // Event handler (log P2P events)
+    // Event handler (log P2P events + handle sync triggers)
+    let shared_for_events = shared.clone();
     tokio::spawn(async move {
         while let Some(event) = event_rx.recv().await {
             match event {
@@ -496,10 +498,39 @@ async fn cmd_start(
                 NodeEvent::NewTransaction(_) => {},
                 NodeEvent::SyncNeeded { peer_addr, peer_height } => {
                     tracing::info!("Sync needed from {} (height: {})", peer_addr, peer_height);
+                    let shared_sync = shared_for_events.clone();
+                    tokio::spawn(async move {
+                        match ChainSync::sync_from_peer(&peer_addr, &shared_sync).await {
+                            Ok(n) if n > 0 => tracing::info!("Synced {} blocks from {}", n, peer_addr),
+                            Ok(_) => {},
+                            Err(e) => tracing::warn!("Sync from {} failed: {}", peer_addr, e),
+                        }
+                    });
                 }
             }
         }
     });
+
+    // Periodic sync: every 30s, pull any missing blocks from all known peers.
+    // Prevents stall if initial handshake sync was missed (e.g. simultaneous restart).
+    {
+        let shared_ps = shared.clone();
+        let node_ps = node.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
+                let peer_addrs: Vec<String> = node_ps.peers.read().await
+                    .keys().cloned().collect();
+                for addr in peer_addrs {
+                    match ChainSync::sync_from_peer(&addr, &shared_ps).await {
+                        Ok(n) if n > 0 => tracing::info!("Periodic sync: {} blocks from {}", n, addr),
+                        Ok(_) => {},
+                        Err(_) => {},
+                    }
+                }
+            }
+        });
+    }
 
     println!("Node started. Press Ctrl+C to stop.");
     axum::serve(listener, app).await?;

--- a/src/network/node.rs
+++ b/src/network/node.rs
@@ -218,6 +218,10 @@ impl Node {
                     }
 
                     // Register peer using actual TCP IP + declared P2P port
+                    let our_height = bc.height();
+                    let our_chain_id = bc.chain_id;
+                    drop(bc);
+
                     let peer = Peer { host: peer_ip.clone(), port, height, chain_id };
                     let peer_addr = peer.addr();
                     peers.write().await.insert(peer_addr.clone(), peer);
@@ -225,17 +229,20 @@ impl Node {
                     let response = Message::Handshake {
                         host: "0.0.0.0".to_string(),
                         port: 0,
-                        height: bc.height(),
-                        chain_id: bc.chain_id,
+                        height: our_height,
+                        chain_id: our_chain_id,
                     };
                     Self::send_message(&mut stream, &response).await?;
 
-                    // If peer has more blocks, request sync
-                    if height > bc.height() {
-                        let our_height = bc.height();
-                        drop(bc);
-                        let get_blocks = Message::GetBlocks { from_height: our_height + 1 };
-                        Self::send_message(&mut stream, &get_blocks).await?;
+                    // If peer has more blocks, trigger proactive sync via a dedicated connection.
+                    // Do NOT send GetBlocks inline here — connect_peer callers only read one
+                    // Handshake response and would close the stream, leaving our GetBlocks unanswered.
+                    if height > our_height {
+                        let sync_addr = format!("{}:{}", peer_ip, port);
+                        let _ = event_tx.send(NodeEvent::SyncNeeded {
+                            peer_addr: sync_addr,
+                            peer_height: height,
+                        }).await;
                     }
                 }
 


### PR DESCRIPTION
## Problem

Chain stalls when multiple validators restart simultaneously. After restart, nodes at diverged heights (e.g. 70,003–70,007) cannot re-sync because:

1. **Protocol bug in `handle_connection`**: When a peer connects with higher height, the inbound handler sent `GetBlocks` inline on the same connection. But `connect_peer` on the other side only reads one Handshake response then closes the stream — leaving the `GetBlocks` permanently unanswered (deadlock).

2. **No recovery mechanism**: If initial handshake sync fails (e.g. race condition during simultaneous restart), there was no periodic re-sync. Chain stays stalled forever.

## Fix

- **`node.rs`**: Replace inline `GetBlocks` in `handle_connection` Handshake handler with `SyncNeeded` event. Sync now happens via a dedicated `ChainSync::sync_from_peer` connection, not inline.
- **`main.rs`**: Handle `SyncNeeded` by spawning `ChainSync::sync_from_peer` on a dedicated connection.
- **`main.rs`**: Add 30-second periodic sync loop that proactively pulls missing blocks from all known peers.

## Result

- Chain recovers from stalls within 30 seconds (first periodic sync tick)
- Future simultaneous restarts will self-heal automatically
- 86/86 tests pass