### PR TITLE
feat(storage): add sentrix-storage crate with libmdbx wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1179,17 @@ dependencies = [
  "crypto-common 0.1.7",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -2755,10 +2793,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libmdbx"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1da773dcce45661428e2b51ca984eb3c64c08f2aa54865397e4b77d1f61c9f07"
+dependencies = [
+ "bitflags 2.11.0",
+ "derive_more",
+ "indexmap 2.14.0",
+ "libc",
+ "mdbx-sys",
+ "parking_lot 0.12.5",
+ "sealed",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "libp2p"
@@ -3208,6 +3272,17 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "mdbx-sys"
+version = "13.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4002b9ffed3dd01364ab005bca653a99b8f550ca4cd755470a9d3a31a44f466"
+dependencies = [
+ "bindgen",
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -4650,6 +4725,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4923,6 +5009,20 @@ dependencies = [
  "sentrix-primitives",
  "serde",
  "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "sentrix-storage"
+version = "2.0.0"
+dependencies = [
+ "bincode",
+ "libmdbx",
+ "sentrix-primitives",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5024,6 +5024,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-rpc", "bin/sentrix"]
+members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-rpc", "crates/sentrix-storage", "bin/sentrix"]
 
 [package]
 name = "sentrix"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -23,3 +23,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
+uuid = { version = "1.0", features = ["v4"] }

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "sentrix-storage"
+version = "2.0.0"
+edition = "2024"
+license = "BUSL-1.1"
+description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"
+publish = false
+
+[dependencies]
+sentrix-primitives = { path = "../sentrix-primitives" }
+
+# Storage backend
+libmdbx = "0.6"
+
+# Encoding
+bincode = "1.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Error handling + logging
+thiserror = "1.0"
+tracing = "0.1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/sentrix-storage/src/chain.rs
+++ b/crates/sentrix-storage/src/chain.rs
@@ -1,0 +1,324 @@
+// chain.rs — High-level chain storage API wrapping MdbxStorage.
+//
+// Drop-in replacement for the current sled-based Storage in sentrix-core.
+// Same method signatures so migration is a find-replace on the type.
+
+use crate::error::{StorageError, StorageResult};
+use crate::mdbx::{MdbxStorage, height_key, key_to_height};
+use crate::tables::*;
+use sentrix_primitives::block::Block;
+use serde::{Serialize, de::DeserializeOwned};
+use std::path::Path;
+
+/// High-level chain storage — wraps MdbxStorage with blockchain-specific methods.
+///
+/// API mirrors the old sled-based `Storage` in sentrix-core so that migration
+/// is a near-drop-in replacement (change type + open call, methods stay the same).
+pub struct ChainStorage {
+    mdbx: MdbxStorage,
+}
+
+impl ChainStorage {
+    /// Open the chain database at the given path.
+    /// Applies the same disk-encryption checks as the old sled Storage.
+    pub fn open(path: &str) -> StorageResult<Self> {
+        let encrypted = std::env::var("SENTRIX_ENCRYPTED_DISK").as_deref() == Ok("true");
+        let dev_override =
+            std::env::var("SENTRIX_ALLOW_UNENCRYPTED_DISK").as_deref() == Ok("true");
+        if !encrypted {
+            if dev_override {
+                tracing::warn!(
+                    "SECURITY WARNING: opening chain DB at '{}' without disk encryption \
+                     confirmation (SENTRIX_ALLOW_UNENCRYPTED_DISK=true).",
+                    path
+                );
+            } else {
+                tracing::error!(
+                    "REFUSING TO OPEN chain DB at '{}': SENTRIX_ENCRYPTED_DISK is not 'true'.",
+                    path
+                );
+                return Err(StorageError::Other(
+                    "disk encryption not confirmed: set SENTRIX_ENCRYPTED_DISK=true \
+                     (or SENTRIX_ALLOW_UNENCRYPTED_DISK=true for dev/test)"
+                        .to_string(),
+                ));
+            }
+        }
+
+        let mdbx = MdbxStorage::open(Path::new(path))?;
+
+        let storage = Self { mdbx };
+        storage.ensure_hash_index()?;
+        Ok(storage)
+    }
+
+    // ── Generic put/get (JSON encoding, matching old sled Storage) ───
+
+    fn put<T: Serialize>(&self, key: &str, value: &T) -> StorageResult<()> {
+        self.mdbx.put_json(TABLE_META, key.as_bytes(), value)
+    }
+
+    fn get<T: DeserializeOwned>(&self, key: &str) -> StorageResult<Option<T>> {
+        self.mdbx.get_json(TABLE_META, key.as_bytes())
+    }
+
+    // ── Hash index migration (same as old sled Storage) ─────
+
+    pub fn ensure_hash_index(&self) -> StorageResult<()> {
+        if self.mdbx.has(TABLE_META, b"hash_index_complete")? {
+            return Ok(());
+        }
+
+        let height = self.load_height()?;
+        let mut indexed_any = false;
+        for i in 0..=height {
+            if let Some(block) = self.load_block(i)? {
+                indexed_any = true;
+                if !self.mdbx.has(TABLE_BLOCK_HASHES, block.hash.as_bytes())? {
+                    self.mdbx
+                        .put(TABLE_BLOCK_HASHES, block.hash.as_bytes(), &height_key(block.index))?;
+                }
+            }
+        }
+
+        if indexed_any {
+            self.put("hash_index_complete", &true)?;
+        }
+        Ok(())
+    }
+
+    // ── Blockchain state ────────────────────────────────────
+
+    pub fn save_blockchain<T: Serialize>(&self, blockchain: &T, chain: &[Block]) -> StorageResult<()> {
+        // Save state (accounts, authority, etc.)
+        self.mdbx.put_json(TABLE_STATE, b"state", blockchain)?;
+
+        // Save each block + hash index
+        let batch = self.mdbx.begin_write()?;
+        for block in chain {
+            let key = format!("block:{}", block.index);
+            let block_json = serde_json::to_vec(block)?;
+            batch.put(TABLE_META, key.as_bytes(), &block_json)?;
+
+            batch.put(
+                TABLE_BLOCK_HASHES,
+                block.hash.as_bytes(),
+                &height_key(block.index),
+            )?;
+        }
+        batch.commit()?;
+
+        if let Some(last) = chain.last() {
+            self.save_height(last.index)?;
+        }
+        self.mdbx.sync()?;
+        Ok(())
+    }
+
+    pub fn load_state<T: DeserializeOwned>(&self) -> StorageResult<Option<T>> {
+        self.mdbx.get_json(TABLE_STATE, b"state")
+    }
+
+    // ── Per-block operations ────────────────────────────────
+
+    pub fn save_block(&self, block: &Block) -> StorageResult<()> {
+        let key = format!("block:{}", block.index);
+        let block_json = serde_json::to_vec(block)?;
+        self.mdbx.put(TABLE_META, key.as_bytes(), &block_json)?;
+        self.mdbx.put(
+            TABLE_BLOCK_HASHES,
+            block.hash.as_bytes(),
+            &height_key(block.index),
+        )?;
+        self.save_height(block.index)?;
+        self.mdbx.sync()?;
+        Ok(())
+    }
+
+    pub fn load_block(&self, index: u64) -> StorageResult<Option<Block>> {
+        let key = format!("block:{}", index);
+        self.get(&key)
+    }
+
+    pub fn load_block_by_hash(&self, hash: &str) -> StorageResult<Option<Block>> {
+        if let Some(height_bytes) = self.mdbx.get(TABLE_BLOCK_HASHES, hash.as_bytes())? {
+            let index = key_to_height(&height_bytes);
+            return self.load_block(index);
+        }
+        Ok(None)
+    }
+
+    pub fn load_blocks_range(&self, from: u64, to: u64) -> StorageResult<Vec<Block>> {
+        let mut blocks = Vec::new();
+        for i in from..=to {
+            if let Some(block) = self.load_block(i)? {
+                blocks.push(block);
+            }
+        }
+        Ok(blocks)
+    }
+
+    // ── Height ──────────────────────────────────────────────
+
+    pub fn save_height(&self, height: u64) -> StorageResult<()> {
+        self.put("height", &height)
+    }
+
+    pub fn load_height(&self) -> StorageResult<u64> {
+        Ok(self.get::<u64>("height")?.unwrap_or(0))
+    }
+
+    // ── Trie tree access (returns raw MdbxStorage for trie backend) ──
+
+    /// Get a reference to the underlying MdbxStorage for trie operations.
+    /// The trie backend needs direct table access for nodes/values/roots.
+    pub fn mdbx(&self) -> &MdbxStorage {
+        &self.mdbx
+    }
+
+    // ── Tx index ────────────────────────────────────────────
+
+    pub fn index_tx(&self, tx_hash: &str, block_index: u64) -> StorageResult<()> {
+        self.mdbx
+            .put(TABLE_TX_INDEX, tx_hash.as_bytes(), &height_key(block_index))
+    }
+
+    pub fn find_tx_block(&self, tx_hash: &str) -> StorageResult<Option<u64>> {
+        match self.mdbx.get(TABLE_TX_INDEX, tx_hash.as_bytes())? {
+            Some(bytes) => Ok(Some(key_to_height(&bytes))),
+            None => Ok(None),
+        }
+    }
+
+    // ── Utility ─────────────────────────────────────────────
+
+    pub fn has_blockchain(&self) -> bool {
+        self.mdbx.has(TABLE_STATE, b"state").unwrap_or(false)
+            || self.mdbx.has(TABLE_META, b"blockchain").unwrap_or(false)
+    }
+
+    pub fn clear(&self) -> StorageResult<()> {
+        for table in ALL_TABLES {
+            self.mdbx.clear_table(table)?;
+        }
+        Ok(())
+    }
+
+    pub fn reset_trie(&self) -> StorageResult<()> {
+        self.mdbx.clear_table(TABLE_TRIE_NODES)?;
+        self.mdbx.clear_table(TABLE_TRIE_VALUES)?;
+        self.mdbx.clear_table(TABLE_TRIE_ROOTS)?;
+        self.mdbx.clear_table(TABLE_TRIE_COMMITTED)?;
+        self.mdbx.sync()?;
+        Ok(())
+    }
+
+    pub fn db_size_bytes(&self) -> u64 {
+        self.mdbx.db_size_bytes().unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_path() -> String {
+        let dir = std::env::temp_dir().join(format!("sentrix_mdbx_test_{}", uuid::Uuid::new_v4()));
+        dir.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn test_open_chain_storage() {
+        let path = temp_path();
+        let storage = ChainStorage::open(&path).unwrap();
+        assert!(!storage.has_blockchain());
+        let _ = std::fs::remove_dir_all(&path);
+    }
+
+    #[test]
+    fn test_save_and_load_block() {
+        let path = temp_path();
+        let storage = ChainStorage::open(&path).unwrap();
+
+        let block = Block::genesis();
+        storage.save_block(&block).unwrap();
+
+        let loaded = storage.load_block(0).unwrap().unwrap();
+        assert_eq!(loaded.index, 0);
+        assert_eq!(loaded.hash, block.hash);
+
+        let _ = std::fs::remove_dir_all(&path);
+    }
+
+    #[test]
+    fn test_load_block_by_hash() {
+        let path = temp_path();
+        let storage = ChainStorage::open(&path).unwrap();
+
+        let block = Block::genesis();
+        storage.save_block(&block).unwrap();
+
+        let found = storage.load_block_by_hash(&block.hash).unwrap().unwrap();
+        assert_eq!(found.index, 0);
+
+        assert!(storage.load_block_by_hash("nonexistent").unwrap().is_none());
+
+        let _ = std::fs::remove_dir_all(&path);
+    }
+
+    #[test]
+    fn test_height() {
+        let path = temp_path();
+        let storage = ChainStorage::open(&path).unwrap();
+
+        storage.save_height(42).unwrap();
+        assert_eq!(storage.load_height().unwrap(), 42);
+
+        let _ = std::fs::remove_dir_all(&path);
+    }
+
+    #[test]
+    fn test_tx_index() {
+        let path = temp_path();
+        let storage = ChainStorage::open(&path).unwrap();
+
+        storage.index_tx("abc123", 10).unwrap();
+        assert_eq!(storage.find_tx_block("abc123").unwrap(), Some(10));
+        assert_eq!(storage.find_tx_block("nonexistent").unwrap(), None);
+
+        let _ = std::fs::remove_dir_all(&path);
+    }
+
+    #[test]
+    fn test_persistence() {
+        let path = temp_path();
+        {
+            let storage = ChainStorage::open(&path).unwrap();
+            let block = Block::genesis();
+            storage.save_block(&block).unwrap();
+        }
+        {
+            let storage = ChainStorage::open(&path).unwrap();
+            let loaded = storage.load_block(0).unwrap().unwrap();
+            assert_eq!(loaded.index, 0);
+        }
+        let _ = std::fs::remove_dir_all(&path);
+    }
+
+    #[test]
+    fn test_clear_and_reset_trie() {
+        let path = temp_path();
+        let storage = ChainStorage::open(&path).unwrap();
+
+        storage.save_block(&Block::genesis()).unwrap();
+        storage.mdbx().put(TABLE_TRIE_NODES, b"node1", b"data").unwrap();
+        assert!(storage.load_block(0).unwrap().is_some());
+
+        storage.reset_trie().unwrap();
+        // Trie cleared but blocks still exist
+        assert!(storage.mdbx().get(TABLE_TRIE_NODES, b"node1").unwrap().is_none());
+        assert!(storage.load_block(0).unwrap().is_some());
+
+        let _ = std::fs::remove_dir_all(&path);
+    }
+}

--- a/crates/sentrix-storage/src/error.rs
+++ b/crates/sentrix-storage/src/error.rs
@@ -1,0 +1,50 @@
+// error.rs — Storage error types
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("MDBX error: {0}")]
+    Mdbx(String),
+
+    #[error("Encoding error: {0}")]
+    Encode(String),
+
+    #[error("Decoding error: {0}")]
+    Decode(String),
+
+    #[error("Key not found: {table}/{key}")]
+    NotFound { table: String, key: String },
+
+    #[error("Table not found: {0}")]
+    TableNotFound(String),
+
+    #[error("Storage error: {0}")]
+    Other(String),
+}
+
+impl From<libmdbx::Error> for StorageError {
+    fn from(e: libmdbx::Error) -> Self {
+        StorageError::Mdbx(e.to_string())
+    }
+}
+
+impl From<bincode::Error> for StorageError {
+    fn from(e: bincode::Error) -> Self {
+        StorageError::Encode(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for StorageError {
+    fn from(e: serde_json::Error) -> Self {
+        StorageError::Encode(e.to_string())
+    }
+}
+
+impl From<StorageError> for sentrix_primitives::SentrixError {
+    fn from(e: StorageError) -> Self {
+        sentrix_primitives::SentrixError::StorageError(e.to_string())
+    }
+}
+
+pub type StorageResult<T> = Result<T, StorageError>;

--- a/crates/sentrix-storage/src/lib.rs
+++ b/crates/sentrix-storage/src/lib.rs
@@ -1,0 +1,29 @@
+//! sentrix-storage — libmdbx-based storage layer for Sentrix blockchain.
+//!
+//! Replaces sled with libmdbx (used by Reth/Erigon) for better performance:
+//! - ACID transactions (proper commit/rollback)
+//! - Ordered iteration via B+ tree
+//! - Memory-mapped I/O (zero-copy reads)
+//! - Battle-tested in production blockchains
+//!
+//! # Tables
+//!
+//! - `blocks`: height → Block (bincode)
+//! - `block_hashes`: hash → height
+//! - `state`: chain state (JSON, backward compat)
+//! - `tx_index`: tx_hash → block_height
+//! - `trie_nodes`: node_hash → TrieNode
+//! - `trie_values`: leaf_key → value
+//! - `trie_roots`: height → root_hash
+//! - `trie_committed_roots`: height → root_hash
+//! - `meta`: metadata key-value pairs
+
+#![allow(missing_docs)]
+
+pub mod error;
+pub mod mdbx;
+pub mod tables;
+
+pub use error::{StorageError, StorageResult};
+pub use mdbx::{MdbxStorage, WriteBatch, height_key, key_to_height};
+pub use tables::*;

--- a/crates/sentrix-storage/src/lib.rs
+++ b/crates/sentrix-storage/src/lib.rs
@@ -20,10 +20,12 @@
 
 #![allow(missing_docs)]
 
+pub mod chain;
 pub mod error;
 pub mod mdbx;
 pub mod tables;
 
+pub use chain::ChainStorage;
 pub use error::{StorageError, StorageResult};
 pub use mdbx::{MdbxStorage, WriteBatch, height_key, key_to_height};
 pub use tables::*;

--- a/crates/sentrix-storage/src/mdbx.rs
+++ b/crates/sentrix-storage/src/mdbx.rs
@@ -5,7 +5,7 @@
 use crate::error::{StorageError, StorageResult};
 use crate::tables::ALL_TABLES;
 use libmdbx::{
-    Database, DatabaseOptions, NoWriteMap, TableFlags, Transaction, WriteFlags, RO, RW,
+    Database, DatabaseOptions, NoWriteMap, TableFlags, Transaction, WriteFlags, RW,
 };
 use serde::{Serialize, de::DeserializeOwned};
 use std::path::Path;
@@ -24,10 +24,10 @@ impl MdbxStorage {
     pub fn open(path: &Path) -> StorageResult<Self> {
         std::fs::create_dir_all(path).map_err(|e| StorageError::Other(e.to_string()))?;
 
-        let mut opts = DatabaseOptions::default();
-        opts.max_tables = Some(16);
-
-        let db = Database::<NoWriteMap>::open_with_options(path, opts)
+        let db = Database::<NoWriteMap>::open_with_options(path, DatabaseOptions {
+            max_tables: Some(16),
+            ..Default::default()
+        })
             .map_err(|e| StorageError::Mdbx(format!("open: {e}")))?;
 
         // Pre-create all named tables

--- a/crates/sentrix-storage/src/mdbx.rs
+++ b/crates/sentrix-storage/src/mdbx.rs
@@ -1,0 +1,351 @@
+// mdbx.rs — libmdbx wrapper for Sentrix chain storage.
+//
+// API: Database<NoWriteMap> → Transaction<RO/RW> → Table → Cursor.
+
+use crate::error::{StorageError, StorageResult};
+use crate::tables::ALL_TABLES;
+use libmdbx::{
+    Database, DatabaseOptions, NoWriteMap, TableFlags, Transaction, WriteFlags, RO, RW,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use std::path::Path;
+
+/// Sentrix storage backed by libmdbx.
+///
+/// Thread-safe: libmdbx `Database` can be shared across threads.
+/// Read transactions are lock-free. Write transactions are serialized.
+pub struct MdbxStorage {
+    db: Database<NoWriteMap>,
+}
+
+impl MdbxStorage {
+    /// Open (or create) the MDBX database at the given path.
+    /// Pre-creates all Sentrix tables on first open.
+    pub fn open(path: &Path) -> StorageResult<Self> {
+        std::fs::create_dir_all(path).map_err(|e| StorageError::Other(e.to_string()))?;
+
+        let mut opts = DatabaseOptions::default();
+        opts.max_tables = Some(16);
+
+        let db = Database::<NoWriteMap>::open_with_options(path, opts)
+            .map_err(|e| StorageError::Mdbx(format!("open: {e}")))?;
+
+        // Pre-create all named tables
+        {
+            let tx = db.begin_rw_txn()?;
+            for &table_name in ALL_TABLES {
+                tx.create_table(Some(table_name), TableFlags::default())?;
+            }
+            tx.commit()?;
+        }
+
+        tracing::info!("MDBX storage opened at {:?} ({} tables)", path, ALL_TABLES.len());
+        Ok(Self { db })
+    }
+
+    // ── Raw key-value operations ────────────────────────────
+
+    /// Put a raw key-value pair into the given table.
+    pub fn put(&self, table: &str, key: &[u8], value: &[u8]) -> StorageResult<()> {
+        let tx = self.db.begin_rw_txn()?;
+        let tbl = tx.open_table(Some(table))?;
+        tx.put(&tbl, key, value, WriteFlags::default())?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Get a raw value from the given table. Returns None if key not found.
+    pub fn get(&self, table: &str, key: &[u8]) -> StorageResult<Option<Vec<u8>>> {
+        let tx = self.db.begin_ro_txn()?;
+        let tbl = tx.open_table(Some(table))?;
+        match tx.get::<Vec<u8>>(&tbl, key) {
+            Ok(Some(val)) => Ok(Some(val)),
+            Ok(None) => Ok(None),
+            Err(libmdbx::Error::NotFound) => Ok(None),
+            Err(e) => Err(StorageError::Mdbx(format!("get: {e}"))),
+        }
+    }
+
+    /// Delete a key from the given table.
+    pub fn delete(&self, table: &str, key: &[u8]) -> StorageResult<bool> {
+        let tx = self.db.begin_rw_txn()?;
+        let tbl = tx.open_table(Some(table))?;
+        let deleted = tx.del(&tbl, key, None).is_ok();
+        tx.commit()?;
+        Ok(deleted)
+    }
+
+    /// Check if a key exists in the given table.
+    pub fn has(&self, table: &str, key: &[u8]) -> StorageResult<bool> {
+        Ok(self.get(table, key)?.is_some())
+    }
+
+    // ── Typed operations (bincode encoding) ─────────────────
+
+    /// Put a serializable value into the given table (bincode).
+    pub fn put_bincode<V: Serialize>(&self, table: &str, key: &[u8], value: &V) -> StorageResult<()> {
+        let encoded = bincode::serialize(value)?;
+        self.put(table, key, &encoded)
+    }
+
+    /// Get a deserializable value from the given table (bincode).
+    pub fn get_bincode<V: DeserializeOwned>(&self, table: &str, key: &[u8]) -> StorageResult<Option<V>> {
+        match self.get(table, key)? {
+            Some(bytes) => Ok(Some(bincode::deserialize(&bytes)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Put a JSON-serializable value (for backward compat with sled's JSON storage).
+    pub fn put_json<V: Serialize>(&self, table: &str, key: &[u8], value: &V) -> StorageResult<()> {
+        let encoded = serde_json::to_vec(value)?;
+        self.put(table, key, &encoded)
+    }
+
+    /// Get a JSON-deserializable value.
+    pub fn get_json<V: DeserializeOwned>(&self, table: &str, key: &[u8]) -> StorageResult<Option<V>> {
+        match self.get(table, key)? {
+            Some(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
+            None => Ok(None),
+        }
+    }
+
+    // ── Batch write transaction ─────────────────────────────
+
+    /// Begin a batch write. All operations are committed atomically.
+    pub fn begin_write(&self) -> StorageResult<WriteBatch<'_>> {
+        let tx = self.db.begin_rw_txn()?;
+        Ok(WriteBatch { tx })
+    }
+
+    // ── Iteration ───────────────────────────────────────────
+
+    /// Iterate all key-value pairs in a table (ordered by key).
+    pub fn iter(&self, table: &str) -> StorageResult<Vec<(Vec<u8>, Vec<u8>)>> {
+        let tx = self.db.begin_ro_txn()?;
+        let tbl = tx.open_table(Some(table))?;
+        let cursor = tx.cursor(&tbl)?;
+        let mut results = Vec::new();
+        for item in cursor {
+            let (key, value) = item?;
+            results.push((key.to_vec(), value.to_vec()));
+        }
+        Ok(results)
+    }
+
+    /// Count entries in a table.
+    pub fn count(&self, table: &str) -> StorageResult<usize> {
+        let tx = self.db.begin_ro_txn()?;
+        let tbl = tx.open_table(Some(table))?;
+        let stat = tx.table_stat(&tbl)?;
+        Ok(stat.entries())
+    }
+
+    // ── Utility ─────────────────────────────────────────────
+
+    /// Clear all data in a specific table.
+    pub fn clear_table(&self, table: &str) -> StorageResult<()> {
+        let tx = self.db.begin_rw_txn()?;
+        let tbl = tx.open_table(Some(table))?;
+        tx.clear_table(&tbl)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Force sync to disk.
+    pub fn sync(&self) -> StorageResult<()> {
+        self.db.sync(true)?;
+        Ok(())
+    }
+}
+
+/// Batch write transaction — all operations commit or rollback atomically.
+pub struct WriteBatch<'env> {
+    tx: Transaction<'env, RW, NoWriteMap>,
+}
+
+impl WriteBatch<'_> {
+    /// Put a raw key-value pair.
+    pub fn put(&self, table: &str, key: &[u8], value: &[u8]) -> StorageResult<()> {
+        let tbl = self.tx.open_table(Some(table))?;
+        self.tx.put(&tbl, key, value, WriteFlags::default())?;
+        Ok(())
+    }
+
+    /// Put a bincode-encoded value.
+    pub fn put_bincode<V: Serialize>(&self, table: &str, key: &[u8], value: &V) -> StorageResult<()> {
+        let encoded = bincode::serialize(value)?;
+        self.put(table, key, &encoded)
+    }
+
+    /// Put a JSON-encoded value.
+    pub fn put_json<V: Serialize>(&self, table: &str, key: &[u8], value: &V) -> StorageResult<()> {
+        let encoded = serde_json::to_vec(value)?;
+        self.put(table, key, &encoded)
+    }
+
+    /// Delete a key.
+    pub fn delete(&self, table: &str, key: &[u8]) -> StorageResult<()> {
+        let tbl = self.tx.open_table(Some(table))?;
+        let _ = self.tx.del(&tbl, key, None); // ignore NotFound
+        Ok(())
+    }
+
+    /// Commit all batched operations atomically.
+    pub fn commit(self) -> StorageResult<()> {
+        self.tx.commit()?;
+        Ok(())
+    }
+}
+
+// ── Height key helper ───────────────────────────────────────
+
+/// Convert a block height to big-endian bytes for ordered MDBX storage.
+pub fn height_key(height: u64) -> [u8; 8] {
+    height.to_be_bytes()
+}
+
+/// Decode a height from big-endian key bytes.
+pub fn key_to_height(key: &[u8]) -> u64 {
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(&key[..8]);
+    u64::from_be_bytes(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tables::*;
+    use tempfile::TempDir;
+
+    fn temp_storage() -> (TempDir, MdbxStorage) {
+        let dir = TempDir::new().unwrap();
+        let storage = MdbxStorage::open(dir.path()).unwrap();
+        (dir, storage)
+    }
+
+    #[test]
+    fn test_open_creates_tables() {
+        let (_dir, storage) = temp_storage();
+        for table in ALL_TABLES {
+            let count = storage.count(table).unwrap();
+            assert_eq!(count, 0, "table {} should be empty", table);
+        }
+    }
+
+    #[test]
+    fn test_put_get_raw() {
+        let (_dir, storage) = temp_storage();
+        storage.put(TABLE_META, b"test_key", b"test_value").unwrap();
+        let val = storage.get(TABLE_META, b"test_key").unwrap();
+        assert_eq!(val, Some(b"test_value".to_vec()));
+    }
+
+    #[test]
+    fn test_get_missing_key() {
+        let (_dir, storage) = temp_storage();
+        let val = storage.get(TABLE_META, b"nonexistent").unwrap();
+        assert!(val.is_none());
+    }
+
+    #[test]
+    fn test_delete() {
+        let (_dir, storage) = temp_storage();
+        storage.put(TABLE_META, b"key", b"value").unwrap();
+        assert!(storage.has(TABLE_META, b"key").unwrap());
+        storage.delete(TABLE_META, b"key").unwrap();
+        assert!(!storage.has(TABLE_META, b"key").unwrap());
+    }
+
+    #[test]
+    fn test_put_get_bincode() {
+        let (_dir, storage) = temp_storage();
+        let value: u64 = 42;
+        storage.put_bincode(TABLE_META, b"height", &value).unwrap();
+        let loaded: Option<u64> = storage.get_bincode(TABLE_META, b"height").unwrap();
+        assert_eq!(loaded, Some(42));
+    }
+
+    #[test]
+    fn test_put_get_json() {
+        let (_dir, storage) = temp_storage();
+        let value = vec!["hello", "world"];
+        storage.put_json(TABLE_META, b"list", &value).unwrap();
+        let loaded: Option<Vec<String>> = storage.get_json(TABLE_META, b"list").unwrap();
+        assert_eq!(loaded, Some(vec!["hello".to_string(), "world".to_string()]));
+    }
+
+    #[test]
+    fn test_batch_write() {
+        let (_dir, storage) = temp_storage();
+        let batch = storage.begin_write().unwrap();
+        batch.put(TABLE_META, b"a", b"1").unwrap();
+        batch.put(TABLE_META, b"b", b"2").unwrap();
+        batch.put(TABLE_META, b"c", b"3").unwrap();
+        batch.commit().unwrap();
+
+        assert_eq!(storage.count(TABLE_META).unwrap(), 3);
+        assert_eq!(storage.get(TABLE_META, b"b").unwrap(), Some(b"2".to_vec()));
+    }
+
+    #[test]
+    fn test_count() {
+        let (_dir, storage) = temp_storage();
+        assert_eq!(storage.count(TABLE_META).unwrap(), 0);
+        storage.put(TABLE_META, b"k1", b"v1").unwrap();
+        storage.put(TABLE_META, b"k2", b"v2").unwrap();
+        assert_eq!(storage.count(TABLE_META).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_clear_table() {
+        let (_dir, storage) = temp_storage();
+        storage.put(TABLE_META, b"k1", b"v1").unwrap();
+        storage.put(TABLE_META, b"k2", b"v2").unwrap();
+        assert_eq!(storage.count(TABLE_META).unwrap(), 2);
+        storage.clear_table(TABLE_META).unwrap();
+        assert_eq!(storage.count(TABLE_META).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_height_key_ordering() {
+        let (_dir, storage) = temp_storage();
+        for h in [0u64, 1, 100, 1000, 999999] {
+            storage
+                .put(TABLE_BLOCKS, &height_key(h), &h.to_le_bytes())
+                .unwrap();
+        }
+        let entries = storage.iter(TABLE_BLOCKS).unwrap();
+        let heights: Vec<u64> = entries.iter().map(|(k, _)| key_to_height(k)).collect();
+        assert_eq!(heights, vec![0, 1, 100, 1000, 999999]);
+    }
+
+    #[test]
+    fn test_persistence_across_reopen() {
+        let dir = TempDir::new().unwrap();
+        {
+            let storage = MdbxStorage::open(dir.path()).unwrap();
+            storage.put(TABLE_META, b"persist", b"yes").unwrap();
+            storage.sync().unwrap();
+        }
+        {
+            let storage = MdbxStorage::open(dir.path()).unwrap();
+            let val = storage.get(TABLE_META, b"persist").unwrap();
+            assert_eq!(val, Some(b"yes".to_vec()));
+        }
+    }
+
+    #[test]
+    fn test_block_roundtrip() {
+        use sentrix_primitives::Block;
+
+        let (_dir, storage) = temp_storage();
+        let block = Block::genesis();
+        let key = height_key(block.index);
+        storage.put_bincode(TABLE_BLOCKS, &key, &block).unwrap();
+
+        let loaded: Block = storage.get_bincode(TABLE_BLOCKS, &key).unwrap().unwrap();
+        assert_eq!(loaded.index, 0);
+        assert_eq!(loaded.hash, block.hash);
+    }
+}

--- a/crates/sentrix-storage/src/mdbx.rs
+++ b/crates/sentrix-storage/src/mdbx.rs
@@ -152,6 +152,12 @@ impl MdbxStorage {
         Ok(())
     }
 
+    /// Get approximate database size on disk.
+    pub fn db_size_bytes(&self) -> StorageResult<u64> {
+        let info = self.db.info()?;
+        Ok(info.map_size() as u64)
+    }
+
     /// Force sync to disk.
     pub fn sync(&self) -> StorageResult<()> {
         self.db.sync(true)?;

--- a/crates/sentrix-storage/src/tables.rs
+++ b/crates/sentrix-storage/src/tables.rs
@@ -1,0 +1,44 @@
+// tables.rs — Table (named database) definitions for Sentrix chain storage.
+//
+// Each table has a specific key format and value encoding.
+// Keys use big-endian u64 for ordered iteration (height scans).
+
+/// Block storage: height (u64 BE) → Block (bincode)
+pub const TABLE_BLOCKS: &str = "blocks";
+
+/// Block hash index: block_hash (hex string bytes) → height (u64 BE)
+pub const TABLE_BLOCK_HASHES: &str = "block_hashes";
+
+/// Chain state: "state" → Blockchain (serde_json, for backward compat)
+pub const TABLE_STATE: &str = "state";
+
+/// Transaction index: tx_hash (hex string bytes) → block_height (u64 BE)
+pub const TABLE_TX_INDEX: &str = "tx_index";
+
+/// Trie nodes: node_hash (32 bytes) → TrieNode (bincode)
+pub const TABLE_TRIE_NODES: &str = "trie_nodes";
+
+/// Trie leaf values: leaf_key (32 bytes) → value bytes
+pub const TABLE_TRIE_VALUES: &str = "trie_values";
+
+/// Trie roots per height: height (u64 BE) → root_hash (32 bytes)
+pub const TABLE_TRIE_ROOTS: &str = "trie_roots";
+
+/// Trie committed roots: height (u64 BE) → root_hash (32 bytes)
+pub const TABLE_TRIE_COMMITTED: &str = "trie_committed_roots";
+
+/// Chain metadata: key string → value bytes (height, hash_index_complete, etc.)
+pub const TABLE_META: &str = "meta";
+
+/// All table names for pre-creation during environment open.
+pub const ALL_TABLES: &[&str] = &[
+    TABLE_BLOCKS,
+    TABLE_BLOCK_HASHES,
+    TABLE_STATE,
+    TABLE_TX_INDEX,
+    TABLE_TRIE_NODES,
+    TABLE_TRIE_VALUES,
+    TABLE_TRIE_ROOTS,
+    TABLE_TRIE_COMMITTED,
+    TABLE_META,
+];


### PR DESCRIPTION
Custom libmdbx wrapper for blockchain persistence (replaces sled). Based on Reth patterns: Database → Transaction → Table → Cursor.

Features:
- ACID transactions (proper commit/rollback)
- Raw, bincode, and JSON encoding support
- Batch write (WriteBatch) for atomic multi-key operations
- Ordered iteration via B+ tree cursors
- Big-endian u64 keys for height-ordered scans
- 9 named tables (blocks, state, trie, tx_index, meta, etc.)

12 unit tests: open, CRUD, encoding, batch, iteration, persistence, Block roundtrip. All 546 workspace tests pass.

Part of sled → libmdbx migration (v2.0.0 breaking change). Not yet integrated — sentrix-core still uses sled.