### PR TITLE
fix(bft): close C-01 BFT signature verification + H-01 chain_id (4 commits)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -807,6 +807,20 @@ fn cmd_validator_rename(address: &str, new_name: &str, admin_key: &str) -> anyho
     Ok(())
 }
 
+/// C-01 gap 2: does `addr` belong to the active validator set?
+///
+/// A valid signature proves the sender *owns* the key, but a non-validator
+/// could still spam syntactically-correct signed BFT messages and pollute
+/// the channel. This check enforces that signers are registered validators,
+/// consulting both the DPoS active set (post-Voyager) and the PoA
+/// authority roster (Pioneer) so PoA and DPoS chains are both covered.
+fn is_active_validator(bc: &Blockchain, addr: &str) -> bool {
+    if bc.stake_registry.is_active(addr) {
+        return true;
+    }
+    bc.authority.is_active_validator(addr)
+}
+
 async fn cmd_start(
     validator_key: Option<String>,
     port: u16,
@@ -1276,6 +1290,17 @@ async fn cmd_start(
                                     );
                                     continue;
                                 }
+                                // C-01 gap 2: reject proposals from non-validators.
+                                {
+                                    let bc = shared_clone.read().await;
+                                    if !is_active_validator(&bc, &proposal.proposer) {
+                                        tracing::warn!(
+                                            "BFT proposal from non-validator {}",
+                                            &proposal.proposer
+                                        );
+                                        continue;
+                                    }
+                                }
                                 if let Ok(block) =
                                     bincode::deserialize::<Block>(&proposal.block_data)
                                 {
@@ -1302,6 +1327,15 @@ async fn cmd_start(
                                     continue;
                                 }
                                 let bc = shared_clone.read().await;
+                                // C-01 gap 2: reject prevotes from non-validators.
+                                if !is_active_validator(&bc, &prevote.validator) {
+                                    drop(bc);
+                                    tracing::warn!(
+                                        "BFT prevote from non-validator {}",
+                                        &prevote.validator
+                                    );
+                                    continue;
+                                }
                                 let stake = bc
                                     .stake_registry
                                     .get_validator(&prevote.validator)
@@ -1319,6 +1353,15 @@ async fn cmd_start(
                                     continue;
                                 }
                                 let bc = shared_clone.read().await;
+                                // C-01 gap 2: reject precommits from non-validators.
+                                if !is_active_validator(&bc, &precommit.validator) {
+                                    drop(bc);
+                                    tracing::warn!(
+                                        "BFT precommit from non-validator {}",
+                                        &precommit.validator
+                                    );
+                                    continue;
+                                }
                                 let stake = bc
                                     .stake_registry
                                     .get_validator(&precommit.validator)
@@ -1327,7 +1370,29 @@ async fn cmd_start(
                                 drop(bc);
                                 bft.on_precommit_weighted(&precommit, stake)
                             }
-                            BftMessage::RoundStatus(status) => bft.on_round_status(&status),
+                            BftMessage::RoundStatus(status) => {
+                                // C-01 gap 1+2: verify signature AND reject statuses
+                                // from non-validators. Unsigned / forged statuses
+                                // would otherwise advance rounds without votes.
+                                if !status.verify_sig() {
+                                    tracing::warn!(
+                                        "Invalid RoundStatus signature from {}",
+                                        &status.validator
+                                    );
+                                    continue;
+                                }
+                                {
+                                    let bc = shared_clone.read().await;
+                                    if !is_active_validator(&bc, &status.validator) {
+                                        tracing::warn!(
+                                            "BFT RoundStatus from non-validator {}",
+                                            &status.validator
+                                        );
+                                        continue;
+                                    }
+                                }
+                                bft.on_round_status(&status)
+                            }
                         };
 
                         // Cascading BFT action loop for peer messages

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1002,7 +1002,10 @@ async fn cmd_start(
                 if voyager_tick_count.is_multiple_of(20)
                     && let Some(ref bft) = bft_engine
                 {
-                    let status = bft.build_round_status();
+                    // C-01: sign RoundStatus before broadcast. Unsigned statuses
+                    // are rejected at the network boundary.
+                    let mut status = bft.build_round_status();
+                    status.sign(&validator_secret_key);
                     lp2p_clone.broadcast_bft_round_status(&status).await;
                 }
 

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -807,20 +807,6 @@ fn cmd_validator_rename(address: &str, new_name: &str, admin_key: &str) -> anyho
     Ok(())
 }
 
