### PR TITLE
docs: add comprehensive chain documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,58 @@
+# Sentrix Chain — Docs
+
+## Architecture
+
+- [Overview](architecture/OVERVIEW.md) — components, module map, data flow
+- [Consensus](architecture/CONSENSUS.md) — PoA round-robin, block production
+- [Networking](architecture/NETWORKING.md) — libp2p, peer management, sync
+- [State](architecture/STATE.md) — trie, sled, state roots, merkle proofs
+- [Transactions](architecture/TRANSACTIONS.md) — tx lifecycle, fees, nonce, mempool
+
+## Security
+
+- [Code Audit V11](security/SECURITY_AUDIT_V11.md) — source review findings (8.3/10)
+- [Attack Vectors](security/ATTACK_VECTORS.md) — 13 scenarios, risk matrix
+- [Pentest Results](security/PENTEST_RESULTS.md) — 6/6 passed
+- [Security Report](security/SECURITY_REPORT.md) — full report
+
+## Operations
+
+- [Deployment](operations/DEPLOYMENT.md) — build, configure, run a node
+- [CI/CD](operations/CI_CD.md) — pipeline, deploy phases
+- [Validators](operations/VALIDATORS.md) — setup, registration, current set
+- [Monitoring](operations/MONITORING.md) — health checks, troubleshooting
+
+## Tokenomics
+
+- [SRX](tokenomics/SRX.md) — supply, halving, fees
+- [Staking](tokenomics/STAKING.md) — DPoS design (Phase 2, planned)
+- [Token Standards](tokenomics/TOKEN_STANDARDS.md) — SRX-20, SNTX
+
+## Roadmap
+
+- [Phase 1](roadmap/PHASE1.md) — PoA (done)
+- [Phase 2](roadmap/PHASE2.md) — DPoS + BFT + EVM (planned)
+- [Changelog](roadmap/CHANGELOG.md) — PR history
+
+## Quick Ref
+
+| | |
+|-|-|
+| Chain ID | 7119 |
+| Block time | 3s |
+| Coin | SRX (1 SRX = 100M sentri) |
+| Max supply | 210M SRX |
+| Reward | 1 SRX/block, halving every 42M blocks |
+| Fees | 50% burn / 50% validator |
+| Consensus | PoA → DPoS (Phase 2) |
+| License | BUSL-1.1 |
+
+## Quick Start
+
+```bash
+cargo build --release
+cargo test
+sentrix wallet generate
+sentrix init --admin-address 0x<addr>
+sentrix start --validator-key <key> --peers [PEER]:30303
+```

--- a/docs/architecture/CONSENSUS.md
+++ b/docs/architecture/CONSENSUS.md
@@ -1,0 +1,76 @@
+# Consensus
+
+Sentrix runs PoA consensus. Validators take turns producing blocks in round-robin order, one block every 3 seconds.
+
+## Round-Robin
+
+Validators sorted by address (lowercase). Producer picked by:
+
+```rust
+sorted_validators[block_height % validator_count]
+```
+
+Deterministic — every node computes the same result independently. No communication needed.
+
+With 7 validators, each one produces a block every 21 seconds.
+
+## Block Production
+
+When it's your turn (`block_producer.rs`):
+
+1. Check `height % count` matches your slot
+2. Build coinbase tx (1 SRX reward)
+3. Clone mempool, take up to 100 txs sorted by fee (highest first)
+4. Assemble block: index, prev hash, timestamp, txs, merkle root
+
+Mempool is cloned not drained — if the block gets rejected, txs survive.
+
+## Two-Pass Validation
+
+Every received block goes through `add_block()`:
+
+Pass 1 (read-only): Check structure, validator auth, all tx signatures/nonces/balances, merkle root. If anything fails → reject entire block. No state changes.
+
+Pass 2 (commit): Credit coinbase, execute transfers, distribute fees (ceil/2 burn, floor/2 validator), run token ops, update trie, persist to sled.
+
+All-or-nothing. No partial state changes.
+
+## Validator Management
+
+Adding a validator needs:
+- Admin auth (string comparison with admin address)
+- Valid secp256k1 pubkey that derives to the claimed address
+- `Wallet::derive_address(pubkey) == address` checked
+
+Min 3 active validators enforced — can't go below that.
+
+Every add/remove/toggle/rename gets logged in the admin audit trail.
+
+### Changing Validator Set (Critical)
+
+This is the one thing that can brick your chain:
+
+```
+1. Stop ALL nodes
+2. Run validator add/remove on EVERY data directory
+3. Start ALL nodes
+```
+
+Doing this while nodes are running = scheduling mismatch = chain stall. Don't.
+
+## Timestamp Rules
+
+```
+block.timestamp >= previous.timestamp    (monotonic)
+block.timestamp <= now + 15s             (not too far ahead)
+```
+
+## Known Limitations
+
+- No fork choice. First block at a height wins. Network partitions can cause permanent splits. Fine for 7 controlled validators, needs fixing before scaling.
+- No block skip. If expected validator is offline, chain waits. No timeout.
+- No block signatures. Block has validator address but isn't signed. Auth is via round-robin schedule check. Signing needed for Phase 2.
+
+## Phase 2
+
+Replaces PoA with DPoS: open registration (15K SRX stake), top 100 by stake, BFT finality (2/3+ votes), slashing. See [Phase 2](../roadmap/PHASE2.md).

