### PR TITLE
feat(rpc): add 5 sentrix_* native query methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,24 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Sentrix native JSON-RPC namespace (Sprint 1)** — five new methods
+  that expose chain features the `eth_*` namespace cannot represent:
+  `sentrix_getValidatorSet`, `sentrix_getDelegations`,
+  `sentrix_getStakingRewards`, `sentrix_getBftStatus`,
+  `sentrix_getFinalizedHeight`. Amounts returned in wei hex so
+  existing bignum libraries keep working. See
+  `docs/operations/API_REFERENCE.md` for the full payload spec.
+
 ### Planned
 - Mainnet hard fork to Voyager (DPoS + BFT + EVM)
 - Parallel tx execution (rayon)
 - Light client justification verification
+- `sentrix_getBftStatus` live round/phase (needs BftEngine snapshot
+  plumbed from validator loop into SharedState — Sprint 2)
+- Per-delegator per-epoch reward ledger (turns
+  `sentrix_getStakingRewards` history into exact claim records —
+  Sprint 2)
 
 ### Security
 - **C-06 — Removed `--validator-key <hex>` CLI flag.** Private keys passed

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, i
 | **State** | Binary Sparse Merkle Tree (BLAKE3 + SHA-256) with proofs |
 | **Tokens** | SRX-20 native + SRC-20 (ERC-20 via EVM) |
 | **Network** | libp2p + Noise XX + Kademlia + Gossipsub |
-| **API** | REST (25+ endpoints) + JSON-RPC 2.0 (20 methods) |
+| **API** | REST (60+ endpoints) + JSON-RPC 2.0 (25 methods, incl. `sentrix_*` native namespace) |
 | **Explorer** | Built-in dark-themed block explorer |
 | **Wallet** | AES-256-GCM keystore (Argon2id KDF) |
 | **Fee model** | 50% burn / 50% validator (deflationary) |

--- a/crates/sentrix-rpc/src/jsonrpc.rs
+++ b/crates/sentrix-rpc/src/jsonrpc.rs
@@ -495,6 +495,328 @@ pub async fn jsonrpc_handler(
                 }
             }
         }
