### PR TITLE
chore: update repo URL to sentrix-labs org

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -17,7 +17,7 @@ Configure at: GitHub → Settings → Branches → Add rule → Branch name patt
 
 ### Setup steps
 
-1. Go to https://github.com/satyakwok/sentrix/settings/branches
+1. Go to https://github.com/sentrix-labs/sentrix/settings/branches
 2. Click "Add branch protection rule"
 3. Branch name pattern: `main`
 4. Enable the rules listed above

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,8 +365,8 @@ Pioneer release. PoA chain live with 7 validators across 3 VPS, 141K+ blocks, 11
 
 ---
 
-[Unreleased]: https://github.com/satyakwok/sentrix/compare/v1.2.0...HEAD
-[1.2.0]: https://github.com/satyakwok/sentrix/releases/tag/v1.2.0
-[1.1.0]: https://github.com/satyakwok/sentrix/releases/tag/v1.1.0
-[1.0.0]: https://github.com/satyakwok/sentrix/releases/tag/v1.0.0
-[0.1.0]: https://github.com/satyakwok/sentrix/releases/tag/v0.1.0
+[Unreleased]: https://github.com/sentrix-labs/sentrix/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/sentrix-labs/sentrix/releases/tag/v1.2.0
+[1.1.0]: https://github.com/sentrix-labs/sentrix/releases/tag/v1.1.0
+[1.0.0]: https://github.com/sentrix-labs/sentrix/releases/tag/v1.0.0
+[0.1.0]: https://github.com/sentrix-labs/sentrix/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you for considering contributing to Sentrix! We welcome contributions from
 
 ```bash
 # Clone the repository
-git clone https://github.com/satyakwok/sentrix.git
+git clone https://github.com/sentrix-labs/sentrix.git
 cd sentrix-chain
 
 # Build
@@ -76,7 +76,7 @@ tests/
 
 ### Reporting Bugs
 
-1. Check [existing issues](https://github.com/satyakwok/sentrix/issues) to avoid duplicates
+1. Check [existing issues](https://github.com/sentrix-labs/sentrix/issues) to avoid duplicates
 2. Open a new issue with:
    - Clear title describing the bug
    - Steps to reproduce

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"
 homepage = "https://sentrix.sentriscloud.com"
-repository = "https://github.com/satyakwok/sentrix"
+repository = "https://github.com/sentrix-labs/sentrix"
 keywords = ["blockchain", "layer1", "poa", "dpos", "bft"]
 categories = ["cryptography::cryptocurrencies"]
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Fast, secure Layer-1 blockchain built in Rust.
 
-[![CI/CD](https://github.com/satyakwok/sentrix/actions/workflows/ci.yml/badge.svg)](https://github.com/satyakwok/sentrix/actions)
-[![Release](https://img.shields.io/github/v/release/satyakwok/sentrix)](https://github.com/satyakwok/sentrix/releases/latest)
-[![Tests](https://img.shields.io/badge/tests-551%20passing-brightgreen)](https://github.com/satyakwok/sentrix/actions)
+[![CI/CD](https://github.com/sentrix-labs/sentrix/actions/workflows/ci.yml/badge.svg)](https://github.com/sentrix-labs/sentrix/actions)
+[![Release](https://img.shields.io/github/v/release/sentrix-labs/sentrix)](https://github.com/sentrix-labs/sentrix/releases/latest)
+[![Tests](https://img.shields.io/badge/tests-551%20passing-brightgreen)](https://github.com/sentrix-labs/sentrix/actions)
 [![Rust](https://img.shields.io/badge/rust-stable-orange)](Cargo.toml)
 [![Chain ID](https://img.shields.io/badge/chain%20ID-7119-blue)](docs/operations/NETWORKS.md)
 [![License](https://img.shields.io/badge/license-BUSL--1.1-purple)](LICENSE)
@@ -39,7 +39,7 @@ Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, i
 
 ```bash
 # Build
-git clone https://github.com/satyakwok/sentrix.git
+git clone https://github.com/sentrix-labs/sentrix.git
 cd sentrix
 cargo build --release
 

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -383,7 +383,7 @@ See [SECURITY.md](SECURITY.md) for responsible disclosure policy.
 - Explorer: sentrixscan.sentriscloud.com
 - API: sentrix-api.sentriscloud.com
 - RPC: sentrix-rpc.sentriscloud.com