--- a/docs/architecture/NETWORKING.md
+++ b/docs/architecture/NETWORKING.md
@@ -1,0 +1,78 @@
+# Networking
+
+All P2P communication goes through libp2p. Transport stack: TCP → Noise XX (encrypted, mutual auth) → Yamux (multiplexed streams).
+
+## Transport
+
+```rust
+// transport.rs — simplified
+tcp::Config::default().nodelay(true)  // low latency
+→ noise::Config::new                  // Noise XX handshake
+→ yamux::Config::default              // stream multiplexing
+```
+
+Noise XX gives mutual authentication (both sides prove identity via Ed25519 keypair) and forward secrecy. No certificates needed.
+
+## Node Identity
+
+Each node has an Ed25519 keypair at `data/identity/node_keypair`, generated on first run. PeerId = hash of public key. Stays the same across restarts even if IP changes.
+
+## Peer Discovery
+
+Manual for now — pass `--peers` on startup:
+
+```bash
+sentrix start --validator-key <key> --peers [NODE_IP]:30303,[NODE_IP]:30303
+```
+
+Peers go through chain_id verification before being added to `verified_peers`. Wrong chain_id = disconnected immediately.
+
+Bootstrap peers re-dialed every 30s if disconnected. Idle timeout set to `Duration::MAX` — connections stay open permanently.
+
+## Messages
+
+Length-prefixed JSON over RequestResponse protocol. 4-byte BE length header, 10 MiB cap.
+
+| Message | What it does |
+|---------|-------------|
+| `NewBlock` | Broadcast new block to all peers |
+| `NewTransaction` | Propagate new tx |
+| `GetBlocks` | Request blocks from a height range |
+| `BlocksResponse` | Return up to 50 blocks |
+| `Handshake` | Chain ID check on connect |
+
+## Sync
+
+Every 30 seconds, check if any peer is ahead. If yes:
+
+1. Request blocks from `local_height + 1` in batches of 50
+2. Validate each block via `add_block()` (same two-pass as locally produced blocks)
+3. Save to sled immediately after each accepted block
+4. Repeat until caught up
+
+Sync and block processing run in `tokio::spawn()` tasks — they don't block the swarm event loop.
+
+## Rate Limiting
+
+- Max 5 connections per IP per 60s
+- IPs that exceed this get banned for 5 minutes
+- Max 50 total peers
+- Rate limiter state auto-pruned periodically
+
+## Ports
+
+| Port | Use |
+|------|-----|
+| 30303 | P2P (libp2p) |
+| 8545 | REST API + JSON-RPC + Explorer |
+
+## Behaviour
+
+```rust
+struct SentrixBehaviour {
+    identify: identify::Behaviour,
+    request_response: request_response::Behaviour<SentrixCodec>,
+}
+```
+
+Identify for peer info exchange, RequestResponse for everything else.

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -1,0 +1,77 @@
+# Architecture Overview
+
+Sentrix is a Layer-1 blockchain written in Rust. PoA consensus, account-based model (like Ethereum), custom Binary Sparse Merkle Tree for state proofs.
+
+## Components
+
+```
+┌──────────────────────────────────────┐
+│              CLI (clap)              │
+├─────────┬─────────┬────────┬────────┤
+│  Core   │ Network │  API   │ Wallet │
+│         │         │        │        │
+│ Chain   │ libp2p  │ REST   │ Keygen │
+│ Mempool │ Noise   │ JSONRPC│ AES-GCM│
+│ Blocks  │ Yamux   │ Explor │ Argon2 │
+│ Trie    │ Sync    │        │        │
+│ VM      │         │        │        │
+├─────────┴─────────┴────────┴────────┤
+│           Storage (sled)            │
+└──────────────────────────────────────┘
+```
+
+## Module Map
+
+```
+src/core/blockchain.rs       Chain state, genesis, constants
+src/core/block_producer.rs   Block creation (coinbase + mempool txs)
+src/core/block_executor.rs   Two-pass validate-then-commit
+src/core/mempool.rs          Priority queue, per-sender caps, TTL
+src/core/authority.rs        Validators, round-robin, admin audit log
+src/core/transaction.rs      ECDSA signing, nonce, chain_id
+src/core/account.rs          Balances (u64 sentri), fee split
+src/core/trie/               State trie — 256-level Binary SMT
+src/core/vm.rs               SRX-20 token engine
+src/core/block.rs            Block struct, hashing
+src/core/merkle.rs           SHA-256 tx merkle root
+src/network/libp2p_node.rs   P2P swarm, broadcast, sync
+src/network/behaviour.rs     Identify + RequestResponse
+src/network/transport.rs     TCP → Noise XX → Yamux
+src/network/sync.rs          Incremental block sync
+src/api/routes.rs            REST (25+ endpoints), rate limiting
+src/api/jsonrpc.rs           JSON-RPC 2.0 (20 methods)
+src/api/explorer.rs          12-page block explorer
+src/wallet/                  Keygen, keystore (Argon2id)
+src/storage/db.rs            sled persistence, hash index
+src/types/error.rs           SentrixError (14 variants)
+```
+
+## How Blocks Work
+
+1. Validator checks if it's their turn: `height % validator_count`
+2. Builds coinbase (1 SRX reward) + grabs up to 100 txs from mempool
+3. Two-pass execution:
+   - **Pass 1**: Validate everything on a copy — if anything fails, reject the whole block
+   - **Pass 2**: Commit — credit coinbase, execute transfers, burn fees, update trie
+4. Broadcast to peers
+
+## Key Decisions
+
+**Account model, not UTXO.** Simpler, natural fit for tokens and future smart contracts.
+
+**sled for storage.** Pure Rust, crash-safe, no C deps. Blocks stored as `block:{index}`, hash index for O(1) lookup.
+
+**Sliding window.** Only last 1,000 blocks in RAM (~2 MB cap). Older blocks read from sled on demand.
+
+**Integer-only balances.** Everything in sentri (1 SRX = 100M sentri). No floats, no rounding bugs.
+
+## Stats
+
+| | |
+|-|-|
+| Source files | ~40 |
+| Lines of code | ~16,000+ |
+| Tests | 277+ |
+| Dependencies | 27 crates |
+| `unsafe` blocks | 0 |
+| License | BUSL-1.1 |

--- a/docs/architecture/STATE.md
+++ b/docs/architecture/STATE.md
@@ -1,0 +1,98 @@
+# State Management
+
+Two storage layers: in-memory sliding window (fast, last 1000 blocks) and sled (durable, everything since genesis). Account state goes through a Binary Sparse Merkle Tree that produces a verifiable root per block.
+
+## Sliding Window
+
+```rust
+const CHAIN_WINDOW_SIZE: usize = 1000;
+```
+
+Only the last 1,000 blocks live in `Vec<Block>`. Older blocks are in sled. RAM stays at ~2 MB regardless of chain height.
+
+## sled
+
+Pure Rust embedded DB. Crash-safe, atomic writes, no external dependencies.
+
+| Key | Value |
+|-----|-------|
+| `state` | Full chain state (accounts, validators, mempool, contracts) |
+| `block:{index}` | Individual block |
+| `hash:{hash}` | Block index (O(1) lookup by hash) |
+| `height` | Current height |
+
+## SentrixTrie
+
+256-level Binary Sparse Merkle Tree for account state. Every block (height ≥ 100,000) gets a state root stamped into its hash.
+
+### How addresses map to trie paths
+
+```
+address → strip 0x → lowercase → hex decode → SHA-256 → 256-bit path
+```
+
+Each bit = left (0) or right (1) traversal. Short-circuit leaves — if a subtree has one value, the leaf sits at the highest unique prefix instead of depth 256.
+
+### Hashing
+
+| Node | Hash |
+|------|------|
+| Leaf | `BLAKE3(0x00 ∥ key ∥ value)` |
+| Internal | `SHA-256(0x01 ∥ left ∥ right)` |
+
+The `0x00`/`0x01` prefix + different hash algorithms = a leaf can never collide with an internal node.
+
+### Storage
+
+4 sled named trees:
+
+| Tree | Contents |
+|------|----------|
+| `trie_nodes` | Node data keyed by hash |
+| `trie_values` | Account values keyed by path |
+| `trie_roots` | State root per block height |
+| `trie_committed_roots` | Reverse index for fast committed root lookup |
+
+LRU cache sits on top of sled. Configurable capacity.
+
+### Committed Root Protection
+
+When a root is committed via `store_root()`, its hash goes into `trie_committed_roots`. During subsequent inserts, `is_committed_root()` is checked before deleting any old node — committed roots never get garbage-collected. Without this, inserting new accounts could accidentally delete nodes that belong to a previous block's state root.
+
+### Merkle Proofs
+
+```rust
+let proof = trie.prove(&key)?;
+let valid = proof.verify(&key, &value, &root);  // no trie access needed
+```
+
+Available via `GET /trie/proof/{address}`.
+
+### GC
+
+Orphaned nodes can pile up. Clean them with:
+
+```bash
+sentrix chain reset-trie  # rebuilds from current account state
+```
+
+### Fork Height
+
+```rust
+const STATE_ROOT_FORK_HEIGHT: u64 = 100_000;
+```
+
+Below this height, state root isn't in the block hash (backward compat with pre-trie blocks). At and above, it's part of the hash chain.
+
+## Account State
+
+```rust
+struct Account {
+    balance: u64,  // sentri
+    nonce: u64,
+}
+```
+
+All balance ops use `checked_add`/`checked_sub`. No floats anywhere.
+
+Fee split on transfer: sender pays `amount + fee`. Receiver gets `amount`. Burn gets `ceil(fee/2)`. Validator gets `floor(fee/2)`. Odd sentri goes to burn side.

