### PR TITLE
fix(p2p): handle duplicate connections + auto-reconnect

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use sentrix::storage::db::Storage;
 use sentrix::api::routes::{create_router, SharedState};
 use sentrix::network::node::{DEFAULT_PORT, NodeEvent};
 use sentrix::network::libp2p_node::{LibP2pNode, make_multiaddr};
+use libp2p::Multiaddr;
 
 const DEFAULT_API_PORT: u16 = 8545;
 
@@ -529,6 +530,36 @@ async fn cmd_start(
             }
         }
     });
+
+    // ── Periodic reconnect to bootstrap peers ────────────
+    // Collect bootstrap multiaddrs for reconnection
+    let bootstrap_addrs: Vec<Multiaddr> = peers_str.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|peer_str| {
+            let parts: Vec<&str> = peer_str.splitn(2, ':').collect();
+            if let [host, port_part] = parts.as_slice()
+                && let Ok(p) = port_part.parse::<u16>()
+            {
+                return make_multiaddr(host, p).ok();
+            }
+            None
+        })
+        .collect();
+
+    if !bootstrap_addrs.is_empty() {
+        let lp2p_reconnect = lp2p.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
+                let count = lp2p_reconnect.peer_count().await;
+                if count < bootstrap_addrs.len() {
+                    tracing::info!("Reconnecting: {} peers, expected {}", count, bootstrap_addrs.len());
+                    lp2p_reconnect.reconnect_peers(bootstrap_addrs.clone()).await;
+                }
+            }
+        });
+    }
 
     // ── Shared: REST API (always started) ───────────────
     let app = create_router(shared.clone());

--- a/src/network/libp2p_node.rs
+++ b/src/network/libp2p_node.rs
@@ -40,6 +40,8 @@ enum SwarmCommand {
     ConnectPeer(Multiaddr),
     Broadcast(SentrixRequest),
     GetPeerCount(tokio::sync::oneshot::Sender<usize>),
+    /// Re-dial bootstrap peers that are no longer connected.
+    ReconnectPeers(Vec<Multiaddr>),
 }
 
 // ── Public handle ────────────────────────────────────────
@@ -105,6 +107,11 @@ impl LibP2pNode {
     pub async fn broadcast_transaction(&self, tx: &Transaction) {
         let req = SentrixRequest::NewTransaction { transaction: tx.clone() };
         let _ = self.cmd_tx.send(SwarmCommand::Broadcast(req)).await;
+    }
+
+    /// Re-dial bootstrap peers that may have disconnected.
+    pub async fn reconnect_peers(&self, addrs: Vec<Multiaddr>) {
+        let _ = self.cmd_tx.send(SwarmCommand::ReconnectPeers(addrs)).await;
     }
 
     /// Returns the number of currently verified (handshaked) peers.
@@ -188,6 +195,13 @@ async fn run_swarm(
                     Some(SwarmCommand::GetPeerCount(reply)) => {
                         let _ = reply.send(verified_peers.len());
                     }
+                    Some(SwarmCommand::ReconnectPeers(addrs)) => {
+                        for addr in addrs {
+                            if let Err(e) = swarm.dial(addr.clone()) {
+                                tracing::warn!("libp2p reconnect dial {} failed: {}", addr, e);
+                            }
+                        }
+                    }
                     None => {
                         tracing::info!("libp2p: command channel closed, stopping swarm");
                         break;
@@ -264,10 +278,15 @@ async fn on_swarm_event(
             pending_handshakes.insert(req_id, peer_id);
         }
 
-        SwarmEvent::ConnectionClosed { peer_id, .. } => {
-            tracing::info!("libp2p: connection to {} closed", peer_id);
-            verified_peers.remove(&peer_id);
-            let _ = event_tx.send(NodeEvent::PeerDisconnected(peer_id.to_string())).await;
+        SwarmEvent::ConnectionClosed { peer_id, num_established, .. } => {
+            tracing::info!("libp2p: connection to {} closed ({} remaining)", peer_id, num_established);
+            // Only remove from verified peers when ALL connections to this peer are gone.
+            // Bidirectional dialing creates 2 connections per peer; libp2p prunes duplicates.
+            // Previously, we removed on ANY close, orphaning the surviving connection.
+            if num_established == 0 {
+                verified_peers.remove(&peer_id);
+                let _ = event_tx.send(NodeEvent::PeerDisconnected(peer_id.to_string())).await;
+            }
         }
 
         SwarmEvent::Behaviour(SentrixBehaviourEvent::Rr(rr_event)) => {


### PR DESCRIPTION
## Summary
- Fix `ConnectionClosed` handler: check `num_established` before removing peer — keep peer if other connections survive
- Add periodic reconnect (30s) to bootstrap peers when peer count drops
- Root cause fix for VPS1 isolation after PR #65 deploy

## Root cause
Bidirectional dialing (VPS1 dials VPS2 AND VPS2 dials VPS1) creates 2 connections per peer. libp2p prunes the duplicate, but our `ConnectionClosed` handler removed the peer from `verified_peers` on ANY close — orphaning the surviving connection.

## Changes
- `libp2p_node.rs`: `ConnectionClosed` checks `num_established == 0` before removing peer
- `libp2p_node.rs`: add `ReconnectPeers` SwarmCommand + `reconnect_peers()` method
- `main.rs`: 30s reconnect timer re-dials bootstrap peers when peer count is low

## Test plan
- [x] 335 tests passing
- [x] 0 clippy warnings
- [ ] CI passes
- [ ] Deploy: VPS1 maintains connections to VPS2 peers (no more isolation)
- [ ] Chain advancing on all 6 nodes