### PR TITLE
fix(bft): sign votes in all cascade loops

### DIFF
--- a/src/core/bft_messages.rs
+++ b/src/core/bft_messages.rs
@@ -203,7 +203,8 @@ pub fn recover_signer(payload: &[u8], signature: &[u8]) -> SentrixResult<String>
 /// Verify that a signature was produced by the claimed validator address.
 pub fn verify_vote_signature(payload: &[u8], signature: &[u8], expected_validator: &str) -> bool {
     if signature.is_empty() {
-        return false; // unsigned votes are invalid
+        tracing::warn!("BFT: UNSIGNED vote from {} (empty signature)", &expected_validator[..12.min(expected_validator.len())]);
+        return false;
     }
     match recover_signer(payload, signature) {
         Ok(ref addr) if addr == expected_validator => true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -913,7 +913,9 @@ async fn cmd_start(
                         loop {
                             match action {
                                 BftAction::BroadcastPrevote(ref prevote) => {
-                                    lp2p_clone.broadcast_bft_prevote(prevote).await;
+                                    let mut signed_pv = prevote.clone();
+                                    signed_pv.sign(&validator_secret_key);
+                                    lp2p_clone.broadcast_bft_prevote(&signed_pv).await;
                                     let bc = shared_clone.read().await;
                                     let our_stake = bc.stake_registry.get_validator(&wallet.address)
                                         .map(|v| v.total_stake()).unwrap_or(0);
@@ -922,7 +924,9 @@ async fn cmd_start(
                                     continue;
                                 }
                                 BftAction::BroadcastPrecommit(ref precommit) => {
-                                    lp2p_clone.broadcast_bft_precommit(precommit).await;
+                                    let mut signed_pc = precommit.clone();
+                                    signed_pc.sign(&validator_secret_key);
+                                    lp2p_clone.broadcast_bft_precommit(&signed_pc).await;
                                     let bc = shared_clone.read().await;
                                     let our_stake = bc.stake_registry.get_validator(&wallet.address)
                                         .map(|v| v.total_stake()).unwrap_or(0);
@@ -1041,7 +1045,9 @@ async fn cmd_start(
                         loop {
                             match action {
                                 BftAction::BroadcastPrevote(ref prevote) => {
-                                    lp2p_clone.broadcast_bft_prevote(prevote).await;
+                                    let mut signed_pv = prevote.clone();
+                                    signed_pv.sign(&validator_secret_key);
+                                    lp2p_clone.broadcast_bft_prevote(&signed_pv).await;
                                     let bc = shared_clone.read().await;
                                     let our_stake = bc.stake_registry.get_validator(&wallet.address)
                                         .map(|v| v.total_stake()).unwrap_or(0);
@@ -1050,7 +1056,9 @@ async fn cmd_start(
                                     continue;
                                 }
                                 BftAction::BroadcastPrecommit(ref precommit) => {
-                                    lp2p_clone.broadcast_bft_precommit(precommit).await;
+                                    let mut signed_pc = precommit.clone();
+                                    signed_pc.sign(&validator_secret_key);
+                                    lp2p_clone.broadcast_bft_precommit(&signed_pc).await;
                                     let bc = shared_clone.read().await;
                                     let our_stake = bc.stake_registry.get_validator(&wallet.address)
                                         .map(|v| v.total_stake()).unwrap_or(0);


### PR DESCRIPTION
Fix: peer message and timeout cascades were broadcasting unsigned votes. Now all 6 broadcast points sign before sending.