--- a/docs/architecture/TRANSACTIONS.md
+++ b/docs/architecture/TRANSACTIONS.md
@@ -1,0 +1,102 @@
+# Transactions
+
+## Types
+
+| Type | From | To | Who creates it |
+|------|------|----|----------------|
+| Coinbase | `COINBASE` | Validator | Automatic (block reward) |
+| Transfer | User | Recipient | User (signed) |
+| Token op | User | Contract | User (via SRX-20) |
+
+## Structure
+
+```rust
+Transaction {
+    txid,           // SHA-256 of signing payload
+    from_address,   // 0x + 40 hex
+    to_address,
+    amount,         // sentri (u64)
+    fee,            // sentri (min 10,000 = 0.0001 SRX)
+    nonce,          // sequential per sender
+    timestamp,
+    signature,      // ECDSA hex
+    public_key,     // secp256k1 hex
+    chain_id,       // 7119
+    data,           // optional — token ops (JSON)
+}
+```
+
+## Signing
+
+ECDSA on secp256k1 (same as Bitcoin/Ethereum).
+
+Payload built from `BTreeMap` (sorted keys → deterministic JSON). The `txid` is SHA-256 of that payload.
+
+On verify: recover pubkey from signature, derive address via Keccak-256, check it matches `from_address`. Can't forge txs from someone else's address.
+
+Chain ID (7119) in the signing payload = replay protection across networks.
+
+## Mempool
+
+Where txs wait before getting into a block.
+
+### Rules to get in
+
+- Valid signature, pubkey derives to from_address
+- Nonce = `on_chain_nonce + pending_count`
+- Balance ≥ amount + fee + pending spends
+- Fee ≥ 10,000 sentri (0.0001 SRX)
+- Valid address format, not zero address
+- Amount > 0 (except token ops)
+- Timestamp not >5min future, not >1hr old
+- No duplicate txid
+- Chain ID = 7119
+
+### Limits
+
+| | |
+|-|-|
+| Total | 10,000 txs |
+| Per sender | 100 txs |
+| Max age | 1 hour (auto-pruned) |
+| Per block | 100 txs |
+
+Higher-fee txs get picked first.
+
+## Fees
+
+Min fee: 0.0001 SRX (10,000 sentri).
+
+```
+Fee → ceil(fee/2) burned + floor(fee/2) to validator
+```
+
+50% burn creates deflationary pressure. Eventually burns > rewards = net deflation.
+
+## Nonce
+
+Sequential counter per address, starting at 0. Must be exact — gaps rejected. Prevents replay within the same chain.
+
+## Coinbase
+
+One per block, always first tx:
+- From: `"COINBASE"`
+- Amount: block reward (1 SRX in Era 0)
+- Fee: 0, nonce: 0, no signature
+
+## Token Operations
+
+Encoded in the `data` field as JSON:
+
+```json
+{"op": "deploy",   "name": "...", "symbol": "...", "supply": N, "decimals": N}
+{"op": "transfer", "contract": "SRX20_...", "to": "0x...", "amount": N}
+{"op": "burn",     "contract": "SRX20_...", "amount": N}
+{"op": "approve",  "contract": "SRX20_...", "spender": "0x...", "amount": N}
+```
+
+Still need SRX for gas. See [Token Standards](../tokenomics/TOKEN_STANDARDS.md).
+
+## Overflow Protection
+
+All monetary math uses `checked_add`/`checked_sub`. Returns error on overflow/underflow. No wrapping, no unchecked arithmetic on balances.

