### PR TITLE
fix(explorer): use 8 decimal precision for SRX amounts

### DIFF
--- a/src/api/explorer.rs
+++ b/src/api/explorer.rs
@@ -240,7 +240,7 @@ pub async fn explorer_transactions(State(state): State<SharedState>) -> Html<Str
             <td class="hash"><a href="/explorer/tx/{}">{}</a></td>
             <td class="mono">{}</td>
             <td class="mono">{}</td>
-            <td>{:.4} SRX</td>
+            <td>{:.8} SRX</td>
             <td>{} sentri</td>
             <td><a href="/explorer/block/{}">#{}</a></td>
             <td>{}</td>
@@ -314,7 +314,7 @@ pub async fn explorer_block(
                     <td class="hash"><a href="/explorer/tx/{}">{}</a></td>
                     <td class="mono">{}</td>
                     <td class="mono">{}</td>
-                    <td>{:.4} SRX</td>
+                    <td>{:.8} SRX</td>
                     <td>{} sentri</td>
                     </tr>"#,
                     badge,
@@ -384,7 +384,7 @@ pub async fn explorer_address(
             r#"<tr>
             <td>{}</td>
             <td class="hash"><a href="/explorer/tx/{}">{}</a></td>
-            <td>{:.4} SRX</td>
+            <td>{:.8} SRX</td>
             <td>{} sentri</td>
             <td><a href="/explorer/block/{}">#{}</a></td>
             </tr>"#,


### PR DESCRIPTION
## Summary
- Changed `{:.4} SRX` → `{:.8} SRX` in transactions list, block detail, and address history tables
- Amounts like 10 sentri now display as `0.00000010 SRX` instead of rounding to `0.0000 SRX`
- tx detail page and address balance already used `{:.8}` — now consistent everywhere

## Test plan
- [ ] `cargo test` — all 114 pass
- [ ] `cargo build --release` — clean
- [ ] Check `/explorer/transactions` Regular tab shows non-zero amounts for small txs