### PR TITLE
fix(consensus): only broadcast block after persistence succeeds (H-09)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -994,13 +994,35 @@ async fn cmd_start(
                     };
 
                     if let Some((height, Some(block_to_save))) = result {
-                        println!("Block {} produced by {}", height, wallet.address);
-                        let _ = storage_clone.save_block(&block_to_save);
-                        {
-                            let bc = shared_clone.read().await;
-                            let _ = storage_clone.save_blockchain(&bc);
+                        // H-09: only broadcast after the block is durably
+                        // persisted. A broadcast of a block we can't recover
+                        // on restart is a fork risk — peers would accept
+                        // blocks extending ours, but after our next restart
+                        // we would rewind to the last saved block and
+                        // diverge from the chain we just helped produce.
+                        if let Err(e) = storage_clone.save_block(&block_to_save) {
+                            tracing::error!(
+                                "H-09: failed to persist block {} produced by {}: {}; \
+                                 skipping broadcast to prevent fork",
+                                height,
+                                wallet.address,
+                                e
+                            );
+                        } else {
+                            println!("Block {} produced by {}", height, wallet.address);
+                            {
+                                let bc = shared_clone.read().await;
+                                if let Err(e) = storage_clone.save_blockchain(&bc) {
+                                    tracing::warn!(
+                                        "save_blockchain snapshot failed at height {}: {} \
+                                         (block already persisted, continuing)",
+                                        height,
+                                        e
+                                    );
+                                }
+                            }
+                            lp2p_clone.broadcast_block(&block_to_save).await;
                         }
-                        lp2p_clone.broadcast_block(&block_to_save).await;
                     }
                     continue;
                 }
@@ -1216,19 +1238,41 @@ async fn cmd_start(
 
                                                         drop(bc);
                                                         if let Some(ref saved_block) = updated {
-                                                            println!(
-                                                                "Block {} produced by {}",
-                                                                height, proposer
-                                                            );
-                                                            let _ = storage_clone
-                                                                .save_block(saved_block);
-                                                            let bc = shared_clone.read().await;
-                                                            let _ =
-                                                                storage_clone.save_blockchain(&bc);
-                                                            drop(bc);
-                                                            lp2p_clone
-                                                                .broadcast_block(saved_block)
-                                                                .await;
+                                                            // H-09: persist before broadcast.
+                                                            if let Err(e) = storage_clone
+                                                                .save_block(saved_block)
+                                                            {
+                                                                tracing::error!(
+                                                                    "H-09: failed to persist \
+                                                                     BFT block {} by {}: {}; \
+                                                                     skipping broadcast",
+                                                                    height,
+                                                                    proposer,
+                                                                    e
+                                                                );
+                                                            } else {
+                                                                println!(
+                                                                    "Block {} produced by {}",
+                                                                    height, proposer
+                                                                );
+                                                                let bc =
+                                                                    shared_clone.read().await;
+                                                                if let Err(e) = storage_clone
+                                                                    .save_blockchain(&bc)
+                                                                {
+                                                                    tracing::warn!(
+                                                                        "save_blockchain \
+                                                                         snapshot failed at \
+                                                                         {}: {}",
+                                                                        height,
+                                                                        e
+                                                                    );
+                                                                }
+                                                                drop(bc);
+                                                                lp2p_clone
+                                                                    .broadcast_block(saved_block)
+                                                                    .await;
+                                                            }
                                                         }
                                                     }
                                                     Err(e) => tracing::warn!(
@@ -1455,15 +1499,38 @@ async fn cmd_start(
 
                                                 drop(bc);
                                                 if let Some(ref saved_block) = updated {
-                                                    println!(
-                                                        "Block {} produced by {}",
-                                                        height, proposer
-                                                    );
-                                                    let _ = storage_clone.save_block(saved_block);
-                                                    let bc = shared_clone.read().await;
-                                                    let _ = storage_clone.save_blockchain(&bc);
-                                                    drop(bc);
-                                                    lp2p_clone.broadcast_block(saved_block).await;
+                                                    // H-09: persist before broadcast.
+                                                    if let Err(e) =
+                                                        storage_clone.save_block(saved_block)
+                                                    {
+                                                        tracing::error!(
+                                                            "H-09: failed to persist BFT block \
+                                                             {} by {}: {}; skipping broadcast",
+                                                            height,
+                                                            proposer,
+                                                            e
+                                                        );
+                                                    } else {
+                                                        println!(
+                                                            "Block {} produced by {}",
+                                                            height, proposer
+                                                        );
+                                                        let bc = shared_clone.read().await;
+                                                        if let Err(e) =
+                                                            storage_clone.save_blockchain(&bc)
+                                                        {
+                                                            tracing::warn!(
+                                                                "save_blockchain snapshot \
+                                                                 failed at {}: {}",
+                                                                height,
+                                                                e
+                                                            );
+                                                        }
+                                                        drop(bc);
+                                                        lp2p_clone
+                                                            .broadcast_block(saved_block)
+                                                            .await;
+                                                    }
                                                 }
                                             }
                                             Err(e) => tracing::warn!("BFT add_block failed: {}", e),


### PR DESCRIPTION
All three block-production call sites (Pioneer PoA, Voyager BFT path A, Voyager BFT path B) previously ignored errors from `storage.save_block(...)` and proceeded to broadcast the block:

    let _ = storage_clone.save_block(&block_to_save);
    ...
    lp2p_clone.broadcast_block(&block_to_save).await;

If the persist fails but the block has already been added to in-memory state, the validator advertises a block it cannot recover from disk after a restart. Peers that precommit against the broadcast then extend our announced head, and on our next restart we rewind to the last durable block and diverge from the canonical chain we helped produce — a fork.

Each site now:
  1. save_block first; on Err, log at ERROR and skip broadcast (BFT round will advance via timeout; peers do not extend an unannounced head).
  2. save_blockchain snapshot failure is non-fatal — the block is already durable, so log WARN and continue with broadcast.