--- a/docs/operations/CI_CD.md
+++ b/docs/operations/CI_CD.md
@@ -1,0 +1,56 @@
+# CI/CD
+
+GitHub Actions pipeline. Every merge to `main` runs tests, builds a binary, and deploys to all production nodes.
+
+## Pipeline
+
+```
+Push to main → TEST → DEPLOY (only main branch)
+```
+
+### Test Job (every push + PR)
+
+1. `cargo deny check` — license + supply chain
+2. `cargo clippy -- -D warnings` — zero warnings (deny unwrap/expect/panic)
+3. `cargo build --release`
+4. `cargo test` — 277+ tests
+5. Upload binary as artifact (1-day retention)
+
+### Deploy Job (main only, after test passes)
+
+Phase 1 — Upload binaries to all VPS while nodes still running (minimize downtime).
+
+Phase 2 — Stop in reverse order:
+```
+[NODE_3] → [NODE_2] → [NODE_1]
+```
+Secondary nodes stop first so primary can finish processing in-flight blocks. Prevents orphan blocks.
+
+Phase 3 — Replace binary on each VPS:
+```bash
+cp /tmp/sentrix-new /opt/sentrix/sentrix && chmod +x /opt/sentrix/sentrix
+```
+
+Phase 4 — Start in forward order:
+```
+[NODE_1] → [NODE_2] → [NODE_3]
+```
+Primary first so peers can connect immediately.
+
+Phase 5 — Health check after 35s stabilization:
+```bash
+curl -sf http://[NODE_IP]:8545/chain/info | jq .height
+```
+Verify all nodes responding and height advancing.
+
+## Branch Protection
+
+`main` requires PR + CI pass. Admin can bypass in emergencies.
+
+## Design Choices
+
+Binary artifacts, not Docker. All nodes get the exact same compiled binary. No registry dependency.
+
+Stop/start order matters. Learned from production — wrong order causes chain forks.
+
+No auto-rollback. If deploy fails health check, investigate manually. Auto-rollback masks root causes.

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -1,0 +1,122 @@
+# Deployment
+
+How to deploy a Sentrix node on a Linux server.
+
+## Requirements
+
+- Linux (Ubuntu 22.04+ / Debian 12+)
+- 2 CPU, 2 GB RAM, 20 GB SSD
+- Ports open: 8545 (API), 30303 (P2P)
+
+## Build from Source
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+
+git clone https://github.com/satyakwok/sentrix.git
+cd sentrix
+cargo build --release
+# → target/release/sentrix
+```
+
+## Docker
+
+```bash
+git clone https://github.com/satyakwok/sentrix.git && cd sentrix
+docker compose up -d --build
+```
+
+Ports 8545 + 30303 exposed, data in named volume, health check on `/health`, auto-restart.
+
+## Bootstrap a Node
+
+```bash
+# Generate wallet
+sentrix wallet generate
+
+# Init chain
+sentrix init --admin-address 0x<your_address>
+
+# Add validator
+sentrix validator add --address 0x<addr> --public-key 04<pubkey> --name "Name"
+
+# Start
+sentrix start --validator-key <key> --peers [PEER_IP]:30303
+```
+
+## Systemd
+
+```ini
+# /etc/systemd/system/sentrix-node.service
+[Unit]
+Description=Sentrix Chain Node
+After=network.target
+
+[Service]
+Type=simple
+User=sentrix
+WorkingDirectory=/opt/sentrix
+ExecStart=/opt/sentrix/sentrix start \
+  --validator-key <key> \
+  --peers [PEER_IP]:30303 \
+  --data-dir /opt/sentrix/data
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65535
+Environment=SENTRIX_API_KEY=<key>
+Environment=RUST_LOG=info
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload && sudo systemctl enable --now sentrix-node
+```
+
+## Environment Variables
+
+| Var | Default | What |
+|-----|---------|------|
+| `SENTRIX_API_KEY` | (none) | Auth for write endpoints. Unset = all public |
+| `SENTRIX_DATA_DIR` | `./data` | Chain data path |
+| `SENTRIX_CORS_ORIGIN` | (none) | CORS origin. Unset = restrictive |
+| `RUST_LOG` | `info` | Log level |
+
+## Firewall
+
+```bash
+sudo ufw allow 22/tcp && sudo ufw allow 8545/tcp && sudo ufw allow 30303/tcp && sudo ufw enable
+```
+
+## Data Directory
+
+```
+data/
+├── chain.db/         # sled (blocks, state, index)
+├── identity/
+│   └── node_keypair  # Ed25519 for libp2p PeerId
+└── wallets/          # encrypted keystores
+```
+
+## Joining the Network
+
+```bash
+sentrix init --admin-address 0x<genesis_admin>
+sentrix start --peers [BOOTSTRAP]:30303
+# Connects via libp2p, verifies chain_id 7119, syncs from genesis
+```
+
+Validator registration needs admin auth — contact the network admin.
+
+## Multiple Validators on One Machine
+
+Different ports + data dirs per validator:
+
+```bash
+sentrix start --validator-key <key1> --port 8545 --p2p-port 30303 --data-dir data1
+sentrix start --validator-key <key2> --port 8546 --p2p-port 30304 --data-dir data2
+```
+
+Each needs its own systemd service file and firewall rules.

--- a/docs/operations/MONITORING.md
+++ b/docs/operations/MONITORING.md
@@ -1,0 +1,93 @@
+# Monitoring & Troubleshooting
+
+## Quick Checks
+
+```bash
+# Chain height + status
+curl -sf http://[NODE_IP]:8545/chain/info | jq
+
+# Health endpoint
+curl -sf http://[NODE_IP]:8545/health
+
+# Compare heights across nodes
+for ip in [NODE_1] [NODE_2] [NODE_3]; do
+  echo "$ip: $(curl -sf http://$ip:8545/chain/info | jq .height)"
+done
+
+# Validator status
+curl -sf http://[NODE_IP]:8545/validators | jq '.[] | {name, active, blocks_produced}'
+
+# Mempool size
+curl -sf http://[NODE_IP]:8545/mempool | jq '. | length'
+
+# Disk usage
+du -sh /opt/sentrix/data/chain.db/
+```
+
+## What to Watch
+
+| Metric | Healthy |
+|--------|---------|
+| Chain height | Increasing every ~3s |
+| Active validators | 7 |
+| Mempool | < 10,000 |
+| Service status | Active (running) |
+
+## Common Issues
+
+### Chain stalled
+
+Height not moving for 30+ seconds.
+
+Validator offline: Check which slot is expected (`height % 7`). Bring that validator back up.
+
+Network partition: Check logs for peer connections (`journalctl -u sentrix-node | grep peer`). Check firewall (`ufw status`).
+
+Validator set mismatch: Different nodes have different validator sets. Stop all → make all data dirs identical → restart all.
+
+Fork: Compare block hashes at same height. If different, stop the forked node → copy chain.db from healthy node → restart.
+
+### Node won't start
+
+**"Address already in use":** `lsof -i :8545` or `ss -tlnp | grep 8545`
+
+**"Binary locked" (Windows):** `taskkill //F //IM sentrix.exe`
+
+**"Permission denied":** `chmod +x /opt/sentrix/sentrix`
+
+### Sync stuck
+
+- Check if peer is actually ahead
+- Look for "rejected block" in logs (chain divergence)
+- "Old validator not authorized" = validator set doesn't match chain history. Copy chain.db from a synced node.
+
+### DB corruption
+
+sled is crash-safe, so this is rare. If it happens:
+
+```bash
+sudo systemctl stop sentrix-node
+cp -r /opt/sentrix/data /opt/sentrix/data.backup
+# Option 1: copy chain.db from healthy node
+# Option 2: delete chain.db and resync from peers
+sudo systemctl start sentrix-node
+```
+
+### Trie issues
+
+```bash
+sentrix chain reset-trie  # rebuild from current accounts
+```
+
+## Logs
+
+```bash
+sudo journalctl -u sentrix-node -f        # follow
+sudo journalctl -u sentrix-node -n 100     # last 100 lines
+```
+
+```bash
+RUST_LOG=info                              # default
+RUST_LOG=debug                             # more detail
+RUST_LOG=sentrix=debug,libp2p=warn         # per-module
+```

--- a/docs/operations/VALIDATORS.md
+++ b/docs/operations/VALIDATORS.md
@@ -1,0 +1,71 @@
+# Validators
+
+7 validators across 3 VPS, round-robin PoA.
+
+## Current Set
+
+| Slot | Name | Address prefix | VPS |
+|------|------|---------------|-----|
+| 0 | Sentrix Treasury | `0x0804...` | 2 |
+| 1 | Sentrix Foundation | `0x753f...` | 1 |
+| 2 | BlockForge Asia | `0x7be6...` | 2 |
+| 3 | PacificStake | `0x7dcc...` | 2 |
+| 4 | Sentrix Core | `0x87c9...` | 3 |
+| 5 | Archipelago Network | `0xd211...` | 2 |
+| 6 | Nusantara Node | `0xdd3c...` | 2 |
+
+Sorted by address. Block producer = `height % 7`.
+
+## Adding a Validator
+
+Needs admin auth + valid secp256k1 pubkey that derives to the address.
+
+```bash
+# CLI
+sentrix validator add --address 0x... --public-key 04... --name "Name"
+
+# API
+curl -X POST http://[NODE_IP]:8545/validators \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: <key>" \
+  -d '{"address":"0x...","public_key":"04...","name":"Name","caller":"<admin>"}'
+```
+
+## Changing Validator Set (Read This)
+
+This is the one procedure that can brick the chain. Round-robin depends on all nodes having the exact same validator set.
+
+```
+1. Stop ALL nodes on ALL machines
+2. Run add/remove on EVERY data directory
+3. Start ALL nodes
+```
+
+If you add a validator to some nodes but not others, they'll disagree on whose turn it is → chain stalls permanently.
+
+## Other Commands
+
+```bash
+sentrix validator list
+sentrix validator toggle --address 0x... --active false
+sentrix validator rename --address 0x... --name "New Name"
+sentrix validator remove --address 0x...
+```
+
+Min 3 active validators enforced — can't go below that.
+
+## Audit Trail
+
+Every operation logged. View with:
+
+```bash
+curl -H "X-API-Key: <key>" http://[NODE_IP]:8545/admin/log
+```
+
+## Economics
+
+Each validator produces ~4,114 blocks/day (with 7 validators, 3s blocks). That's ~4,114 SRX/day from rewards alone, plus `floor(fee/2)` from each included transaction.
+
+## Phase 2
+
+DPoS: open registration with 15K SRX stake, top 100 by stake score, epoch-based rotation, slashing. See [Phase 2](../roadmap/PHASE2.md).

