### PR TITLE
fix(ci): auto-detect sentrix service name on VPS2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,16 @@ jobs:
           ssh -i ~/.ssh/id_rsa_vps2 "$VPS2_USER@$VPS2_HOST" "
             sudo mv /tmp/sentrix_new /opt/sentrix/sentrix
             sudo chmod +x /opt/sentrix/sentrix
-            sudo systemctl restart sentrix-node
-            sleep 2
-            systemctl is-active sentrix-node
+            SERVICE=\$(systemctl list-units --type=service --no-legend 2>/dev/null | grep -i sentrix | awk '{print \$1}' | head -1)
+            if [ -n \"\$SERVICE\" ]; then
+              sudo systemctl restart \"\$SERVICE\"
+              sleep 2
+              systemctl is-active \"\$SERVICE\"
+            else
+              sudo pkill -f '/opt/sentrix/sentrix' || true
+              sleep 1
+              sudo nohup /opt/sentrix/sentrix >> /var/log/sentrix.log 2>&1 &
+              sleep 2
+              pgrep -f '/opt/sentrix/sentrix' && echo 'active' || (echo 'failed to start'; exit 1)
+            fi
           "


### PR DESCRIPTION
VPS2 does not have a 'sentrix-node' systemctl service. This fix detects the service name dynamically via systemctl list-units, falling back to pkill+nohup if no service is found.