### PR TITLE
fix(bft): skip Pioneer authority check in Voyager mode

### DIFF
--- a/src/core/block_producer.rs
+++ b/src/core/block_producer.rs
@@ -10,10 +10,22 @@ impl Blockchain {
     pub fn create_block(&mut self, validator_address: &str) -> SentrixResult<Block> {
         let next_height = self.height() + 1;
 
-        // Check authorization
+        // Check authorization (Pioneer round-robin)
         if !self.authority.is_authorized(validator_address, next_height)? {
             return Err(SentrixError::NotYourTurn);
         }
+
+        self.build_block(validator_address)
+    }
+
+    /// Create a block without Pioneer authority check.
+    /// Used in Voyager BFT mode where proposer is selected by DPoS weighted round-robin.
+    pub fn create_block_voyager(&mut self, validator_address: &str) -> SentrixResult<Block> {
+        self.build_block(validator_address)
+    }
+
+    fn build_block(&mut self, validator_address: &str) -> SentrixResult<Block> {
+        let next_height = self.height() + 1;
 
         // Build transaction list — coinbase first
         // Coinbase uses the block's timestamp — deterministic across all nodes for the same block.

--- a/src/main.rs
+++ b/src/main.rs
@@ -705,9 +705,9 @@ async fn cmd_start(
                     drop(bc);
 
                     if we_are_proposer {
-                        // We're the proposer — create block and broadcast proposal
+                        // We're the proposer — create block (Voyager: skip Pioneer authority)
                         let mut bc = shared_clone.write().await;
-                        match bc.create_block(&wallet.address) {
+                        match bc.create_block_voyager(&wallet.address) {
                             Ok(block) => {
                                 let block_hash = block.hash.clone();
                                 let block_data = bincode::serialize(&block).unwrap_or_default();


### PR DESCRIPTION
DPoS proposer was rejected by Pioneer round-robin. Add create_block_voyager() without authority check.