### PR TITLE
fix(rpc): /sentrix_status — eager uptime init + PoA validator count

### DIFF
--- a/crates/sentrix-rpc/src/routes.rs
+++ b/crates/sentrix-rpc/src/routes.rs
@@ -271,6 +271,12 @@ async fn write_rate_limit_middleware(
 
 // ── Router ───────────────────────────────────────────────
 pub fn create_router(state: SharedState) -> Router {
+    // Eagerly pin the process start time so /sentrix_status and /metrics
+    // report uptime relative to boot, not to the first handler call that
+    // happened to trigger the OnceLock. Without this, uptime_seconds was
+    // 0 on the first /sentrix_status request and undercounted thereafter.
+    let _ = START_TIME.get_or_init(Instant::now);
+
     // CORS uses a fail-safe restrictive default — no cross-origin allowed unless SENTRIX_CORS_ORIGIN is set.
     // Use SENTRIX_CORS_ORIGIN=* for local development only; set specific origins in production.
     let cors = match std::env::var("SENTRIX_CORS_ORIGIN").ok().as_deref() {
@@ -540,7 +546,14 @@ pub async fn sentrix_status(State(state): State<SharedState>) -> Json<serde_json
     // Window start = earliest block we can answer from RAM. Useful for
     // clients deciding whether to use this node as a history source.
     let earliest_height = bc.chain.first().map(|b| b.index).unwrap_or(0);
-    let active_validators = bc.stake_registry.active_count();
+    // PoA reads from the authority set; Voyager/BFT reads from the DPoS
+    // stake registry. Picking the wrong source returns 0 (the other set
+    // is empty on that chain).
+    let active_validators = if consensus == "PoA" {
+        bc.authority.active_count()
+    } else {
+        bc.stake_registry.active_count()
+    };
     // "Syncing" here means we are behind any known peer. Without a peer
     // view here, we approximate `syncing = false` (operators watching this
     // should cross-check with /chain/info window_is_partial).

--- a/tests/integration_sentrix_status.rs
+++ b/tests/integration_sentrix_status.rs
@@ -106,3 +106,25 @@ async fn uptime_is_monotonic_across_calls() {
     let u2 = r2.0["uptime_seconds"].as_u64().expect("uptime u64");
     assert!(u2 >= u1, "uptime must be monotonic ({u1} → {u2})");
 }
+
+#[tokio::test]
+async fn active_validator_count_reflects_consensus_source() {
+    // Pre-fix this returned 0 on mainnet because the handler only
+    // queried stake_registry (DPoS). PoA chains surface active count
+    // via `authority.active_count()` instead.
+    let (bc, _admin) = common::setup_single_validator();
+    let state = shared(bc);
+    let resp = sentrix_status(State(state)).await;
+    let consensus = resp.0["consensus"].as_str().expect("consensus");
+    let count = resp.0["validators"]["active_count"]
+        .as_u64()
+        .expect("active_count u64");
+    if consensus == "PoA" {
+        assert!(
+            count >= 1,
+            "PoA chain should surface at least one authority validator, got {count}",
+        );
+    }
+    // BFT path needs a stake-registry fixture that
+    // `setup_single_validator` doesn't build — covered separately.
+}


### PR DESCRIPTION
## Summary
Two cosmetic follow-ups on #13 (PR #149) surfaced during live verify on testnet + mainnet:

1. **`uptime_seconds` always 0 on first call** — `START_TIME` was a `OnceLock` initialised lazily by whichever handler was called first. Pin it eagerly in `create_router` so uptime is measured from boot.

2. **`validators.active_count` = 0 on mainnet** — handler read only `stake_registry.active_count()` (DPoS-only). Mainnet is PoA so the stake registry is empty. Switch on consensus tag: PoA → `authority.active_count()`, BFT → `stake_registry.active_count()`. Same pattern used by `sentrix_getValidatorSet` PoA fallback (#138).

## Before
```json
{ "consensus": "PoA", "uptime_seconds": 0, "validators": { "active_count": 0 } }
```

## After
```json
{ "consensus": "PoA", "uptime_seconds": 42, "validators": { "active_count": 3 } }
```

## Test plan
- [x] 5 integration tests pass (1 new for PoA active count)
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [ ] CI green
- [ ] After merge: `curl https://sentrix-rpc.sentriscloud.com/sentrix_status` shows `active_count >= 3` + `uptime_seconds > 0` immediately after deploy