### PR TITLE
chore(deps): document yamux 0.12 non-reachability + dismiss CVE-2026-32314

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -6,9 +6,22 @@
 # vulnerability/unmaintained/yanked keys were removed in v0.16 (PR #611).
 # All advisories are denied by default; use ignore[] for known exceptions.
 [advisories]
-# RUSTSEC-2020-0105 (net2) — cargo-deny v0.19.x has a parse bug on this advisory file.
-# The crate is not in our dependency tree; safe to ignore for CI.
-ignore = ["RUSTSEC-2020-0105"]
+ignore = [
+    # RUSTSEC-2020-0105 (net2) — cargo-deny v0.19.x has a parse bug on this
+    # advisory file. The crate is not in our dependency tree; safe to ignore.
+    "RUSTSEC-2020-0105",
+
+    # GHSA-vxx9-2994-q338 / CVE-2026-32314 — yamux 0.12.1 remote-panic via
+    # malformed Data frame (SYN, len=262145). Fix is in yamux 0.13.10,
+    # which IS in our tree — `libp2p-yamux 0.47` pulls both 0.12.1 and
+    # 0.13.10 unconditionally and the default `yamux::Config::default()`
+    # constructs the `Config013` variant at connection setup, so the
+    # vulnerable 0.12 decoder is never wired to a live socket at runtime.
+    # Remove this ignore once libp2p-yamux 0.48+ drops v0.12 compat and
+    # the 0.12.1 package disappears from Cargo.lock.
+    # Dependabot alert: https://github.com/satyakwok/sentrix/security/dependabot/3
+    "GHSA-vxx9-2994-q338",
+]
 
 # ── Licenses ────────────────────────────────────────────────
 [licenses]


### PR DESCRIPTION
## Summary
Closes Dependabot alert #3 (yamux GHSA-vxx9-2994-q338 / CVE-2026-32314) via dismissal, because the vulnerability is not reachable at runtime and the upstream fix path is blocked.

## Why a bump doesn't work
- `libp2p 0.56` and `libp2p-yamux 0.47` are both **latest** on crates.io.
- `libp2p-yamux 0.47` unconditionally depends on **BOTH** `yamux 0.12.1` AND `yamux 0.13.10`. No feature flag to disable the older copy — verified by reading `libp2p-yamux-0.47.0/Cargo.toml`.
- `cargo update -p yamux@0.12.1` returns "0 packages to update" because 0.12.1 is the latest 0.12.x.

## Why the CVE is not exploitable in our binary
- `yamux::Config::default()` at `libp2p-yamux-0.47.0/src/lib.rs:232` returns `Self(Either::Right(Config013::default()))` — the 0.13.10 decoder.
- Our code uses `Config::default()` exclusively:
  - `crates/sentrix-network/src/libp2p_node.rs:317`
  - `crates/sentrix-network/src/transport.rs:33`
- The exploit path (malformed Data|SYN frame with `len > DEFAULT_CREDIT`) requires a 0.12 decoder. Our connections bind 0.13.10 at setup. The 0.12 code sits in the binary as dead code.

## Actions
- **Dependabot alert #3 dismissed** (reason: `tolerable_risk`) with the reachability analysis in the dismissal comment.
- **`deny.toml`** advisories ignore extended with `GHSA-vxx9-2994-q338` + an inline comment documenting the analysis and the revert condition.

## Revert condition
Remove the GHSA ignore once libp2p-yamux 0.48+ is released (it will drop v0.12 compat) and `yamux 0.12.1` leaves `Cargo.lock`.

## Tests
- 575/575 passing
- Clippy `-D warnings` clean
- `cargo deny check licenses bans sources` passes
- `cargo deny check advisories` still panics on the pre-existing RUSTSEC-2020-0105 parse bug; advisories check remains disabled in CI per the ci.yml comment.

## Commit
- `4a815fc chore(deps): document yamux 0.12 non-reachability, ignore unreachable CVE`

## No deploy needed
Config-only change; no code compiled into the binary changes. CI will build + test on this PR but the post-merge deploy will produce an identical binary to the currently-running one (modulo an unrelated transitive `syn` resolver pick in Cargo.lock).