### PR TITLE
fix(consensus,rpc): overflow/validation hardening batch (P1)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -293,7 +293,13 @@ impl Blockchain {
         for tx in block.transactions.iter().skip(1) {
             self.accounts
                 .transfer(&tx.from_address, &tx.to_address, tx.amount, tx.fee)?;
-            total_fee += tx.fee;
+            // P1: checked_add — 5000 tx × max fee is far below u64::MAX
+            // in practice, but the guard is cheap and prevents a silent
+            // wrap if MAX_TX_PER_BLOCK or MIN_TX_FEE are ever tuned
+            // upward past the implicit ceiling.
+            total_fee = total_fee.checked_add(tx.fee).ok_or_else(|| {
+                SentrixError::Internal("block total_fee overflow".to_string())
+            })?;
 
             // Execute token operation if present in data field
             if let Some(token_op) = TokenOp::decode(&tx.data) {

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -398,8 +398,15 @@ impl Blockchain {
             return 0;
         }
 
-        let halvings = self.height() / HALVING_INTERVAL;
-        let reward = BLOCK_REWARD >> halvings; // divide by 2^halvings
+        // P1: halving bit-shift overflow. `u64 >> 64+` is undefined in
+        // Rust (panics in debug, implementation-defined in release) and
+        // `halvings` is `height / HALVING_INTERVAL` — after ~21×42M blocks
+        // (~28 years at 1 s blocks) `halvings` reaches 64 and the shift
+        // would crash the validator. checked_shr returns `None` at ≥64
+        // so we clamp the reward to 0 (matching the intended "reward
+        // halved to nothing" semantics).
+        let halvings: u32 = (self.height() / HALVING_INTERVAL).try_into().unwrap_or(u32::MAX);
+        let reward = BLOCK_REWARD.checked_shr(halvings).unwrap_or(0);
 
         if reward == 0 {
             return 0;

--- a/crates/sentrix-primitives/src/account.rs
+++ b/crates/sentrix-primitives/src/account.rs
@@ -137,7 +137,16 @@ impl AccountDB {
                 .balance
                 .checked_sub(total)
                 .ok_or_else(|| SentrixError::Internal("balance underflow".to_string()))?;
-            sender.nonce += 1;
+            // P1: nonce overflow. u64 wraps to 0 at u64::MAX + 1, which
+            // would then let an attacker replay any previously-signed tx
+            // whose nonce matched the wrapped value. checked_add keeps
+            // the chain safe by surfacing the condition as an Err — at
+            // current mainnet throughput this is unreachable in any
+            // practical lifetime, but the guard is cheap.
+            sender.nonce = sender
+                .nonce
+                .checked_add(1)
+                .ok_or_else(|| SentrixError::Internal("nonce overflow".to_string()))?;
         }
 
         // Credit recipient

--- a/crates/sentrix-rpc/src/jsonrpc.rs
+++ b/crates/sentrix-rpc/src/jsonrpc.rs
@@ -284,7 +284,23 @@ pub async fn jsonrpc_handler(
 
             // Convert Ethereum value (wei) to Sentrix sentri (1 SRX = 1e18 wei = 1e8 sentri)
             // 1 sentri = 1e10 wei
-            let value_wei: u128 = value_u256.try_into().unwrap_or(u128::MAX);
+            //
+            // P1: reject instead of saturating on U256→u128 overflow.
+            // Pre-fix, a caller could set `value = U256::MAX` and have
+            // it silently saturate to `u128::MAX`, then divide by 1e10
+            // to produce a nonsensical u64 amount. Surface the
+            // out-of-range condition as a JSON-RPC error so the client
+            // sees the rejection rather than a mangled amount.
+            let value_wei: u128 = match value_u256.try_into() {
+                Ok(v) => v,
+                Err(_) => {
+                    return Json(JsonRpcResponse::err(
+                        id,
+                        -32602,
+                        "tx value exceeds u128 (not representable on Sentrix)",
+                    ));
+                }
+            };
             let amount_sentri = (value_wei / 10_000_000_000u128) as u64;
 
             // Build Sentrix Transaction. txid = keccak256 of raw bytes (Ethereum tx hash)


### PR DESCRIPTION
fix(consensus,rpc): overflow/validation hardening batch (P1)

Four defense-in-depth guards, all trivial but each closing an observed
or plausibly-reachable panic/wrap path in the reward, nonce, fee, and
eth_sendRawTransaction flows. No consensus behaviour changes for
well-formed inputs.

* blockchain.rs — get_block_reward: `BLOCK_REWARD >> halvings` is UB
  once halvings ≥ 64 (release: implementation-defined; debug: panic).
  At HALVING_INTERVAL = 42M and 1 s blocks the overflow condition is
  ~28 years out, but `checked_shr` clamps to 0 at zero cost and makes
  the intent explicit. Also coerces halvings to u32 up front (required
  by checked_shr).

* account.rs — AccountDB::transfer: `sender.nonce += 1` panics on u64
  overflow. Swapped for `checked_add(1)` with an Err so the chain
  surfaces the condition instead of crashing a validator if nonce
  space ever exhausts.

* block_executor.rs — Pass 2 fee accumulation: `total_fee += tx.fee`
  silently wraps. Swapped for `checked_add`. At current
  MAX_TX_PER_BLOCK (5000) × MIN_TX_FEE (10_000) the wrap is
  unreachable by ~3 orders of magnitude, but the guard keeps the
  invariant checked if either constant is tuned upward.

* jsonrpc.rs — eth_sendRawTransaction: `U256 → u128` via
  `try_into().unwrap_or(u128::MAX)` silently saturated an overflow
  value to the max representable sentri amount. Now returns a
  JSON-RPC -32602 "value exceeds u128" error so clients see the
  rejection instead of a mangled amount.

The timestamp-strict-monotonic item from the audit (block.timestamp
must be strictly greater than parent) was explored and reverted in
the same session — forcing the producer-side timestamp up to
`parent + 1` when multiple blocks land in the same wall-clock second
also pushed timestamps past the 15 s future-clock guard for
back-to-back block bursts in tests. Reopened as a follow-up that
needs a producer-side "wait for wall clock to advance" primitive
before the strict check can land.