--- a/docs/roadmap/CHANGELOG.md
+++ b/docs/roadmap/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+## [0.1.0] — 2026-04-15
+
+Phase 1 complete.
+
+### Added
+
+Core: PoA round-robin consensus, account model, two-pass atomic block validation, ECDSA secp256k1 signing with chain_id, SHA-256 merkle tree, halving (42M blocks), fee split (50% burn / 50% validator), genesis premine (63M SRX), checked arithmetic everywhere.
+
+Trie: 256-level Binary SMT (BLAKE3 leaf + SHA-256 internal), sled-backed (4 trees), LRU cache, merkle proofs, state root in block hash (post height 100K), committed root protection, GC.
+
+Tokens: SRX-20 standard — deploy, transfer, burn, mint, approve/transferFrom. Deterministic contract addresses. Max supply enforcement. SNTX deployed (10B).
+
+Network: libp2p (TCP + Noise XX + Yamux). Persistent Ed25519 identity. Auto-reconnect. Per-IP rate limiting (5/60s, 5-min ban). Max 50 peers. Incremental sync with sled persistence. Block processing in spawned tasks.
+
+API: 25+ REST endpoints. 20 JSON-RPC methods (Ethereum-compatible). 12-page block explorer. Rate limiting (60/min/IP). Constant-time API key comparison. CORS restrictive. 500 concurrency, 1 MiB body, 100 batch.
+
+Wallet: secp256k1 keygen, Keccak-256 addresses. AES-256-GCM keystore. Argon2id v2 KDF (backward-compat PBKDF2 v1). Zeroize on drop.
+
+Storage: sled embedded DB. Per-block persistence + hash index. 1000-block sliding window.
+
+Infra: 17 CLI commands. CI/CD (cargo deny → clippy → build → test → 3-VPS deploy). 4-phase deploy with health check. Branch protection.
+
+Security: 11 audit rounds (94 findings, 78 fixed). Zero `unsafe`. No-panic CI enforcement. 6/6 pentest pass.
+
+### Major PRs
+
+| PR | What |
+|----|------|
+| #36–#40 | Security V4 (23 findings fixed) |
+| #41 | Security V5 (11 findings) |
+| #43 | Split blockchain.rs → 6 modules |
+| #44 | Security V6 (13 findings) |
+| #45 | libp2p integration |
+| #46 | Integration tests (45 tests) |
+| #48–#55 | SentrixTrie |
+| #57–#60 | Security V7 |
+| #65 | libp2p default (legacy TCP removed) |
+| #69 | Idle timeout fix |
+| #72–#73 | Security V8+V9 |
+| #74 | Public repo cleanup |
+| #79 | H1/H2 fork fix |
+| #80 | CI/CD deploy order fix |
+| #81 | VPS3 + 3-VPS pipeline |
+| #82 | P0 security hardening |

--- a/docs/roadmap/PHASE1.md
+++ b/docs/roadmap/PHASE1.md
@@ -1,0 +1,48 @@
+# Phase 1 — PoA Chain (Complete)
+
+Done. Live in production.
+
+## What's Running
+
+- PoA consensus, round-robin, 3s blocks
+- 7 validators on 3 VPS, full mesh peering
+- Account model with Ethereum-style addresses
+- Two-pass atomic block validation
+- ECDSA secp256k1 signing with chain_id replay protection
+- SentrixTrie (256-level Binary SMT, BLAKE3+SHA-256)
+- SRX-20 tokens (SNTX deployed, 10B supply)
+- libp2p networking (Noise XX + Yamux)
+- REST API (25+ endpoints) + JSON-RPC 2.0 (20 methods)
+- Block explorer (12 pages, dark theme)
+- Encrypted keystore (AES-256-GCM, Argon2id)
+- sled storage with 1000-block sliding window
+- CI/CD: GitHub Actions → test → build → 3-VPS deploy
+- Branch protection on main (PR + CI required)
+
+## Numbers
+
+| | |
+|-|-|
+| Tests | 277+ |
+| PRs merged | #1–#81 |
+| Audit rounds | 11 (94 findings, 78 fixed) |
+| Chain height | 131,000+ |
+| `unsafe` blocks | 0 |
+| Clippy warnings | 0 |
+
+## Security Audits
+
+| Audit | Findings | Status |
+|-------|----------|--------|
+| V4 | 23 | All fixed ✅ |
+| V5 | 11 | All fixed ✅ |
+| V6 | 13 | All fixed ✅ |
+| V7 | 15 | All fixed ✅ |
+| V8 | 12 | All fixed ✅ |
+| V9 | 20 | 4 fixed, 16 tracked |
+| V10 | Enterprise — 43/45 (95%) | Complete ✅ |
+| V11 | 22 | Report available |
+
+## What's Next
+
+Phase 2: DPoS + BFT + EVM. See [PHASE2.md](PHASE2.md).

