### PR TITLE
fix(security): Security Audit V8 — all findings fixed

### DIFF
--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -85,20 +85,21 @@ pub struct SignedTxRequest {
     pub transaction: Transaction,
 }
 
-// H-05 FIX: Constant-time string comparison — no early return on length mismatch
-// (early return leaks key length via timing oracle)
+// V8-API-H-02: Use `subtle` crate for constant-time comparison instead of hand-rolled impl.
 pub fn constant_time_eq(a: &str, b: &str) -> bool {
+    use subtle::ConstantTimeEq;
     let a_bytes = a.as_bytes();
     let b_bytes = b.as_bytes();
+    // Pad both to max_len so comparison traverses equal bytes regardless of input length.
     let max_len = a_bytes.len().max(b_bytes.len());
-    // Include length difference in result so mismatched lengths always return false
-    let mut result: u8 = (a_bytes.len() ^ b_bytes.len()) as u8;
-    for i in 0..max_len {
-        let ab = if i < a_bytes.len() { a_bytes[i] } else { 0 };
-        let bb = if i < b_bytes.len() { b_bytes[i] } else { 0 };
-        result |= ab ^ bb;
-    }
-    result == 0
+    let mut a_padded = vec![0u8; max_len];
+    let mut b_padded = vec![0u8; max_len];
+    a_padded[..a_bytes.len()].copy_from_slice(a_bytes);
+    b_padded[..b_bytes.len()].copy_from_slice(b_bytes);
+    // Length difference must also cause failure (constant-time).
+    let len_eq: subtle::Choice = (a_bytes.len() as u64).ct_eq(&(b_bytes.len() as u64));
+    let content_eq: subtle::Choice = a_padded.ct_eq(&b_padded);
+    (len_eq & content_eq).into()
 }
 
 
