### PR TITLE
feat(explorer): analytics charts

### DIFF
--- a/src/api/explorer.rs
+++ b/src/api/explorer.rs
@@ -3,7 +3,9 @@
 use axum::{
     extract::{State, Path},
     response::Html,
+    Json,
 };
+use serde::Serialize;
 use crate::api::routes::SharedState;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
@@ -12,6 +14,11 @@ use tokio::sync::Mutex as TokioMutex;
 struct CachedPage { html: String, at: Instant }
 static HOME_CACHE: OnceLock<TokioMutex<Option<CachedPage>>> = OnceLock::new();
 static RICHLIST_CACHE: OnceLock<TokioMutex<Option<CachedPage>>> = OnceLock::new();
+
+#[derive(Serialize, Clone)]
+pub struct DailyStat { pub date: String, pub blocks: u64, pub transactions: u64 }
+struct DailyCache { data: Vec<DailyStat>, at: Instant }
+static DAILY_CACHE: OnceLock<TokioMutex<Option<DailyCache>>> = OnceLock::new();
 
 // C-04 FIX: HTML escape to prevent XSS
 pub fn html_escape(s: &str) -> String {
@@ -121,7 +128,108 @@ h3 { margin: 24px 0 12px; font-size: 16px; color: #9ca3af; }
 .search-bar button { padding: 9px 18px; border-radius: 8px; background: #1e3a5f; color: #60a5fa; border: 1px solid #3b82f6; font-size: 14px; cursor: pointer; }
 .search-bar button:hover { background: #2a4f7f; }
 .search-error { color: #f87171; font-size: 13px; margin-top: 6px; min-height: 18px; }
+.charts { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 24px 0; }
+.chart-card { background: #111827; border: 1px solid #1f2937; border-radius: 12px; padding: 16px; }
+.chart-title { color: #9ca3af; font-size: 13px; text-transform: uppercase; letter-spacing: .05em; margin-bottom: 12px; }
+canvas { display: block; max-width: 100%; }
+@media (max-width: 700px) { .charts { grid-template-columns: 1fr; } }
 "#;
+
+/// Format day_key (days since 1970-01-01) as "dd/mm"
+fn fmt_day(day_key: u64) -> String {
+    let mut d = day_key;
+    let mut y = 1970u64;
+    loop {
+        let dy = if (y % 4 == 0 && y % 100 != 0) || y % 400 == 0 { 366 } else { 365 };
+        if d < dy { break; }
+        d -= dy;
+        y += 1;
+    }
+    let leap = (y % 4 == 0 && y % 100 != 0) || y % 400 == 0;
+    let dims = [31u64, if leap { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut m = 0usize;
+    for &dim in &dims {
+        if d < dim { break; }
+        d -= dim;
+        m += 1;
+    }
+    format!("{:02}/{:02}", d + 1, m + 1)
+}
+
+const CHART_SECTION: &str = r#"
+<div class="charts">
+  <div class="chart-card">
+    <div class="chart-title">Daily Transactions — last 14 days</div>
+    <canvas id="chart-tx"></canvas>
+  </div>
+  <div class="chart-card">
+    <div class="chart-title">Daily Blocks — last 14 days</div>
+    <canvas id="chart-blk"></canvas>
+  </div>
+</div>
+<script>
+(function(){
+  var c1=document.getElementById('chart-tx');
+  var c2=document.getElementById('chart-blk');
+  if(!c1||!c2)return;
+  function sz(c){c.width=c.parentElement.clientWidth-32;c.height=200;}
+  function drawLine(c,data,key,color){
+    sz(c);
+    var w=c.width,h=c.height,ctx=c.getContext('2d');
+    var vals=data.map(function(d){return+(d[key])||0;});
+    var labs=data.map(function(d){return d.date;});
+    var mv=Math.max.apply(null,vals)||1;
+    var p={t:20,r:16,b:36,l:52};
+    var iw=w-p.l-p.r,ih=h-p.t-p.b,n=vals.length;
+    var st=n>1?iw/(n-1):iw;
+    ctx.fillStyle='#111827';ctx.fillRect(0,0,w,h);
+    for(var g=0;g<=4;g++){
+      var gy=p.t+ih*(1-g/4);
+      ctx.strokeStyle='#1f2937';ctx.lineWidth=1;
+      ctx.beginPath();ctx.moveTo(p.l,gy);ctx.lineTo(w-p.r,gy);ctx.stroke();
+      ctx.fillStyle='#6b7280';ctx.font='10px Segoe UI';ctx.textAlign='right';
+      ctx.fillText(Math.round(mv*g/4),p.l-4,gy+4);
+    }
+    ctx.fillStyle='#6b7280';ctx.font='10px Segoe UI';ctx.textAlign='center';
+    for(var li=0;li<n;li++)if(li%2===0||n<=7)ctx.fillText(labs[li],p.l+li*st,h-p.b+14);
+    ctx.fillStyle=color+'22';ctx.beginPath();ctx.moveTo(p.l,p.t+ih);
+    for(var fi=0;fi<n;fi++)ctx.lineTo(p.l+fi*st,p.t+ih*(1-vals[fi]/mv));
+    ctx.lineTo(p.l+(n-1)*st,p.t+ih);ctx.closePath();ctx.fill();
+    ctx.strokeStyle=color;ctx.lineWidth=2;ctx.beginPath();
+    for(var pi=0;pi<n;pi++){var px=p.l+pi*st,py=p.t+ih*(1-vals[pi]/mv);if(pi===0)ctx.moveTo(px,py);else ctx.lineTo(px,py);}
+    ctx.stroke();
+    ctx.fillStyle=color;
+    for(var di=0;di<n;di++){ctx.beginPath();ctx.arc(p.l+di*st,p.t+ih*(1-vals[di]/mv),3,0,Math.PI*2);ctx.fill();}
+  }
+  function drawBar(c,data,key,color){
+    sz(c);
+    var w=c.width,h=c.height,ctx=c.getContext('2d');
+    var vals=data.map(function(d){return+(d[key])||0;});
+    var labs=data.map(function(d){return d.date;});
+    var mv=Math.max.apply(null,vals)||1;
+    var p={t:20,r:16,b:36,l:52};
+    var iw=w-p.l-p.r,ih=h-p.t-p.b,n=vals.length;
+    var gap=iw/n,bw=gap*0.65;
+    ctx.fillStyle='#111827';ctx.fillRect(0,0,w,h);
+    for(var g=0;g<=4;g++){
+      var gy=p.t+ih*(1-g/4);
+      ctx.strokeStyle='#1f2937';ctx.lineWidth=1;
+      ctx.beginPath();ctx.moveTo(p.l,gy);ctx.lineTo(w-p.r,gy);ctx.stroke();
+      ctx.fillStyle='#6b7280';ctx.font='10px Segoe UI';ctx.textAlign='right';
+      ctx.fillText(Math.round(mv*g/4),p.l-4,gy+4);
+    }
+    for(var bi=0;bi<n;bi++){
+      var bh=ih*vals[bi]/mv;
+      ctx.fillStyle=color+'bb';ctx.fillRect(p.l+bi*gap+(gap-bw)/2,p.t+ih-bh,bw,bh);
+      if(bi%2===0||n<=7){ctx.fillStyle='#6b7280';ctx.font='10px Segoe UI';ctx.textAlign='center';ctx.fillText(labs[bi],p.l+bi*gap+gap/2,h-p.b+14);}
+    }
+  }
+  fetch('/stats/daily').then(function(r){return r.json();}).then(function(data){
+    drawLine(c1,data,'transactions','#3b82f6');
+    drawBar(c2,data,'blocks','#f59e0b');
+  }).catch(function(){});
+})();
+</script>"#;
 
 fn page(title: &str, body: &str) -> Html<String> {
     Html(format!(r#"<!DOCTYPE html>
@@ -284,6 +392,7 @@ pub async fn explorer_home(State(state): State<SharedState>) -> Html<String> {
         </div>
     </div>
     {}
+    {}
     <h3>Latest Blocks</h3>
     <table>
     <tr><th>Height</th><th>Hash</th><th>Timestamp</th><th>Txs</th><th>Validator</th></tr>
@@ -297,6 +406,7 @@ pub async fn explorer_home(State(state): State<SharedState>) -> Html<String> {
         stats["total_minted_srx"].as_f64().unwrap_or(0.0),
         stats["total_burned_srx"].as_f64().unwrap_or(0.0),
         stats["deployed_tokens"],
+        CHART_SECTION,
         nav_tabs("home"),
         blocks_html,
     );
@@ -307,6 +417,66 @@ pub async fn explorer_home(State(state): State<SharedState>) -> Html<String> {
         *guard = Some(CachedPage { html: result.0.clone(), at: Instant::now() });
     }
     result
+}
+
+// ── Daily stats endpoint ─────────────────────────────────
+pub async fn stats_daily(State(state): State<SharedState>) -> Json<Vec<DailyStat>> {
+    const TTL: Duration = Duration::from_secs(300); // 5 min cache
+    let cache = DAILY_CACHE.get_or_init(|| TokioMutex::new(None));
+    {
+        let guard = cache.lock().await;
+        if let Some(ref c) = *guard {
+            if c.at.elapsed() < TTL {
+                return Json(c.data.clone());
+            }
+        }
+    }
+
+    let bc = state.read().await;
+    let height = bc.height();
+    const WIB: u64 = 7 * 3600;
+
+    let today_day = bc.get_block(height)
+        .map(|b| (b.timestamp + WIB) / 86400)
+        .unwrap_or(0);
+
+    let mut map: std::collections::HashMap<u64, (u64, u64)> = std::collections::HashMap::new();
+
+    if today_day > 0 {
+        let earliest = today_day.saturating_sub(13);
+        for i in 0..=height {
+            if let Some(block) = bc.get_block(i) {
+                let day = (block.timestamp + WIB) / 86400;
+                if day >= earliest && day <= today_day {
+                    let e = map.entry(day).or_insert((0, 0));
+                    e.0 += 1;
+                    e.1 += block.transactions.iter().filter(|t| !t.is_coinbase()).count() as u64;
+                }
+            }
+        }
+    }
+
+    let earliest = today_day.saturating_sub(13);
+    let mut result: Vec<DailyStat> = (0..14u64).map(|i| {
+        let day = earliest + i;
+        let (blocks, txs) = map.get(&day).copied().unwrap_or((0, 0));
+        DailyStat { date: fmt_day(day), blocks, transactions: txs }
+    }).collect();
+
+    // If chain has no blocks yet, fill with placeholder dates from system time
+    if today_day == 0 {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let now_day = SystemTime::now().duration_since(UNIX_EPOCH)
+            .map(|d| (d.as_secs() + WIB) / 86400).unwrap_or(0);
+        result = (0..14u64).map(|i| DailyStat {
+            date: fmt_day(now_day.saturating_sub(13) + i),
+            blocks: 0, transactions: 0,
+        }).collect();
+    }
+
+    let mut guard = cache.lock().await;
+    *guard = Some(DailyCache { data: result.clone(), at: Instant::now() });
+    Json(result)
 }
 
 // ── Blocks list ──────────────────────────────────────────

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -174,6 +174,8 @@ pub fn create_router(state: SharedState) -> Router {
         .route("/address/:address/info",          get(get_address_info))
         // ── RPC ──────────────────────────────────────────────────
         .route("/rpc",                            post(rpc_dispatcher))
+        // ── Stats ────────────────────────────────────────────────
+        .route("/stats/daily",                    get(explorer::stats_daily))
         // ── Explorer ─────────────────────────────────────────────
         .nest("/explorer", explorer_router(state.clone()))
         .layer(cors)


### PR DESCRIPTION
## Summary
- New `GET /stats/daily` endpoint: last 14 days blocks + non-coinbase transactions, grouped by WIB (UTC+7), 5-minute server-side cache
- Explorer home: 2 HTML5 Canvas charts below stat cards
  - Line chart: daily transactions (#3b82f6 blue)
  - Bar chart: daily block count (#f59e0b gold)
- Pure JavaScript only, zero external libraries, responsive (2-col desktop / 1-col mobile)

## Test plan
- [ ] 114 tests passing (cargo test)
- [ ] Release build clean (cargo build --release)
- [ ] GET /stats/daily returns 14-element JSON array
- [ ] Charts render on /explorer home page