### PR TITLE
fix(bft): re-propose on TimeoutAdvanceRound and SkipRound (P1 testnet…

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1242,6 +1242,46 @@ async fn cmd_start(
                                         BftAction::TimeoutAdvanceRound => {
                                             bft.advance_round();
                                             tracing::info!("BFT timeout — round {}", bft.round());
+                                            // P1: re-propose if we are the proposer for the
+                                            // new round. Without this the testnet stalls at
+                                            // a height indefinitely: the proposer for the
+                                            // new round never emits a proposal, peers prevote
+                                            // nil, precommit nil, skip-round, and loop.
+                                            let bc_r = shared_clone.read().await;
+                                            let we_propose =
+                                                bft.is_proposer(&bc_r.stake_registry);
+                                            drop(bc_r);
+                                            if we_propose {
+                                                let mut bc = shared_clone.write().await;
+                                                if let Ok(block) =
+                                                    bc.create_block_voyager(&wallet.address)
+                                                {
+                                                    let block_hash = block.hash.clone();
+                                                    let block_data =
+                                                        bincode::serialize(&block)
+                                                            .unwrap_or_default();
+                                                    let mut proposal = Proposal {
+                                                        height: bft.height(),
+                                                        round: bft.round(),
+                                                        block_hash: block_hash.clone(),
+                                                        block_data,
+                                                        proposer: wallet.address.clone(),
+                                                        signature: vec![],
+                                                    };
+                                                    proposal.sign(&validator_secret_key);
+                                                    drop(bc);
+                                                    lp2p_clone
+                                                        .broadcast_bft_proposal(&proposal)
+                                                        .await;
+                                                    proposed_block = Some(block);
+                                                    let _ = bft.on_own_proposal(&block_hash);
+                                                    tracing::info!(
+                                                        "BFT: proposed block after timeout \
+                                                         at round {}",
+                                                        bft.round()
+                                                    );
+                                                }
+                                            }
                                             break;
                                         }
                                         BftAction::SkipRound => {
@@ -1252,6 +1292,43 @@ async fn cmd_start(
                                                 bft.round(),
                                                 bft.height()
                                             );
+                                            // P1: re-propose on skip-round if we are the new
+                                            // round's proposer. Same stall pattern as above.
+                                            let bc_r = shared_clone.read().await;
+                                            let we_propose =
+                                                bft.is_proposer(&bc_r.stake_registry);
+                                            drop(bc_r);
+                                            if we_propose {
+                                                let mut bc = shared_clone.write().await;
+                                                if let Ok(block) =
+                                                    bc.create_block_voyager(&wallet.address)
+                                                {
+                                                    let block_hash = block.hash.clone();
+                                                    let block_data =
+                                                        bincode::serialize(&block)
+                                                            .unwrap_or_default();
+                                                    let mut proposal = Proposal {
+                                                        height: bft.height(),
+                                                        round: bft.round(),
+                                                        block_hash: block_hash.clone(),
+                                                        block_data,
+                                                        proposer: wallet.address.clone(),
+                                                        signature: vec![],
+                                                    };
+                                                    proposal.sign(&validator_secret_key);
+                                                    drop(bc);
+                                                    lp2p_clone
+                                                        .broadcast_bft_proposal(&proposal)
+                                                        .await;
+                                                    proposed_block = Some(block);
+                                                    let _ = bft.on_own_proposal(&block_hash);
+                                                    tracing::info!(
+                                                        "BFT: proposed block after skip-round \
+                                                         at round {}",
+                                                        bft.round()
+                                                    );
+                                                }
+                                            }
                                             break;
                                         }
                                         BftAction::SyncNeeded { .. } => {
@@ -1599,6 +1676,42 @@ async fn cmd_start(
                                         "BFT timeout — advanced to round {}",
                                         bft.round()
                                     );
+                                    // P1: re-propose if we are the new-round proposer.
+                                    // Without this the testnet stalls indefinitely —
+                                    // the new round has no proposal, peers prevote nil,
+                                    // precommit nil, skip-round, and loop.
+                                    let bc_r = shared_clone.read().await;
+                                    let we_propose = bft.is_proposer(&bc_r.stake_registry);
+                                    drop(bc_r);
+                                    if we_propose {
+                                        let mut bc = shared_clone.write().await;
+                                        if let Ok(block) =
+                                            bc.create_block_voyager(&wallet.address)
+                                        {
+                                            let block_hash = block.hash.clone();
+                                            let block_data = bincode::serialize(&block)
+                                                .unwrap_or_default();
+                                            let mut proposal = Proposal {
+                                                height: bft.height(),
+                                                round: bft.round(),
+                                                block_hash: block_hash.clone(),
+                                                block_data,
+                                                proposer: wallet.address.clone(),
+                                                signature: vec![],
+                                            };
+                                            proposal.sign(&validator_secret_key);
+                                            drop(bc);
+                                            lp2p_clone
+                                                .broadcast_bft_proposal(&proposal)
+                                                .await;
+                                            proposed_block = Some(block);
+                                            let _ = bft.on_own_proposal(&block_hash);
+                                            tracing::info!(
+                                                "BFT: proposed block after timeout at round {}",
+                                                bft.round()
+                                            );
+                                        }
+                                    }
                                     break;
                                 }
                                 BftAction::SkipRound => {
@@ -1610,6 +1723,41 @@ async fn cmd_start(
                                         bft.round(),
                                         bft.height()
                                     );
+                                    // P1: re-propose on skip-round if we are the new
+                                    // round's proposer.
+                                    let bc_r = shared_clone.read().await;
+                                    let we_propose = bft.is_proposer(&bc_r.stake_registry);
+                                    drop(bc_r);
+                                    if we_propose {
+                                        let mut bc = shared_clone.write().await;
+                                        if let Ok(block) =
+                                            bc.create_block_voyager(&wallet.address)
+                                        {
+                                            let block_hash = block.hash.clone();
+                                            let block_data = bincode::serialize(&block)
+                                                .unwrap_or_default();
+                                            let mut proposal = Proposal {
+                                                height: bft.height(),
+                                                round: bft.round(),
+                                                block_hash: block_hash.clone(),
+                                                block_data,
+                                                proposer: wallet.address.clone(),
+                                                signature: vec![],
+                                            };
+                                            proposal.sign(&validator_secret_key);
+                                            drop(bc);
+                                            lp2p_clone
+                                                .broadcast_bft_proposal(&proposal)
+                                                .await;
+                                            proposed_block = Some(block);
+                                            let _ = bft.on_own_proposal(&block_hash);
+                                            tracing::info!(
+                                                "BFT: proposed block after skip-round at \
+                                                 round {}",
+                                                bft.round()
+                                            );
+                                        }
+                                    }
                                     break;
                                 }
                                 _ => break,


### PR DESCRIPTION
… stall)

Two of the four `BftAction::TimeoutAdvanceRound` / `BftAction::SkipRound` sites in the validator loop only called `bft.advance_round()` and then `break`ed. The matching Voyager-BFT path (around line 1474) did the right thing: after `advance_round`, check whether we are the new round's proposer via `bft.is_proposer(&stake_registry)` and, if so, build/sign/broadcast a fresh proposal. The two missing sites left the new round with no proposal at all, so the other validators prevoted nil, precommitted nil, skip-rounded again, and the height stalled forever.

Confirmed in live testnet journalctl output on 2026-04-19 (testnet stuck at height 13494 / round 352+ with only 2 of 4 validators visibly voting; the pattern increments the round every ~30 s without ever finalising the block).

Each of the four sites now replicates the proposal-build-and-sign sequence inline. The two already-correct sites (path B, lines 1474 and 1510 pre-patch) are left as-is; the two fixed sites are:
  * path A BftAction::TimeoutAdvanceRound + SkipRound (~1242, 1247)
  * periodic-tick BftAction::TimeoutAdvanceRound + SkipRound (~1596, 1604)

After this lands, a rolling restart of the four testnet validators should drain the backlog of skip-rounds at height 13495 and resume block production. Mainnet is PoA (not BFT) so it is not affected.