### PR TITLE
docs: sync CHANGELOG + RELEASE with fast-deploy workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,21 +11,47 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - **chore(rpc): expand root endpoint self-describe with full REST
-  surface + JSON-RPC namespaces** — `GET /` now returns the complete
-  REST endpoint map (accounts, staking, epoch, mempool, metrics) plus
-  a `jsonrpc_namespaces` section advertising `eth_*`, `net_*`, `web3_*`,
-  `sentrix_*`. Adds `consensus` (PoA/BFT from chain_id) and
-  `native_token` ("SRX") top-level fields so wallets can discover chain
-  semantics without scraping docs.
+  surface + JSON-RPC namespaces** (PR #140) — `GET /` now returns the
+  complete REST endpoint map (accounts, staking, epoch, mempool,
+  metrics) plus a `jsonrpc_namespaces` section advertising `eth_*`,
+  `net_*`, `web3_*`, `sentrix_*`. Adds `consensus` (PoA/BFT from
+  chain_id) and `native_token` ("SRX") top-level fields so wallets can
+  discover chain semantics without scraping docs.
+- **feat(ops): fast-deploy.sh as primary deploy path** (PR #139) — new
+  `scripts/fast-deploy.sh` builds on VPS4, uploads binary via wg1 SCP,
+  rolling restart with bounded health check. Cuts deploy time from
+  ~10–12 min (CI cold cargo cache) to ~3–5 min. CI `deploy` job
+  disabled (`if: false`) — CI still runs tests for audit trail. New
+  `scripts/emergency-deploy.sh` for break-glass cases.
+- **fix(deploy): build in bullseye container to match VPS1/VPS2 glibc**
+  (PR #141) — `fast-deploy.sh` build step runs inside
+  `rust:1.95-bullseye` (glibc 2.31) so binaries work on every target
+  regardless of VPS4 host OS. Fixes crash-loop on commit e49e01d where
+  a VPS4 24.04 native build (glibc 2.39) failed to load on VPS1/VPS2
+  (22.04, glibc 2.35).
 
 ### Added
-- **Sentrix native JSON-RPC namespace (Sprint 1)** — five new methods
-  that expose chain features the `eth_*` namespace cannot represent:
-  `sentrix_getValidatorSet`, `sentrix_getDelegations`,
+- **Sentrix native JSON-RPC namespace (Sprint 1)** (PR #137) — five
+  new methods that expose chain features the `eth_*` namespace cannot
+  represent: `sentrix_getValidatorSet`, `sentrix_getDelegations`,
   `sentrix_getStakingRewards`, `sentrix_getBftStatus`,
   `sentrix_getFinalizedHeight`. Amounts returned in wei hex so
   existing bignum libraries keep working. See
   `docs/operations/API_REFERENCE.md` for the full payload spec.
+
+### Fixed
+- **sentrix_getValidatorSet PoA fallback (Sprint 1.1)** (PR #138) — on
+  mainnet `stake_registry` is empty pre-Voyager, so the initial
+  Sprint 1 implementation returned `validators: []`. The handler now
+  falls back to `AuthorityManager` when `is_voyager_height(height)` is
+  false or the DPoS registry is empty, and marks the response
+  `consensus: "PoA"`. DPoS path unchanged for post-Voyager / testnet.
+- **BFT catch_up silent validator** (PR #134, issue #133) — after a
+  catch-up round the validator was left silent in the Propose phase
+  because `our_prevote_cast` stayed false. Added an explicit nil
+  prevote emission + flag flip so the validator always participates in
+  the next round's quorum. Surfaced via a TPS benchmark that stalled
+  testnet briefly.
 
 ### Planned
 - Mainnet hard fork to Voyager (DPoS + BFT + EVM)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,13 +20,32 @@ Sentrix follows [Semantic Versioning](https://semver.org/):
 
 ## Deployment
 
-Deployment is fully automated via CI/CD (GitHub Actions). **Never deploy manually via SSH.**
+Primary path: **`scripts/fast-deploy.sh`** (runs from VPS4). Builds
+inside a `rust:1.95-bullseye` container (glibc 2.31, compatible with
+both 22.04 and 24.04 targets), uploads the binary to VPS1/VPS2/VPS3
+via wg1 SCP, and does a rolling restart with a bounded health check.
+~3–5 minutes end-to-end.
 
-Pipeline: Push to `main` → Test → Build → Upload binary → Stop VPS3/VPS2/VPS1 → Replace → Start VPS1/VPS2/VPS3 → Health check
+```bash
+./scripts/fast-deploy.sh mainnet          # asks for confirmation
+./scripts/fast-deploy.sh testnet          # silent
+SENTRIX_ROLLBACK=/opt/sentrix/releases/<prev> \
+  ./scripts/fast-deploy.sh mainnet        # instant rollback
+```
+
+CI still runs tests on every PR (for audit trail) but the GitHub
+Actions `deploy` job is disabled — `fast-deploy.sh` is the only path
+that ships a binary to prod. This avoids the race where both CI and
+`fast-deploy` would redeploy the same commit.
+
+Break-glass: **`scripts/emergency-deploy.sh`** skips the preflight
+test gate and requires a strict confirmation phrase. Use only when
+GitHub Actions is down, chain has halted, or an exploit needs a
+bypass of the normal regression gate.
 
 ## Hotfix Process
 
 1. Branch from `main`
 2. Fix + test
-3. PR with `fix(scope):` commit message
-4. Merge triggers auto-deploy
+3. PR with `fix(scope):` commit message — auto-merge on green CI
+4. Run `./scripts/fast-deploy.sh mainnet` from VPS4 after merge


### PR DESCRIPTION
## Summary

- CHANGELOG.md `[Unreleased]` was missing entries for PR #137 (Sprint 1 RPC), #138 (PoA fallback), #139 (fast-deploy), #141 (docker build fix), and issue #133 / PR #134 (BFT catch_up silent validator).
- RELEASE.md still claimed "Never deploy manually via SSH" and described the old CI-deploys-everything flow. The actual primary path is now `scripts/fast-deploy.sh`; CI deploy job is disabled.

## Changes

- `CHANGELOG.md` — expand `[Unreleased]` with Sprint 1 + 1.1 + fast-deploy + bullseye build + BFT catch_up fix, all tagged with their PR numbers.
- `RELEASE.md` — rewrite "Deployment" section for fast-deploy.sh primary + emergency-deploy.sh break-glass. Hotfix process reflects run-locally workflow.