### PR TITLE
feat: add sentrix_sendTransaction and sentrix_getBalance RPC methods

### DIFF
--- a/src/api/jsonrpc.rs
+++ b/src/api/jsonrpc.rs
@@ -4,6 +4,8 @@ use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use crate::api::routes::{SharedState, ApiKey};
+use crate::core::transaction::Transaction;
+use crate::wallet::wallet::Wallet;
 
 // ── JSON-RPC types ───────────────────────────────────────
 #[derive(Debug, Deserialize)]
@@ -167,6 +169,57 @@ pub async fn jsonrpc_handler(
                 }
                 None => Ok(json!(null)),
             }
+        }
+        "sentrix_sendTransaction" => {
+            // params[0] = { "from": "0x...", "to": "0x...", "amount": N, "private_key": "hex" }
+            let p = &params[0];
+            let to = p["to"].as_str().unwrap_or("").to_lowercase();
+            let amount = p["amount"].as_u64().unwrap_or(0);
+            let private_key = p["private_key"].as_str().unwrap_or("");
+            let fee = p["fee"].as_u64().unwrap_or(0);
+
+            if to.is_empty() || private_key.is_empty() || amount == 0 {
+                Err((-32602, "sentrix_sendTransaction requires: to, amount, private_key"))
+            } else {
+                let wallet = match Wallet::from_private_key(private_key) {
+                    Ok(w) => w,
+                    Err(_) => return Json(JsonRpcResponse::err(id, -32602, "invalid private_key")),
+                };
+                let sk = match wallet.get_secret_key() {
+                    Ok(k) => k,
+                    Err(_) => return Json(JsonRpcResponse::err(id, -32602, "invalid private_key")),
+                };
+                let pk = match wallet.get_public_key() {
+                    Ok(k) => k,
+                    Err(_) => return Json(JsonRpcResponse::err(id, -32602, "invalid private_key")),
+                };
+
+                let mut bc = state.write().await;
+                let nonce = bc.accounts.get_nonce(&wallet.address);
+                let chain_id = bc.chain_id;
+
+                let tx = match Transaction::new(
+                    wallet.address.clone(), to.clone(),
+                    amount, fee, nonce, String::new(), chain_id, &sk, &pk,
+                ) {
+                    Ok(t) => t,
+                    Err(e) => return Json(JsonRpcResponse::err(id, -32603, &e.to_string())),
+                };
+
+                let txid = tx.txid.clone();
+                match bc.add_to_mempool(tx) {
+                    Ok(()) => Ok(json!({ "txid": txid, "status": "pending_in_mempool" })),
+                    Err(e) => return Json(JsonRpcResponse::err(id, -32603, &e.to_string())),
+                }
+            }
+        }
+        "sentrix_getBalance" => {
+            // alias for eth_getBalance — returns SRX as float string
+            let address = params[0].as_str().unwrap_or("").to_lowercase();
+            let bc = state.read().await;
+            let balance = bc.accounts.get_balance(&address);
+            let wei = balance as u128 * 10_000_000_000u128;
+            Ok(json!(to_hex_u128(wei)))
         }
         "eth_sendRawTransaction" => {
             Err((-32601, "eth_sendRawTransaction not yet supported — use POST /transactions REST API"))


### PR DESCRIPTION
## Summary
- Adds `sentrix_sendTransaction` JSON-RPC method: accepts `{to, amount, private_key, fee}`, builds and signs a native SRX transfer server-side, submits to mempool
- Adds `sentrix_getBalance` as an alias for `eth_getBalance` (hex wei)
- Required by the faucet app to send tokens via JSON-RPC

## Test plan
- [x] All 111 existing tests pass
- [x] `sentrix_sendTransaction` creates valid signed transaction and returns txid
- [x] `sentrix_getBalance` returns correct balance in hex wei
- [x] Invalid private key returns -32602 error
- [x] Missing required params returns -32602 error