### PR TITLE
fix(storage): graceful recovery when blocks missing in sled

### DIFF
--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -103,13 +103,36 @@ impl Storage {
             let window_start = height.saturating_sub(CHAIN_WINDOW_SIZE as u64 - 1);
             let mut blocks = Vec::with_capacity((height - window_start + 1) as usize);
             for i in window_start..=height {
-                let key = format!("block:{}", i);
-                match self.get::<Block>(&key)? {
+                match self.load_block(i)? {
                     Some(block) => blocks.push(block),
                     None => {
-                        return Err(SentrixError::StorageError(
-                            format!("missing block {} during chain reconstruction", i)
-                        ));
+                        // PR #62: Missing block — caused by pre-PR#61 sync_from_peer()
+                        // not persisting blocks. Adjust height to last available block
+                        // so the node can start and re-sync from peers.
+                        let effective = if let Some(last) = blocks.last() {
+                            last.index
+                        } else {
+                            // First block in window missing — scan backwards
+                            let mut h = window_start.saturating_sub(1);
+                            while h > 0 && self.load_block(h)?.is_none() {
+                                h = h.saturating_sub(1);
+                            }
+                            // Reload window from found height
+                            let new_start = h.saturating_sub(CHAIN_WINDOW_SIZE as u64 - 1);
+                            for j in new_start..=h {
+                                if let Some(b) = self.load_block(j)? {
+                                    blocks.push(b);
+                                }
+                            }
+                            h
+                        };
+                        tracing::warn!(
+                            "Block {} missing in sled (stored height = {}). \
+                             Adjusting height to {}. Node will re-sync from peers.",
+                            i, height, effective
+                        );
+                        self.save_height(effective)?;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- `load_blockchain()` no longer crashes when blocks are missing in the sliding window
- Adjusts height to last available contiguous block and logs a warning
- Node recovers via P2P sync (blocks now persisted thanks to PR #61)

## Root cause
Pre-PR#61 `sync_from_peer()` advanced sled height without persisting block data. On restart, `load_blockchain()` tried to load non-existent blocks and crashed with `missing block N during chain reconstruction`.

## Changes
- `src/storage/db.rs`: replace hard error with graceful height adjustment + backwards scan

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — 335 passing
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [ ] CI passes
- [ ] Deploy fixes VPS1 crash loop (currently stuck on `missing block 101840`)