### PR TITLE
docs: relabel SNTX/SRTX as SRC-20 (EVM), not SRX-20 (native)

### DIFF
--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -246,8 +246,8 @@ Sentrix operates a three-token model:
 | Token | Type | Supply | Role |
 |---|---|---|---|
 | **SRX** | Native coin | 210,000,000 (fixed) | Gas fees, validator rewards, base currency, store of value |
-| **SNTX** | SRX-20 | 10,000,000,000 | Utility — ecosystem rewards, governance voting, staking incentives |
-| **SRTX** | SRX-20 | TBD | Payment — stablecoin for daily transactions |
+| **SNTX** | SRC-20 | 10,000,000,000 | Utility — ecosystem rewards, governance voting, staking incentives |
+| **SRTX** | SRC-20 | TBD | Payment — stablecoin for daily transactions |
 
 **Flywheel effect:** Every SNTX and SRTX transaction requires SRX for gas. As token usage grows, more SRX is burned, increasing scarcity and value of SRX. This creates a positive feedback loop where ecosystem growth directly benefits the native coin holders.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@
 
 - [SRX](tokenomics/SRX.md) — supply, halving, fees
 - [Staking](tokenomics/STAKING.md) — DPoS design (Voyager, planned)
-- [Token Standards](tokenomics/TOKEN_STANDARDS.md) — SRX-20, SNTX
+- [Token Standards](tokenomics/TOKEN_STANDARDS.md) — SRX-20 (native) + SRC-20 (EVM), SNTX + SRTX planned
 
 ## Roadmap
 

--- a/docs/tokenomics/TOKEN_STANDARDS.md
+++ b/docs/tokenomics/TOKEN_STANDARDS.md
@@ -49,7 +49,7 @@ Explorer: `/explorer/tokens` and `/explorer/token/{contract}`.
 
 ## SNTX
 
-First SRX-20 token. Sentrix Utility.
+First SRC-20 token (ERC-20 via Sentrix EVM). Sentrix Utility.
 
 | | |
 |-|-|


### PR DESCRIPTION
## Summary
Three-token economy docs incorrectly labeled SNTX and SRTX as SRX-20. These tokens need features (governance voting, staking bonus, stablecoin collateral) that the native SRX-20 engine cannot support — they will be deployed as SRC-20 (ERC-20 via Sentrix EVM / revm).

## Files
- `WHITEPAPER.md` §7.5 Three-Token Economy table
- `docs/tokenomics/TOKEN_STANDARDS.md` SNTX section
- `docs/README.md` link description

## Note
SRX-20 label preserved as the native (non-EVM) token engine name. SRC-20 is the EVM-based standard (ERC-20 compatible) for Sentrix chain, to be used for SNTX + SRTX deployment post-Voyager mainnet fork.