### PR TITLE
feat(bft): wire BFT consensus to validator loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2921,7 +2921,7 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "sentrix"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -345,6 +345,8 @@ async fn get_blocks(
             "tx_count": b.tx_count(),
             "validator": b.validator,
             "merkle_root": b.merkle_root,
+            "round": b.round,
+            "has_justification": b.justification.is_some(),
         }))
         .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -539,8 +539,40 @@ async fn cmd_start(
 
                     // ── Block production (Pioneer or Voyager) ───
                     match bc.create_block(&wallet.address) {
-                        Ok(block) => {
+                        Ok(mut block) => {
                             let height = block.index;
+
+                            // ── BFT consensus (Voyager only) ──────
+                            if voyager_activated {
+                                use sentrix::core::bft::{BftEngine, BftAction};
+                                let total_active_stake: u64 = bc.stake_registry.active_set.iter()
+                                    .filter_map(|a| bc.stake_registry.get_validator(a))
+                                    .map(|v| v.total_stake())
+                                    .sum();
+                                let our_stake = bc.stake_registry.get_validator(&wallet.address)
+                                    .map(|v| v.total_stake()).unwrap_or(0);
+                                let block_hash = block.hash.clone();
+                                let mut bft = BftEngine::new(
+                                    height, wallet.address.clone(), total_active_stake,
+                                );
+
+                                // Propose → self-prevote → self-precommit → finalize
+                                if let BftAction::BroadcastPrevote(prevote) =
+                                    bft.on_proposal(&block_hash, &wallet.address, &bc.stake_registry)
+                                    && let BftAction::BroadcastPrecommit(precommit) =
+                                        bft.on_prevote_weighted(&prevote, our_stake)
+                                    && let BftAction::FinalizeBlock { round, justification, .. } =
+                                        bft.on_precommit_weighted(&precommit, our_stake)
+                                {
+                                    block.round = round;
+                                    block.justification = Some(justification);
+                                    tracing::info!(
+                                        "BFT finalized height={} round={}",
+                                        height, round,
+                                    );
+                                }
+                            }
+
                             match bc.add_block(block) {
                                 Ok(()) => {
                                     let updated = bc.latest_block().ok().cloned();
@@ -657,15 +689,15 @@ async fn cmd_start(
                 NodeEvent::SyncNeeded { peer_addr, peer_height } => {
                     tracing::info!("Sync needed from {} (height: {})", peer_addr, peer_height);
                 }
-                // BFT events — handled by BFT state machine in Voyager mode (future)
+                // BFT events — logged; multi-validator routing in future
                 NodeEvent::BftProposal(p) => {
-                    tracing::debug!("BFT proposal received: height={} round={}", p.height, p.round);
+                    tracing::info!("BFT proposal received: height={} round={}", p.height, p.round);
                 }
                 NodeEvent::BftPrevote(v) => {
-                    tracing::debug!("BFT prevote received: height={} round={}", v.height, v.round);
+                    tracing::info!("BFT prevote received: height={} round={}", v.height, v.round);
                 }
                 NodeEvent::BftPrecommit(c) => {
-                    tracing::debug!("BFT precommit received: height={} round={}", c.height, c.round);
+                    tracing::info!("BFT precommit received: height={} round={}", c.height, c.round);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Wire BFT state machine (propose → prevote → precommit → finalize) into validator loop after Voyager fork height
- Blocks post-fork now carry `round` field and `BlockJustification` with precommit signatures
- Single-validator self-voting: instant supermajority (100% stake), zero-latency BFT rounds
- API `/chain/blocks` returns `round` + `has_justification` fields
- BFT P2P events logged at info level (was debug)

## Test plan
- [x] 463 tests passing
- [x] Clippy clean
- [ ] CI passes
- [ ] Merge → CI/CD deploys to 3 VPS
- [ ] Verify testnet logs show "BFT finalized" after deploy
- [ ] Verify `/chain/blocks?limit=1` returns `has_justification: true`