### PR TITLE
feat(trie): integrate SentrixTrie into blockchain — state root, zero-balance deletion, proof API

### DIFF
--- a/src/core/blockchain.rs
+++ b/src/core/blockchain.rs
@@ -255,9 +255,18 @@ impl Blockchain {
         let trie = self.state_trie.as_mut()?;
         for (addr, balance, nonce) in updates {
             let key = address_to_key(&addr);
-            let value = account_value_bytes(balance, nonce);
-            if let Err(e) = trie.insert(&key, &value) {
-                tracing::warn!("trie: insert failed for {}: {}", addr, e);
+            if balance == 0 {
+                // Remove zero-balance accounts from the trie — prevents dead entries
+                // from accumulating and keeps the tree compact.
+                // delete() is a no-op if the key was never inserted.
+                if let Err(e) = trie.delete(&key) {
+                    tracing::warn!("trie: delete zero-balance {} failed: {}", addr, e);
+                }
+            } else {
+                let value = account_value_bytes(balance, nonce);
+                if let Err(e) = trie.insert(&key, &value) {
+                    tracing::warn!("trie: insert failed for {}: {}", addr, e);
+                }
             }
         }
         match trie.commit(block_index) {
@@ -1127,5 +1136,91 @@ mod tests {
     #[test]
     fn test_v510_hash_version_constant_is_1() {
         assert_eq!(HASH_VERSION, 1, "HASH_VERSION must be 1 (SHA-256)");
+    }
+
+    // ── SentrixTrie unit tests ────────────────────────────
+
+    fn temp_db() -> (tempfile::TempDir, sled::Db) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db  = sled::open(dir.path()).unwrap();
+        (dir, db)
+    }
+
+    /// A freshly constructed Blockchain must have state_trie = None.
+    #[test]
+    fn test_state_trie_none_by_default() {
+        let bc = setup_chain();
+        assert!(bc.state_trie.is_none(), "state_trie must be None before init_trie()");
+    }
+
+    /// trie_root_at() must return None when the trie has not been initialized.
+    #[test]
+    fn test_trie_root_at_without_init_returns_none() {
+        let bc = setup_chain();
+        assert_eq!(bc.trie_root_at(0), None);
+        assert_eq!(bc.trie_root_at(1), None);
+    }
+
+    /// After init_trie() + add_block(), trie_root_at(1) must return Some(root).
+    #[test]
+    fn test_trie_initialized_commits_root_per_block() {
+        let (_dir, db) = temp_db();
+        let mut bc = setup_chain();
+        bc.init_trie(&db).unwrap();
+        assert!(bc.state_trie.is_some());
+
+        let block = bc.create_block("validator1").unwrap();
+        bc.add_block(block).unwrap();
+
+        let root = bc.trie_root_at(1);
+        assert!(root.is_some(), "trie_root_at(1) must be Some after adding block 1");
+    }
+
+    /// trie_root_at() must return None for a version that has not been committed yet.
+    #[test]
+    fn test_trie_root_at_uncommitted_version_returns_none() {
+        let (_dir, db) = temp_db();
+        let mut bc = setup_chain();
+        bc.init_trie(&db).unwrap();
+        // No blocks added — version 1 has not been committed
+        assert_eq!(bc.trie_root_at(1), None, "uncommitted version must return None");
+    }
+
+    /// Multiple blocks must each have a distinct committed root persisted in the trie.
+    #[test]
+    fn test_trie_multiple_blocks_all_roots_persisted() {
+        let (_dir, db) = temp_db();
+        let mut bc = setup_chain();
+        bc.init_trie(&db).unwrap();
+
+        for i in 1u64..=3 {
+            let block = bc.create_block("validator1").unwrap();
+            bc.add_block(block).unwrap();
+            assert!(bc.trie_root_at(i).is_some(), "root at height {} must be committed", i);
+        }
+    }
+
+    /// Block.state_root must be Some when the trie is active, None otherwise.
+    #[test]
+    fn test_state_root_stamped_on_block_iff_trie_active() {
+        // Without trie: state_root should be None
+        let mut bc_no_trie = setup_chain();
+        let b1 = bc_no_trie.create_block("validator1").unwrap();
+        bc_no_trie.add_block(b1).unwrap();
+        assert!(
+            bc_no_trie.latest_block().unwrap().state_root.is_none(),
+            "state_root must be None when trie is not initialized"
+        );
+
+        // With trie: state_root should be Some
+        let (_dir, db) = temp_db();
+        let mut bc_trie = setup_chain();
+        bc_trie.init_trie(&db).unwrap();
+        let b2 = bc_trie.create_block("validator1").unwrap();
+        bc_trie.add_block(b2).unwrap();
+        assert!(
+            bc_trie.latest_block().unwrap().state_root.is_some(),
+            "state_root must be Some when trie is initialized"
+        );
     }
 }

--- a/tests/integration_trie.rs
+++ b/tests/integration_trie.rs
@@ -2,7 +2,8 @@
 // tests/integration_trie.rs - Sentrix — SentrixTrie integration tests
 
 use secp256k1::{Secp256k1, rand::rngs::OsRng};
-use sentrix::core::blockchain::Blockchain;
+use sentrix::core::blockchain::{Blockchain, CHAIN_ID, BLOCK_REWARD};
+use sentrix::core::transaction::{Transaction, MIN_TX_FEE};
 use sentrix::core::trie::{
     SentrixTrie, address_to_key, account_value_bytes, account_value_decode, empty_hash,
 };
@@ -24,6 +25,21 @@ fn make_validator() -> (secp256k1::SecretKey, String, String) {
     let pk_hex  = hex::encode(pk.serialize());
     (sk, addr, pk_hex)
 }
+
+/// Generate a funded sender keypair. Returns (sk, pk, address).
+fn make_sender(
+    bc: &mut Blockchain,
+    balance: u64,
+) -> (secp256k1::SecretKey, secp256k1::PublicKey, String) {
+    let secp = Secp256k1::new();
+    let (sk, pk) = secp.generate_keypair(&mut OsRng);
+    let addr = Wallet::derive_address(&pk);
+    bc.accounts.credit(&addr, balance).unwrap();
+    (sk, pk, addr)
+}
+
+/// A well-formed recipient address used as TX destination.
+const RECV_ADDR: &str = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
 /// Build a Blockchain with one real validator + trie initialized.
 /// Returns (bc, validator_address).
@@ -302,5 +318,185 @@ fn test_trie_persists_after_restart() {
         let mut trie = SentrixTrie::open(&db, 1).unwrap();
         let got = trie.get(&key).unwrap();
         assert_eq!(got.as_deref(), Some(val.as_slice()), "data must survive DB reopen");
+    }
+}
+
+// ── Transaction-based trie tests ──────────────────────────────
+
+/// TX recipient (with positive balance) must appear in the trie after the block.
+#[test]
+fn test_tx_recipient_appears_in_trie() {
+    let (_dir, db) = temp_db();
+    let (mut bc, vaddr) = setup(&db);
+
+    let (sk, pk, _sender) = make_sender(&mut bc, 50_000_000 + MIN_TX_FEE);
+
+    let tx = Transaction::new(
+        Wallet::derive_address(&pk),
+        RECV_ADDR.to_string(),
+        50_000_000,
+        MIN_TX_FEE,
+        0,
+        String::new(),
+        CHAIN_ID,
+        &sk,
+        &pk,
+    ).unwrap();
+    bc.add_to_mempool(tx).unwrap();
+
+    let block = bc.create_block(&vaddr).unwrap();
+    bc.add_block(block).unwrap();
+
+    let recv_key = address_to_key(RECV_ADDR);
+    let root = bc.latest_block().unwrap().state_root.unwrap();
+    let trie_height = bc.height();
+    let mut trie = SentrixTrie::open(&db, trie_height).unwrap();
+    let proof = trie.prove(&recv_key).unwrap();
+
+    assert!(proof.found, "recipient must be in trie after receiving funds");
+    assert!(proof.verify_membership(&root), "membership proof must verify against block state_root");
+    let (bal, _) = account_value_decode(&proof.value).unwrap();
+    assert_eq!(bal, 50_000_000, "trie balance must equal received amount");
+}
+
+/// A sender whose balance reaches zero after a TX must be removed from the trie.
+#[test]
+fn test_zero_balance_sender_removed_from_trie() {
+    let (_dir, db) = temp_db();
+    let (mut bc, vaddr) = setup(&db);
+
+    // Block 1: partially spend — sender stays in trie with residual balance
+    let residual    = 500_000u64;
+    let total_funds = 10_000_000 + MIN_TX_FEE + residual + MIN_TX_FEE;
+    let (sk, pk, sender) = make_sender(&mut bc, total_funds);
+
+    let tx1 = Transaction::new(
+        sender.clone(), RECV_ADDR.to_string(),
+        10_000_000, MIN_TX_FEE, 0, String::new(), CHAIN_ID, &sk, &pk,
+    ).unwrap();
+    bc.add_to_mempool(tx1).unwrap();
+    let b1 = bc.create_block(&vaddr).unwrap();
+    bc.add_block(b1).unwrap();
+
+    // Sender should be in trie with residual balance
+    let sender_key = address_to_key(&sender);
+    let mut trie = SentrixTrie::open(&db, bc.height()).unwrap();
+    assert!(trie.get(&sender_key).unwrap().is_some(), "sender must be in trie after block 1");
+
+    // Block 2: drain remaining balance to zero
+    let tx2 = Transaction::new(
+        sender.clone(), RECV_ADDR.to_string(),
+        residual, MIN_TX_FEE, 1, String::new(), CHAIN_ID, &sk, &pk,
+    ).unwrap();
+    bc.add_to_mempool(tx2).unwrap();
+    let b2 = bc.create_block(&vaddr).unwrap();
+    bc.add_block(b2).unwrap();
+
+    // Sender balance is now 0 — must be deleted from trie
+    let mut trie2 = SentrixTrie::open(&db, bc.height()).unwrap();
+    let got = trie2.get(&sender_key).unwrap();
+    assert!(got.is_none(), "zero-balance sender must be removed from trie");
+}
+
+/// Validator balance in trie must match the AccountDB balance after a block.
+#[test]
+fn test_trie_validator_balance_matches_after_block() {
+    let (_dir, db) = temp_db();
+    let (mut bc, vaddr) = setup(&db);
+
+    let block = bc.create_block(&vaddr).unwrap();
+    bc.add_block(block).unwrap();
+
+    let expected = bc.accounts.get_balance(&vaddr);
+    let key = address_to_key(&vaddr);
+    let mut trie = SentrixTrie::open(&db, bc.height()).unwrap();
+    let proof = trie.prove(&key).unwrap();
+
+    assert!(proof.found, "validator must be in trie");
+    let (bal, _) = account_value_decode(&proof.value).unwrap();
+    assert_eq!(bal, expected, "trie balance must equal AccountDB balance");
+    assert_eq!(bal, BLOCK_REWARD, "validator earned exactly one block reward");
+}
+
+/// Merkle proof for a TX recipient verifies against the block's state_root.
+#[test]
+fn test_proof_verified_after_block_with_tx() {
+    let (_dir, db) = temp_db();
+    let (mut bc, vaddr) = setup(&db);
+
+    let (sk, pk, _) = make_sender(&mut bc, 5_000_000 + MIN_TX_FEE);
+    let tx = Transaction::new(
+        Wallet::derive_address(&pk),
+        RECV_ADDR.to_string(),
+        5_000_000, MIN_TX_FEE, 0, String::new(), CHAIN_ID, &sk, &pk,
+    ).unwrap();
+    bc.add_to_mempool(tx).unwrap();
+
+    let block = bc.create_block(&vaddr).unwrap();
+    bc.add_block(block).unwrap();
+
+    let root = bc.latest_block().unwrap().state_root.unwrap();
+    let key  = address_to_key(RECV_ADDR);
+    let mut trie = SentrixTrie::open(&db, bc.height()).unwrap();
+    let proof = trie.prove(&key).unwrap();
+
+    assert!(proof.found);
+    assert!(proof.verify_membership(&root), "proof must verify against block state_root");
+    // Non-membership proof for a deleted account also verifies against the same root
+    let absent_key = address_to_key("0x0000000000000000000000000000000000000001");
+    let np = trie.prove(&absent_key).unwrap();
+    assert!(!np.found);
+    assert!(np.verify_nonmembership(&root));
+}
+
+/// After zero-balance deletion the state root must differ from the previous block.
+#[test]
+fn test_state_root_changes_on_zero_balance_deletion() {
+    let (_dir, db) = temp_db();
+    let (mut bc, vaddr) = setup(&db);
+
+    // Block 1: give sender some balance (lands in trie)
+    // Initial: 2_000_000 + 2×fee → after tx1: 1_000_000 + fee → after tx2: 0
+    let (sk, pk, sender) = make_sender(&mut bc, 2_000_000 + 2 * MIN_TX_FEE);
+    let tx1 = Transaction::new(
+        sender.clone(), RECV_ADDR.to_string(),
+        1_000_000, MIN_TX_FEE, 0, String::new(), CHAIN_ID, &sk, &pk,
+    ).unwrap();
+    bc.add_to_mempool(tx1).unwrap();
+    let b1 = bc.create_block(&vaddr).unwrap();
+    bc.add_block(b1).unwrap();
+    let root1 = bc.latest_block().unwrap().state_root.unwrap();
+
+    // Block 2: drain sender to zero → deletion path (spends exact residual)
+    let tx2 = Transaction::new(
+        sender.clone(), RECV_ADDR.to_string(),
+        1_000_000, MIN_TX_FEE, 1, String::new(), CHAIN_ID, &sk, &pk,
+    ).unwrap();
+    bc.add_to_mempool(tx2).unwrap();
+    let b2 = bc.create_block(&vaddr).unwrap();
+    bc.add_block(b2).unwrap();
+    let root2 = bc.latest_block().unwrap().state_root.unwrap();
+
+    assert_ne!(root1, root2, "deleting an account must change the state root");
+}
+
+/// Every block must have a recoverable state root via trie_root_at().
+#[test]
+fn test_state_root_history_per_block() {
+    let (_dir, db) = temp_db();
+    let (mut bc, vaddr) = setup(&db);
+
+    let n = 5u64;
+    let mut roots = Vec::new();
+    for _ in 0..n {
+        let block = bc.create_block(&vaddr).unwrap();
+        bc.add_block(block).unwrap();
+        roots.push(bc.latest_block().unwrap().state_root.unwrap());
+    }
+
+    for (i, &expected) in roots.iter().enumerate() {
+        let version = (i + 1) as u64;
+        let stored = bc.trie_root_at(version);
+        assert_eq!(stored, Some(expected), "state root at version {} must be recoverable", version);
     }
 }


### PR DESCRIPTION
## Summary
- `update_trie_for_block()`: delete zero-balance accounts from trie (prevents dead entries accumulating)
- 12 new tests (+12 → **325 total**)

## What was already in place
- `block.state_root: Option<[u8;32]>` stamped per block ✅
- `init_trie()` / `update_trie_for_block()` in blockchain.rs ✅
- `block_executor.rs` calls `update_trie_for_block()` after Pass 2 ✅
- `db.rs` calls `init_trie()` on load ✅
- `GET /address/:addr/proof` + `GET /chain/state-root/:height` API endpoints ✅

## New: zero-balance deletion
When `update_trie_for_block` snapshots touched accounts, any address whose balance is **0** is now `trie.delete()`-d instead of inserted. This keeps the tree compact and prevents zombie entries.

## New tests (+12)
**Integration** (`integration_trie.rs`): `test_tx_recipient_appears_in_trie`, `test_zero_balance_sender_removed_from_trie`, `test_trie_validator_balance_matches_after_block`, `test_proof_verified_after_block_with_tx`, `test_state_root_changes_on_zero_balance_deletion`, `test_state_root_history_per_block`

**Unit** (`blockchain.rs`): `test_state_trie_none_by_default`, `test_trie_root_at_without_init_returns_none`, `test_trie_initialized_commits_root_per_block`, `test_trie_root_at_uncommitted_version_returns_none`, `test_trie_multiple_blocks_all_roots_persisted`, `test_state_root_stamped_on_block_iff_trie_active`

## Verification
- `cargo build` → 0 warnings
- `cargo clippy -- -D warnings` → clean
- `cargo deny check bans` → clean
- `cargo test` → **325 passed, 0 failed**