### PR TITLE
chore: fix all warnings — dead_code, unused imports, missing_docs

### DIFF
--- a/src/core/block_executor.rs
+++ b/src/core/block_executor.rs
@@ -244,8 +244,6 @@ mod tests {
         bc
     }
 
-    const RECV: &str = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
-
     // Pass 1 rejection must not mutate state
     #[test]
     fn test_add_block_invalid_validator_leaves_state_clean() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 
 use sentrix::core::blockchain::{Blockchain, CHAIN_ID, TOTAL_PREMINE, BLOCK_REWARD};
-use sentrix::core::transaction::{Transaction, MIN_TX_FEE};
+use sentrix::core::transaction::Transaction;
 use sentrix::wallet::wallet::Wallet;
 
 /// Admin address used in all tests (matches FOUNDER_ADDRESS — receives genesis premine).

--- a/tests/integration_chain_validation.rs
+++ b/tests/integration_chain_validation.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 // integration_chain_validation.rs — Chain validation and block rejection tests
 //
 // Tests:
@@ -11,7 +12,7 @@
 mod common;
 
 use sentrix::core::block::Block;
-use sentrix::core::blockchain::{Blockchain, BLOCK_REWARD, CHAIN_ID};
+use sentrix::core::blockchain::BLOCK_REWARD;
 use sentrix::core::transaction::{Transaction, MIN_TX_FEE};
 use sentrix::wallet::wallet::Wallet;
 
@@ -104,7 +105,7 @@ fn test_block_with_timestamp_before_previous_rejected() {
 /// A TX with an incorrect chain_id inside a block must cause add_block to fail.
 #[test]
 fn test_block_with_wrong_chain_id_tx_rejected() {
-    let (mut bc, val) = common::setup_single_validator();
+    let (mut bc, _val) = common::setup_single_validator();
 
     // Create a TX signed for a different chain (chain_id = 1)
     let sender = common::funded_wallet(&mut bc, 500_000_000);

--- a/tests/integration_mempool.rs
+++ b/tests/integration_mempool.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 // integration_mempool.rs — Mempool stress tests
 // Covers: per-sender limit, global size limit, TTL rejection, fee ordering,
 // mempool clearance after block production.

--- a/tests/integration_restart.rs
+++ b/tests/integration_restart.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 // integration_restart.rs — Node restart persistence tests
 // Verifies that all chain state survives a full shutdown → storage save → reload cycle.
 

--- a/tests/integration_sliding_window.rs
+++ b/tests/integration_sliding_window.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 // integration_sliding_window.rs — Sliding window (CHAIN_WINDOW_SIZE) tests
 //
 // Sentrix keeps only the last CHAIN_WINDOW_SIZE (1_000) blocks in RAM.

--- a/tests/integration_supply.rs
+++ b/tests/integration_supply.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 // integration_supply.rs — Conservation of value (supply invariant) tests
 //
 // The fundamental invariant of the Sentrix chain:

--- a/tests/integration_sync.rs
+++ b/tests/integration_sync.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 // integration_sync.rs — Two-node block synchronisation tests
 // Verifies that Node B can reconstruct identical chain state by applying
 // blocks received from Node A one by one.

--- a/tests/integration_token.rs
+++ b/tests/integration_token.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 // integration_token.rs — SRX-20 token deploy + transfer + burn + mint tests
 // All token operations go through the standard mempool → add_block path (no shortcuts).
 

--- a/tests/integration_trie.rs
+++ b/tests/integration_trie.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 // tests/integration_trie.rs - Sentrix — SentrixTrie integration tests
 
 use secp256k1::{Secp256k1, rand::rngs::OsRng};

--- a/tests/integration_tx.rs
+++ b/tests/integration_tx.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 // integration_tx.rs — Transaction lifecycle end-to-end tests
 // Covers: mempool acceptance, block inclusion, balance changes, double-spend protection,
 // insufficient balance, fee distribution, and nonce sequencing.


### PR DESCRIPTION
## Summary
- Remove unused `const RECV` in `block_executor.rs` (dead_code)
- Remove unused `MIN_TX_FEE` import in `tests/common/mod.rs`
- Remove unused `Blockchain`, `CHAIN_ID` imports + rename `val` → `_val` in `integration_chain_validation.rs`
- Add `#![allow(missing_docs)]` to all 9 integration test files

## Result
- **0 warnings** (`cargo build` + `cargo test`)
- **312 tests passing**, 0 failed