### PR TITLE
chore(rpc): expand root self-describe with full API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **chore(rpc): expand root endpoint self-describe with full REST
+  surface + JSON-RPC namespaces** — `GET /` now returns the complete
+  REST endpoint map (accounts, staking, epoch, mempool, metrics) plus
+  a `jsonrpc_namespaces` section advertising `eth_*`, `net_*`, `web3_*`,
+  `sentrix_*`. Adds `consensus` (PoA/BFT from chain_id) and
+  `native_token` ("SRX") top-level fields so wallets can discover chain
+  semantics without scraping docs.
+
 ### Added
 - **Sentrix native JSON-RPC namespace (Sprint 1)** — five new methods
   that expose chain features the `eth_*` namespace cannot represent:

--- a/crates/sentrix-rpc/src/routes.rs
+++ b/crates/sentrix-rpc/src/routes.rs
@@ -473,18 +473,38 @@ fn explorer_router(_state: SharedState) -> Router<SharedState> {
 
 // ── Handlers ─────────────────────────────────────────────
 async fn root() -> Json<serde_json::Value> {
+    let chain_id = sentrix_core::blockchain::get_chain_id();
+    let consensus = if chain_id == 7119 { "PoA" } else { "BFT" };
     Json(serde_json::json!({
         "name": "Sentrix",
-        "chain_id": sentrix_core::blockchain::get_chain_id(),
         "version": env!("CARGO_PKG_VERSION"),
+        "chain_id": chain_id,
+        "consensus": consensus,
+        "native_token": "SRX",
         "docs": {
-            "chain_info": "/chain/info",
-            "blocks": "/chain/blocks",
-            "tokens": "/tokens",
-            "validators": "/validators",
-            "explorer": "/explorer",
-            "health": "/health",
-            "rpc": "POST /rpc"
+            "rpc_jsonrpc": "POST /rpc",
+            "rest": {
+                "chain_info": "/chain/info",
+                "blocks": "/chain/blocks",
+                "transactions": "/transactions",
+                "accounts": "/accounts/{address}",
+                "tokens": "/tokens",
+                "validators": "/validators",
+                "staking": "/staking",
+                "epoch": "/epoch/current",
+                "mempool": "/mempool"
+            },
+            "ops": {
+                "health": "/health",
+                "metrics": "/metrics",
+                "explorer_builtin": "/explorer"
+            }
+        },
+        "jsonrpc_namespaces": {
+            "eth_": "Ethereum-compatible (MetaMask, ethers.js, Hardhat)",
+            "net_": "Network info",
+            "web3_": "Client version",
+            "sentrix_": "Native Sentrix (validators, BFT, staking, delegations, finality)"
         }
     }))
 }

--- a/docs/operations/API_REFERENCE.md
+++ b/docs/operations/API_REFERENCE.md
@@ -12,7 +12,7 @@ Base URL: `https://testnet-rpc.sentriscloud.com` (testnet) or `https://sentrix-r
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/` | Node info (name, version, chain_id, links) |
+| GET | `/` | Node self-describe (name, version, chain_id, consensus, endpoint map, JSON-RPC namespaces) — see [Root response](#root-response) |
 | GET | `/health` | Health check (`{"status":"ok"}`) |
 | GET | `/metrics` | Prometheus-format metrics (block height, validators, mempool, uptime) |
 | GET | `/chain/info` | Chain stats (height, supply, validators, mempool, etc.) |
@@ -295,6 +295,53 @@ curl -X POST http://localhost:8545/transactions \
   -H "X-API-Key: your-api-key-here" \
   -d '{"transaction": { ... }}'
 ```
+
+---
+
+## Root response
+
+`GET /` returns the node self-describe payload used by wallets and
+explorers for chain discovery.
+
+```json
+{
+  "name": "Sentrix",
+  "version": "2.0.0",
+  "chain_id": 7119,
+  "consensus": "PoA",
+  "native_token": "SRX",
+  "docs": {
+    "rpc_jsonrpc": "POST /rpc",
+    "rest": {
+      "chain_info": "/chain/info",
+      "blocks": "/chain/blocks",
+      "transactions": "/transactions",
+      "accounts": "/accounts/{address}",
+      "tokens": "/tokens",
+      "validators": "/validators",
+      "staking": "/staking",
+      "epoch": "/epoch/current",
+      "mempool": "/mempool"
+    },
+    "ops": {
+      "health": "/health",
+      "metrics": "/metrics",
+      "explorer_builtin": "/explorer"
+    }
+  },
+  "jsonrpc_namespaces": {
+    "eth_": "Ethereum-compatible (MetaMask, ethers.js, Hardhat)",
+    "net_": "Network info",
+    "web3_": "Client version",
+    "sentrix_": "Native Sentrix (validators, BFT, staking, delegations, finality)"
+  }
+}
+```
+
+`consensus` is derived from `chain_id` (`7119` → `PoA`, otherwise →
+`BFT`). `native_token` is `SRX` on every network. The endpoint map
+lists the canonical path per resource — handlers are registered in
+`crates/sentrix-rpc/src/routes.rs`.
 
 ---
 


### PR DESCRIPTION
## Summary

- `GET /` previously listed 7 stale endpoints. Sprint 1 + 1.1 shipped ~30 more REST endpoints and 4 JSON-RPC namespaces that were invisible to wallets scraping the root.
- Expand the handler to advertise the full REST surface (accounts, staking, epoch, mempool, metrics), add `jsonrpc_namespaces` map (`eth_*`, `net_*`, `web3_*`, `sentrix_*`), and surface `consensus` (PoA/BFT from `chain_id`) + `native_token` ("SRX").
- Handler only — no new endpoints, no route changes.

## Changes

- `crates/sentrix-rpc/src/routes.rs:475-511` — `fn root()` expanded; all advertised paths verified against the axum router registration in the same file.
- `docs/operations/API_REFERENCE.md` — new `## Root response` section with full example payload.
- `CHANGELOG.md` — entry under `[Unreleased] / Changed`.

## Test plan

- [x] `cargo build -p sentrix-rpc --release` clean
- [x] `cargo clippy -p sentrix-rpc --release -- -D warnings` clean
- [ ] CI green
- [ ] Post-deploy: `curl https://sentrix-rpc.sentriscloud.com/` returns expanded payload