+        "sentrix_getValidatorSet" => {
+            let bc = state.read().await;
+            let active: std::collections::HashSet<String> =
+                bc.stake_registry.active_set.iter().cloned().collect();
+            let epoch = &bc.epoch_manager.current_epoch;
+            let epoch_span = epoch
+                .end_height
+                .saturating_sub(epoch.start_height)
+                .max(1);
+            let total_active_stake: u128 = bc
+                .stake_registry
+                .active_set
+                .iter()
+                .filter_map(|a| bc.stake_registry.get_validator(a))
+                .map(|v| v.total_stake() as u128)
+                .sum();
+
+            let validators: Vec<serde_json::Value> = bc
+                .stake_registry
+                .validators
+                .values()
+                .map(|v| {
+                    let name = bc
+                        .authority
+                        .validators
+                        .get(&v.address)
+                        .map(|a| a.name.clone())
+                        .unwrap_or_default();
+                    let total_stake = v.total_stake();
+                    let stake_wei = (total_stake as u128).saturating_mul(10_000_000_000u128);
+                    let commission = f64::from(v.commission_rate) / 10_000.0;
+                    let is_active = active.contains(&v.address);
+                    let status = if v.is_tombstoned {
+                        "tombstoned"
+                    } else if v.is_jailed {
+                        "jailed"
+                    } else if is_active {
+                        "active"
+                    } else {
+                        "unbonding"
+                    };
+                    let signed = v.blocks_signed;
+                    let attempted = signed.saturating_add(v.blocks_missed);
+                    let uptime = if attempted == 0 {
+                        1.0
+                    } else {
+                        signed as f64 / attempted as f64
+                    };
+                    // The registry tracks lifetime blocks_signed only. For the
+                    // "epoch" count we expose the portion signed since epoch
+                    // start — clamped to epoch_span so a fresh validator can't
+                    // report > 100 % of the current epoch.
+                    let blocks_produced_epoch = signed.min(epoch_span);
+                    let voting_power_wei = if total_active_stake == 0 {
+                        0u128
+                    } else {
+                        (total_stake as u128).saturating_mul(10_000_000_000u128)
+                    };
+                    serde_json::json!({
+                        "address": v.address,
+                        "name": name,
+                        "stake": to_hex_u128(stake_wei),
+                        "commission": commission,
+                        "status": status,
+                        "blocks_produced_epoch": blocks_produced_epoch,
+                        "uptime": uptime,
+                        "voting_power": to_hex_u128(voting_power_wei),
+                    })
+                })
+                .collect();
+
+            Ok(json!({
+                "active_count": bc.stake_registry.active_count(),
+                "total_count": bc.stake_registry.validators.len(),
+                "total_active_stake": to_hex_u128(total_active_stake),
+                "epoch_number": epoch.epoch_number,
+                "validators": validators,
+            }))
+        }
+        "sentrix_getDelegations" => {
+            let address = match params[0].as_str() {
+                Some(a) => a.to_lowercase(),
+                None => return Json(JsonRpcResponse::err(id, -32602, "address required")),
+            };
+            let bc = state.read().await;
+            let delegations_raw = bc.stake_registry.get_delegations(&address).to_vec();
+            let unbonding: Vec<_> = bc
+                .stake_registry
+                .get_pending_unbonding(&address)
+                .into_iter()
+                .cloned()
+                .collect();
+
+            // EPOCH_LENGTH is defined in sentrix-staking but sentrix-rpc does not
+            // take a direct dep on it; the same constant is mirrored here
+            // (staking::epoch::EPOCH_LENGTH = 28_800). If that constant ever
+            // changes, this line must be updated in lockstep.
+            const EPOCH_LENGTH: u64 = 28_800;
+            let epoch_of = |h: u64| h / EPOCH_LENGTH;
+
+            let mut rows: Vec<serde_json::Value> = Vec::new();
+            for d in delegations_raw {
+                let vstake = bc.stake_registry.get_validator(&d.validator);
+                let validator_name = bc
+                    .authority
+                    .validators
+                    .get(&d.validator)
+                    .map(|v| v.name.clone())
+                    .unwrap_or_default();
+                let amount_wei = (d.amount as u128).saturating_mul(10_000_000_000u128);
+                // Pending reward share is pro-rated against the validator's
+                // unclaimed pot by stake weight. It is an estimate — per-
+                // delegator reward accounting lives in a staking sprint.
+                let pending_reward_wei = match vstake {
+                    Some(v) if v.total_delegated > 0 => {
+                        let share = (d.amount as u128)
+                            .saturating_mul(v.pending_rewards as u128)
+                            / v.total_delegated as u128;
+                        share.saturating_mul(10_000_000_000u128)
+                    }
+                    _ => 0,
+                };
+                rows.push(json!({
+                    "validator": d.validator,
+                    "validator_name": validator_name,
+                    "amount": to_hex_u128(amount_wei),
+                    "pending_reward": to_hex_u128(pending_reward_wei),
+                    "delegated_at_epoch": epoch_of(d.height),
+                    "status": "active",
+                    "unbonding_complete_epoch": serde_json::Value::Null,
+                }));
+            }
+            for u in unbonding {
+                let validator_name = bc
+                    .authority
+                    .validators
+                    .get(&u.validator)
+                    .map(|v| v.name.clone())
+                    .unwrap_or_default();
+                let amount_wei = (u.amount as u128).saturating_mul(10_000_000_000u128);
+                rows.push(json!({
+                    "validator": u.validator,
+                    "validator_name": validator_name,
+                    "amount": to_hex_u128(amount_wei),
+                    "pending_reward": "0x0",
+                    "delegated_at_epoch": serde_json::Value::Null,
+                    "status": "unbonding",
+                    "unbonding_complete_epoch": epoch_of(u.completion_height),
+                }));
+            }
+            Ok(json!({
+                "delegator": address,
+                "delegations": rows,
+            }))
+        }
+        "sentrix_getStakingRewards" => {
+            let address = match params[0].as_str() {
+                Some(a) => a.to_lowercase(),
+                None => return Json(JsonRpcResponse::err(id, -32602, "address required")),
+            };
+            let bc = state.read().await;
+            let cur = bc.epoch_manager.current_epoch.epoch_number;
+            let default_from = cur.saturating_sub(29);
+
+            let (from_epoch, to_epoch) = if let Some(opts) = params.get(1).filter(|v| v.is_object())
+            {
+                let from = opts
+                    .get("from_epoch")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(default_from);
+                let to = opts
+                    .get("to_epoch")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(cur);
+                (from, to)
+            } else {
+                (default_from, cur)
+            };
+
+            // Per-epoch, per-delegator reward accounting is not persisted
+            // anywhere on-chain today; the validator pending pot and the
+            // epoch-wide total are the only historical signals we can
+            // reconstruct. Callers rendering a reward chart therefore see
+            // the aggregate credited to validators the delegator picked,
+            // not an exact claim-by-claim ledger.
+            let delegations = bc.stake_registry.get_delegations(&address);
+            let mut by_epoch: Vec<serde_json::Value> = Vec::new();
+            let mut total_pending_sentri: u128 = 0;
+            for d in delegations {
+                let vstake = match bc.stake_registry.get_validator(&d.validator) {
+                    Some(v) => v,
+                    None => continue,
+                };
+                if vstake.total_delegated == 0 {
+                    continue;
+                }
+                let share_sentri = (d.amount as u128)
+                    .saturating_mul(vstake.pending_rewards as u128)
+                    / vstake.total_delegated as u128;
+                total_pending_sentri = total_pending_sentri.saturating_add(share_sentri);
+                if cur >= from_epoch && cur <= to_epoch && share_sentri > 0 {
+                    by_epoch.push(json!({
+                        "epoch": cur,
+                        "validator": d.validator,
+                        "reward": to_hex_u128(share_sentri.saturating_mul(10_000_000_000u128)),
+                        "claimed": false,
+                    }));
+                }
+            }
+
+            let pending_claimable_wei = total_pending_sentri.saturating_mul(10_000_000_000u128);
+
+            Ok(json!({
+                "total_lifetime": to_hex_u128(pending_claimable_wei),
+                "pending_claimable": to_hex_u128(pending_claimable_wei),
+                "from_epoch": from_epoch,
+                "to_epoch": to_epoch,
+                "by_epoch": by_epoch,
+            }))
+        }
+        "sentrix_getBftStatus" => {
+            let bc = state.read().await;
+            let latest = match bc.latest_block() {
+                Ok(b) => b.clone(),
+                Err(_) => {
+                    return Json(JsonRpcResponse::err(id, -32603, "chain empty"));
+                }
+            };
+            let next_height = latest.index.saturating_add(1);
+            let consensus = if sentrix_core::blockchain::Blockchain::is_voyager_height(
+                next_height,
+            ) {
+                "BFT"
+            } else {
+                "PoA"
+            };
+            // Live BFT round/phase state is owned by the validator loop's
+            // BftEngine and not yet published into Blockchain. For now we
+            // expose the chain-level finality view (last block carrying a
+            // BFT justification) and, in BFT mode, the weighted proposer
+            // the engine WOULD select for the next round-0.
+            let (finalized_height, finalized_hash) = if consensus == "PoA" {
+                (latest.index, latest.hash.clone())
+            } else {
+                let mut h = latest.index;
+                let mut hash = latest.hash.clone();
+                for b in bc.chain.iter().rev() {
+                    if b.justification.is_some() {
+                        h = b.index;
+                        hash = b.hash.clone();
+                        break;
+                    }
+                }
+                (h, hash)
+            };
+            let current_leader = if consensus == "PoA" {
+                bc.authority
+                    .expected_validator(next_height)
+                    .map(|v| v.address.clone())
+                    .unwrap_or_default()
+            } else {
+                bc.stake_registry
+                    .weighted_proposer(next_height, 0)
+                    .unwrap_or_default()
+            };
+            let rounds_since_last_block = if consensus == "BFT" {
+                latest.round as u64
+            } else {
+                0
+            };
+
+            if consensus == "PoA" {
+                Ok(json!({
+                    "consensus": "PoA",
+                    "current_leader": current_leader,
+                    "last_finalized_height": finalized_height,
+                    "last_finalized_hash": finalized_hash,
+                }))
+            } else {
+                Ok(json!({
+                    "consensus": "BFT",
+                    "current_round": serde_json::Value::Null,
+                    "current_view": serde_json::Value::Null,
+                    "current_leader": current_leader,
+                    "phase": serde_json::Value::Null,
+                    "rounds_since_last_block": rounds_since_last_block,
+                    "last_finalized_height": finalized_height,
+                    "last_finalized_hash": finalized_hash,
+                }))
+            }
+        }
+        "sentrix_getFinalizedHeight" => {
+            let bc = state.read().await;
+            let latest = match bc.latest_block() {
+                Ok(b) => b.clone(),
+                Err(_) => {
+                    return Json(JsonRpcResponse::err(id, -32603, "chain empty"));
+                }
+            };
+            let next_height = latest.index.saturating_add(1);
+            let bft = sentrix_core::blockchain::Blockchain::is_voyager_height(next_height);
+            let (finalized_height, finalized_hash) = if !bft {
+                (latest.index, latest.hash.clone())
+            } else {
+                let mut h = latest.index;
+                let mut hash = latest.hash.clone();
+                for b in bc.chain.iter().rev() {
+                    if b.justification.is_some() {
+                        h = b.index;
+                        hash = b.hash.clone();
+                        break;
+                    }
+                }
+                (h, hash)
+            };
+            Ok(json!({
+                "finalized_height": finalized_height,
+                "finalized_hash": finalized_hash,
+                "latest_height": latest.index,
+                "blocks_behind_finality": latest.index.saturating_sub(finalized_height),
+            }))
+        }
         "eth_syncing" => Ok(json!(false)),
         "eth_accounts" => Ok(json!([])),
         "eth_getCode" => {

--- a/docs/operations/API_REFERENCE.md
+++ b/docs/operations/API_REFERENCE.md
@@ -102,7 +102,154 @@ POST to `/rpc` with `Content-Type: application/json`.
 | Method | Description |
 |--------|-------------|
 | `sentrix_sendTransaction` | Submit a pre-signed Sentrix native transaction |
-| `sentrix_getBalance` | Balance in SRX (float string) |
+| `sentrix_getBalance` | Balance in wei (hex, × 10^10 conversion from sentri) |
+
+### Sentrix Native Methods (Sprint 1 — 2026-04-19)
+
+Methods that expose chain features MetaMask / `eth_*` cannot represent:
+DPoS validator set, delegation ledger, BFT finality, staking rewards.
+All amounts returned in **wei hex** (`sentri × 10^10`) so the same
+bignum libraries used for `eth_*` work here too.
+
+#### `sentrix_getValidatorSet`
+
+Returns the current DPoS validator set plus voting power distribution.
+
+Request:
+```json
+{"jsonrpc":"2.0","method":"sentrix_getValidatorSet","params":[],"id":1}
+```
+
+Response:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "active_count": 3,
+    "total_count": 3,
+    "total_active_stake": "0x...",
+    "epoch_number": 0,
+    "validators": [
+      {
+        "address": "0x...",
+        "name": "Foundation",
+        "stake": "0x...",
+        "commission": 0.1,
+        "status": "active",
+        "blocks_produced_epoch": 1234,
+        "uptime": 0.99,
+        "voting_power": "0x..."
+      }
+    ]
+  }
+}
+```
+
+`status` ∈ `"active" | "jailed" | "tombstoned" | "unbonding"`.
+`commission` is a float 0..1 (basis points ÷ 10 000).
+`uptime` = `blocks_signed / (blocks_signed + blocks_missed)`.
+
+#### `sentrix_getDelegations`
+
+Returns the delegations made by one address. Active delegations plus
+entries currently unbonding. Params: `[address: string]`.
+
+```json
+{"jsonrpc":"2.0","method":"sentrix_getDelegations","params":["0xdel..."],"id":1}
+```
+
+Each row:
+
+```json
+{
+  "validator": "0xval...",
+  "validator_name": "Foundation",
+  "amount": "0x... (wei)",
+  "pending_reward": "0x... (wei, estimate)",
+  "delegated_at_epoch": 12,
+  "status": "active",
+  "unbonding_complete_epoch": null
+}
+```
+
+`pending_reward` is a stake-weighted estimate against the validator's
+pending pool — per-delegator reward accounting is not yet persisted
+(tracked for a later sprint).
+
+#### `sentrix_getStakingRewards`
+
+Returns reward accrual for a delegator. Params:
+`[address: string, { from_epoch?: u64, to_epoch?: u64 }]`. Default window
+is the last 30 epochs.
+
+```json
+{
+  "total_lifetime": "0x... (wei)",
+  "pending_claimable": "0x... (wei)",
+  "from_epoch": 14,
+  "to_epoch": 44,
+  "by_epoch": [
+    { "epoch": 44, "validator": "0xval...", "reward": "0x...", "claimed": false }
+  ]
+}
+```
+
+Historical per-epoch per-delegator rewards are not persisted in the
+current chain state; the response returns the current epoch's
+stake-weighted share. Exact per-claim history requires the
+reward-ledger follow-up.
+
+#### `sentrix_getBftStatus`
+
+Returns consensus mode + finality view.
+
+PoA (mainnet today):
+
+```json
+{
+  "consensus": "PoA",
+  "current_leader": "0x...",
+  "last_finalized_height": 44700,
+  "last_finalized_hash": "..."
+}
+```
+
+BFT (post-Voyager / testnet):
+
+```json
+{
+  "consensus": "BFT",
+  "current_round": null,
+  "current_view": null,
+  "current_leader": "0xproposer_for_next_round_0",
+  "phase": null,
+  "rounds_since_last_block": 0,
+  "last_finalized_height": 21300,
+  "last_finalized_hash": "..."
+}
+```
+
+Live `current_round` / `phase` require the validator-loop `BftEngine`
+snapshot to be published into shared state — tracked as a Sprint 2
+dependency. Chain-side fields (leader, finality) are always populated.
+
+#### `sentrix_getFinalizedHeight`
+
+Shortcut to the finality view from `sentrix_getBftStatus`.
+
+```json
+{
+  "finalized_height": 44700,
+  "finalized_hash": "...",
+  "latest_height": 44700,
+  "blocks_behind_finality": 0
+}
+```
+
+PoA: `finalized_height == latest_height` (instant finality per
+round-robin signer). BFT: `latest - finalized` = number of blocks
+still in the pipeline.
 
 ### Batch requests
 

--- a/tests/integration_sentrix_native_rpc.rs
+++ b/tests/integration_sentrix_native_rpc.rs
@@ -1,0 +1,196 @@
+#![allow(missing_docs, clippy::expect_used, clippy::unwrap_used)]
+// integration_sentrix_native_rpc.rs — Sprint 1 coverage for the five
+// sentrix_* JSON-RPC methods added in feat/sprint1-sentrix-native-rpc.
+//
+// Tests boot an in-memory Blockchain with 3 validators + 2 delegators,
+// wrap it as the SharedState the RPC handler expects, invoke
+// jsonrpc_handler with a synthetic request per method, and assert the
+// response shape matches the Sprint 1 spec. No network / systemd / VPS.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use sentrix::core::blockchain::Blockchain;
+use sentrix::wallet::wallet::Wallet;
+use sentrix_rpc::jsonrpc::{JsonRpcRequest, jsonrpc_handler};
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+
+fn make_request(method: &str, params: Value) -> JsonRpcRequest {
+    JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        method: method.to_string(),
+        params: Some(params),
+        id: Some(json!(1)),
+    }
+}
+
+fn setup_chain_with_dpos() -> (Arc<RwLock<Blockchain>>, String, String, String, String) {
+    let (mut bc, admin) = common::setup_single_validator();
+    // `common::setup_single_validator` uses a hardcoded admin address for
+    // authority.add_validator — replay that through the admin handle.
+    let admin_addr = bc.authority.admin_address.clone();
+
+    let val1 = Wallet::generate();
+    let val2 = Wallet::generate();
+    let val3 = Wallet::generate();
+    let del1 = Wallet::generate();
+    let del2 = Wallet::generate();
+
+    let min_stake = sentrix_staking::MIN_SELF_STAKE;
+    for (i, v) in [&val1, &val2, &val3].iter().enumerate() {
+        bc.stake_registry
+            .register_validator(
+                &v.address,
+                min_stake.saturating_add(i as u64 * 1_000_000_000),
+                1000,
+                0,
+            )
+            .expect("register");
+        bc.authority
+            .add_validator(
+                &admin_addr,
+                v.address.clone(),
+                format!("Validator {}", i + 1),
+                v.public_key.clone(),
+            )
+            .expect("add_validator");
+    }
+    let _ = admin;
+
+    bc.stake_registry
+        .delegate(&del1.address, &val1.address, 5_000_000_000, 10)
+        .expect("delegate");
+    bc.stake_registry
+        .delegate(&del2.address, &val2.address, 7_000_000_000, 12)
+        .expect("delegate");
+    bc.stake_registry
+        .update_active_set();
+
+    (
+        Arc::new(RwLock::new(bc)),
+        val1.address,
+        val2.address,
+        del1.address,
+        del2.address,
+    )
+}
+
+#[tokio::test]
+async fn test_sentrix_get_validator_set_shape() {
+    let (state, _, _, _, _) = setup_chain_with_dpos();
+    let resp = jsonrpc_handler(State(state), Json(make_request("sentrix_getValidatorSet", json!([])))).await;
+    let result = resp.0.result.expect("result");
+    assert!(result.get("validators").and_then(|v| v.as_array()).is_some(), "validators array");
+    assert!(result.get("active_count").is_some());
+    assert!(result.get("total_count").is_some());
+    assert!(result.get("total_active_stake").is_some());
+    let first = &result["validators"][0];
+    for field in [
+        "address",
+        "name",
+        "stake",
+        "commission",
+        "status",
+        "blocks_produced_epoch",
+        "uptime",
+        "voting_power",
+    ] {
+        assert!(first.get(field).is_some(), "missing field: {field}");
+    }
+    assert!(
+        first["stake"].as_str().unwrap().starts_with("0x"),
+        "stake must be hex"
+    );
+}
+
+#[tokio::test]
+async fn test_sentrix_get_delegations_shape() {
+    let (state, val1, _val2, del1, _del2) = setup_chain_with_dpos();
+    let resp = jsonrpc_handler(
+        State(state),
+        Json(make_request("sentrix_getDelegations", json!([del1]))),
+    )
+    .await;
+    let result = resp.0.result.expect("result");
+    let list = result["delegations"].as_array().expect("delegations array");
+    assert_eq!(list.len(), 1, "del1 has exactly one active delegation");
+    let d = &list[0];
+    assert_eq!(d["validator"].as_str().unwrap(), val1);
+    assert!(d["amount"].as_str().unwrap().starts_with("0x"));
+    assert!(d["pending_reward"].as_str().unwrap().starts_with("0x"));
+    assert_eq!(d["status"].as_str().unwrap(), "active");
+}
+
+#[tokio::test]
+async fn test_sentrix_get_delegations_requires_address() {
+    let (state, _, _, _, _) = setup_chain_with_dpos();
+    let resp = jsonrpc_handler(
+        State(state),
+        Json(make_request("sentrix_getDelegations", json!([]))),
+    )
+    .await;
+    let err = resp.0.error.expect("error");
+    assert_eq!(err.code, -32602, "address required → -32602 invalid params");
+}
+
+#[tokio::test]
+async fn test_sentrix_get_staking_rewards_default_window() {
+    let (state, _, _, del1, _) = setup_chain_with_dpos();
+    let resp = jsonrpc_handler(
+        State(state),
+        Json(make_request("sentrix_getStakingRewards", json!([del1]))),
+    )
+    .await;
+    let result = resp.0.result.expect("result");
+    assert!(result["total_lifetime"].as_str().unwrap().starts_with("0x"));
+    assert!(result["pending_claimable"].as_str().unwrap().starts_with("0x"));
+    assert!(result["by_epoch"].is_array());
+    assert!(result["from_epoch"].is_number());
+    assert!(result["to_epoch"].is_number());
+}
+
+#[tokio::test]
+async fn test_sentrix_get_bft_status_poa_mode() {
+    // Default chain (no VOYAGER_FORK_HEIGHT env) stays on PoA, so the
+    // status payload is the PoA subset with finalized = latest.
+    let (state, _, _, _, _) = setup_chain_with_dpos();
+    let resp = jsonrpc_handler(
+        State(state.clone()),
+        Json(make_request("sentrix_getBftStatus", json!([]))),
+    )
+    .await;
+    let result = resp.0.result.expect("result");
+    assert_eq!(result["consensus"].as_str().unwrap(), "PoA");
+    assert!(result.get("current_leader").is_some());
+    assert!(result.get("last_finalized_height").is_some());
+    assert!(result.get("last_finalized_hash").is_some());
+    // PoA response does NOT include BFT-only fields.
+    assert!(result.get("current_round").is_none(), "PoA must omit current_round");
+}
+
+#[tokio::test]
+async fn test_sentrix_get_finalized_height_poa_equals_latest() {
+    let (state, _, _, _, _) = setup_chain_with_dpos();
+    let latest = state.read().await.height();
+    let resp = jsonrpc_handler(
+        State(state),
+        Json(make_request("sentrix_getFinalizedHeight", json!([]))),
+    )
+    .await;
+    let result = resp.0.result.expect("result");
+    assert_eq!(result["latest_height"].as_u64().unwrap(), latest);
+    assert_eq!(
+        result["finalized_height"].as_u64().unwrap(),
+        latest,
+        "PoA instant finality: finalized == latest"
+    );
+    assert_eq!(
+        result["blocks_behind_finality"].as_u64().unwrap(),
+        0,
+        "PoA lag should be zero"
+    );
+}


### PR DESCRIPTION
Sprint 1 of the sentrix_* native RPC namespace. See commit message for method spec + Sprint 2 caveats.