@@ -122,6 +123,12 @@ async fn ip_rate_limit_middleware(
 
     let allowed = if let Some(limiter) = request.extensions().get::<IpRateLimiter>().cloned() {
         let mut map = limiter.lock().await;  // V6-M-03: async lock — yields instead of blocking thread
+
+        // V8-API-M-02: prevent unbounded HashMap growth — evict stale entries
+        if map.len() > 10_000 {
+            map.retain(|_, (_, ts)| ts.elapsed().as_secs() < RATE_LIMIT_WINDOW_SECS);
+        }
+
         let now = Instant::now();
         let entry = map.entry(ip).or_insert((0, now));
         if entry.1.elapsed().as_secs() >= RATE_LIMIT_WINDOW_SECS {
@@ -385,7 +392,7 @@ async fn validate_chain(
     }
 
     // Full O(n) chain scan — only runs when height has changed
-    let valid = bc.is_valid_chain();
+    let valid = bc.is_valid_chain_window();
     VALIDATE_CACHE_HEIGHT.store(height, Ordering::Relaxed);
     VALIDATE_CACHE_RESULT.store(valid, Ordering::Relaxed);
 
@@ -630,6 +637,8 @@ async fn get_wallet_info(
     State(state): State<SharedState>,
     Path(address): Path<String>,
 ) -> Json<serde_json::Value> {
+    // V8-API-H-01: normalize address to lowercase for case-insensitive lookup
+    let address = address.to_lowercase();
     let bc = state.read().await;
     let balance = bc.accounts.get_balance(&address);
     let nonce = bc.accounts.get_nonce(&address);
@@ -764,6 +773,8 @@ async fn get_address_info(
     State(state): State<SharedState>,
     Path(address): Path<String>,
 ) -> Json<serde_json::Value> {
+    // V8-API-H-01: normalize address to lowercase for case-insensitive lookup
+    let address = address.to_lowercase();
     let bc = state.read().await;
     let balance = bc.accounts.get_balance(&address);
     let nonce = bc.accounts.get_nonce(&address);

--- a/src/core/block.rs
+++ b/src/core/block.rs
@@ -96,18 +96,31 @@ impl Block {
     }
 
     // Genesis block — block 0, no previous hash
+    // V8-CRIT-02: Hardcoded timestamp for deterministic genesis across all nodes.
     pub fn genesis() -> Self {
+        const GENESIS_TIMESTAMP: u64 = 1_712_620_800; // 2024-04-09 00:00:00 UTC
         let genesis_tx = Transaction::new_coinbase(
             "GENESIS".to_string(),
             0,
             0,
+            GENESIS_TIMESTAMP,
         );
-        Self::new(
-            0,
-            "0".repeat(64),
-            vec![genesis_tx],
-            "GENESIS".to_string(),
-        )
+
+        let txids: Vec<String> = vec![genesis_tx.txid.clone()];
+        let merkle = merkle_root(&txids);
+
+        let mut block = Self {
+            index: 0,
+            previous_hash: "0".repeat(64),
+            transactions: vec![genesis_tx],
+            timestamp: GENESIS_TIMESTAMP,
+            merkle_root: merkle,
+            validator: "GENESIS".to_string(),
+            hash: String::new(),
+            state_root: None,
+        };
+        block.hash = block.calculate_hash();
+        block
     }
 
     pub fn tx_count(&self) -> usize {
@@ -228,7 +241,7 @@ mod tests {
         let block1 = Block::new(
             1,
             genesis.hash.clone(),
-            vec![Transaction::new_coinbase("validator1".to_string(), 100_000_000, 1)],
+            vec![Transaction::new_coinbase("validator1".to_string(), 100_000_000, 1, 1_712_620_800)],
             "validator1".to_string(),
         );
         assert!(block1.validate_structure(1, &genesis.hash).is_ok());
@@ -254,7 +267,7 @@ mod tests {
         let mut block = Block::new(
             STATE_ROOT_FORK_HEIGHT,
             "0".repeat(64),
-            vec![Transaction::new_coinbase("v1".to_string(), 100_000_000, STATE_ROOT_FORK_HEIGHT)],
+            vec![Transaction::new_coinbase("v1".to_string(), 100_000_000, STATE_ROOT_FORK_HEIGHT, 1_712_620_800)],
             "v1".to_string(),
         );
         // state_root = None → "0"*64 sentinel in hash

--- a/src/core/block_executor.rs
+++ b/src/core/block_executor.rs
@@ -2,7 +2,7 @@
 
 use hex;
 use std::collections::{HashMap, HashSet};
-use crate::core::blockchain::{Blockchain, CHAIN_WINDOW_SIZE};
+use crate::core::blockchain::{Blockchain, CHAIN_WINDOW_SIZE, is_valid_sentrix_address};
 use crate::core::block::{Block, STATE_ROOT_FORK_HEIGHT};
 use crate::core::transaction::TokenOp;
 use crate::types::error::{SentrixError, SentrixResult};
@@ -85,10 +85,16 @@ impl Blockchain {
             // Validate token operation if present
             if let Some(token_op) = TokenOp::decode(&tx.data) {
                 match &token_op {
-                    TokenOp::Transfer { contract, amount, .. } => {
+                    TokenOp::Transfer { contract, to, amount } => {
                         if !self.contracts.exists(contract) {
                             return Err(SentrixError::InvalidTransaction(
                                 format!("token contract {} not found", contract)
+                            ));
+                        }
+                        // V8-H-02: validate target address
+                        if !is_valid_sentrix_address(to) {
+                            return Err(SentrixError::InvalidTransaction(
+                                format!("invalid token transfer target address: '{}'", to)
                             ));
                         }
                         let token_bal = self.contracts.get_token_balance(contract, &tx.from_address);
@@ -107,17 +113,29 @@ impl Blockchain {
                             return Err(SentrixError::InsufficientBalance { have: token_bal, need: *amount });
                         }
                     }
-                    TokenOp::Mint { contract, .. } => {
+                    TokenOp::Mint { contract, to, .. } => {
                         if !self.contracts.exists(contract) {
                             return Err(SentrixError::InvalidTransaction(
                                 format!("token contract {} not found", contract)
                             ));
                         }
+                        // V8-H-02: validate target address
+                        if !is_valid_sentrix_address(to) {
+                            return Err(SentrixError::InvalidTransaction(
+                                format!("invalid token mint target address: '{}'", to)
+                            ));
+                        }
                     }
-                    TokenOp::Approve { contract, .. } => {
+                    TokenOp::Approve { contract, spender, .. } => {
                         if !self.contracts.exists(contract) {
                             return Err(SentrixError::InvalidTransaction(
                                 format!("token contract {} not found", contract)
+                            ));
+                        }
+                        // V8-H-02: validate spender address
+                        if !is_valid_sentrix_address(spender) {
+                            return Err(SentrixError::InvalidTransaction(
+                                format!("invalid token approve spender address: '{}'", spender)
                             ));
                         }
                     }
@@ -231,16 +249,16 @@ impl Blockchain {
                     }
                     Some(received_root) => {
                         // Received block: verify peer's state_root matches ours (V7-C-01).
+                        // V8-CRIT-01: reject the block on mismatch instead of logging.
                         if received_root != computed_root {
-                            tracing::error!(
-                                "V7-C-01 CRITICAL: state_root mismatch at block {} — \
-                                 received {}, computed {}. Possible state divergence.",
-                                last.index,
-                                hex::encode(received_root),
-                                hex::encode(computed_root),
-                            );
-                            // Override with locally-computed root.
-                            // TODO: full rollback + block rejection in a future release.
+                            return Err(SentrixError::ChainValidationFailed(
+                                format!(
+                                    "state_root mismatch at block {}: received {}, computed {}",
+                                    last.index,
+                                    hex::encode(received_root),
+                                    hex::encode(computed_root),
+                                )
+                            ));
                         }
                         last.state_root = Some(computed_root);
                     }

--- a/src/core/block_producer.rs
+++ b/src/core/block_producer.rs
@@ -16,11 +16,17 @@ impl Blockchain {
         }
 
         // Build transaction list — coinbase first
+        // V8-CRIT-03: Use the block timestamp for the coinbase (deterministic).
+        let block_timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
         let reward = self.get_block_reward();
         let coinbase = Transaction::new_coinbase(
             validator_address.to_string(),
             reward,
             next_height,
+            block_timestamp,
         );
 
         let mut transactions = vec![coinbase];

--- a/src/core/blockchain.rs
+++ b/src/core/blockchain.rs
@@ -158,7 +158,8 @@ impl Blockchain {
     }
 
     // ── Chain validation ─────────────────────────────────
-    pub fn is_valid_chain(&self) -> bool {
+    // V8-M-03: renamed from is_valid_chain → is_valid_chain_window to clarify scope
+    pub fn is_valid_chain_window(&self) -> bool {
         for i in 1..self.chain.len() {
             let block = &self.chain[i];
             let prev = &self.chain[i - 1];
@@ -393,7 +394,7 @@ mod tests {
         let bc = setup_chain();
         assert_eq!(bc.height(), 0);
         assert_eq!(bc.total_minted, TOTAL_PREMINE);
-        assert!(bc.is_valid_chain());
+        assert!(bc.is_valid_chain_window());
     }
 
     #[test]
@@ -409,7 +410,7 @@ mod tests {
         assert_eq!(block.index, 1);
         bc.add_block(block).unwrap();
         assert_eq!(bc.height(), 1);
-        assert!(bc.is_valid_chain());
+        assert!(bc.is_valid_chain_window());
     }
 
     #[test]
@@ -456,7 +457,7 @@ mod tests {
 
         // Tamper with txid — breaks merkle root integrity
         bc.chain[1].transactions[0].txid = "tampered".to_string();
-        assert!(!bc.is_valid_chain());
+        assert!(!bc.is_valid_chain_window());
     }
 
     #[test]
@@ -780,9 +781,10 @@ mod tests {
         ).unwrap();
 
         // Create transfer transaction
+        let bob = TEST_RECV; // V8-H-02: use valid-format address
         let token_op = TokenOp::Transfer {
             contract: contract.clone(),
-            to: "bob".to_string(),
+            to: bob.to_string(),
             amount: 100_000,
         };
         let tx = Transaction::new(
@@ -798,7 +800,7 @@ mod tests {
 
         // Verify token balances
         assert_eq!(bc.token_balance(&contract, &alice), 400_000);
-        assert_eq!(bc.token_balance(&contract, "bob"), 100_000);
+        assert_eq!(bc.token_balance(&contract, bob), 100_000);
     }
 
     #[test]

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -64,6 +64,13 @@ impl Blockchain {
             ));
         }
 
+        // V8-H-03: Reject duplicate txid (same transaction submitted twice)
+        if self.mempool.iter().any(|existing| existing.txid == tx.txid) {
+            return Err(SentrixError::InvalidTransaction(
+                format!("duplicate txid in mempool: {}", tx.txid)
+            ));
+        }
+
         // Basic validation
         let expected_nonce = self.accounts.get_nonce(&tx.from_address)
             + self.mempool_pending_count(&tx.from_address);

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -33,7 +33,8 @@ impl TokenOp {
     }
 
     pub fn is_token_op(data: &str) -> bool {
-        data.contains("\"op\":")
+        // V8-M-02: use the real decoder instead of naive string match
+        Self::decode(data).is_some()
     }
 }
 
@@ -96,12 +97,7 @@ impl Transaction {
         Ok(tx)
     }
 
-    pub fn new_coinbase(to_address: String, amount: u64, block_index: u64) -> Self {
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-
+    pub fn new_coinbase(to_address: String, amount: u64, block_index: u64, block_timestamp: u64) -> Self {
         let mut tx = Self {
             txid: String::new(),
             from_address: COINBASE_ADDRESS.to_string(),
@@ -110,7 +106,7 @@ impl Transaction {
             fee: 0,
             nonce: 0,
             data: format!("block_{}", block_index),
-            timestamp,
+            timestamp: block_timestamp,
             chain_id: 0,
             signature: String::new(),
             public_key: String::new(),
@@ -249,7 +245,7 @@ mod tests {
 
     #[test]
     fn test_coinbase_transaction() {
-        let tx = Transaction::new_coinbase("SRX_validator".to_string(), 100_000_000, 1);
+        let tx = Transaction::new_coinbase("SRX_validator".to_string(), 100_000_000, 1, 1_712_620_800);
         assert!(tx.is_coinbase());
         assert_eq!(tx.amount, 100_000_000);
         assert!(!tx.txid.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -585,7 +585,7 @@ fn cmd_chain_validate() -> anyhow::Result<()> {
     let storage = Storage::open(&get_db_path())?;
     let bc = storage.load_blockchain()?
         .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-    let valid = bc.is_valid_chain();
+    let valid = bc.is_valid_chain_window();
     println!("Chain valid: {}", valid);
     println!("Height: {}", bc.height());
     println!("Total blocks: {}", bc.height() + 1);

--- a/src/network/node.rs
+++ b/src/network/node.rs
@@ -161,6 +161,12 @@ impl Node {
                     let peer_ip = peer_addr.ip();
                     {
                         let mut counts = connection_counts.lock().await;
+
+                        // V8-M-06: prevent unbounded HashMap growth — evict stale entries
+                        if counts.len() > 10_000 {
+                            counts.retain(|_, (_, ts)| ts.elapsed() <= RATE_LIMIT_WINDOW);
+                        }
+
                         let entry = counts.entry(peer_ip).or_insert((0, Instant::now()));
                         if entry.1.elapsed() > RATE_LIMIT_WINDOW {
                             *entry = (0, Instant::now());

--- a/src/network/sync.rs
+++ b/src/network/sync.rs
@@ -65,6 +65,14 @@ impl ChainSync {
                     }
                     let mut bc = blockchain.write().await;
                     for block in &blocks {
+                        // V8-M-05: verify block index continuity before applying
+                        if block.index != current {
+                            tracing::warn!(
+                                "Sync: expected block index {}, got {} — aborting sync",
+                                current, block.index
+                            );
+                            return Ok(total_synced);
+                        }
                         match bc.add_block(block.clone()) {
                             Ok(()) => {
                                 // PR #61: persist each synced block to sled immediately.

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -31,17 +31,31 @@ impl Storage {
     }
 
     // L-01 FIX: Scan all stored blocks and write missing hash→index entries.
-    // O(n) only on first open when old data lacks the hash index; subsequent opens are O(1).
+    // V8-H-04: O(1) check via sentinel key — skip the full O(n) scan on subsequent opens.
     pub fn ensure_hash_index(&self) -> SentrixResult<()> {
+        // Fast path: if hash_index_complete marker exists, all blocks are already indexed.
+        if self.db.contains_key("hash_index_complete").unwrap_or(false) {
+            return Ok(());
+        }
+
         let height = self.load_height()?;
+        let mut indexed_any = false;
         for i in 0..=height {
             let key = format!("block:{}", i);
             if let Some(block) = self.get::<Block>(&key)? {
+                indexed_any = true;
                 let hash_key = format!("hash:{}", block.hash);
                 if self.get::<u64>(&hash_key)?.is_none() {
                     self.put(&hash_key, &block.index)?;
                 }
             }
+        }
+
+        // Mark indexing as complete so future opens skip the scan.
+        // Only set sentinel if blocks actually exist — prevents false-positive
+        // on empty DBs (e.g. first open before any blocks are stored).
+        if indexed_any {
+            self.put("hash_index_complete", &true)?;
         }
         Ok(())
     }

--- a/tests/integration_chain_validation.rs
+++ b/tests/integration_chain_validation.rs
@@ -23,7 +23,7 @@ fn test_valid_chain_passes() {
     for _ in 0..50 {
         common::mine_empty_block(&mut bc, &val.address);
     }
-    assert!(bc.is_valid_chain(), "valid 50-block chain should pass validation");
+    assert!(bc.is_valid_chain_window(), "valid 50-block chain should pass validation");
 }
 
 /// A block with a wrong previous_hash must be rejected.
@@ -33,7 +33,11 @@ fn test_block_with_wrong_prev_hash_rejected() {
     common::mine_empty_block(&mut bc, &val.address);
 
     // Craft a block with a tampered previous_hash
-    let coinbase = Transaction::new_coinbase(val.address.clone(), BLOCK_REWARD, 2);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let coinbase = Transaction::new_coinbase(val.address.clone(), BLOCK_REWARD, 2, now);
     let tampered_block = Block::new(
         2,
         "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
@@ -53,7 +57,11 @@ fn test_block_from_unauthorized_validator_rejected() {
 
     let intruder = Wallet::generate();
     let prev_hash = bc.latest_block().expect("latest_block").hash.clone();
-    let coinbase = Transaction::new_coinbase(intruder.address.clone(), BLOCK_REWARD, 2);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let coinbase = Transaction::new_coinbase(intruder.address.clone(), BLOCK_REWARD, 2, now);
     let bad_block = Block::new(2, prev_hash, vec![coinbase], intruder.address.clone());
 
     let result = bc.add_block(bad_block);
@@ -73,7 +81,11 @@ fn test_block_with_oversized_coinbase_rejected() {
 
     let prev_hash = bc.latest_block().expect("latest_block").hash.clone();
     let inflated_reward = BLOCK_REWARD * 100; // 100× block reward
-    let coinbase = Transaction::new_coinbase(val.address.clone(), inflated_reward, 2);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let coinbase = Transaction::new_coinbase(val.address.clone(), inflated_reward, 2, now);
     let bad_block = Block::new(2, prev_hash, vec![coinbase], val.address.clone());
 
     let result = bc.add_block(bad_block);
@@ -99,7 +111,7 @@ fn test_block_with_timestamp_before_previous_rejected() {
     // A valid second block should always succeed
     common::mine_empty_block(&mut bc, &val.address);
     assert_eq!(bc.height(), 2, "two blocks should have been mined");
-    assert!(bc.is_valid_chain(), "chain should still be valid");
+    assert!(bc.is_valid_chain_window(), "chain should still be valid");
 }
 
 /// A TX with an incorrect chain_id inside a block must cause add_block to fail.
@@ -163,7 +175,7 @@ fn test_chain_validity_after_mixed_blocks() {
     }
 
     assert_eq!(bc.height(), 50);
-    assert!(bc.is_valid_chain(), "50-block mixed chain must be valid");
+    assert!(bc.is_valid_chain_window(), "50-block mixed chain must be valid");
 }
 
 /// A second blockchain independently mines the same transactions and reaches
@@ -181,6 +193,6 @@ fn test_independent_chains_have_same_height() {
     }
 
     assert_eq!(bc1.height(), bc2.height(), "independently mined chains must have same height");
-    assert!(bc1.is_valid_chain());
-    assert!(bc2.is_valid_chain());
+    assert!(bc1.is_valid_chain_window());
+    assert!(bc2.is_valid_chain_window());
 }

--- a/tests/integration_restart.rs
+++ b/tests/integration_restart.rs
@@ -52,7 +52,7 @@ fn test_restart_preserves_full_state() {
     );
 
     // Chain must still be valid
-    assert!(loaded.is_valid_chain(), "chain invalid after restart");
+    assert!(loaded.is_valid_chain_window(), "chain invalid after restart");
 
     // Block hashes must be identical for all blocks in the sliding window
     let window_start = loaded.chain_window_start();
@@ -124,5 +124,5 @@ fn test_restart_height_integrity() {
     let storage2 = Storage::open(&path).expect("reopen");
     let loaded = storage2.load_blockchain().expect("load").expect("no state");
     assert_eq!(loaded.height(), expected_height, "height must survive restart");
-    assert!(loaded.is_valid_chain(), "reloaded chain must be valid");
+    assert!(loaded.is_valid_chain_window(), "reloaded chain must be valid");
 }

--- a/tests/integration_sliding_window.rs
+++ b/tests/integration_sliding_window.rs
@@ -155,7 +155,7 @@ fn test_sliding_window_survives_restart() {
     let reloaded_latest = loaded.get_block(height_before).expect("latest in window");
     assert_eq!(reloaded_latest.hash, latest_hash, "latest block hash must survive restart");
 
-    assert!(loaded.is_valid_chain(), "chain must be valid after reload");
+    assert!(loaded.is_valid_chain_window(), "chain must be valid after reload");
 }
 
 /// Blocks added after a window overflow do not appear in get_block() for evicted indices.

--- a/tests/integration_sync.rs
+++ b/tests/integration_sync.rs
@@ -53,8 +53,8 @@ fn test_two_node_sync_empty_blocks() {
     assert_eq!(bal_a, bal_b, "validator balances must match after sync");
 
     // Both chains must be valid
-    assert!(bc_a.is_valid_chain(), "node A chain invalid");
-    assert!(bc_b.is_valid_chain(), "node B chain invalid");
+    assert!(bc_a.is_valid_chain_window(), "node A chain invalid");
+    assert!(bc_b.is_valid_chain_window(), "node B chain invalid");
 }
 
 /// Blocks containing user transactions must sync correctly: balances and tx history
@@ -107,7 +107,7 @@ fn test_two_node_sync_with_transactions() {
         "receiver balance mismatch after sync"
     );
 
-    assert!(bc_b.is_valid_chain(), "node B chain invalid after tx sync");
+    assert!(bc_b.is_valid_chain_window(), "node B chain invalid after tx sync");
 }
 
 /// Applying the same block twice must be rejected (duplicate block).


### PR DESCRIPTION
## Summary
- **CRIT-01**: State root mismatch now returns `ChainValidationFailed` error instead of logging and accepting
- **CRIT-02**: Genesis block uses hardcoded timestamp `1712620800` (2024-04-09 00:00:00 UTC) for deterministic genesis across all nodes
- **CRIT-03**: `new_coinbase()` takes `block_timestamp` parameter instead of using `SystemTime::now()` — all callers updated
- **H-02**: Token operation Pass 1 validation now checks `is_valid_sentrix_address()` for Transfer `to`, Mint `to`, and Approve `spender`
- **H-03**: Mempool rejects duplicate txids
- **H-04**: `ensure_hash_index()` uses sentinel key for O(1) skip on subsequent opens
- **API-H-01**: `get_wallet_info` and `get_address_info` normalize address to lowercase
- **API-H-02**: `constant_time_eq` replaced with `subtle::ConstantTimeEq`
- **M-02**: `is_token_op()` uses `Self::decode()` instead of naive string match
- **M-03**: `is_valid_chain` renamed to `is_valid_chain_window` — all callers updated
- **M-05**: `sync_from_peer()` verifies `block.index == current` before `add_block()`
- **M-06/API-M-02**: Rate limiter HashMaps in node.rs and routes.rs cleaned when >10k entries

## Test plan
- [x] `cargo build` — compiles cleanly
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] `cargo test` — 335 tests pass (269 unit + 66 integration)
- [ ] Manual smoke test on testnet before merge