--- a/docs/roadmap/PHASE2.md
+++ b/docs/roadmap/PHASE2.md
@@ -1,0 +1,50 @@
+# Phase 2 — DPoS + BFT + EVM (Planned)
+
+> Design finalized. Not implemented yet. Target: Q3 2026.
+
+## Three Things
+
+### 1. DPoS
+
+Replace admin-appointed validators with stake-weighted selection.
+
+- Min self-stake: 15,000 SRX
+- Active set: top 100 by `self_stake + delegated_stake`
+- Epoch: 28,800 blocks (~1 day) — validator set recalculated at boundary
+- Slashing: 1-5% for downtime, 20% + permaban for double-signing
+- Commission: validators set their own rate (5-20%)
+
+### 2. BFT Finality
+
+After a block is produced, validators vote. 2/3+ votes = block is final, can't be reorged. With 100 validators, need 67+ votes.
+
+### 3. EVM via revm
+
+Smart contracts in Solidity. Using [revm](https://github.com/bluealloy/revm) (Paradigm's EVM, used by reth). Battle-tested, pure Rust, audited.
+
+Gas pricing: 0.1 sentri/gas. Block gas limit: 30M. Transfer ≈ 0.000021 SRX.
+
+Why revm and not custom VM: DPoS + BFT is already hard. EVM compatibility gives immediate access to existing tooling. Custom VM can wait for Phase 4 if demand justifies it.
+
+## TODO
+
+- [ ] DPoS: stake registry, delegation, epoch logic, commission, rewards, unbonding, slashing
+- [ ] BFT: block signatures, vote collection, 2/3+ threshold, fork choice
+- [ ] EVM: revm integration, gas metering, gas limit, eth_call, eth_estimateGas
+
+## Migration
+
+No chain reset. Protocol upgrade at a predetermined fork height. Existing 7 validators grandfathered in. Staking opens for new validators.
+
+## Prerequisites
+
+- [x] P0 security (peer limits, rate limiting)
+- [ ] Block-level validator signatures
+- [ ] Fork choice rule
+- [ ] State root rollback mechanism
+
+## Future Phases
+
+**Phase 3 (Q4 2026, if needed):** Sharding. Only if >1K TPS demand proven.
+
+**Phase 4 (2027+, if demand):** Custom VM with parallel execution. 90% Solidity compat. Would need external audit (Zellic/Trail of Bits).

--- a/docs/security/ATTACK_VECTORS.md
+++ b/docs/security/ATTACK_VECTORS.md
@@ -1,0 +1,125 @@
+# Attack Vector Analysis
+
+13 attack scenarios analyzed across network, consensus, state, and API layers.
+
+---
+
+## Network
+
+### 1.1 DDoS on P2P (port 30303)
+
+Protected. Max 50 peers, 5 conn/IP/60s rate limit, 5-min ban, 10 MiB message cap, Noise XX handshake overhead.
+
+### 1.2 DDoS on RPC (port 8545)
+
+Protected. 60 req/min per IP, 500 concurrent, 1 MiB body limit, CORS restrictive by default. Deploy behind nginx/Cloudflare for extra safety.
+
+### 1.3 Sybil — Fake Nodes
+
+Peer cap limits damage but no reputation system yet. All peers treated equally. No subnet diversity check — one /24 could fill all slots.
+
+Risk: MEDIUM. Peer cap prevents resource exhaustion but attacker could still occupy slots.
+Todo: Peer scoring, subnet diversity, authenticated handshake.
+
+### 1.4 Eclipse — Isolate a Validator
+
+Bootstrap peers re-dialed every 30s. Block validation catches bad blocks. But sync picks from one peer (not random), no minimum peer requirement, no checkpoints.
+
+Risk: LOW. Needs control of many IPs + bootstrap knowledge.
+
+### 1.5 MITM
+
+Protected. Noise XX = encrypted + mutually authenticated. PeerId from Ed25519 key.
+
+---
+
+## Consensus
+
+### 2.1 Validator Spoofing
+
+Protected. `add_block()` checks `is_authorized()` per height. Validator registration requires crypto proof (pubkey → address derivation). No block-level signatures yet though — planned for Phase 2.
+
+### 2.2 Double Spend
+
+Protected. Strict nonce validation, txid dedup, balance includes pending, chain_id replay protection, canonical BTreeMap signing payload.
+
+### 2.3 Block Withholding
+
+Validator doesn't broadcast → chain stalls at their slot. No timeout/skip mechanism exists.
+
+Risk: MEDIUM. Most likely real-world issue (node goes offline).
+Todo: Implement validator timeout + skip to next in rotation.
+
+### 2.4 Long Range Attack
+
+Protected. Only authorized validators can produce. Timestamp bounds enforced. State root in block hash (post 100K). Would need multiple compromised validator keys.
+
+### 2.5 Nothing-at-Stake
+
+N/A — PoA, not PoS. Relevant for Phase 2 DPoS. Will need slashing + unbonding period.
+
+---
+
+## State
+
+### 3.1 State Bloat
+
+Min fee is low (0.0001 SRX). Mempool caps (10K total, 100/sender, 1hr TTL) help. But AccountDB grows unbounded — no zero-balance pruning.
+
+Risk: MEDIUM long-term.
+
+### 3.2 Storage Exhaustion
+
+Blocks never deleted (by design). sled grows linearly. At current block size and 3s intervals, this is manageable for years. `db_size_bytes()` available for monitoring.
+
+### 3.3 Trie Manipulation
+
+Protected. BLAKE3 + SHA-256 domain-separated hashing. State root verified on received blocks (post 100K). Content-addressed storage = corruption changes hash immediately.
+
+---
+
+## API
+
+### 4.1 RPC Spam
+
+Protected. Rate limiting, concurrency cap, body limit, batch limit (100), API key on write endpoints.
+
+### 4.2 Malformed JSON-RPC
+
+Protected. Proper error codes (-32700, -32600, -32601). Safe serde deserialization. No panics.
+
+### 4.3 Heavy Queries
+
+`/chain/validate` gated + cached. Listings paginated (max 100). `/richlist` could be slow on large state — should add pagination + auth.
+
+### 4.4 API Key Bypass
+
+Constant-time comparison via `subtle`. If `SENTRIX_API_KEY` not set, everything's open (by design for dev, not for prod).
+
+---
+
+## Risk Matrix
+
+```
+                 LOW        MEDIUM      HIGH
+           ┌──────────┬──────────┬──────────┐
+  HIGH     │          │ Block    │          │
+           │          │ withhold │          │
+  MEDIUM   │          │ Sybil    │          │
+           │          │ Bloat    │          │
+  LOW      │ Long rng │ RPC misc │ Malformd │
+           │ Dbl spnd │          │          │
+           └──────────┴──────────┴──────────┘
+```
+
+HIGH+HIGH quadrant is empty. No critical-and-likely attacks.
+
+---
+
+## Priority
+
+P0 (done ✅): libp2p peer limit, per-IP rate limit, legacy TCP deprecated.
+
+P1: Block skip mechanism, peer reputation, randomize sync peer.
+
+P2: Block signatures, richlist pagination, API key startup warning, raise min fee.

--- a/docs/security/PENTEST_RESULTS.md
+++ b/docs/security/PENTEST_RESULTS.md
@@ -1,0 +1,24 @@
+# Penetration Test Results
+
+6 automated bash scripts (curl + nc). Non-destructive, safe for production.
+
+## Results
+
+| # | Test | Result |
+|---|------|--------|
+| 1 | **RPC Flood** — 1000 rapid requests to `/chain/info` | ✅ Rate limiting kicks in at ~60/min. Node stays responsive. |
+| 2 | **P2P Flood** — 120 simultaneous TCP connections to :30303 | ✅ Capped at 50 peers. Per-IP ban after 5 conn/60s. API unaffected. |
+| 3 | **TX Spam** — 100 rapid txs + duplicate nonce | ✅ Per-sender cap (100) enforced. Dup nonce rejected. Balance checks work. |
+| 4 | **Malformed** — 40+ edge cases (bad JSON, SQL injection, XSS, wrong types, long strings, null bytes) | ✅ No panics. Proper error responses. HTML escaped in explorer. |
+| 5 | **Double Spend** — 2 txs same nonce, same sender | ✅ First accepted, second rejected (`InvalidNonce`). |
+| 6 | **Oversized** — 1KB→10MB payloads, batch 10→500 | ✅ 1 MiB HTTP body limit, 100 batch limit, 10 MiB P2P limit all enforced. |
+
+**6/6 passed.**
+
+## Running
+
+```bash
+./pentest/run_all.sh                      # local node
+./pentest/run_all.sh [NODE_IP]:8545       # specific node
+./pentest/test4_malformed.sh localhost:8545  # individual test
+```

--- a/docs/security/SECURITY_AUDIT_V11.md
+++ b/docs/security/SECURITY_AUDIT_V11.md
@@ -1,0 +1,84 @@
+# Security Audit V11 — Code Review
+
+**Scope:** 39 files, ~6,500 lines. Manual line-by-line review.
+
+## TL;DR
+
+0 critical, 2 high, 5 medium, 7 low, 8 info (positive findings). Overall **8.3/10**. No fund-loss vulnerabilities. Main concerns are fee tracking architecture and timestamp determinism.
+
+Good stuff found: zero `unsafe`, CI-enforced no-panic (clippy deny unwrap/expect/panic), checked math everywhere, constant-time API key comparison, Argon2id keystore, committed root protection in trie, canonical BTreeMap signing payload, pubkey→address verified on every tx.
+
+---
+
+## HIGH
+
+### H01: Fee Burn Tracked in Two Places
+
+`AccountDB::transfer()` tracks `ceil(fee/2)` as burned. Then `add_block()` credits `floor(fee/2)` to validator. The math works out — net balances are correct. But the logic is split across two modules which makes it confusing to reason about.
+
+Files: `account.rs`, `block_executor.rs`
+Fix: Consolidate fee handling into one place.
+
+### H02: Block Timestamp Not Deterministic
+
+`SystemTime::now()` called twice — once for coinbase in `create_block()`, once for the block in `Block::new()`. They can differ. Means same logical block → different hash.
+
+Not exploitable in PoA (one validator per slot), but matters if a validator restarts mid-slot.
+
+Files: `block_producer.rs`, `block.rs`
+Fix: Capture timestamp once, pass to both.
+
+---
+
+## MEDIUM
+
+| ID | Finding | File |
+|----|---------|------|
+| M01 | No fork choice rule — first block at a height wins, no reorg | `block_executor.rs` |
+| M02 | Mempool nonce = on-chain + pending count. If a pending tx expires, subsequent txs get wrong nonce | `mempool.rs` |
+| M03 | Legacy TCP broadcasts open new connection per peer per message (~1000 conn/min with 50 peers) | `node.rs` |
+| M04 | `jsonrpc_handler()` has no auth — relies on route-level dispatcher. If exposed directly, auth bypassed | `jsonrpc.rs` |
+| M05 | State root check happens AFTER Pass 2 commits state. Mismatch = error returned but state already mutated | `block_executor.rs` |
+
+---
+
+## LOW
+
+| ID | Finding |
+|----|---------|
+| L01 | Block timestamp future window 15s = 5x block interval. Could tighten to 6s |
+| L02 | Admin address is just a string — no crypto binding to a real keypair |
+| L03 | Coinbase recipient not validated against `block.validator` |
+| L04 | Token contract address collision loop is unbounded (theoretical) |
+| L05 | `get_transaction` does O(N) linear scan — no txid index |
+| L06 | Rate limiter fallback is `true` (allow) if extension missing |
+| L07 | Peer height in HashMap never updated after initial handshake |
+
+---
+
+## INFO (Good Findings)
+
+| ID | What | Verdict |
+|----|------|---------|
+| I01 | `signing_payload()` falls back to `"{}"` — practically impossible | Fine |
+| I02 | Genesis has hardcoded timestamp — deterministic | Good ✓ |
+| I03 | Clippy deny unwrap/expect/panic — CI enforced | Excellent ✓ |
+| I04 | `Zeroizing<[u8; 32]>` for private key, no Clone | Good ✓ |
+| I05 | BLAKE3 leaf + SHA-256 internal — domain separated | Good ✓ |
+| I06 | CORS restrictive by default | Good ✓ |
+| I07 | Approve requires reset to 0 first — prevents front-run | Good ✓ |
+| I08 | HTML escaping on all explorer output — no XSS | Good ✓ |
+
+---
+
+## Scores
+
+| Category | Score |
+|----------|-------|
+| Consensus | 8/10 |
+| State management | 9/10 |
+| Transactions | 9/10 |
+| Networking | 7/10 |
+| API security | 8/10 |
+| Code quality | 9/10 |
+| **Overall** | **8.3/10** |

--- a/docs/security/SECURITY_REPORT.md
+++ b/docs/security/SECURITY_REPORT.md
@@ -1,0 +1,54 @@
+# Security Report v1.0
+
+Score: 8.3/10 — production-ready for PoA early mainnet.
+
+After 10 prior audit rounds (94 findings, 78 fixed), the codebase is in good shape. Zero `unsafe`, no-panic policy enforced via CI, checked arithmetic everywhere, constant-time crypto. Not typical for a project this young.
+
+No fund-loss vulnerabilities. No data corruption risks. Main gap is DoS resistance on the network layer (mostly addressed now).
+
+## Chain
+
+| | |
+|-|-|
+| Rust 2024, 39 files, ~6,500 LoC | 277+ tests |
+| PoA round-robin, 3s blocks | Chain ID 7119 |
+| 210M SRX max supply | 27 crates |
+
+## Code Audit
+
+Full report: [SECURITY_AUDIT_V11.md](SECURITY_AUDIT_V11.md)
+
+0 critical. 2 high (fee tracking split, timestamp non-determinism — neither is fund-loss). 5 medium. 7 low. 8 positive findings.
+
+| Category | Score |
+|----------|-------|
+| Consensus | 8/10 |
+| State | 9/10 |
+| Transactions | 9/10 |
+| Networking | 7/10 |
+| API | 8/10 |
+| Code quality | 9/10 |
+
+## Attack Vectors
+
+Full report: [ATTACK_VECTORS.md](ATTACK_VECTORS.md)
+
+13 vectors analyzed. HIGH+HIGH quadrant empty. Biggest real risk: block withholding (validator offline → chain stall). P0 network items all fixed.
+
+Already solid: tx signing, double spend protection, mempool caps, rate limiting, state trie proofs, chain_id replay protection, validator crypto verification.
+
+## Pentest
+
+Full report: [PENTEST_RESULTS.md](PENTEST_RESULTS.md)
+
+6/6 tests passed. RPC flood, P2P flood, tx spam, malformed input, double spend, oversized payloads — all handled correctly.
+
+## What to Fix
+
+Done ✅: libp2p peer limit, per-IP rate limit, legacy TCP deprecated.
+
+Next: Block skip mechanism, peer reputation, sync randomization, block-level signatures (for Phase 2).
+
+## Context
+
+The chain currently runs on 3 VPS with 7 validators under founder control. In this environment, actual risk from all findings is LOW. Risk increases as the chain opens to public validators and external traffic.

--- a/docs/tokenomics/SRX.md
+++ b/docs/tokenomics/SRX.md
@@ -1,0 +1,78 @@
+# SRX
+
+Native coin. Used for fees, validator rewards, and staking (Phase 2).
+
+## Units
+
+```
+1 SRX = 100,000,000 sentri
+```
+
+Everything internal is u64 in sentri. No floats.
+
+## Supply
+
+Hard cap: 210,000,000 SRX. Can't change without a fork.
+
+| Source | SRX | % |
+|--------|-----|---|
+| Premine | 63,000,000 | 30% |
+| Block rewards | ≤147,000,000 | 70% |
+
+### Premine
+
+| Wallet | SRX | Purpose |
+|--------|-----|---------|
+| Founder | 21,000,000 | Treasury, ops |
+| Ecosystem | 21,000,000 | Grants, partnerships |
+| Early Validator | 10,500,000 | Validator incentives |
+| Reserve | 10,500,000 | Emergency |
+
+### Actual Max Circulating
+
+Mining rewards converge to 84M SRX total (geometric series). So: 63M + 84M = **147M SRX** actual max. The 210M cap is never reached.
+
+## Halving
+
+Block reward halves every 42M blocks (~4 years).
+
+| Era | Blocks | Reward | Start |
+|-----|--------|--------|-------|
+| 0 | 0 – 41.9M | 1 SRX | 2026 |
+| 1 | 42M – 83.9M | 0.5 SRX | ~2030 |
+| 2 | 84M – 125.9M | 0.25 SRX | ~2034 |
+| 3 | 126M – 167.9M | 0.125 SRX | ~2038 |
+
+```rust
+fn get_block_reward(height: u64) -> u64 {
+    BLOCK_REWARD >> (height / HALVING_INTERVAL) // 1 SRX >> era
+}
+```
+
+## Fees
+
+Min fee: 0.0001 SRX (10,000 sentri).
+
+```
+ceil(fee/2) → burned permanently
+floor(fee/2) → block validator
+```
+
+Odd sentri goes to burn. Eventually burns > rewards = deflation.
+
+## Address Format
+
+`0x` + 40 hex chars. Derived from `Keccak-256(secp256k1 pubkey)[12..32]`. Same as Ethereum — MetaMask/ethers.js work out of the box.
+
+## Constants
+
+```rust
+CHAIN_ID           = 7119
+MAX_SUPPLY         = 21_000_000_000_000_000  // 210M in sentri
+BLOCK_REWARD       = 100_000_000             // 1 SRX
+HALVING_INTERVAL   = 42_000_000
+BLOCK_TIME_SECS    = 3
+MIN_TX_FEE         = 10_000                  // 0.0001 SRX
+CHAIN_WINDOW_SIZE  = 1000
+STATE_ROOT_FORK_HEIGHT = 100_000
+```

--- a/docs/tokenomics/STAKING.md
+++ b/docs/tokenomics/STAKING.md
@@ -1,0 +1,53 @@
+# Staking (Phase 2 — Planned)
+
+> Not implemented yet. This is the finalized design.
+
+## How It Works
+
+Phase 2 switches from PoA (admin picks validators) to DPoS (stake picks validators). Anyone with 15K SRX can register. Token holders delegate to their preferred validators.
+
+**Active set:** Top 100 by `self_stake + delegated_stake`. Recalculated every epoch (28,800 blocks ≈ 1 day).
+
+## Delegation
+
+Lock SRX to a validator. You keep ownership, they get voting weight. Rewards split proportionally after validator takes commission (5-20%, self-set).
+
+Claim rewards manually — no auto-compound. Undelegate → unbonding period → SRX returned.
+
+## Slashing
+
+### Liveness (offline)
+
+| Missed blocks | Penalty |
+|---------------|---------|
+| 1-5 | Warning |
+| 6-50 | 1% stake |
+| 50+ | 5% stake + kicked |
+
+### Safety (malicious)
+
+| Violation | Penalty |
+|-----------|---------|
+| Double signing | 20% stake + permanent ban |
+| TX manipulation | 20% stake + permanent ban |
+
+Slash split: 50% burned, 50% to Ecosystem Fund. Delegators not directly slashed but should redelegate away from slashed validators.
+
+## Economics
+
+With 100 validators, 3s blocks:
+- ~288 blocks/day per validator
+- ~288+ SRX/day from rewards (Era 0)
+- Plus fee revenue
+
+Cost to attack (51%): 51 validators × 15K SRX = 765K SRX minimum, plus 20% slash risk.
+
+## Gas (EVM)
+
+Phase 2 adds gas metering via revm:
+
+| | |
+|-|-|
+| Gas price | 0.1 sentri/gas |
+| Block gas limit | 30,000,000 |
+| Transfer | ~21K gas = 0.000021 SRX |

--- a/docs/tokenomics/TOKEN_STANDARDS.md
+++ b/docs/tokenomics/TOKEN_STANDARDS.md
@@ -1,0 +1,68 @@
+# Token Standards
+
+## SRX-20
+
+Fungible token standard, like ERC-20. Anyone can deploy.
+
+### Deploy
+
+```bash
+sentrix token deploy --name "My Token" --symbol "MTK" --supply 1000000 --decimals 18 --deployer-key <key> --fee 100000
+```
+
+Creates contract at `SRX20_<sha256(txid)>`. Full supply minted to deployer. Fee: 50% burn, 50% ecosystem.
+
+### Operations
+
+Transfer: `sentrix token transfer --contract SRX20_... --to 0x... --amount 1000 --from-key <key> --gas 10000`
+
+Burn: `sentrix token burn --contract SRX20_... --amount 500 --from-key <key> --gas 10000`
+
+Approve: Allow a third party to spend your tokens. Must reset to 0 before setting a new allowance (prevents the classic ERC-20 front-running attack).
+
+Mint: Owner only. Can't exceed max_supply set at deploy.
+
+All operations need SRX for gas — you need SRX even if you're only moving tokens.
+
+### API
+
+| Endpoint | Method |
+|----------|--------|
+| `/tokens` | GET — list all tokens |
+| `/tokens/{contract}` | GET — token details |
+| `/tokens/{contract}/balance/{addr}` | GET — balance |
+| `/tokens/deploy` | POST — deploy (needs API key) |
+| `/tokens/{contract}/transfer` | POST — transfer (needs API key) |
+| `/tokens/{contract}/burn` | POST — burn (needs API key) |
+
+Explorer: `/explorer/tokens` and `/explorer/token/{contract}`.
+
+### vs ERC-20
+
+| | ERC-20 | SRX-20 |
+|-|--------|--------|
+| Gas token | ETH | SRX |
+| Contract address | EVM deployment | `SRX20_` + deterministic hash |
+| Approve front-run | Vulnerable | Mitigated (reset to 0 first) |
+| Max supply | Optional | Built-in, enforced in mint() |
+| VM | EVM | Native engine (Phase 1), revm (Phase 2) |
+
+## SNTX
+
+First SRX-20 token. Sentrix Utility.
+
+| | |
+|-|-|
+| Supply | 10,000,000,000 |
+| Ecosystem | 5B |
+| Founder | 2B |
+| Early Validator | 1.5B |
+| Reserve | 1.5B |
+
+Planned uses: governance, fee discounts, staking boosts.
+
+## Planned
+
+**SRC-20 (Phase 2):** EVM-compatible via revm. Solidity ABI, gas metering, events.
+
+**SRTX (Future):** USD-pegged stablecoin. SRX-collateralized.


### PR DESCRIPTION
## Summary

- 20 documentation files across 5 categories: architecture, security, operations, tokenomics, roadmap
- Written from actual codebase analysis and private audit reports
- All sensitive data redacted (IPs, SSH users, keys use `[NODE_IP]` placeholders)
- Rewritten from private founder docs into public-facing format

### Structure
```
docs/
├── architecture/    (5 files: overview, consensus, networking, state, transactions)
├── security/        (4 files: V11 audit, attack vectors, pentest, report)
├── operations/      (4 files: deployment, CI/CD, validators, monitoring)
├── tokenomics/      (3 files: SRX, staking, token standards)
├── roadmap/         (3 files: phase 1, phase 2, changelog)
└── README.md        (index)
```

## Test plan

- [ ] Review all docs for accidental credential/IP leaks
- [ ] Verify technical accuracy against current codebase
- [ ] Check all internal doc links work