### PR TITLE
fix(api): read SENTRIX_API_PORT from env var for multi-validator deployments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,14 @@ use sentrix::api::routes::{create_router, SharedState};
 use sentrix::network::node::{DEFAULT_PORT, Node, NodeEvent};
 use sentrix::network::sync::ChainSync;
 
-const API_PORT: u16 = 8545;
+const DEFAULT_API_PORT: u16 = 8545;
+
+fn get_api_port() -> u16 {
+    std::env::var("SENTRIX_API_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_API_PORT)
+}
 
 fn get_data_dir() -> std::path::PathBuf {
     // Check SENTRIX_DATA_DIR env var first (Docker / custom deploy)
@@ -433,7 +440,7 @@ async fn cmd_start(
 
     // Start REST API
     let app = create_router(shared.clone());
-    let api_addr = format!("0.0.0.0:{}", API_PORT);
+    let api_addr = format!("0.0.0.0:{}", get_api_port());
     println!("REST API listening on http://{}", api_addr);
 
     let listener = tokio::net::TcpListener::bind(&api_addr).await?;


### PR DESCRIPTION
## Problem

`API_PORT` was hardcoded to `8545` in `main.rs`. Running 5 validators on the same machine (VPS2) causes all of them to try to bind port 8545 → 4 out of 5 crash with `Address already in use`.

## Fix

Add `get_api_port()` that reads `SENTRIX_API_PORT` env var, falling back to `8545` if not set.

VPS2 service files already have `Environment=SENTRIX_API_PORT=8546` etc. set — they just weren't being used before.

## Also included

Restored `fix(sync)` changes from PR #10 that were inadvertently reverted:
- Proactive block sync on handshake via `SyncNeeded` event  
- 30-second periodic sync loop

## Test

86/86 tests pass.