### PR TITLE
perf(validator): Pioneer-mode 200ms poll gated on BLOCK_TIME_SECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   refresh on epoch rotation, and cache reset on height advance.
 
 ### Changed
+- **perf(validator): Pioneer-mode poll 3s → 200ms + `BLOCK_TIME_SECS`
+  gate** — the Pioneer/PoA validator loop previously slept a fixed 3s
+  between block attempts, so the effective mainnet block time
+  oscillated around 3s instead of the configured 1s. The loop now
+  polls every 200ms and only attempts to build a block when at least
+  `BLOCK_TIME_SECS` has elapsed since the last one, giving a
+  consistent ~1s cadence with at most 200ms jitter. No change to
+  block validation rules.
 - **refactor(token): rename SRX-20 → SRC-20 across code + docs for
   naming consistency.** Address prefix `SRX20_` → `SRC20_`. **BREAKING:**
   contract address prefix changed. Safe — zero native tokens deployed

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -4,7 +4,7 @@
 use clap::{Parser, Subcommand};
 use libp2p::Multiaddr;
 use sentrix::api::routes::{SharedState, create_router};
-use sentrix::core::blockchain::Blockchain;
+use sentrix::core::blockchain::{BLOCK_TIME_SECS, Blockchain};
 use sentrix::core::transaction::{TOKEN_OP_ADDRESS, TokenOp, Transaction};
 use sentrix::network::libp2p_node::{LibP2pNode, make_multiaddr};
 use sentrix::network::node::{DEFAULT_PORT, NodeEvent};
@@ -962,6 +962,14 @@ async fn cmd_start(
             let mut bft_engine: Option<BftEngine> = None;
             let mut voyager_tick_count: u64 = 0;
             let mut proposed_block: Option<Block> = None;
+            // Pioneer mode: track last block time for a fine-grained poll loop.
+            // Poll every PIONEER_TICK, but only attempt to build a block when
+            // at least BLOCK_TIME_SECS has elapsed since the last one. Gives
+            // a consistent ~1s cadence without blocking the loop for 3s when
+            // nothing is happening (previous 3s sleep made the effective
+            // block time oscillate around 3s instead of the configured 1s).
+            let mut pioneer_last_block = tokio::time::Instant::now()
+                - tokio::time::Duration::from_secs(BLOCK_TIME_SECS);
 
             loop {
                 if shutdown_flag_clone.load(Ordering::Acquire) {
@@ -1002,10 +1010,23 @@ async fn cmd_start(
                 }
 
                 // ════════════════════════════════════════════════
-                // Pioneer mode: original 3s polling, no BFT
+                // Pioneer mode: 200ms poll, produce block once per
+                // BLOCK_TIME_SECS. This replaces the original 3s fixed
+                // sleep which made the effective block time oscillate
+                // around 3s instead of the configured 1s.
                 // ════════════════════════════════════════════════
                 if !voyager_activated {
-                    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+                    const PIONEER_TICK: tokio::time::Duration =
+                        tokio::time::Duration::from_millis(200);
+                    tokio::time::sleep(PIONEER_TICK).await;
+
+                    // Gate block production on BLOCK_TIME_SECS so the tighter
+                    // poll doesn't produce a burst of sub-second blocks.
+                    if pioneer_last_block.elapsed()
+                        < tokio::time::Duration::from_secs(BLOCK_TIME_SECS)
+                    {
+                        continue;
+                    }
 
                     let result = {
                         let mut bc = shared_clone.write().await;
@@ -1028,6 +1049,7 @@ async fn cmd_start(
                     };
 
                     if let Some((height, Some(block_to_save))) = result {
+                        pioneer_last_block = tokio::time::Instant::now();
                         // H-09: only broadcast after the block is durably
                         // persisted. A broadcast of a block we can't recover
                         // on restart is a fork risk — peers would accept


### PR DESCRIPTION
## Summary
Closes backlog P0 #2. Pioneer/PoA validator loop previously slept a fixed 3s between block attempts, so the effective mainnet block time oscillated around 3s instead of the configured \`BLOCK_TIME_SECS = 1\`.

## Change
Replace \`tokio::time::sleep(Duration::from_secs(3))\` with a 200ms tick + \`pioneer_last_block.elapsed() < BLOCK_TIME_SECS → continue\` gate. A local \`Instant\` tracks when we last produced a block; on every 200ms wake, if not enough time has passed we skip and go back to sleep.

Result: consistent ~1s blocks with at most 200ms jitter. No new per-block state, no change to validation rules, no BFT interaction (Pioneer is PoA only).

## Scope
- \`bin/sentrix/src/main.rs\`: +25 / -3 (new \`pioneer_last_block\` state, 200ms tick, elapsed gate)
- \`CHANGELOG.md\`: entry under \`[Unreleased]\` / \`Changed\`

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` clean
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [ ] CI green
- [ ] After merge: deploy mainnet, observe block cadence converges on ~1s (previously ~2-3s)