### PR TITLE
docs: update README + CHANGELOG — PR #32-#46, 247 tests, libp2p, audit complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,138 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Planned
-- Full P2P listener + message handler
-- Multi-node deployment and testing
-- GitHub Actions CI pipeline
-- Public documentation site
+- Step 5: SentrixTrie (Merkle Patricia Trie state root)
+- VPS3 setup (genesis_node_3)
+- Phase 2: DPoS + BFT Finality design implementation
+
+---
+
+## [Post-0.1.0 Incremental] — 2026-04-13
+
+### PR #46 — Step 4: Integration Tests
+- Add `tests/` directory with 8 comprehensive integration test suites
+- `tests/common/mod.rs` — shared helpers: setup_single_validator, mine_empty_block, funded_wallet, make_tx, make_tx_nonce
+- `tests/integration_restart.rs` — 3 tests: save/reload state, height integrity, mempool persistence
+- `tests/integration_sync.rs` — 4 tests: two-node sync, duplicate block rejection, out-of-order rejection
+- `tests/integration_tx.rs` — 6 tests: TX lifecycle, double-spend, nonce checks, balance, validator reward
+- `tests/integration_token.rs` — 6 tests: deploy, transfer, burn, mint, cap enforcement, balance check
+- `tests/integration_mempool.rs` — 7 tests: per-sender limit, global limit, TTL, future timestamp, fee priority, pending spend
+- `tests/integration_supply.rs` — 6 tests: supply invariant at genesis/empty blocks/with TXs/high fees, BLOCK_REWARD increment
+- `tests/integration_chain_validation.rs` — 9 tests: valid chain, wrong prev_hash, unauthorized validator, coinbase overflow, chain_id, hash tampering
+- `tests/integration_sliding_window.rs` — 4 tests: eviction, window_start formula, stats metadata, restart preservation
+- Add `[dev-dependencies] tempfile = "3"` to Cargo.toml
+- **Total: 247 tests (202 unit + 45 integration)**
+
+### PR #45 — Step 3: libp2p + Noise XX Encryption
+- Add `src/network/transport.rs` — `build_transport()`: TCP + Noise XX handshake + Yamux multiplexing, boxed transport
+- Add `src/network/behaviour.rs` — `SentrixBehaviour` (Identify + RequestResponse<SentrixCodec>); `SentrixRequest/Response` enums; length-prefixed JSON codec (10 MiB cap)
+- Add `src/network/libp2p_node.rs` — `LibP2pNode` with command channel pattern; swarm event loop; chain_id validation; `verified_peers` HashSet; `broadcast_block()`, `broadcast_transaction()`
+- Update `src/main.rs` — `sentrix start --use-libp2p` flag; full if/else branch (libp2p vs legacy TCP)
+- Add `futures = "0.3"` and `async-trait = "0.1"` to Cargo.toml
+- Update libp2p features: add `tokio`, `request-response`, `macros`
+- **219 tests at time of merge**
+
+### PR #44 — Security Audit V6: All 13 Findings Fixed
+- `V6-C-01` [CRITICAL]: `compute_contract_address()` now uses `tx.txid` (deterministic) — fixes consensus divergence on multi-node
+- `V6-H-01` [HIGH]: `create_block()` clones mempool txs (not drain) — txs survive if `add_block()` fails
+- `V6-H-02` [HIGH]: `chain/mempool/total_minted/contracts` → `pub(crate)`; `authority/accounts` remain `pub`
+- `V6-M-01` [MEDIUM]: `deploy_token/token_transfer/token_burn` → `pub(crate)` in token_ops.rs
+- `V6-M-02` [MEDIUM]: cargo-deny advisories re-enabled in deny.toml
+- `V6-M-03` [MEDIUM]: `IpRateLimiter` → `tokio::sync::Mutex` (async-safe, no blocking)
+- `V6-M-04` [MEDIUM]: `get_address_tx_count()` returns window-aware JSON with `window_tx_count`, `is_partial` fields
+- `V6-L-01` [LOW]: O(n) mempool insert TODO comment added
+- `V6-L-02` [LOW]: `get_address_history()` standardized to newest-first across all paths
+- `V6-L-03` [LOW]: 16 new unit tests in 5 new modules (202 total)
+- `V6-L-04` [LOW]: Zero-address SRX transfer rejected (except TokenOp)
+- `V6-I-01` [INFO]: `chain_stats()` + `get_address_tx_count()` expose window metadata
+- `V6-I-02` [INFO]: All V5 fixes verified intact post-refactor
+- **202 tests at time of merge**
+
+### PR #43 — Step 2: Split blockchain.rs into 6 Focused Modules
+- Split `blockchain.rs` (1665 lines) into:
+  - `blockchain.rs` (~170 lines) — struct, constants, genesis, core state
+  - `mempool.rs` — `add_to_mempool()`, `prune_mempool()`, mempool queries
+  - `block_producer.rs` — `create_block()`
+  - `block_executor.rs` — `add_block()` (two-pass validation + commit)
+  - `token_ops.rs` — `deploy_token()`, `token_transfer()`, `token_burn()`, token queries
+  - `chain_queries.rs` — `get_transaction()`, `get_address_history()`, `chain_stats()`, `richlist()`
+- All `impl Blockchain` blocks; all public API unchanged
+- Zero logic changes — pure refactor
+- **186 tests at time of merge**
+
+### PR #42 — Step 1: Config Tooling (cargo-deny + clippy)
+- Add `deny.toml`: BUSL-1.1 allowlist, ban wildcards, skip known multi-version transitive deps
+- Add `.clippy.toml`: deny `unwrap_used`/`expect_used`/`panic` in prod paths; warn `large_futures`/`todo`; `allow-*-in-tests=true`
+- Add `[lints.clippy]` + `[lints.rust]` to `Cargo.toml`; `license = "BUSL-1.1"`
+- Fix all pre-existing clippy warnings: `collapsible_if`, `manual_is_multiple_of`, `unwrap_used`, `redundant_binds`
+- CI pipeline: `cargo deny check` + `cargo clippy -- -D warnings` before build/test
+- **186 tests at time of merge**
+
+### PR #41 — Security Audit V5: All 11 Findings Fixed
+- `V5-01`: `MIN_ACTIVE_VALIDATORS=3` enforced in remove/toggle; `collusion_risk()` method
+- `V5-02`: Token `max_supply` cap in deploy+mint (0=unlimited); `#[serde(default)]` backward compat
+- `V5-03`: `handshake_done` flag in node.rs; pre-handshake messages rejected
+- `V5-04`: `tracing::warn!` if `SENTRIX_ENCRYPTED_DISK != "true"` in Storage::open()
+- `V5-05`: `is_valid_sentrix_address()` check in `add_validator()` before crypto check
+- `V5-06`: Per-IP rate limit (60 req/min) in routes.rs + nginx `limit_req_zone`
+- `V5-07`: RBF TODO comment in `add_to_mempool()`
+- `V5-08`: Dockerfile base image pinning comment
+- `V5-09`: CI SSH key rotation reminder comment
+- `V5-10`: `HASH_VERSION=1` constant
+- `V5-11`: `MAX_ADMIN_LOG_SIZE=10_000` with `trim_admin_log()`
+- **186 tests at time of merge**
+
+### PR #40 — Argon2id Keystore v2 + Admin Audit Trail
+- Wallet keystore upgraded: PBKDF2 → Argon2id (m=65536, t=3, p=4); old v1 still loadable (backward compat)
+- `AdminEvent` enum + `admin_log: Vec<AdminEvent>` in `AuthorityManager`
+- `GET /admin/log` endpoint (X-API-Key required)
+- `trim_admin_log()` to cap log at `MAX_ADMIN_LOG_SIZE=10_000`
+- **152 tests at time of merge** (+7 tests from PR #39 base)
+
+### PR #39 — Sliding Window Chain Cache (OOM Fix)
+- `CHAIN_WINDOW_SIZE=1000`: only last 1000 blocks kept in RAM (~2 MB)
+- `chain` field changed from `Vec<Block>` to `VecDeque<Block>` (capacity-bounded)
+- `chain_window_start()` method: `height.saturating_sub(CHAIN_WINDOW_SIZE - 1)`
+- `load_blockchain()` loads only window (not full chain history)
+- `height()` derived from last block index (not vec length)
+- `chain_stats()` exposes `window_start_block`, `window_is_partial` fields
+- **152 tests at time of merge**
+
+### PR #38 — Security Audit V4: Low Severity Fixes
+- `L-01`: Hash index migration at `Storage::open()`; O(n) fallback removed from `load_block_by_hash()`
+- `L-02`: `burn = (fee+1)/2` (ceiling rounding) — odd fees no longer lost
+- `L-03`: Token name (1–64 chars) + symbol (1–10 ASCII alphanumeric) validation in `ContractRegistry::deploy()`
+- `L-04`: `Wallet.secret_key_hex` → `Zeroizing<[u8; 32]>`; manual Drop removed; `secret_key_hex()` method added
+- `L-05`: `serde_json::to_value().unwrap()` → proper error mapping in routes.rs
+- **145 tests at time of merge**
+
+### PR #37 — Security Audit V4: Medium Severity Fixes
+- `M-02`: Constant-time API key comparison (no early return on length mismatch)
+- `M-03`: Mempool timestamp validation: reject >+5min future or >1h old
+- `M-04`: `MEMPOOL_MAX_AGE_SECS=3600`; `prune_mempool()` called after every block
+- `M-05`: `SRX20Contract::mint(caller, to, amount)` — owner check inside the method
+- `M-06`: CORS default → restrictive when `SENTRIX_CORS_ORIGIN` not set
+- `M-07`: `/chain/validate` requires X-API-Key + caches result per block height
+- **130 tests at time of merge**
+
+### PR #36 — Security Audit V4: Critical + High Fixes
+- `C-01`: Private key removed from all server endpoints; client signs locally; faucet rewritten
+- `C-02`: `ConcurrencyLimitLayer(500)` added; nginx upstream handles per-IP rate limiting
+- `C-03`: `MAX_MEMPOOL_SIZE=10_000` + `MAX_MEMPOOL_PER_SENDER=100` enforced
+- `H-01`: `sync.rs` validates `chain_id` in peer handshake
+- `H-02`: `add_validator()` validates secp256k1 pubkey derives to given address
+- `H-03`: `coinbase.verify()` requires empty sig+pubkey (blocks ECDSA bypass)
+- `H-04`: `add_to_mempool()` validates `to_address` format (0x+40hex)
+- `H-05`: `constant_time_eq()` fixed; REST normalizes addresses
+- `M-01`: `signing_payload()` `unwrap()` → `unwrap_or_else`
+- **114 tests at time of merge**
+
+### PR #34 — Domain rename
+- Updated all URLs to sentriscloud.com subdomains
+
+### PR #33 — CI/CD VPS2 fix
+- Fixed GitHub Actions deploy workflow for VPS2 multi-validator setup
+
+### PR #32 — Explorer analytics charts
+- Added analytics charts to block explorer home page
+- TX volume chart, block time histogram, fee distribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you for considering contributing to Sentrix! We welcome contributions from
 
 ```bash
 # Clone the repository
-git clone https://github.com/satyakwok/sentrix-chain.git
+git clone https://github.com/satyakwok/sentrix.git
 cd sentrix-chain
 
 # Build
@@ -33,14 +33,41 @@ cargo build --release
 
 ```
 src/
-├── core/        # Blockchain engine (consensus, blocks, transactions, tokens)
-├── wallet/      # Key generation, encryption
-├── storage/     # sled database persistence
-├── network/     # P2P TCP networking
-├── api/         # REST API, JSON-RPC, block explorer
-├── types/       # Shared error types
-├── lib.rs       # Library root
-└── main.rs      # CLI entry point
+├── core/
+│   ├── blockchain.rs      # Blockchain struct, genesis, constants
+│   ├── mempool.rs         # Mempool management (add, prune, limits)
+│   ├── block_producer.rs  # Block creation (create_block)
+│   ├── block_executor.rs  # Block validation + commit (add_block)
+│   ├── token_ops.rs       # SRX-20 operations
+│   ├── chain_queries.rs   # Read-only chain queries
+│   ├── block.rs           # Block struct + hash
+│   ├── transaction.rs     # TX struct + ECDSA sign/verify
+│   ├── account.rs         # Balance + nonce state
+│   ├── authority.rs       # PoA validator management
+│   ├── merkle.rs          # SHA-256 Merkle tree
+│   └── vm.rs              # SRX-20 token engine
+├── network/
+│   ├── node.rs            # Legacy TCP P2P
+│   ├── sync.rs            # Chain sync protocol
+│   ├── transport.rs       # libp2p TCP + Noise + Yamux
+│   ├── behaviour.rs       # libp2p SentrixBehaviour
+│   └── libp2p_node.rs     # libp2p node runner
+├── wallet/                # Key generation, Argon2id keystore
+├── storage/               # sled per-block persistence
+├── api/                   # REST API, JSON-RPC, block explorer
+├── types/                 # Shared error types
+├── lib.rs                 # Library root
+└── main.rs                # CLI entry point (17 commands)
+tests/
+├── common/mod.rs          # Shared test helpers
+├── integration_restart.rs
+├── integration_sync.rs
+├── integration_tx.rs
+├── integration_token.rs
+├── integration_mempool.rs
+├── integration_supply.rs
+├── integration_chain_validation.rs
+└── integration_sliding_window.rs
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![Build](https://img.shields.io/badge/build-passing-brightgreen)]()
 [![Rust](https://img.shields.io/badge/rust-1.94-orange)](https://www.rust-lang.org/)
-[![Tests](https://img.shields.io/badge/tests-105%20passing-brightgreen)]()
+[![Tests](https://img.shields.io/badge/tests-247%20passing-brightgreen)]()
 [![Consensus](https://img.shields.io/badge/consensus-PoA-blue)]()
 [![License](https://img.shields.io/badge/license-BUSL--1.1-purple)](LICENSE)
 [![Chain ID](https://img.shields.io/badge/chain%20ID-7119-yellow)]()
@@ -50,7 +50,7 @@ Sentrix is **Ethereum-tooling compatible** — MetaMask, ethers.js, and web3.js 
 | **Signatures** | ECDSA secp256k1 |
 | **Token standard** | SRX-20 (ERC-20 compatible) |
 | **Fee split** | 50% validator / 50% burned |
-| **Wallet encryption** | AES-256-GCM + PBKDF2-SHA256 (600k iterations) |
+| **Wallet encryption** | AES-256-GCM + Argon2id (m=65536, t=3, p=4) / PBKDF2 v1 backward compat |
 | **Storage** | sled embedded database (per-block) |
 | **Language** | Rust (zero unsafe, pure implementation) |
 | **Binary size** | ~4.4 MB (single static binary) |
@@ -195,12 +195,17 @@ Supports single requests and batch requests.
 ### Block Explorer
 
 ```
-/explorer                        Dashboard (stats + recent blocks)
+/explorer                        Dashboard (stats + recent blocks + analytics charts)
 /explorer/block/{index}          Block detail with transactions
 /explorer/address/{address}      Address balance + transaction history
 /explorer/tx/{txid}              Transaction detail
 /explorer/validators             Validator list and stats
+/explorer/validator/{address}    Validator detail
 /explorer/tokens                 Deployed SRX-20 tokens
+/explorer/token/{contract}       Token detail
+/explorer/richlist               Top addresses by balance
+/explorer/mempool                Pending transactions
+/explorer/search                 Search by block/tx/address
 ```
 
 ---
@@ -260,7 +265,7 @@ sentrix token list
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                     sentrix (CLI)                            │
-│                  16 commands via clap                        │
+│                  17 commands via clap                        │
 └──────────┬──────────────────────┬───────────────────────────┘
            │                      │
   ┌────────▼────────┐   ┌────────▼────────┐


### PR DESCRIPTION
Updates public-facing documentation to reflect all changes from PR #32 through PR #46.

- README.md: tests badge 105→247, wallet encryption (Argon2id), explorer 11 pages, CLI 17 commands
- CHANGELOG.md: complete history for PR #32–#46 (14 new entries covering all steps, security audits, and fixes)
- CONTRIBUTING.md: fix clone URL, update project structure to show 6 core modules + libp2p network files + tests/ directory