### PR TITLE
chore: fix 0BSD license warning + upgrade CI to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   test:

--- a/deny.toml
+++ b/deny.toml
@@ -25,7 +25,6 @@ allow = [
     "BSD-3-Clause",
     "BSL-1.0",
     "BUSL-1.1",
-    "0BSD",
     "CC0-1.0",
     "ISC",
     "Unlicense",


### PR DESCRIPTION
## Summary
- Remove unused `0BSD` license from `deny.toml` allowlist (`cargo deny check licenses` was emitting a license-not-encountered warning)
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to workflow-level `env` in `ci.yml` — suppresses Node.js 16/20 deprecation warnings for all actions in one place