### PR TITLE
fix(p2p): move block processing out of swarm loop

### DIFF
--- a/src/network/behaviour.rs
+++ b/src/network/behaviour.rs
@@ -174,9 +174,11 @@ impl SentrixBehaviour {
             identify::Config::new(SENTRIX_PROTOCOL.to_string(), local_public_key),
         );
 
+        let rr_config = request_response::Config::default()
+            .with_request_timeout(std::time::Duration::from_secs(60));
         let rr = request_response::Behaviour::new(
             [(SENTRIX_PROTOCOL.to_string(), ProtocolSupport::Full)],
-            request_response::Config::default(),
+            rr_config,
         );
 
         Self { identify, rr }

--- a/src/network/libp2p_node.rs
+++ b/src/network/libp2p_node.rs
@@ -446,36 +446,46 @@ async fn on_inbound_request(
             }
         }
 
-        // ── NewBlock — apply to chain ─────────────────────
+        // ── NewBlock — apply to chain (spawned to avoid blocking swarm) ──
         SentrixRequest::NewBlock { block } => {
-            let mut bc = blockchain.write().await;
-            match bc.add_block(*block.clone()) {
-                Ok(()) => {
-                    tracing::info!("libp2p: applied block {} from {}", block.index, peer);
-                    drop(bc);
-                    let _ = event_tx.send(NodeEvent::NewBlock(*block)).await;
-                }
-                Err(e) => {
-                    tracing::warn!("libp2p: rejected block from {}: {}", peer, e);
-                }
-            }
+            // ACK immediately so peer doesn't timeout waiting for response
             let _ = swarm.behaviour_mut().rr.send_response(channel, SentrixResponse::Ack);
+            // Process block in background — never hold write lock in swarm loop
+            let bc = blockchain.clone();
+            let etx = event_tx.clone();
+            tokio::spawn(async move {
+                let mut chain = bc.write().await;
+                match chain.add_block(*block.clone()) {
+                    Ok(()) => {
+                        tracing::info!("libp2p: applied block {} from {}", block.index, peer);
+                        drop(chain);
+                        let _ = etx.send(NodeEvent::NewBlock(*block)).await;
+                    }
+                    Err(e) => {
+                        tracing::warn!("libp2p: rejected block from {}: {}", peer, e);
+                    }
+                }
+            });
         }
 
-        // ── NewTransaction — add to mempool ──────────────
+        // ── NewTransaction — add to mempool (spawned) ────
         SentrixRequest::NewTransaction { transaction } => {
-            let mut bc = blockchain.write().await;
-            if bc.add_to_mempool(transaction.clone()).is_ok() {
-                drop(bc);
-                let _ = event_tx.send(NodeEvent::NewTransaction(transaction)).await;
-            }
             let _ = swarm.behaviour_mut().rr.send_response(channel, SentrixResponse::Ack);
+            let bc = blockchain.clone();
+            let etx = event_tx.clone();
+            tokio::spawn(async move {
+                let mut chain = bc.write().await;
+                if chain.add_to_mempool(transaction.clone()).is_ok() {
+                    drop(chain);
+                    let _ = etx.send(NodeEvent::NewTransaction(transaction)).await;
+                }
+            });
         }
 
