### PR TITLE
chore: update .gitignore — add test-ledger, rs.bk, log patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,12 @@ core.*
 
 # Duplicate env template (keep .env.example only)
 env.example
+
+# Test artifacts
+/test-ledger/
+
+# Rust editor backup files
+**/*.rs.bk
+
+# Log files
+log-*.txt


### PR DESCRIPTION
Adds 3 missing ignore patterns:
- `/test-ledger/` — test artifacts
- `**/*.rs.bk` — Rust editor backup files
- `log-*.txt` — log files