### PR TITLE
docs: sync public docs with v2.0.0 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl http://localhost:8545/health
 | RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
 | Chain ID | `7120` |
 | Symbol | `SRX` |
-| Explorer | `https://testnet-scan.sentriscloud.com/explorer` |
+| Explorer | `https://sentrixscan.sentriscloud.com` (toggle to Testnet in UI) |
 
 Full guide: [docs/operations/METAMASK.md](docs/operations/METAMASK.md). Deploy a smart contract via Remix: [docs/operations/SMART_CONTRACT_GUIDE.md](docs/operations/SMART_CONTRACT_GUIDE.md). EVM internals: [docs/architecture/EVM.md](docs/architecture/EVM.md).
 
@@ -93,7 +93,7 @@ bin/sentrix/              CLI binary
 | **Consensus** | PoA (3 validators) | DPoS + BFT (4 validators) |
 | **Block time** | 1 second | 1 second |
 | **EVM** | Disabled | Active — MetaMask compatible |
-| **Explorer** | [sentrixscan.sentriscloud.com](https://sentrixscan.sentriscloud.com/explorer) | [testnet-scan.sentriscloud.com](https://testnet-scan.sentriscloud.com/explorer) |
+| **Explorer** | [sentrixscan.sentriscloud.com](https://sentrixscan.sentriscloud.com) | [sentrixscan.sentriscloud.com](https://sentrixscan.sentriscloud.com) (same unified UI, toggle Testnet) |
 
 **Wallet:** [sentrix-wallet.sentriscloud.com](https://sentrix-wallet.sentriscloud.com)
 **Faucet:** [faucet.sentriscloud.com](https://faucet.sentriscloud.com)

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@
 | | |
 |-|-|
 | Chain ID | 7119 |
-| Block time | 3s |
+| Block time | 1s |
 | Coin | SRX (1 SRX = 100M sentri) |
 | Max supply | 210M SRX |
 | Reward | 1 SRX/block, halving every 42M blocks |

--- a/docs/architecture/CONSENSUS.md
+++ b/docs/architecture/CONSENSUS.md
@@ -12,7 +12,7 @@ sorted_validators[block_height % validator_count]
 
 Deterministic — every node computes the same result independently. No communication needed.
 
-With 3 validators, each one produces a block every 3 seconds.
+With 3 validators and 1s blocks, each one produces a block every 3 seconds (1s × 3 slots).
 
 ## Block Production
 
@@ -20,7 +20,7 @@ When it's your turn (`block_producer.rs`):
 
 1. Check `height % count` matches your slot
 2. Build coinbase tx (1 SRX reward)
-3. Clone mempool, take up to 100 txs sorted by fee (highest first)
+3. Clone mempool, take up to 5,000 txs sorted by fee (highest first)
 4. Assemble block: index, prev hash, timestamp, txs, merkle root
 
 Mempool is cloned not drained — if the block gets rejected, txs survive.
@@ -67,7 +67,7 @@ block.timestamp <= now + 15s             (not too far ahead)
 
 ## Known Limitations
 
-- No fork choice. First block at a height wins. Network partitions can cause permanent splits. Fine for 7 controlled validators, needs fixing before scaling.
+- No fork choice. First block at a height wins. Network partitions can cause permanent splits. Fine for 3 controlled validators, needs fixing before scaling.
 - No block skip. If expected validator is offline, chain waits. No timeout.
 - No block signatures. Block has validator address but isn't signed. Auth is via round-robin schedule check. Signing needed for Voyager.
 

--- a/docs/architecture/EVM.md
+++ b/docs/architecture/EVM.md
@@ -129,7 +129,7 @@ Network Name:     Sentrix Testnet
 RPC URL:          https://testnet-rpc.sentriscloud.com/rpc
 Chain ID:         7120
 Currency Symbol:  SRX
-Block Explorer:   https://testnet-explorer.sentriscloud.com
+Block Explorer:   https://sentrixscan.sentriscloud.com
 ```
 
 ## Known Limitations

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -69,9 +69,9 @@ src/types/error.rs           SentrixError (14 variants)
 
 | | |
 |-|-|
-| Source files | ~40 |
-| Lines of code | ~16,000+ |
-| Tests | 525+ |
-| Dependencies | 27 crates |
+| Source files | ~50 |
+| Lines of code | ~22,500+ |
+| Tests | 551 |
+| Workspace crates | 12 + 1 binary |
 | `unsafe` blocks | 0 |
 | License | BUSL-1.1 |

--- a/docs/operations/CI_CD.md
+++ b/docs/operations/CI_CD.md
@@ -13,7 +13,7 @@ Push to main → TEST → DEPLOY (only main branch)
 1. `cargo deny check` — license + supply chain
 2. `cargo clippy --tests -- -D warnings` — zero warnings (deny unwrap/expect/panic)
 3. `cargo build --release`
-4. `cargo test` — 525+ tests
+4. `cargo test` — 551 tests
 5. Upload binary as artifact (1-day retention)
 
 ### Deploy Job (main only, after test passes)

--- a/docs/operations/DEVELOPER_QUICKSTART.md
+++ b/docs/operations/DEVELOPER_QUICKSTART.md
@@ -10,7 +10,7 @@ Build on Sentrix in 10 minutes. Deploy a smart contract, read chain state, and s
 |---|---|
 | RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
 | Chain ID | `7120` |
-| Explorer | `https://testnet-explorer.sentriscloud.com` |
+| Explorer | `https://sentrixscan.sentriscloud.com` |
 | Faucet | `https://faucet.sentriscloud.com` |
 
 ### MetaMask setup
@@ -23,7 +23,7 @@ Settings → Networks → Add network manually:
 | RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
 | Chain ID | `7120` |
 | Symbol | `SRX` |
-| Block Explorer | `https://testnet-explorer.sentriscloud.com` |
+| Block Explorer | `https://sentrixscan.sentriscloud.com` |
 
 Get test SRX from the [faucet](https://faucet.sentriscloud.com).
 
@@ -56,7 +56,7 @@ contract MyToken {
 
 3. Compile → Solidity 0.8.20+
 4. Deploy → Environment: "Injected Provider — MetaMask" → Deploy
-5. Confirm in MetaMask → mined in ~3s
+5. Confirm in MetaMask → mined in ~1s
 
 ## ethers.js / viem
 

--- a/docs/operations/METAMASK.md
+++ b/docs/operations/METAMASK.md
@@ -13,7 +13,7 @@ Sentrix Testnet is fully MetaMask-compatible (chain ID 7120). Mainnet (chain ID 
    | **New RPC URL** | `https://testnet-rpc.sentriscloud.com/rpc` |
    | **Chain ID** | `7120` |
    | **Currency Symbol** | `SRX` |
-   | **Block Explorer URL** | `https://testnet-explorer.sentriscloud.com` |
+   | **Block Explorer URL** | `https://sentrixscan.sentriscloud.com` |
 
 3. Save. Switch to "Sentrix Testnet" in the network dropdown.
 
@@ -69,7 +69,7 @@ curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
 
 **Transaction stuck pending:**
 - Check `eth_getTransactionReceipt` directly via curl — receipt may already exist
-- Block time is 3s; expect confirmation within 1-2 blocks
+- Block time is 1s; expect confirmation within 1-2 blocks
 
 **eth_call returns "0x":**
 - The call executed but returned no data, or the call reverted silently

--- a/docs/operations/MONITORING.md
+++ b/docs/operations/MONITORING.md
@@ -28,8 +28,8 @@ du -sh /opt/sentrix/data/chain.db/
 
 | Metric | Healthy |
 |--------|---------|
-| Chain height | Increasing every ~3s |
-| Active validators | 7 |
+| Chain height | Increasing every ~1s |
+| Active validators | 3 (mainnet) / 4 (testnet BFT+DPoS) |
 | Mempool | < 10,000 |
 | Service status | Active (running) |
 
@@ -39,7 +39,7 @@ du -sh /opt/sentrix/data/chain.db/
 
 Height not moving for 30+ seconds.
 
-Validator offline: Check which slot is expected (`height % 7`). Bring that validator back up.
+Validator offline: Check which slot is expected (`height % 3`). Bring that validator back up.
 
 Network partition: Check logs for peer connections (`journalctl -u sentrix-node | grep peer`). Check firewall (`ufw status`).
 

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -9,8 +9,8 @@
 | Explorer | https://sentrixscan.sentriscloud.com |
 | P2P port | 30303 |
 | API port | 8545 |
-| Block time | 3s |
-| Validators | 7 (PoA round-robin) |
+| Block time | 1s |
+| Validators | 3 (PoA round-robin: Foundation, Treasury, Core) |
 | Native coin | SRX |
 
 ## Testnet
@@ -19,12 +19,11 @@
 |-|-|
 | Chain ID | 7120 (0x1bd0) |
 | RPC | https://testnet-rpc.sentriscloud.com/rpc |
-| Explorer | https://testnet-explorer.sentriscloud.com |
-| Scan | https://testnet-scan.sentriscloud.com |
+| Explorer | https://sentrixscan.sentriscloud.com (unified UI, toggle Testnet) |
 | API | https://testnet-api.sentriscloud.com |
 | P2P port | 31303–31306 |
 | API port | 9545 |
-| Block time | 3s |
+| Block time | 1s |
 | Validators | 4 (DPoS + BFT, 3/4 fault tolerance) |
 | EVM | Active — Solidity contracts, MetaMask compatible |
 | Voyager fork height | 10 |
@@ -44,7 +43,7 @@ Add network manually:
 | RPC URL | https://sentrix-rpc.sentriscloud.com | https://testnet-rpc.sentriscloud.com/rpc |
 | Chain ID | 7119 | 7120 |
 | Symbol | SRX | SRX |
-| Explorer | https://sentrixscan.sentriscloud.com | https://testnet-explorer.sentriscloud.com |
+| Explorer | https://sentrixscan.sentriscloud.com | https://sentrixscan.sentriscloud.com (toggle Testnet) |
 
 ### ethers.js
 

--- a/docs/operations/SMART_CONTRACT_GUIDE.md
+++ b/docs/operations/SMART_CONTRACT_GUIDE.md
@@ -20,7 +20,7 @@ In MetaMask → **Networks → Add network manually**:
 | New RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
 | Chain ID | `7120` |
 | Currency symbol | `SRX` |
-| Block explorer URL | `https://testnet-explorer.sentriscloud.com` |
+| Block explorer URL | `https://sentrixscan.sentriscloud.com` |
 
 Save and switch to Sentrix Testnet. You should see your SRX balance.
 
@@ -82,7 +82,7 @@ Expand the deployed contract and call any function:
 You can also verify the deployment via the explorer:
 
 ```
-https://testnet-explorer.sentriscloud.com/explorer/tx/<your-tx-hash>
+https://sentrixscan.sentriscloud.com/tx/<your-tx-hash>
 ```
 
 ## Hardhat / Foundry

--- a/docs/operations/VALIDATORS.md
+++ b/docs/operations/VALIDATORS.md
@@ -1,20 +1,18 @@
 # Validators
 
-3 validators across 3 VPS, round-robin PoA.
+3 validators across 3 VPS, round-robin PoA (v2.0.0).
 
 ## Current Set
 
-| Slot | Name | Address prefix | VPS |
-|------|------|---------------|-----|
-| 0 | Sentrix Treasury | `0x0804...` | 2 |
-| 1 | Sentrix Foundation | `0x753f...` | 1 |
-| 2 | BlockForge Asia | `0x7be6...` | 2 |
-| 3 | PacificStake | `0x7dcc...` | 2 |
-| 4 | Sentrix Core | `0x87c9...` | 3 |
-| 5 | Archipelago Network | `0xd211...` | 2 |
-| 6 | Nusantara Node | `0xdd3c...` | 2 |
+| Slot | Name | Address prefix | VPS | Service |
+|------|------|---------------|-----|---------|
+| 0 | Sentrix Treasury | `0x0804...` | VPS2 | sentrix-val5 |
+| 1 | Sentrix Foundation | `0x753f...` | VPS1 | sentrix-node |
+| 2 | Sentrix Core | `0x87c9...` | VPS3 | sentrix-core |
 
-Sorted by address. Block producer = `height % 7`.
+Sorted by address. Block producer = `height % 3`.
+
+(Nusantara, BlockForge Asia, PacificStake, Archipelago — decommissioned during v2.0.0 reset; services stopped, NOT on chain.)
 
 ## Adding a Validator
 
@@ -64,7 +62,7 @@ curl -H "X-API-Key: <key>" http://[NODE_IP]:8545/admin/log
 
 ## Economics
 
-Each validator produces ~28,800 blocks/day (with 3 validators, 1s blocks). That's ~28,800 SRX/day from rewards alone, plus `floor(fee/2)` from each included transaction.
+Each validator produces ~28,800 blocks/day (3 validators × 1s blocks ÷ 3 slots). That's ~28,800 SRX/day per validator from rewards alone, plus `floor(fee/2)` from each included transaction.
 
 ## Voyager
 

--- a/docs/roadmap/PHASE1.md
+++ b/docs/roadmap/PHASE1.md
@@ -4,7 +4,7 @@ Done. Live in production.
 
 ## What's Running
 
-- PoA consensus, round-robin, 3s blocks
+- PoA consensus, round-robin, 1s blocks (v2.0.0; was 3s in v1.x)
 - 3 validators on 3 VPS (v2.0.0), full mesh peering
 - Account model with Ethereum-style addresses
 - Two-pass atomic block validation
@@ -24,8 +24,8 @@ Done. Live in production.
 
 | | |
 |-|-|
-| Tests | 525+ |
-| PRs merged | #1–#94 |
+| Tests | 551 |
+| PRs merged | #1–#111 |
 | Audit rounds | 11 (116 findings, 78+ fixed) |
 | Chain height | 141,000+ |
 | Pentest | 6/6 passed on live node |

--- a/docs/security/SECURITY_REPORT.md
+++ b/docs/security/SECURITY_REPORT.md
@@ -10,9 +10,9 @@ No fund-loss vulnerabilities. No data corruption risks. Main gap is DoS resistan
 
 | | |
 |-|-|
-| Rust 2024, 50+ files, ~17,000+ LoC | 525+ tests |
-| PoA round-robin, 3s blocks | Chain ID 7119 |
-| 210M SRX max supply | 27 crates |
+| Rust 2024, 50+ files, ~22,500+ LoC | 551 tests |
+| PoA round-robin, 1s blocks (v2.0.0) | Chain ID 7119 |
+| 210M SRX max supply | 12 crates + 1 binary |
 
 ## Code Audit
 

--- a/docs/tokenomics/STAKING.md
+++ b/docs/tokenomics/STAKING.md
@@ -35,9 +35,9 @@ Slash split: 50% burned, 50% to Ecosystem Fund. Delegators not directly slashed 
 
 ## Economics
 
-With 100 validators, 3s blocks:
-- ~288 blocks/day per validator
-- ~288+ SRX/day from rewards (Era 0)
+With 100 validators, 1s blocks:
+- ~864 blocks/day per validator (86,400 ÷ 100)
+- ~864 SRX/day from rewards (Era 0, pre-halving)
 - Plus fee revenue
 
 Cost to attack (51%): 51 validators × 15K SRX = 765K SRX minimum, plus 20% slash risk.


### PR DESCRIPTION
## Summary

Refresh all public docs to match current v2.0.0 production state. No code changes.

## Changes

- **Block time:** 3s → 1s (v2.0.0 live since 2026-04-18)
- **Mainnet validators:** 7 → 3 (Foundation VPS1, Treasury VPS2, Core VPS3). Decommissioned set (Nusantara, BlockForge, PacificStake, Archipelago) noted as historical.
- **Mempool cap:** MAX_TX_PER_BLOCK 100 → 5000 (CONSENSUS.md)
- **Tests:** 525+ → 551
- **LOC / crates:** ~16K → ~22.5K, 27 crates → 12 + binary
- **Explorer URLs:** `testnet-explorer.sentriscloud.com` + `testnet-scan.sentriscloud.com` → unified `sentrixscan.sentriscloud.com` (mainnet/testnet toggle in UI). Old records deleted from Cloudflare.
- **Roadmap/PHASE1:** PR range updated #1–#111
- **STAKING economics:** recomputed for 1s blocks (100 validators → ~864 blocks/day each)

## Files touched (15)

- `README.md`
- `docs/README.md`
- `docs/architecture/{CONSENSUS,EVM,OVERVIEW}.md`
- `docs/operations/{CI_CD,DEVELOPER_QUICKSTART,METAMASK,MONITORING,NETWORKS,SMART_CONTRACT_GUIDE,VALIDATORS}.md`
- `docs/roadmap/PHASE1.md`
- `docs/security/SECURITY_REPORT.md`
- `docs/tokenomics/STAKING.md`

## Test plan

- [ ] CI passes (no code changed, only markdown)
- [ ] Spot-check explorer + RPC URLs on Cloudflare (unified sentrixscan works)
- [ ] Review VALIDATORS.md table vs current systemd state on VPS1/2/3