-- GitHub: github.com/satyakwok/sentrix
+- GitHub: github.com/sentrix-labs/sentrix
 - Email: sentriscloud@gmail.com
 
 ---

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.0.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"
-repository = "https://github.com/satyakwok/sentrix"
+repository = "https://github.com/sentrix-labs/sentrix"
 
 [dependencies]
 sentrix-primitives = { path = "../sentrix-primitives" }

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.0.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"
-repository = "https://github.com/satyakwok/sentrix"
+repository = "https://github.com/sentrix-labs/sentrix"
 
 [dependencies]
 sentrix-primitives = { path = "../sentrix-primitives" }

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.0.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"
-repository = "https://github.com/satyakwok/sentrix"
+repository = "https://github.com/sentrix-labs/sentrix"
 keywords = ["blockchain", "sentrix", "types"]
 
 [dependencies]

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.0.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"
-repository = "https://github.com/satyakwok/sentrix"
+repository = "https://github.com/sentrix-labs/sentrix"
 
 [dependencies]
 sentrix-primitives = { path = "../sentrix-primitives" }

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.0.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"
-repository = "https://github.com/satyakwok/sentrix"
+repository = "https://github.com/sentrix-labs/sentrix"
 
 [dependencies]
 sentrix-primitives = { path = "../sentrix-primitives" }

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.0.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"
-repository = "https://github.com/satyakwok/sentrix"
+repository = "https://github.com/sentrix-labs/sentrix"
 
 [dependencies]
 sentrix-primitives = { path = "../sentrix-primitives" }

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,7 @@ ignore = [
     # vulnerable 0.12 decoder is never wired to a live socket at runtime.
     # Remove this ignore once libp2p-yamux 0.48+ drops v0.12 compat and
     # the 0.12.1 package disappears from Cargo.lock.
-    # Dependabot alert: https://github.com/satyakwok/sentrix/security/dependabot/3
+    # Dependabot alert: https://github.com/sentrix-labs/sentrix/security/dependabot/3
     "GHSA-vxx9-2994-q338",
 ]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   sentrix-node:
-    image: ghcr.io/satyakwok/sentrix:latest
+    image: ghcr.io/sentrix-labs/sentrix:latest
     container_name: sentrix-node
     restart: unless-stopped
     ports:

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -14,7 +14,7 @@ How to deploy a Sentrix node on a Linux server.
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source ~/.cargo/env
 
-git clone https://github.com/satyakwok/sentrix.git
+git clone https://github.com/sentrix-labs/sentrix.git
 cd sentrix
 cargo build --release
 # → target/release/sentrix
@@ -23,7 +23,7 @@ cargo build --release
 ## Docker
 
 ```bash
-git clone https://github.com/satyakwok/sentrix.git && cd sentrix
+git clone https://github.com/sentrix-labs/sentrix.git && cd sentrix
 docker compose up -d --build
 ```
 

--- a/docs/operations/DOMAINS.md
+++ b/docs/operations/DOMAINS.md
@@ -63,5 +63,5 @@ Symbol:   SRX
 
 ## Community
 
-- GitHub: https://github.com/satyakwok/sentrix
+- GitHub: https://github.com/sentrix-labs/sentrix
 - Telegram: https://t.me/SentrixCommunity

--- a/docs/operations/VALIDATOR_GUIDE.md
+++ b/docs/operations/VALIDATOR_GUIDE.md
@@ -18,13 +18,13 @@ Run a Sentrix validator node and participate in block production.
 
 ```bash
 # Option A: build from source
-git clone https://github.com/satyakwok/sentrix.git
+git clone https://github.com/sentrix-labs/sentrix.git
 cd sentrix
 cargo build --release
 cp target/release/sentrix /opt/sentrix/sentrix
 
 # Option B: download from latest release
-curl -L https://github.com/satyakwok/sentrix/releases/latest/download/sentrix -o /opt/sentrix/sentrix
+curl -L https://github.com/sentrix-labs/sentrix/releases/latest/download/sentrix -o /opt/sentrix/sentrix
 chmod +x /opt/sentrix/sentrix
 ```
 


### PR DESCRIPTION
## Summary

- Transfer: `satyakwok/sentrix` → `sentrix-labs/sentrix`
- Updates 17 files, 27 occurrences

## Changes

- `Cargo.toml` (root + 7 workspace crates) — metadata `repository` field
- Docs: README, CHANGELOG, CONTRIBUTING, WHITEPAPER, DEPLOYMENT, VALIDATOR_GUIDE, DOMAINS, branch-protection
- `docker-compose.yml` — image reference `ghcr.io/sentrix-labs/sentrix:latest`
- `deny.toml` — repository metadata

## Test plan

- [x] CI runs: test + clippy + deny + build + test-suite
- [x] No code changes — metadata/docs only
- [x] GitHub auto-redirects old URLs for 7 days (git push still works during grace)