### PR TITLE
refactor: consolidate CHAIN_ID usage + dedupe MAX_SUPPLY

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -446,7 +446,7 @@ impl Blockchain {
             .build()
             .unwrap_or_default();
 
-        match execute_tx(in_mem_db, evm_tx, INITIAL_BASE_FEE) {
+        match execute_tx(in_mem_db, evm_tx, INITIAL_BASE_FEE, self.chain_id) {
             Ok(receipt) => {
                 tracing::info!(
                     "EVM tx {}: success={} gas_used={} contract={:?}",

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -19,6 +19,12 @@ use std::sync::Arc;
 // ── Chain constants ──────────────────────────────────────
 pub const MAX_SUPPLY: u64 = 210_000_000 * 100_000_000; // in sentri
 pub const BLOCK_REWARD: u64 = 100_000_000; // 1 SRX in sentri
+
+/// MAX_SUPPLY expressed in whole SRX as f64 — used by RPC/explorer display paths.
+/// Single source of truth; do NOT redefine as a local constant.
+pub fn max_supply_srx() -> f64 {
+    (MAX_SUPPLY / 100_000_000) as f64
+}
 pub const HALVING_INTERVAL: u64 = 42_000_000; // blocks
 pub const BLOCK_TIME_SECS: u64 = 1;
 pub const MAX_TX_PER_BLOCK: usize = 5000;

--- a/crates/sentrix-evm/src/executor.rs
+++ b/crates/sentrix-evm/src/executor.rs
@@ -29,13 +29,33 @@ pub struct TxReceipt {
 /// Execute a single EVM transaction against an in-memory database.
 ///
 /// The db is consumed. Returns the receipt and the accumulated state changes.
-pub fn execute_tx(db: InMemoryDB, tx: TxEnv, block_base_fee: u64) -> Result<TxReceipt, String> {
-    execute_tx_inner(db, tx, block_base_fee, false)
+///
+/// # Arguments
+/// * `chain_id` — active chain ID for EIP-155 replay protection. If the tx
+///   carries its own `chain_id` (EIP-155 signed), it MUST equal this value
+///   or execution is rejected. Caller is authoritative — this function has
+///   no default/fallback.
+pub fn execute_tx(
+    db: InMemoryDB,
+    tx: TxEnv,
+    block_base_fee: u64,
+    chain_id: u64,
+) -> Result<TxReceipt, String> {
+    execute_tx_inner(db, tx, block_base_fee, false, chain_id)
 }
 
 /// Read-only variant — disables balance/nonce checks for eth_call.
-pub fn execute_call(db: InMemoryDB, tx: TxEnv, block_base_fee: u64) -> Result<TxReceipt, String> {
-    execute_tx_inner(db, tx, block_base_fee, true)
+///
+/// # Arguments
+/// * `chain_id` — active chain ID for EIP-155 replay protection (see
+///   [`execute_tx`] for semantics).
+pub fn execute_call(
+    db: InMemoryDB,
+    tx: TxEnv,
+    block_base_fee: u64,
+    chain_id: u64,
+) -> Result<TxReceipt, String> {
+    execute_tx_inner(db, tx, block_base_fee, true, chain_id)
 }
 
 fn execute_tx_inner(
@@ -43,10 +63,21 @@ fn execute_tx_inner(
     tx: TxEnv,
     block_base_fee: u64,
     read_only: bool,
+    chain_id: u64,
 ) -> Result<TxReceipt, String> {
     use revm::Context;
 
-    let chain_id = tx.chain_id.unwrap_or(7119);
+    // EIP-155 replay protection: reject tx whose embedded chain_id doesn't
+    // match the executor's configured chain_id. `None` (pre-EIP-155 legacy
+    // tx) is allowed through; revm will enforce its own rules.
+    if let Some(tx_chain_id) = tx.chain_id
+        && tx_chain_id != chain_id
+    {
+        return Err(format!(
+            "chain_id mismatch: tx signed for chain {}, executor configured for chain {}",
+            tx_chain_id, chain_id
+        ));
+    }
     let ctx = Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.chain_id = chain_id;
@@ -131,7 +162,7 @@ mod tests {
             .build()
             .unwrap_or_default();
 
-        let result = execute_tx(db, tx, INITIAL_BASE_FEE);
+        let result = execute_tx(db, tx, INITIAL_BASE_FEE, 7119);
         assert!(result.is_ok(), "execute_tx failed: {:?}", result.err());
         let r = result.unwrap();
         assert!(r.success);
@@ -170,11 +201,85 @@ mod tests {
             .build()
             .unwrap_or_default();
 
-        let result = execute_tx(db, tx, INITIAL_BASE_FEE);
+        let result = execute_tx(db, tx, INITIAL_BASE_FEE, 7119);
         assert!(result.is_ok(), "deploy failed: {:?}", result.err());
         let r = result.unwrap();
         assert!(r.success);
         assert!(r.contract_address.is_some());
         assert!(r.gas_used > 21_000);
+    }
+
+    fn funded_sender_db() -> (InMemoryDB, Address) {
+        let mut db = InMemoryDB::default();
+        let sender = Address::from([0x01u8; 20]);
+        db.insert_account_info(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u128),
+                nonce: 0,
+                code_hash: revm::primitives::KECCAK_EMPTY,
+                account_id: None,
+                code: None,
+            },
+        );
+        (db, sender)
+    }
+
+    // EIP-155: if the tx declares a chain_id, executor MUST reject when it
+    // doesn't match the configured chain_id (replay-attack guard).
+    #[test]
+    fn test_chain_id_mismatch_rejected() {
+        let (db, sender) = funded_sender_db();
+        let receiver = Address::from([0x02u8; 20]);
+
+        let tx = TxEnv::builder()
+            .caller(sender)
+            .kind(TxKind::Call(receiver))
+            .value(U256::from(100_000u64))
+            .gas_limit(21_000)
+            .gas_price((INITIAL_BASE_FEE + 1_000) as u128)
+            .nonce(0)
+            .chain_id(Some(9999)) // tx signed for different chain
+            .build()
+            .unwrap_or_default();
+
+        let result = execute_tx(db, tx, INITIAL_BASE_FEE, 7119);
+        assert!(result.is_err(), "mismatch should be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("chain_id mismatch"),
+            "expected chain_id mismatch error, got: {}",
+            err
+        );
+    }
+
+    // Pre-EIP-155 legacy transactions carry no chain_id; the executor should
+    // still accept them (revm itself enforces downstream rules).
+    #[test]
+    fn test_chain_id_none_allowed() {
+        let (db, sender) = funded_sender_db();
+        let receiver = Address::from([0x02u8; 20]);
+
+        let tx = TxEnv::builder()
+            .caller(sender)
+            .kind(TxKind::Call(receiver))
+            .value(U256::from(100_000u64))
+            .gas_limit(21_000)
+            .gas_price((INITIAL_BASE_FEE + 1_000) as u128)
+            .nonce(0)
+            .chain_id(None) // legacy pre-EIP-155 tx
+            .build()
+            .unwrap_or_default();
+
+        let result = execute_tx(db, tx, INITIAL_BASE_FEE, 7119);
+        // Must not trip the chain_id check. If revm itself fails for another
+        // reason that's fine — we only care that the mismatch path isn't taken.
+        if let Err(e) = &result {
+            assert!(
+                !e.contains("chain_id mismatch"),
+                "None chain_id must not be rejected as mismatch: {}",
+                e
+            );
+        }
     }
 }

--- a/crates/sentrix-rpc/src/explorer.rs
+++ b/crates/sentrix-rpc/src/explorer.rs
@@ -1029,7 +1029,6 @@ pub async fn explorer_tokens(State(state): State<SharedState>) -> Html<String> {
 
 // ── Rich List ─────────────────────────────────────────────
 pub async fn explorer_richlist(State(state): State<SharedState>) -> Html<String> {
-    const TOTAL_SUPPLY: f64 = 210_000_000.0; // SRX
     const RICHLIST_TTL: Duration = Duration::from_secs(30);
     let cache = RICHLIST_CACHE.get_or_init(|| TokioMutex::new(None));
     {
@@ -1056,7 +1055,7 @@ pub async fn explorer_richlist(State(state): State<SharedState>) -> Html<String>
     let mut rows = String::new();
     for (rank, (address, balance_sentri)) in holders.iter().enumerate() {
         let balance_srx = *balance_sentri as f64 / 100_000_000.0;
-        let pct = balance_srx / TOTAL_SUPPLY * 100.0;
+        let pct = balance_srx / sentrix_core::blockchain::max_supply_srx() * 100.0;
         rows.push_str(&format!(
             r#"<tr>
             <td style="color:#6b7280">#{}</td>

--- a/crates/sentrix-rpc/src/jsonrpc.rs
+++ b/crates/sentrix-rpc/src/jsonrpc.rs
@@ -353,6 +353,9 @@ pub async fn jsonrpc_handler(
             let bc = state.read().await;
             use sentrix_evm::database::parse_sentrix_address;
 
+            // Snapshot chain_id before bc is dropped — execute_call below needs it.
+            let chain_id = bc.chain_id;
+
             let from_addr =
                 parse_sentrix_address(from_str).unwrap_or(alloy_primitives::Address::ZERO);
             let to_addr = parse_sentrix_address(to_str);
@@ -369,7 +372,7 @@ pub async fn jsonrpc_handler(
                 .gas_limit(gas_limit)
                 .gas_price(0)
                 .nonce(bc.accounts.get_nonce(from_str))
-                .chain_id(Some(bc.chain_id))
+                .chain_id(Some(chain_id))
                 .build()
                 .unwrap_or_default();
 
@@ -416,7 +419,7 @@ pub async fn jsonrpc_handler(
             }
             drop(bc);
 
-            match sentrix_evm::executor::execute_call(in_mem_db, tx, base_fee) {
+            match sentrix_evm::executor::execute_call(in_mem_db, tx, base_fee, chain_id) {
                 Ok(receipt) => {
                     let output_hex = format!("0x{}", hex::encode(&receipt.output));
                     Ok(json!(output_hex))

--- a/crates/sentrix-rpc/src/routes.rs
+++ b/crates/sentrix-rpc/src/routes.rs
@@ -927,7 +927,6 @@ async fn get_token_trades_list(
 }
 
 async fn get_richlist(State(state): State<SharedState>) -> Json<serde_json::Value> {
-    const TOTAL_SUPPLY_SENTRI: u64 = 210_000_000 * 100_000_000;
     let bc = state.read().await;
     let mut holders: Vec<serde_json::Value> = bc
         .accounts
@@ -935,7 +934,7 @@ async fn get_richlist(State(state): State<SharedState>) -> Json<serde_json::Valu
         .iter()
         .filter(|(_, a)| a.balance > 0)
         .map(|(addr, a)| {
-            let pct = a.balance as f64 / TOTAL_SUPPLY_SENTRI as f64 * 100.0;
+            let pct = a.balance as f64 / sentrix_core::blockchain::MAX_SUPPLY as f64 * 100.0;
             serde_json::json!({
                 "address": addr,
                 "balance_sentri": a.balance,


### PR DESCRIPTION
## Summary
Consolidate CHAIN_ID usage across sentrix-evm, sentrix-core, and sentrix-rpc. Eliminates silent fallback bug and adds EIP-155 replay protection.

## Changes
- `sentrix-evm`: `execute_tx` / `execute_call` / `execute_tx_inner` now accept `chain_id: u64` param
- Remove `.unwrap_or(7119)` silent fallback
- Add EIP-155 validation: reject tx where `tx.chain_id != configured chain_id`
- `sentrix-core/block_executor.rs` + `sentrix-rpc/jsonrpc.rs`: pass `chain_id` to EVM calls
- `sentrix-rpc/explorer.rs` + `sentrix-rpc/routes.rs`: dedupe `TOTAL_SUPPLY` / `TOTAL_SUPPLY_SENTRI` constants, use canonical `MAX_SUPPLY` from blockchain module
- Add `max_supply_srx()` helper for f64 display conversions

## Tests
- 557/557 passing (+2 EIP-155 regression tests: `test_chain_id_mismatch_rejected`, `test_chain_id_none_allowed`)
- Clippy clean with `-D warnings`
- Zero hardcoded `7119` in production paths

## Audit Items Closed
- H-04: chain_id hardcoded fallback — CLOSED
- H-01: chain_id validation — HARDENED (now enforced at network handshake + RPC eth_sendRawTransaction + EVM executor)

## Commits
- `3cdacae refactor(evm): remove hardcoded CHAIN_ID fallback, require chain_id param`
- `5a77dbe refactor(rpc): dedupe MAX_SUPPLY constants, import from blockchain module`

## Test plan
- [x] `cargo test --workspace` — 557/557 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace --release` — clean
- [x] Pre-commit hook — passed both commits
- [ ] CI green
- [ ] Post-merge: auto-deploy to VPS1/2/3 + testnet validators