### PR TITLE
fix(fork): prevent H1/H2 hash inconsistency + trie shutdown guarantee (#78)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -533,9 +533,15 @@ async fn cmd_start(
                     match bc.create_block(&wallet.address) {
                         Ok(block) => {
                             let height = block.index;
-                            let block_clone = block.clone();
                             match bc.add_block(block) {
-                                Ok(()) => Some((height, block_clone)),
+                                Ok(()) => {
+                                    // Capture H2: above STATE_ROOT_FORK_HEIGHT, add_block()
+                                    // stamps state_root and recomputes the block hash in-place.
+                                    // Must use latest_block() here — NOT a pre-add_block clone —
+                                    // so disk and broadcast always carry the canonical H2 hash.
+                                    let updated = bc.latest_block().ok().cloned();
+                                    Some((height, updated))
+                                }
                                 Err(e) => { tracing::warn!("add_block failed: {}", e); None }
                             }
                         }
@@ -543,16 +549,16 @@ async fn cmd_start(
                     }
                 }; // write lock released here — API reads no longer stalled
 
-                if let Some((height, block_clone)) = result {
+                if let Some((height, Some(block_to_save))) = result {
                     println!("Block {} produced by {}", height, wallet.address);
                     // save_block (fast — only block data + height) every block.
                     // Full state (accounts, validators, tokens) via read lock — API still serves.
-                    let _ = storage_clone.save_block(&block_clone);
+                    let _ = storage_clone.save_block(&block_to_save);
                     {
                         let bc = shared_clone.read().await;
                         let _ = storage_clone.save_blockchain(&bc);
                     }
-                    lp2p_clone.broadcast_block(&block_clone).await;
+                    lp2p_clone.broadcast_block(&block_to_save).await;
                 }
             }
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 
 use clap::{Parser, Subcommand};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::RwLock;
 use sentrix::core::blockchain::Blockchain;
 use sentrix::core::transaction::{Transaction, TokenOp, TOKEN_OP_ADDRESS};
@@ -503,6 +504,10 @@ async fn cmd_start(
         }
     }
 
