### PR TITLE
chore: add deny.toml skip entries for libp2p transitive duplicates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,22 @@ skip = [
     # secp256k1 and libp2p bring in different versions of common crates
     { name = "bitflags" },
     { name = "getrandom" },   # libp2p pulls in 0.2, 0.3, 0.4 transitively
+    # libp2p transitive duplicates
+    { name = "cpufeatures" },
+    { name = "parking_lot" },
+    { name = "parking_lot_core" },
+    { name = "r-efi" },
+    { name = "rand" },
+    { name = "rand_chacha" },
+    { name = "rand_core" },
+    { name = "redox_syscall" },
+    { name = "socket2" },
+    { name = "thiserror" },
+    { name = "thiserror-impl" },
+    { name = "tower" },
+    { name = "unsigned-varint" },
+    { name = "windows-sys" },
+    { name = "yamux" },
 ]
 
 # ── Sources ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add 15 skip entries to `deny.toml` `[bans]` for crates duplicated by libp2p's transitive dependency tree
- `cargo deny check bans` now passes with 0 errors and 0 warnings

## Skipped duplicates
`cpufeatures`, `parking_lot`, `parking_lot_core`, `r-efi`, `rand`, `rand_chacha`, `rand_core`, `redox_syscall`, `socket2`, `thiserror`, `thiserror-impl`, `tower`, `unsigned-varint`, `windows-sys`, `yamux`