### PR TITLE
feat(infra): add VPS3 Sentrix Core + CI/CD 3-VPS deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,6 @@ jobs:
       - name: Make binary executable
         run: chmod +x ./release/sentrix
 
-      # V5-09: Rotate VPS_SSH_KEY secrets periodically (recommended: every 90 days).
-      # PR #63: Graceful deploy — stop first, replace binary, then start.
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh
@@ -78,8 +76,11 @@ jobs:
           chmod 600 ~/.ssh/id_rsa_vps1
           echo "${{ secrets.VPS2_SSH_KEY }}" > ~/.ssh/id_rsa_vps2
           chmod 600 ~/.ssh/id_rsa_vps2
+          echo "${{ secrets.VPS3_SSH_KEY }}" > ~/.ssh/id_rsa_vps3
+          chmod 600 ~/.ssh/id_rsa_vps3
           ssh-keyscan -H ${{ secrets.VPS1_HOST }} >> ~/.ssh/known_hosts
           ssh-keyscan -H ${{ secrets.VPS2_HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan -H ${{ secrets.VPS3_HOST }} >> ~/.ssh/known_hosts
 
       # Phase 1: Upload binary to all VPS while nodes are still running
       - name: Upload binary to VPS1
@@ -92,9 +93,20 @@ jobs:
           scp -i ~/.ssh/id_rsa_vps2 ./release/sentrix \
             ${{ secrets.VPS2_USER }}@${{ secrets.VPS2_HOST }}:/tmp/sentrix_new
 
-      # Phase 2: Stop ALL validators — VPS2 first, then VPS1
-      # Order matters: VPS2 has 5 validators that would produce orphan blocks
-      # if VPS1 went offline first with old code still running on VPS2.
+      - name: Upload binary to VPS3
+        run: |
+          scp -i ~/.ssh/id_rsa_vps3 ./release/sentrix \
+            ${{ secrets.VPS3_USER }}@${{ secrets.VPS3_HOST }}:/tmp/sentrix_new
+
+      # Phase 2: Stop ALL validators — VPS3 first, then VPS2, then VPS1
+      # Order matters: stop remote validators first to prevent orphan blocks.
+      - name: Stop VPS3 node
+        run: |
+          ssh -i ~/.ssh/id_rsa_vps3 ${{ secrets.VPS3_USER }}@${{ secrets.VPS3_HOST }} "
+            sudo systemctl stop sentrix-core || true
+            echo 'stopped sentrix-core'
+          "
+
       - name: Stop VPS2 validators
         run: |
           ssh -i ~/.ssh/id_rsa_vps2 ${{ secrets.VPS2_USER }}@${{ secrets.VPS2_HOST }} "
@@ -108,9 +120,8 @@ jobs:
       - name: Stop VPS1 node
         run: |
           ssh -i ~/.ssh/id_rsa_vps1 ${{ secrets.VPS1_USER }}@${{ secrets.VPS1_HOST }} "
-            echo '--- Stopping VPS1 sentrix-node ---'
             sudo systemctl stop sentrix-node || true
-            echo '  stopped sentrix-node'
+            echo 'stopped sentrix-node'
           "
 
       # Phase 3: Replace binary on all VPS
@@ -130,7 +141,15 @@ jobs:
             echo 'VPS2 binary replaced'
           "
 
-      # Phase 4: Start ALL validators
+      - name: Replace binary VPS3
+        run: |
+          ssh -i ~/.ssh/id_rsa_vps3 ${{ secrets.VPS3_USER }}@${{ secrets.VPS3_HOST }} "
+            sudo mv /tmp/sentrix_new /opt/sentrix/sentrix
+            sudo chmod +x /opt/sentrix/sentrix
+            echo 'VPS3 binary replaced'
+          "
+
+      # Phase 4: Start ALL — VPS1 first (anchor), then VPS2 + VPS3
       - name: Start VPS1 node
         run: |
           ssh -i ~/.ssh/id_rsa_vps1 ${{ secrets.VPS1_USER }}@${{ secrets.VPS1_HOST }} "
@@ -149,7 +168,14 @@ jobs:
             done
           "
 
-      # Phase 5: Health check — verify chain is advancing on both VPS
+      - name: Start VPS3 node
+        run: |
+          ssh -i ~/.ssh/id_rsa_vps3 ${{ secrets.VPS3_USER }}@${{ secrets.VPS3_HOST }} "
+            sudo systemctl start sentrix-core
+            echo 'VPS3 sentrix-core started'
+          "
+
+      # Phase 5: Health check — verify chain is advancing on all VPS
       - name: Health check
         run: |
           echo '--- Waiting 20s for nodes to stabilize ---'
@@ -159,7 +185,9 @@ jobs:
             | python3 -c "import sys,json; print(json.load(sys.stdin)['height'])" 2>/dev/null || echo "0")
           VPS2_H0=$(curl -sf --max-time 10 http://${{ secrets.VPS2_HOST }}:8545/chain/info \
             | python3 -c "import sys,json; print(json.load(sys.stdin)['height'])" 2>/dev/null || echo "0")
-          echo "Height T0 — VPS1: $VPS1_H0 | VPS2: $VPS2_H0"
+          VPS3_H0=$(curl -sf --max-time 10 http://${{ secrets.VPS3_HOST }}:8545/chain/info \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['height'])" 2>/dev/null || echo "0")
+          echo "Height T0 — VPS1: $VPS1_H0 | VPS2: $VPS2_H0 | VPS3: $VPS3_H0"
 
           sleep 15
 
@@ -167,13 +195,16 @@ jobs:
             | python3 -c "import sys,json; print(json.load(sys.stdin)['height'])" 2>/dev/null || echo "0")
           VPS2_H1=$(curl -sf --max-time 10 http://${{ secrets.VPS2_HOST }}:8545/chain/info \
             | python3 -c "import sys,json; print(json.load(sys.stdin)['height'])" 2>/dev/null || echo "0")
-          echo "Height T1 — VPS1: $VPS1_H1 | VPS2: $VPS2_H1"
+          VPS3_H1=$(curl -sf --max-time 10 http://${{ secrets.VPS3_HOST }}:8545/chain/info \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['height'])" 2>/dev/null || echo "0")
+          echo "Height T1 — VPS1: $VPS1_H1 | VPS2: $VPS2_H1 | VPS3: $VPS3_H1"
 
-          if [ "$VPS1_H1" -gt "$VPS1_H0" ] && [ "$VPS2_H1" -gt "$VPS2_H0" ]; then
-            echo "Chain advancing on both VPS. Deploy successful."
+          if [ "$VPS1_H1" -gt "$VPS1_H0" ] && [ "$VPS2_H1" -gt "$VPS2_H0" ] && [ "$VPS3_H1" -gt "$VPS3_H0" ]; then
+            echo "Chain advancing on all 3 VPS. Deploy successful."
           else
             echo "ERROR: Chain not advancing after deploy!"
             echo "  VPS1: $VPS1_H0 -> $VPS1_H1"
             echo "  VPS2: $VPS2_H0 -> $VPS2_H1"
+            echo "  VPS3: $VPS3_H0 -> $VPS3_H1"
             exit 1
           fi

--- a/src/api/explorer.rs
+++ b/src/api/explorer.rs
@@ -45,6 +45,7 @@ fn address_label(addr: &str) -> Option<&'static str> {
         a if a.starts_with("0x7be6d0") => Some("BlockForge Asia"),
         a if a.starts_with("0x7dcc4f") => Some("PacificStake"),
         a if a.starts_with("0xd2116b") => Some("Archipelago Network"),
+        a if a.starts_with("0x87c997") => Some("Sentrix Core"),
         a if a.starts_with("0xeb70fd") => Some("Ecosystem Fund"),
         _ => None,
     }


### PR DESCRIPTION
## Summary
- Add Sentrix Core (0x87c997...) explorer label — 7th validator on VPS3 (XXXXXXXXXXX)
- Update CI/CD deploy pipeline to include VPS3: upload binary, stop/start sentrix-core, health check all 3 VPS
- Deploy order: stop→replace all → start VPS

## Required GitHub Secrets (new)
| Secret | Value |
|---|---|
| VPS3_HOST | xxxxxxxxxxx |
| VPS3_USER | xxxxxxxxxxx |
| VPS3_SSH_KEY | SSH private key for VPS3 |

## Test plan
- [x] 343 tests passing (277 unit + 66 integration)
- [x] Clippy clean
- [x] New Nodes live — sentrix-core service running, syncing blocks
- [x] 7 validators active, all 3 VPS in sync at height 131,248+
- [x] Sentrix Core producing blocks (10+ already)