-/// C-01 gap 2: does `addr` belong to the active validator set?
-///
-/// A valid signature proves the sender *owns* the key, but a non-validator
-/// could still spam syntactically-correct signed BFT messages and pollute
-/// the channel. This check enforces that signers are registered validators,
-/// consulting both the DPoS active set (post-Voyager) and the PoA
-/// authority roster (Pioneer) so PoA and DPoS chains are both covered.
-fn is_active_validator(bc: &Blockchain, addr: &str) -> bool {
-    if bc.stake_registry.is_active(addr) {
-        return true;
-    }
-    bc.authority.is_active_validator(addr)
-}
-
 async fn cmd_start(
     validator_key: Option<String>,
     port: u16,
@@ -1283,24 +1269,11 @@ async fn cmd_start(
                                 if proposal.round != bft.round() {
                                     continue;
                                 }
-                                if !proposal.verify_sig() {
-                                    tracing::warn!(
-                                        "Invalid proposal signature from {}",
-                                        &proposal.proposer
-                                    );
-                                    continue;
-                                }
-                                // C-01 gap 2: reject proposals from non-validators.
-                                {
-                                    let bc = shared_clone.read().await;
-                                    if !is_active_validator(&bc, &proposal.proposer) {
-                                        tracing::warn!(
-                                            "BFT proposal from non-validator {}",
-                                            &proposal.proposer
-                                        );
-                                        continue;
-                                    }
-                                }
+                                // Signature + validator-set membership are
+                                // now enforced at the libp2p network boundary
+                                // (see `is_active_bft_signer` in libp2p_node.rs);
+                                // by construction every proposal reaching this
+                                // point has already passed both checks.
                                 if let Ok(block) =
                                     bincode::deserialize::<Block>(&proposal.block_data)
                                 {
@@ -1318,24 +1291,11 @@ async fn cmd_start(
                                     continue;
                                 }
                             }
+                            // Messages reaching this point have already been
+                                // signature-verified AND membership-checked at the
+                                // libp2p network boundary (C-01 gaps 1/2/3).
                             BftMessage::Prevote(prevote) => {
-                                if !prevote.verify_sig() {
-                                    tracing::warn!(
-                                        "Invalid prevote signature from {}",
-                                        &prevote.validator
-                                    );
-                                    continue;
-                                }
                                 let bc = shared_clone.read().await;
-                                // C-01 gap 2: reject prevotes from non-validators.
-                                if !is_active_validator(&bc, &prevote.validator) {
-                                    drop(bc);
-                                    tracing::warn!(
-                                        "BFT prevote from non-validator {}",
-                                        &prevote.validator
-                                    );
-                                    continue;
-                                }
                                 let stake = bc
                                     .stake_registry
                                     .get_validator(&prevote.validator)
@@ -1345,23 +1305,7 @@ async fn cmd_start(
                                 bft.on_prevote_weighted(&prevote, stake)
                             }
                             BftMessage::Precommit(precommit) => {
-                                if !precommit.verify_sig() {
-                                    tracing::warn!(
-                                        "Invalid precommit signature from {}",
-                                        &precommit.validator
-                                    );
-                                    continue;
-                                }
                                 let bc = shared_clone.read().await;
-                                // C-01 gap 2: reject precommits from non-validators.
-                                if !is_active_validator(&bc, &precommit.validator) {
-                                    drop(bc);
-                                    tracing::warn!(
-                                        "BFT precommit from non-validator {}",
-                                        &precommit.validator
-                                    );
-                                    continue;
-                                }
                                 let stake = bc
                                     .stake_registry
                                     .get_validator(&precommit.validator)
@@ -1370,29 +1314,7 @@ async fn cmd_start(
                                 drop(bc);
                                 bft.on_precommit_weighted(&precommit, stake)
                             }
-                            BftMessage::RoundStatus(status) => {
-                                // C-01 gap 1+2: verify signature AND reject statuses
-                                // from non-validators. Unsigned / forged statuses
-                                // would otherwise advance rounds without votes.
-                                if !status.verify_sig() {
-                                    tracing::warn!(
-                                        "Invalid RoundStatus signature from {}",
-                                        &status.validator
-                                    );
-                                    continue;
-                                }
-                                {
-                                    let bc = shared_clone.read().await;
-                                    if !is_active_validator(&bc, &status.validator) {
-                                        tracing::warn!(
-                                            "BFT RoundStatus from non-validator {}",
-                                            &status.validator
-                                        );
-                                        continue;
-                                    }
-                                }
-                                bft.on_round_status(&status)
-                            }
+                            BftMessage::RoundStatus(status) => bft.on_round_status(&status),
                         };
 
                         // Cascading BFT action loop for peer messages

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -530,12 +530,15 @@ impl BftEngine {
         BftAction::Wait
     }
 
-    /// Build a RoundStatus message for gossiping to peers
+    /// Build an UNSIGNED RoundStatus for gossiping. Callers must invoke
+    /// [`RoundStatus::sign`] before broadcasting — unsigned statuses are
+    /// rejected at the network boundary (see C-01 fix).
     pub fn build_round_status(&self) -> RoundStatus {
         RoundStatus {
             height: self.state.height,
             round: self.state.round,
             validator: self.our_address.clone(),
+            signature: Vec::new(),
         }
     }
 
@@ -865,6 +868,7 @@ mod tests {
             height: 100,
             round: 5,
             validator: "0xval001".into(),
+            signature: Vec::new(),
         };
         let action = engine.on_round_status(&status);
         assert!(matches!(action, BftAction::Wait));
@@ -881,6 +885,7 @@ mod tests {
             height: 100,
             round: 1, // only 1 ahead
             validator: "0xval001".into(),
+            signature: Vec::new(),
         };
         let action = engine.on_round_status(&status);
         assert!(matches!(action, BftAction::Wait));
@@ -896,6 +901,7 @@ mod tests {
             height: 200,
             round: 0,
             validator: "0xval001".into(),
+            signature: Vec::new(),
         };
         let action = engine.on_round_status(&status);
         match action {
@@ -914,6 +920,7 @@ mod tests {
             height: 50,
             round: 10,
             validator: "0xval001".into(),
+            signature: Vec::new(),
         };
         let action = engine.on_round_status(&status);
         assert!(matches!(action, BftAction::Wait));
@@ -929,6 +936,7 @@ mod tests {
             height: 100,
             round: 3,
             validator: "0xval001".into(),
+            signature: Vec::new(),
         };
         let action = engine.on_round_status(&status);
         assert!(matches!(action, BftAction::Wait));
@@ -944,6 +952,7 @@ mod tests {
             height: 100,
             round: 2,
             validator: "0xval001".into(),
+            signature: Vec::new(),
         };
         let action = engine.on_round_status(&status);
         assert!(matches!(action, BftAction::Wait));
@@ -971,6 +980,7 @@ mod tests {
             height: 100,
             round: 3,
             validator: "0xval001".into(),
+            signature: Vec::new(),
         };
         engine.on_round_status(&status);
         assert_eq!(engine.round(), 2); // caught up to peer - 1
@@ -980,6 +990,7 @@ mod tests {
             height: 100,
             round: 3,
             validator: "0xval002".into(),
+            signature: Vec::new(),
         };
         engine.on_round_status(&status2);
         assert_eq!(engine.round(), 2); // stays at 2

--- a/crates/sentrix-bft/src/messages.rs
+++ b/crates/sentrix-bft/src/messages.rs
@@ -105,11 +105,54 @@ pub use sentrix_primitives::justification::{
 
 /// Periodically gossiped by validators so that peers returning from partition
 /// can learn the current (height, round) without waiting for a vote.
+///
+/// Signed with the validator's secp256k1 key to close audit finding C-01:
+/// an unsigned RoundStatus lets an attacker advance `self.state.round` or
+/// trigger `SyncNeeded` with arbitrary heights, enabling round-manipulation
+/// and block-sync-hijack attacks. `signature` is `#[serde(default)]` so
+/// legacy encodings deserialize (as empty), but `verify_sig` rejects an
+/// empty signature.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoundStatus {
     pub height: u64,
     pub round: u32,
     pub validator: String,
+    #[serde(default)]
+    pub signature: Vec<u8>,
+}
+
+impl RoundStatus {
+    /// Canonical signing payload — domain-separated to prevent cross-type
+    /// signature reuse (proposal=0x01, prevote=0x02, precommit=0x03, this=0x04).
+    pub fn signing_payload(height: u64, round: u32, validator: &str) -> Vec<u8> {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&height.to_le_bytes());
+        payload.extend_from_slice(&round.to_le_bytes());
+        payload.extend_from_slice(validator.as_bytes());
+        payload.push(0x04); // domain separator: round_status
+        payload
+    }
+
+    /// Sign this status in place with the given secret key.
+    pub fn sign(&mut self, secret_key: &SecretKey) {
+        let payload = Self::signing_payload(self.height, self.round, &self.validator);
+        self.signature = sign_payload(&payload, secret_key);
+    }
+
+    /// Verify the signature matches the claimed validator. An empty signature
+    /// always fails — this is the C-01 barrier that stops legacy/forged
+    /// RoundStatus messages from manipulating consensus state.
+    pub fn verify_sig(&self) -> bool {
+        if self.signature.is_empty() {
+            tracing::warn!(
+                "BFT: unsigned RoundStatus from {} — rejected (C-01)",
+                &self.validator[..12.min(self.validator.len())]
+            );
+            return false;
+        }
+        let payload = Self::signing_payload(self.height, self.round, &self.validator);
+        verify_vote_signature(&payload, &self.signature, &self.validator)
+    }
 }
 
 // ── BFT Network Message Wrapper ─────────────────────────────
@@ -507,5 +550,105 @@ mod tests {
         let sig = sign_payload(payload, &sk);
         let recovered = recover_signer(payload, &sig).unwrap();
         assert_eq!(recovered, wallet.address);
+    }
+
+    // ── RoundStatus signature tests (C-01) ──────────────────
+
+    #[test]
+    fn test_round_status_sign_verify_positive() {
+        let wallet = make_wallet();
+        let sk = wallet.get_secret_key().unwrap();
+        let mut status = RoundStatus {
+            height: 42,
+            round: 3,
+            validator: wallet.address.clone(),
+            signature: Vec::new(),
+        };
+        status.sign(&sk);
+        assert!(status.verify_sig());
+    }
+
+    #[test]
+    fn test_round_status_unsigned_rejected() {
+        // C-01 barrier: empty signature must fail — this is what stops
+        // pre-upgrade nodes from injecting unsigned round manipulations.
+        let status = RoundStatus {
+            height: 42,
+            round: 3,
+            validator: "0xsome_address".into(),
+            signature: Vec::new(),
+        };
+        assert!(!status.verify_sig());
+    }
+
+    #[test]
+    fn test_round_status_tampered_height_rejected() {
+        let wallet = make_wallet();
+        let sk = wallet.get_secret_key().unwrap();
+        let mut status = RoundStatus {
+            height: 42,
+            round: 3,
+            validator: wallet.address.clone(),
+            signature: Vec::new(),
+        };
+        status.sign(&sk);
+        status.height = 999_999; // attacker rewrites height after signing
+        assert!(!status.verify_sig());
+    }
+
+    #[test]
+    fn test_round_status_tampered_round_rejected() {
+        let wallet = make_wallet();
+        let sk = wallet.get_secret_key().unwrap();
+        let mut status = RoundStatus {
+            height: 42,
+            round: 3,
+            validator: wallet.address.clone(),
+            signature: Vec::new(),
+        };
+        status.sign(&sk);
+        status.round = 50; // attacker rewrites round to force catch-up
+        assert!(!status.verify_sig());
+    }
+
+    #[test]
+    fn test_round_status_wrong_validator_rejected() {
+        let wallet = make_wallet();
+        let sk = wallet.get_secret_key().unwrap();
+        let mut status = RoundStatus {
+            height: 42,
+            round: 3,
+            validator: wallet.address.clone(),
+            signature: Vec::new(),
+        };
+        status.sign(&sk);
+        status.validator = "0xwrongaddress0000000000000000000000000000".into();
+        assert!(!status.verify_sig());
+    }
+
+    #[test]
+    fn test_round_status_domain_separation_prevents_reuse() {
+        // Ensure a signature over a Prevote-shaped payload does NOT verify
+        // as a RoundStatus signature (cross-type reuse attack).
+        let wallet = make_wallet();
+        let sk = wallet.get_secret_key().unwrap();
+        // Sign a prevote-domain payload
+        let mut pv = Prevote {
+            height: 42,
+            round: 3,
+            block_hash: Some(wallet.address.clone()), // shape of validator field
+            validator: wallet.address.clone(),
+            signature: vec![],
+        };
+        pv.sign(&sk);
+        // Plug the prevote signature into a RoundStatus with matching fields
+        let status = RoundStatus {
+            height: 42,
+            round: 3,
+            validator: wallet.address.clone(),
+            signature: pv.signature,
+        };
+        // Domain separator byte (0x02 vs 0x04) makes these incompatible.
+        assert!(!status.verify_sig());
     }
 }

--- a/crates/sentrix-core/src/authority.rs
+++ b/crates/sentrix-core/src/authority.rs
@@ -107,6 +107,18 @@ impl AuthorityManager {
         Ok(expected.address == address)
     }
 
+    /// Is this address in the registered-and-active validator set?
+    ///
+    /// Unlike `is_authorized`, this is not round-specific — it answers
+    /// "is the caller a known validator at all?". Used at the BFT network
+    /// boundary to reject consensus messages from non-validator peers
+    /// (C-01 gap 2). Admin-toggled-off validators return `false`.
+    pub fn is_active_validator(&self, address: &str) -> bool {
+        self.validators
+            .get(address)
+            .is_some_and(|v| v.is_active)
+    }
+
     // Admin operations
     pub fn add_validator(
         &mut self,
@@ -494,6 +506,33 @@ mod tests {
         let expected = mgr.expected_validator(0).unwrap().address.clone();
         assert!(mgr.is_authorized(&expected, 0).unwrap());
         assert!(!mgr.is_authorized("wrong_address", 0).unwrap());
+    }
+
+    // C-01 gap 2: is_active_validator must recognise registered+active
+    // addresses, reject unknown ones, and reject toggled-off ones.
+    #[test]
+    fn test_is_active_validator_membership() {
+        let mut mgr = setup_4();
+        let active_addrs: Vec<String> = mgr
+            .active_validators()
+            .iter()
+            .map(|v| v.address.clone())
+            .collect();
+        assert!(!active_addrs.is_empty());
+        for addr in &active_addrs {
+            assert!(mgr.is_active_validator(addr), "{} should be active", addr);
+        }
+        assert!(
+            !mgr.is_active_validator("0xunknown"),
+            "unknown address must be rejected"
+        );
+        // Toggle one off — it must stop returning true.
+        let off = active_addrs[0].clone();
+        mgr.toggle_validator("admin", &off).unwrap();
+        assert!(
+            !mgr.is_active_validator(&off),
+            "toggled-off validator must be rejected"
+        );
     }
 
     #[test]

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -815,13 +815,27 @@ async fn on_inbound_request(
         }
 
         // ── NewBlock — apply to chain (spawned to avoid blocking swarm) ──
+        // H-01: fast-reject cross-chain blocks at the network boundary.
+        // The transaction-level `tx.validate(.., chain_id)` inside add_block
+        // still catches this downstream, but rejecting up front avoids
+        // acquiring the chain write lock and spawning a doomed task.
         SentrixRequest::NewBlock { block } => {
-            // ACK immediately so peer doesn't timeout waiting for response
             let _ = swarm
                 .behaviour_mut()
                 .rr
                 .send_response(channel, SentrixResponse::Ack);
-            // Process block in background — never hold write lock in swarm loop
+            if let Some(tx) = block.transactions.iter().find(|t| !t.is_coinbase())
+                && tx.chain_id != our_chain_id
+            {
+                tracing::warn!(
+                    "libp2p: dropping block {} from {}: chain_id mismatch ({} vs {})",
+                    block.index,
+                    peer,
+                    tx.chain_id,
+                    our_chain_id
+                );
+                return;
+            }
             let bc = blockchain.clone();
             let etx = event_tx.clone();
             tokio::spawn(async move {
@@ -843,11 +857,21 @@ async fn on_inbound_request(
         }
 
         // ── NewTransaction — add to mempool (spawned) ────
+        // H-01: reject cross-chain transactions at the network boundary.
         SentrixRequest::NewTransaction { transaction } => {
             let _ = swarm
                 .behaviour_mut()
                 .rr
                 .send_response(channel, SentrixResponse::Ack);
+            if transaction.chain_id != our_chain_id {
+                tracing::warn!(
+                    "libp2p: dropping tx from {}: chain_id mismatch ({} vs {})",
+                    peer,
+                    transaction.chain_id,
+                    our_chain_id
+                );
+                return;
+            }
             let bc = blockchain.clone();
             let etx = event_tx.clone();
             tokio::spawn(async move {

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -892,11 +892,29 @@ async fn on_inbound_request(
         }
 
         // ── BFT Proposal ────────────────────────────────
+        // C-01 gap 3: verify signature AND validator-set membership at
+        // the network boundary. Forged or non-validator messages are
+        // ACKed (so the peer's libp2p state transitions cleanly) and
+        // silently dropped — they never reach the BFT event channel.
         SentrixRequest::BftProposal { proposal } => {
             let _ = swarm
                 .behaviour_mut()
                 .rr
                 .send_response(channel, SentrixResponse::Ack);
+            if !proposal.verify_sig() {
+                tracing::warn!(
+                    "libp2p: dropping BFT proposal from {}: bad signature",
+                    &proposal.proposer
+                );
+                return;
+            }
+            if !is_active_bft_signer(blockchain, &proposal.proposer).await {
+                tracing::warn!(
+                    "libp2p: dropping BFT proposal from non-validator {}",
+                    &proposal.proposer
+                );
+                return;
+            }
             let _ = event_tx.send(NodeEvent::BftProposal(*proposal)).await;
         }
 
@@ -906,6 +924,20 @@ async fn on_inbound_request(
                 .behaviour_mut()
                 .rr
                 .send_response(channel, SentrixResponse::Ack);
+            if !prevote.verify_sig() {
+                tracing::warn!(
+                    "libp2p: dropping BFT prevote from {}: bad signature",
+                    &prevote.validator
+                );
+                return;
+            }
+            if !is_active_bft_signer(blockchain, &prevote.validator).await {
+                tracing::warn!(
+                    "libp2p: dropping BFT prevote from non-validator {}",
+                    &prevote.validator
+                );
+                return;
+            }
             let _ = event_tx.send(NodeEvent::BftPrevote(prevote)).await;
         }
 
@@ -915,6 +947,20 @@ async fn on_inbound_request(
                 .behaviour_mut()
                 .rr
                 .send_response(channel, SentrixResponse::Ack);
+            if !precommit.verify_sig() {
+                tracing::warn!(
+                    "libp2p: dropping BFT precommit from {}: bad signature",
+                    &precommit.validator
+                );
+                return;
+            }
+            if !is_active_bft_signer(blockchain, &precommit.validator).await {
+                tracing::warn!(
+                    "libp2p: dropping BFT precommit from non-validator {}",
+                    &precommit.validator
+                );
+                return;
+            }
             let _ = event_tx.send(NodeEvent::BftPrecommit(precommit)).await;
         }
 
@@ -924,9 +970,36 @@ async fn on_inbound_request(
                 .behaviour_mut()
                 .rr
                 .send_response(channel, SentrixResponse::Ack);
+            if !status.verify_sig() {
+                tracing::warn!(
+                    "libp2p: dropping BFT round-status from {}: bad signature",
+                    &status.validator
+                );
+                return;
+            }
+            if !is_active_bft_signer(blockchain, &status.validator).await {
+                tracing::warn!(
+                    "libp2p: dropping BFT round-status from non-validator {}",
+                    &status.validator
+                );
+                return;
+            }
             let _ = event_tx.send(NodeEvent::BftRoundStatus(status)).await;
         }
     }
+}
+
+/// Check if `addr` is a current BFT-authorised validator. Consults the
+/// DPoS stake registry first (post-Voyager), then falls back to the PoA
+/// authority roster (Pioneer). Matches the helper in `bin/sentrix/main.rs`
+/// — the two live on opposite sides of the channel and both sides harden
+/// for defence in depth.
+async fn is_active_bft_signer(blockchain: &SharedBlockchain, addr: &str) -> bool {
+    let bc = blockchain.read().await;
+    if bc.stake_registry.is_active(addr) {
+        return true;
+    }
+    bc.authority.is_active_validator(addr)
 }
 
 // ── Inbound response handler ─────────────────────────────


### PR DESCRIPTION
## Summary
Closes audit finding **C-01** (BFT signature verification, 3 gaps) and **H-01** (chain_id validation on NewBlock/NewTransaction). Four atomic commits, signature + membership verification now authoritative at the libp2p network boundary.

## Gap 1 — RoundStatus signature (`203a9f5`)
RoundStatus was the one BFT message type without a signature. `on_round_status` trusted peer-declared `height` / `round`, enabling `SyncNeeded` hijack and vote-wipe round catch-up. Added secp256k1 signature with domain separator `0x04` (distinct from 0x01/0x02/0x03 for proposal/prevote/precommit). Signature `#[serde(default)]` for wire-compat; `verify_sig` rejects empty explicitly.

## Gap 2 — Validator-set membership (`e5d51f9`)
`verify_sig` only proves the signer owns the key, not that they are a *validator*. Added `AuthorityManager::is_active_validator(addr)` — HashMap lookup filtered on `is_active`. Applied at all 4 BFT event-loop arms in `main.rs`.

## Gap 3 — Network-boundary verification (`f0af2f4`)
Previously sig + membership ran inside the event loop, **after** the message was ACKed and pushed onto the 256-slot `NodeEvent` channel (C-07 DoS amplifier). Moved both gates into `on_inbound_request` in `libp2p_node.rs`. Event loop now trusts the gate; duplicate checks removed.

## Bonus H-01 — cross-chain fast-reject (`ceb3c97`)
`tx.validate` already catches cross-chain txs deep in `add_block` / `add_to_mempool`. Added network-boundary fast-reject for `NewBlock` (checks first non-coinbase tx.chain_id) and `NewTransaction` (checks tx.chain_id) so a forged message never acquires the chain write lock.

## Tests
- **575/575 passing** (+7 new: 6 RoundStatus sig + 1 membership)
- Clippy `-D warnings` clean
- Release build clean

## Commits
```
ceb3c97 fix(network): fast-reject cross-chain NewBlock/NewTx (H-01)
f0af2f4 fix(bft): move BFT verification to network boundary (C-01 gap 3)
e5d51f9 fix(bft): enforce validator-set membership (C-01 gap 2)
203a9f5 fix(bft): sign + verify RoundStatus messages (C-01 gap 1)
```

## Wire compatibility
RoundStatus serde_default on signature means old encodings still deserialize. A v1 peer sending unsigned RoundStatus to an upgraded peer: signature empty → verify_sig false → message dropped. BFT liveness unaffected because RoundStatus is advisory (peers still advance rounds via timeout). During rolling restart the cluster has mixed versions for ~minutes; BFT consensus uses Proposal / Prevote / Precommit (already signed in both versions), so consensus itself is not stalled.

## Deploy plan
Testnet (VPS3) first, observe for 1 hour that chain advances, then mainnet 3-validator rolling restart.

## Test plan
- [x] `cargo test --workspace` — 575/575
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace --release`
- [x] Pre-commit hook passes each commit
- [ ] CI green
- [ ] Testnet deploy + 1h observation: testnet BFT still advancing
- [ ] Mainnet deploy: 3 validators rolling restart, cluster health pass