### PR TITLE
ci: deploy to VPS2 on every main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,21 +95,30 @@ jobs:
       - name: Build release binary
         run: cargo build --release
 
-      - name: Install SSH key
+      - name: Deploy to VPS1
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.VPS1_SSH_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H ${{ secrets.VPS1_HOST }} >> ~/.ssh/known_hosts
-
-      - name: Copy binary to VPS1
-        run: |
           scp target/release/sentrix \
             ${{ secrets.VPS1_USER }}@${{ secrets.VPS1_HOST }}:/tmp/sentrix_new
-
-      - name: Install and restart on VPS1
-        run: |
           ssh ${{ secrets.VPS1_USER }}@${{ secrets.VPS1_HOST }} "
+            sudo mv /tmp/sentrix_new /opt/sentrix/sentrix
+            sudo chmod +x /opt/sentrix/sentrix
+            sudo systemctl restart sentrix-node
+            sleep 2
+            systemctl is-active sentrix-node
+          "
+
+      - name: Deploy to VPS2
+        run: |
+          echo "${{ secrets.VPS2_SSH_KEY }}" > ~/.ssh/id_rsa_vps2
+          chmod 600 ~/.ssh/id_rsa_vps2
+          ssh-keyscan -H ${{ secrets.VPS2_HOST }} >> ~/.ssh/known_hosts
+          scp -i ~/.ssh/id_rsa_vps2 target/release/sentrix \
+            ${{ secrets.VPS2_USER }}@${{ secrets.VPS2_HOST }}:/tmp/sentrix_new
+          ssh -i ~/.ssh/id_rsa_vps2 ${{ secrets.VPS2_USER }}@${{ secrets.VPS2_HOST }} "
             sudo mv /tmp/sentrix_new /opt/sentrix/sentrix
             sudo chmod +x /opt/sentrix/sentrix
             sudo systemctl restart sentrix-node


### PR DESCRIPTION
## Summary
- VPS2 (103.175.219.233) was never receiving binary updates — CI/CD only deployed to VPS1
- This adds a parallel VPS2 deploy step in the same job, right after VPS1
- VPS2 hosts the faucet, CoinBlast, and validators — all of which need the up-to-date chain binary

## Secrets required
Add these in GitHub repo Settings → Secrets → Actions:
- `VPS2_SSH_KEY` — private SSH key for VPS2
- `VPS2_HOST` — `103.175.219.233`
- `VPS2_USER` — SSH username for VPS2