-        // ── GetBlocks — respond with up to 100 blocks ────
+        // ── GetBlocks — respond with up to 50 blocks (reduced from 100 to stay under 10MB) ──
         SentrixRequest::GetBlocks { from_height } => {
             let bc = blockchain.read().await;
-            let to = bc.height().min(from_height.saturating_add(99));
+            let to = bc.height().min(from_height.saturating_add(49));
             let blocks: Vec<Block> = (from_height..=to)
                 .filter_map(|i| bc.get_block(i).cloned())
                 .collect();
@@ -521,33 +531,41 @@ async fn on_inbound_response(
     our_chain_id: u64,
 ) -> Option<(PeerId, u64)> {
     // ── Step 3d: handle BlocksResponse from GetBlocks sync ──
+    // Block processing is spawned to a background task so the swarm loop
+    // stays responsive. Without this, the write lock blocks all event processing,
+    // causing cascade peer disconnects (root cause of VPS1 isolation 2026-04-14).
     if let SentrixResponse::BlocksResponse { blocks } = &response
         && let Some(sync_peer) = pending_syncs.remove(&request_id)
     {
         if blocks.is_empty() {
             return None;
         }
-        let mut synced = 0u64;
-        let mut bc = blockchain.write().await;
-        for block in blocks {
-            match bc.add_block(block.clone()) {
-                Ok(()) => {
-                    // Emit NewBlock so main.rs event handler persists to sled
-                    let _ = event_tx.send(NodeEvent::NewBlock(block.clone())).await;
-                    synced += 1;
-                }
-                Err(e) => {
-                    tracing::warn!("libp2p sync: block {} failed: {}", block.index, e);
-                    break;
+        let block_count = blocks.len();
+        let bc = blockchain.clone();
+        let etx = event_tx.clone();
+        let blocks_owned = blocks.clone();
+        let peer_str = sync_peer.to_string();
+        tokio::spawn(async move {
+            let mut chain = bc.write().await;
+            let mut synced = 0u64;
+            for block in &blocks_owned {
+                match chain.add_block(block.clone()) {
+                    Ok(()) => {
+                        let _ = etx.send(NodeEvent::NewBlock(block.clone())).await;
+                        synced += 1;
+                    }
+                    Err(e) => {
+                        tracing::warn!("libp2p sync: block {} failed: {}", block.index, e);
+                        break;
+                    }
                 }
             }
-        }
-        drop(bc);
-        if synced > 0 {
-            tracing::info!("libp2p: synced {} blocks from {}", synced, sync_peer);
-        }
-        // If we got a full batch (100 blocks), request more
-        if blocks.len() >= 100 {
+            if synced > 0 {
+                tracing::info!("libp2p: synced {} blocks from {}", synced, peer_str);
+            }
+        });
+        // If we got a full batch (50 blocks), request more
+        if block_count >= 50 {
             let next_height = blocks.last().map(|b| b.index + 1).unwrap_or(0);
             return Some((sync_peer, next_height));
         }

--- a/src/network/transport.rs
+++ b/src/network/transport.rs
@@ -30,7 +30,7 @@ pub fn build_transport(keypair: &Keypair) -> SentrixResult<SentrixTransport> {
     let noise_config = noise::Config::new(keypair)
         .map_err(|e| SentrixError::NetworkError(format!("noise init failed: {e}")))?;
 
-    let transport = tcp::tokio::Transport::new(tcp::Config::default())
+    let transport = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true))
         .upgrade(upgrade::Version::V1)
         .authenticate(noise_config)
         .multiplex(yamux::Config::default())


### PR DESCRIPTION
## Root Cause Analysis

`blockchain.write().await` inside the swarm event loop blocked ALL event processing for 50-500ms during block sync. Other peers' keepalive frames couldn't be processed → Yamux timeout → cascade disconnect of ALL peers.

**3 blocking points identified and fixed:**
1. `on_inbound_response` BlocksResponse — held write lock for up to 100 blocks
2. `on_inbound_request` NewBlock — held write lock for single block validation + trie update  
3. `on_inbound_request` NewTransaction — held write lock for mempool insertion

## Fixes

| Change | File | Impact |
|--------|------|--------|
| Spawn task for BlocksResponse sync | libp2p_node.rs | Swarm never blocks during batch sync |
| Spawn task for NewBlock processing | libp2p_node.rs | ACK immediately, process in background |
| Spawn task for NewTransaction | libp2p_node.rs | ACK immediately, process in background |
| Reduce batch 100→50 blocks | libp2p_node.rs | Stay under 10MB message limit |
| TCP nodelay | transport.rs | Low-latency frame delivery |
| RequestResponse timeout 30s→60s | behaviour.rs | More time for large responses |

## Architecture (Before → After)

**Before:** Swarm loop holds write lock → blocks events → peers timeout
```
swarm event → blockchain.write().await → process 100 blocks → release → handle next event
                    ↑ ALL OTHER EVENTS BLOCKED HERE
```

**After:** Swarm loop spawns tasks → stays responsive
```
swarm event → ACK peer → tokio::spawn(blockchain.write + process) → handle next event immediately
                                  ↑ runs in separate task, doesn't block swarm
```

## Test plan
- [x] 335 tests passing, 0 clippy warnings
- [ ] CI passes
- [ ] Deploy + data3 recovery
- [ ] VPS1 maintains connections to VPS2 (no cascade disconnect)
- [ ] Chain advancing on all 6 nodes
- [ ] Monitor 10 minutes for stability