+    // Shutdown flag — set to true by the signal handler to stop the validator loop
+    // cleanly before the process exits (guarantees trie.commit() is not interrupted).
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
+
     // Validator loop
     if let Some(key_hex) = validator_key {
         let wallet = Wallet::from_private_key(&key_hex)?;
@@ -510,8 +515,15 @@ async fn cmd_start(
         let shared_clone = shared.clone();
         let storage_clone = storage.clone();
         let lp2p_clone = lp2p.clone();
+        let shutdown_flag_clone = shutdown_flag.clone();
         tokio::spawn(async move {
             loop {
+                // Stop before acquiring the write lock so the shutdown handler
+                // can obtain it immediately without racing a new block cycle.
+                if shutdown_flag_clone.load(Ordering::Acquire) {
+                    tracing::info!("Validator loop: shutdown flag set — exiting");
+                    break;
+                }
                 tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
                 // Release write lock before disk I/O so API reads are not
@@ -633,6 +645,19 @@ async fn cmd_start(
             let _ = tokio::signal::ctrl_c().await;
             tracing::info!("Ctrl+C received — shutting down");
         }
+
+        // 1. Signal the validator loop to stop — prevents a new block cycle from
+        //    starting while we are trying to save state.
+        shutdown_flag.store(true, Ordering::Release);
+
+        // 2. Acquire the write lock and immediately drop it.
+        //    This waits for any in-progress add_block() (and therefore trie.commit())
+        //    to finish before we take a snapshot — guarantees the trie root is committed.
+        tracing::info!("Graceful shutdown: waiting for in-progress block to complete...");
+        drop(shutdown_shared.write().await);
+
+        // 3. Save state under a read lock so API requests can still be served
+        //    until axum finishes its own graceful drain.
         tracing::info!("Graceful shutdown: saving state to disk...");
         let bc = shutdown_shared.read().await;
         if let Err(e) = shutdown_storage.save_blockchain(&bc) {

--- a/src/network/libp2p_node.rs
+++ b/src/network/libp2p_node.rs
@@ -460,8 +460,11 @@ async fn on_inbound_request(
                 match chain.add_block(*block.clone()) {
                     Ok(()) => {
                         tracing::info!("libp2p: applied block {} from {}", block.index, peer);
+                        // Capture H2 (with state_root + recomputed hash) before releasing
+                        // the write lock — same fix as validator loop (PR #78).
+                        let updated = chain.latest_block().ok().cloned().unwrap_or(*block);
                         drop(chain);
-                        let _ = etx.send(NodeEvent::NewBlock(*block)).await;
+                        let _ = etx.send(NodeEvent::NewBlock(updated)).await;
                     }
                     Err(e) => {
                         tracing::warn!("libp2p: rejected block from {}: {}", peer, e);
@@ -553,7 +556,10 @@ async fn on_inbound_response(
             for block in &blocks_owned {
                 match chain.add_block(block.clone()) {
                     Ok(()) => {
-                        let _ = etx.send(NodeEvent::NewBlock(block.clone())).await;
+                        // Use H2 (post-add_block state_root hash) — not the raw peer block (PR #78).
+                        let updated = chain.latest_block().ok().cloned()
+                            .unwrap_or_else(|| block.clone());
+                        let _ = etx.send(NodeEvent::NewBlock(updated)).await;
                         synced += 1;
                     }
                     Err(e) => {

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -91,15 +91,17 @@ impl Storage {
         // Save state (accounts, authority, contracts, mempool, metadata)
         self.put("state", blockchain)?;
 
-        // Save each block individually: key = "block:{index}" + hash index
+        // Save each block individually: key = "block:{index}" + hash index.
+        // Always overwrite — no contains_key guard — so an H2 block (with recomputed
+        // state_root hash) corrects any stale H1 entry that was written before
+        // add_block() stamped the state_root (fork-prevention, PR #78).
         for block in &blockchain.chain {
             let key = format!("block:{}", block.index);
-            if !self.db.contains_key(&key).unwrap_or(false) {
-                self.put(&key, block)?;
-                // Hash → index lookup
-                let hash_key = format!("hash:{}", block.hash);
-                self.put(&hash_key, &block.index)?;
-            }
+            self.put(&key, block)?;
+            // Hash → index lookup (old hash entries for the same index become
+            // harmless orphans in sled; they are never queried in normal operation)
+            let hash_key = format!("hash:{}", block.hash);
+            self.put(&hash_key, &block.index)?;
         }
 
         self.save_height(blockchain.height())?;
@@ -412,6 +414,33 @@ mod tests {
         let bc = Blockchain::new("admin".to_string());
         storage.save_blockchain(&bc).unwrap();
         assert!(storage.db_size_bytes() > 0);
+        let _ = std::fs::remove_dir_all(&path);
+    }
+
+    // ── PR-78: save_blockchain overwrites stale block (H1→H2 correction) ──
+
+    #[test]
+    fn test_save_blockchain_overwrites_stale_block() {
+        // Regression: save_blockchain must overwrite an existing block so that
+        // an H2 block (state_root + recomputed hash) corrects any stale H1 entry.
+        let path = temp_db_path();
+        let storage = Storage::open(&path).unwrap();
+
+        let bc = Blockchain::new("admin".to_string());
+        let canonical_hash = bc.chain[0].hash.clone();
+
+        // Simulate an H1 block already on disk with a wrong hash.
+        let mut stale = bc.chain[0].clone();
+        stale.hash = "stale_h1_hash".to_string();
+        storage.save_block(&stale).unwrap();
+
+        // save_blockchain carries the canonical (H2) version — must overwrite.
+        storage.save_blockchain(&bc).unwrap();
+
+        let stored = storage.load_block(0).unwrap().unwrap();
+        assert_eq!(stored.hash, canonical_hash,
+            "save_blockchain must overwrite stale H1 block with canonical H2 block");
+
         let _ = std::fs::remove_dir_all(&path);
     }
 


### PR DESCRIPTION
## Root cause

Above `STATE_ROOT_FORK_HEIGHT` (100,000), `add_block()` stamps `state_root` and recomputes the block hash in-place (**H1 → H2**). Three code paths were capturing or sending the pre-`add_block` block (H1) instead of the updated one (H2):

- **`main.rs` validator loop** — `block_clone` was captured *before* `add_block()`, so `save_block` and `broadcast_block` both sent H1
- **`libp2p_node.rs` NewBlock handler** — emitted `NodeEvent::NewBlock(*block)` (peer's H1) not the locally-committed H2
- **`libp2p_node.rs` sync loop** — same issue for every block in a `BlocksResponse` batch
- **`storage/db.rs` `save_blockchain`** — `contains_key` guard prevented H2 from correcting a stale H1 on disk

Result: on any node restart, `load_blockchain()` reads H1 from disk. The next block's `previous_hash` = H2, so `validate_structure` rejects it with `"invalid previous hash"` → **chain stall/fork**.

## Fixes

| File | Change |
|------|--------|
| `src/main.rs` | Capture `bc.latest_block()` *after* `add_block()` — not a pre-add clone |
| `src/network/libp2p_node.rs` | Same fix in `NewBlock` handler and `BlocksResponse` sync loop |
| `src/storage/db.rs` | Remove `contains_key` guard — always overwrite so H2 corrects any stale H1 |

Also includes **PR #78a**: `fix(node): guarantee trie commit completes before graceful shutdown` (shutdown `AtomicBool` + write-lock drain in signal handler).

## Test plan

- [x] 277 tests passing (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Regression test `test_save_blockchain_overwrites_stale_block` added to `storage/db.rs`
- [ ] Deploy to VPS and monitor chain height advancing without stall across validator restarts