### PR TITLE
refactor(rpc): extract jsonrpc helpers to submodule (backlog #11 phase 1)

### DIFF
--- a/crates/sentrix-rpc/src/jsonrpc/helpers.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/helpers.rs
@@ -1,0 +1,268 @@
+// helpers.rs — shared helpers used by all JSON-RPC namespace modules
+// (eth / net / web3 / sentrix). Pulled out of the monolithic
+// `jsonrpc.rs` during the backlog #11 refactor so each namespace file
+// can stay focused on its handlers.
+
+use serde_json::Value;
+
+pub(super) fn to_hex(n: u64) -> String {
+    format!("0x{:x}", n)
+}
+
+pub(super) fn to_hex_u128(n: u128) -> String {
+    format!("0x{:x}", n)
+}
+
+/// M-11: validate a JSON-RPC address parameter before it is used as a
+/// trie/DB lookup key. Accepts exactly `0x` + 40 hex lowercase and
+/// returns the normalised string, or `Err` with an error message suitable
+/// for JSON-RPC -32602 (Invalid params). Prevents oddly-shaped strings
+/// (empty, too-long, non-hex) from reaching the account store where
+/// they are merely a silent miss, wasting compute per malformed request
+/// under adversarial load.
+pub(super) fn normalize_rpc_address(s: &str) -> Result<String, &'static str> {
+    if s.len() != 42 {
+        return Err("address must be 42 chars (0x + 40 hex)");
+    }
+    let lower = s.to_lowercase();
+    if !lower.starts_with("0x") {
+        return Err("address must start with 0x");
+    }
+    if !lower[2..].chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("address must be lowercase hex after 0x");
+    }
+    Ok(lower)
+}
+
+/// M-11: validate a JSON-RPC 32-byte hash parameter (tx hash, block
+/// hash). Same rationale as `normalize_rpc_address` — keeps malformed
+/// hex out of DB lookups.
+pub(super) fn normalize_rpc_hash(s: &str) -> Result<String, &'static str> {
+    let stripped = s.strip_prefix("0x").unwrap_or(s);
+    if stripped.len() != 64 {
+        return Err("hash must be 32 bytes (64 hex chars)");
+    }
+    if !stripped.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("hash must be hex");
+    }
+    Ok(stripped.to_lowercase())
+}
+
+pub(super) fn parse_hex_u64(v: &Value) -> Option<u64> {
+    match v {
+        Value::String(s) => {
+            let s = s.trim_start_matches("0x");
+            u64::from_str_radix(s, 16).ok()
+        }
+        Value::Number(n) => n.as_u64(),
+        _ => None,
+    }
+}
+
+pub(super) fn resolve_block_tag(v: Option<&Value>, latest: u64) -> Result<u64, &'static str> {
+    match v {
+        None => Ok(latest),
+        Some(Value::String(s)) => match s.as_str() {
+            "latest" | "pending" | "safe" | "finalized" => Ok(latest),
+            "earliest" => Ok(0),
+            hex if hex.starts_with("0x") => {
+                u64::from_str_radix(&hex[2..], 16).map_err(|_| "invalid hex block number")
+            }
+            _ => Err("invalid block tag"),
+        },
+        Some(Value::Number(n)) => n.as_u64().ok_or("invalid block number"),
+        _ => Err("invalid block parameter"),
+    }
+}
+
+/// Address filter accepts either a single string or an array. Normalizes to
+/// lowercase 20-byte arrays; unparseable entries are silently skipped so
+/// malformed filters still work against the rest of the query.
+pub(super) fn parse_address_filter(v: Option<&Value>) -> Vec<[u8; 20]> {
+    let mut out = Vec::new();
+    let push = |s: &str, out: &mut Vec<[u8; 20]>| {
+        let s = s.trim_start_matches("0x");
+        if let Ok(bytes) = hex::decode(s)
+            && bytes.len() == 20
+        {
+            let mut arr = [0u8; 20];
+            arr.copy_from_slice(&bytes);
+            out.push(arr);
+        }
+    };
+    match v {
+        None | Some(Value::Null) => {}
+        Some(Value::String(s)) => push(s, &mut out),
+        Some(Value::Array(arr)) => {
+            for item in arr {
+                if let Some(s) = item.as_str() {
+                    push(s, &mut out);
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Topics filter: outer index is position (topic0..topic3). Inner vec is the
+/// OR-set for that position — empty means wildcard. `None` in topics[i]
+/// means the position is omitted entirely (also wildcard).
+pub(super) type TopicFilter = Vec<Option<Vec<[u8; 32]>>>;
+
+pub(super) fn parse_topic_filter(v: Option<&Value>) -> TopicFilter {
+    let mut out: TopicFilter = Vec::new();
+    let parse_one = |s: &str| -> Option<[u8; 32]> {
+        let s = s.trim_start_matches("0x");
+        let bytes = hex::decode(s).ok()?;
+        if bytes.len() != 32 {
+            return None;
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        Some(arr)
+    };
+    let arr = match v {
+        Some(Value::Array(a)) => a,
+        _ => return out,
+    };
+    for slot in arr {
+        match slot {
+            Value::Null => out.push(None),
+            Value::String(s) => out.push(Some(parse_one(s).into_iter().collect())),
+            Value::Array(inner) => {
+                let set: Vec<[u8; 32]> = inner
+                    .iter()
+                    .filter_map(|x| x.as_str().and_then(parse_one))
+                    .collect();
+                out.push(Some(set));
+            }
+            _ => out.push(None),
+        }
+    }
+    out
+}
+
+pub(super) fn log_matches(
+    log: &sentrix_evm::StoredLog,
+    addrs: &[[u8; 20]],
+    topics: &TopicFilter,
+) -> bool {
+    if !addrs.is_empty() && !addrs.iter().any(|a| a == &log.address) {
+        return false;
+    }
+    for (i, slot) in topics.iter().enumerate() {
+        let Some(set) = slot else { continue };
+        if set.is_empty() {
+            continue;
+        }
+        let topic = match log.topics.get(i) {
+            Some(t) => t,
+            None => return false,
+        };
+        if !set.iter().any(|s| s == topic) {
+            return false;
+        }
+    }
+    true
+}
+
+pub(super) fn collect_logs(
+    bc: &sentrix_core::blockchain::Blockchain,
+    from: u64,
+    to: u64,
+    addrs: &[[u8; 20]],
+    topics: &TopicFilter,
+) -> Vec<Value> {
+    let storage = match bc.mdbx_storage.as_ref() {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+    let all = match storage.iter(sentrix_storage::tables::TABLE_LOGS) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for (k, v) in all {
+        if k.len() < 16 {
+            continue;
+        }
+        let mut h_bytes = [0u8; 8];
+        h_bytes.copy_from_slice(&k[..8]);
+        let height = u64::from_be_bytes(h_bytes);
+        if height < from || height > to {
+            continue;
+        }
+        if let Some(bloom_bytes) = storage
+            .get(sentrix_storage::tables::TABLE_BLOOM, &h_bytes)
+            .ok()
+            .flatten()
+            && bloom_bytes.len() == 256
+            && !addrs.is_empty()
+        {
+            let mut bloom = [0u8; 256];
+            bloom.copy_from_slice(&bloom_bytes);
+            let any_hit = addrs.iter().any(|a| sentrix_evm::bloom_contains(&bloom, a));
+            if !any_hit {
+                continue;
+            }
+        }
+        let Ok(log) = bincode::deserialize::<sentrix_evm::StoredLog>(&v) else {
+            continue;
+        };
+        if log_matches(&log, addrs, topics) {
+            out.push(log.to_rpc_json());
+        }
+    }
+    out
+}
+
+pub(super) fn load_logs_for_tx(
+    bc: &sentrix_core::blockchain::Blockchain,
+    block_height: u64,
+    txid: &str,
+) -> (Vec<Value>, String) {
+    let mut target_hash = [0u8; 32];
+    if let Ok(decoded) = hex::decode(txid.trim_start_matches("0x")) {
+        let n = decoded.len().min(32);
+        target_hash[..n].copy_from_slice(&decoded[..n]);
+    }
+    let storage = match bc.mdbx_storage.as_ref() {
+        Some(s) => s,
+        None => return (Vec::new(), "0x".to_string() + &"00".repeat(256)),
+    };
+    let prefix = block_height.to_be_bytes();
+    let entries = match storage.iter(sentrix_storage::tables::TABLE_LOGS) {
+        Ok(v) => v,
+        Err(_) => return (Vec::new(), "0x".to_string() + &"00".repeat(256)),
+    };
+    let mut logs = Vec::new();
+    let mut bloom = sentrix_evm::empty_bloom();
+    for (k, v) in entries {
+        if k.len() < 8 || k[..8] != prefix {
+            continue;
+        }
+        let Ok(log) = bincode::deserialize::<sentrix_evm::StoredLog>(&v) else {
+            continue;
+        };
+        if log.tx_hash == target_hash {
+            sentrix_evm::add_log_to_bloom(&mut bloom, &log.address, &log.topics);
+            logs.push(log.to_rpc_json());
+        }
+    }
+    (logs, format!("0x{}", hex::encode(bloom)))
+}
+
+pub(super) fn block_gas_used_ratio(bc: &sentrix_core::blockchain::Blockchain, height: u64) -> f64 {
+    let block = match bc.chain.iter().find(|b| b.index == height) {
+        Some(b) => b,
+        None => return 0.0,
+    };
+    let total_gas: u64 = block
+        .transactions
+        .iter()
+        .filter(|t| t.is_evm_tx())
+        .map(|_| 21_000u64)
+        .sum();
+    (total_gas as f64) / (sentrix_evm::gas::BLOCK_GAS_LIMIT as f64)
+}

--- a/crates/sentrix-rpc/src/jsonrpc/mod.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/mod.rs
@@ -1,6 +1,18 @@
-// jsonrpc.rs - Sentrix — Ethereum-compatible JSON-RPC 2.0
+// jsonrpc/mod.rs - Sentrix — Ethereum-compatible JSON-RPC 2.0 dispatcher.
+//
+// Namespace-specific handlers (eth_*, net_*, web3_*, sentrix_*) live in
+// sibling modules under `crate::jsonrpc::` — this file wires them up
+// behind the batch/single dispatcher and keeps the JSON-RPC 2.0
+// envelope types. Shared helpers are in `helpers.rs`. (backlog #11)
+
+mod helpers;
 
 use crate::routes::{ApiKey, SharedState};
+use helpers::{
+    block_gas_used_ratio, collect_logs, load_logs_for_tx, normalize_rpc_address,
+    normalize_rpc_hash, parse_address_filter, parse_hex_u64, parse_topic_filter, resolve_block_tag,
+    to_hex, to_hex_u128,
+};
 use sentrix_primitives::transaction::Transaction;
 use axum::{Json, extract::State};
 use serde::{Deserialize, Serialize};
@@ -51,48 +63,6 @@ impl JsonRpcResponse {
             id,
         }
     }
-}
-
-fn to_hex(n: u64) -> String {
-    format!("0x{:x}", n)
-}
-fn to_hex_u128(n: u128) -> String {
-    format!("0x{:x}", n)
-}
-
-/// M-11: validate a JSON-RPC address parameter before it is used as a
-/// trie/DB lookup key. Accepts exactly `0x` + 40 hex lowercase and
-/// returns the normalised string, or `Err` with an error message suitable
-/// for JSON-RPC -32602 (Invalid params). Prevents oddly-shaped strings
-/// (empty, too-long, non-hex) from reaching the account store where
-/// they are merely a silent miss, wasting compute per malformed request
-/// under adversarial load.
-fn normalize_rpc_address(s: &str) -> Result<String, &'static str> {
-    if s.len() != 42 {
-        return Err("address must be 42 chars (0x + 40 hex)");
-    }
-    let lower = s.to_lowercase();
-    if !lower.starts_with("0x") {
-        return Err("address must start with 0x");
-    }
-    if !lower[2..].chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err("address must be lowercase hex after 0x");
-    }
-    Ok(lower)
-}
-
-/// M-11: validate a JSON-RPC 32-byte hash parameter (tx hash, block
-/// hash). Same rationale as `normalize_rpc_address` — keeps malformed
-/// hex out of DB lookups.
-fn normalize_rpc_hash(s: &str) -> Result<String, &'static str> {
-    let stripped = s.strip_prefix("0x").unwrap_or(s);
-    if stripped.len() != 64 {
-        return Err("hash must be 32 bytes (64 hex chars)");
-    }
-    if !stripped.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err("hash must be hex");
-    }
-    Ok(stripped.to_lowercase())
 }
 
 // ── Main handler ─────────────────────────────────────────
@@ -1039,221 +1009,6 @@ pub async fn rpc_dispatcher(
     }
 }
 
-// ── Sprint 2 helpers: eth_getLogs, eth_feeHistory, receipt logs ──
-
-fn parse_hex_u64(v: &Value) -> Option<u64> {
-    match v {
-        Value::String(s) => {
-            let s = s.trim_start_matches("0x");
-            u64::from_str_radix(s, 16).ok()
-        }
-        Value::Number(n) => n.as_u64(),
-        _ => None,
-    }
-}
-
-fn resolve_block_tag(v: Option<&Value>, latest: u64) -> Result<u64, &'static str> {
-    match v {
-        None => Ok(latest),
-        Some(Value::String(s)) => match s.as_str() {
-            "latest" | "pending" | "safe" | "finalized" => Ok(latest),
-            "earliest" => Ok(0),
-            hex if hex.starts_with("0x") => u64::from_str_radix(&hex[2..], 16)
-                .map_err(|_| "invalid hex block number"),
-            _ => Err("invalid block tag"),
-        },
-        Some(Value::Number(n)) => n.as_u64().ok_or("invalid block number"),
-        _ => Err("invalid block parameter"),
-    }
-}
-
-/// Address filter accepts either a single string or an array. Normalizes to
-/// lowercase 20-byte arrays; unparseable entries are silently skipped so
-/// malformed filters still work against the rest of the query.
-fn parse_address_filter(v: Option<&Value>) -> Vec<[u8; 20]> {
-    let mut out = Vec::new();
-    let push = |s: &str, out: &mut Vec<[u8; 20]>| {
-        let s = s.trim_start_matches("0x");
-        if let Ok(bytes) = hex::decode(s)
-            && bytes.len() == 20
-        {
-            let mut arr = [0u8; 20];
-            arr.copy_from_slice(&bytes);
-            out.push(arr);
-        }
-    };
-    match v {
-        None | Some(Value::Null) => {}
-        Some(Value::String(s)) => push(s, &mut out),
-        Some(Value::Array(arr)) => {
-            for item in arr {
-                if let Some(s) = item.as_str() {
-                    push(s, &mut out);
-                }
-            }
-        }
-        _ => {}
-    }
-    out
-}
-
-/// Topics filter: outer index is position (topic0..topic3). Inner vec is the
-/// OR-set for that position — empty means wildcard. `None` in topics[i]
-/// means the position is omitted entirely (also wildcard).
-type TopicFilter = Vec<Option<Vec<[u8; 32]>>>;
-
-fn parse_topic_filter(v: Option<&Value>) -> TopicFilter {
-    let mut out: TopicFilter = Vec::new();
-    let parse_one = |s: &str| -> Option<[u8; 32]> {
-        let s = s.trim_start_matches("0x");
-        let bytes = hex::decode(s).ok()?;
-        if bytes.len() != 32 {
-            return None;
-        }
-        let mut arr = [0u8; 32];
-        arr.copy_from_slice(&bytes);
-        Some(arr)
-    };
-    let arr = match v {
-        Some(Value::Array(a)) => a,
-        _ => return out,
-    };
-    for slot in arr {
-        match slot {
-            Value::Null => out.push(None),
-            Value::String(s) => out.push(Some(parse_one(s).into_iter().collect())),
-            Value::Array(inner) => {
-                let set: Vec<[u8; 32]> = inner
-                    .iter()
-                    .filter_map(|x| x.as_str().and_then(parse_one))
-                    .collect();
-                out.push(Some(set));
-            }
-            _ => out.push(None),
-        }
-    }
-    out
-}
-
-fn log_matches(log: &sentrix_evm::StoredLog, addrs: &[[u8; 20]], topics: &TopicFilter) -> bool {
-    if !addrs.is_empty() && !addrs.iter().any(|a| a == &log.address) {
-        return false;
-    }
-    for (i, slot) in topics.iter().enumerate() {
-        let Some(set) = slot else { continue };
-        if set.is_empty() {
-            continue;
-        }
-        let topic = match log.topics.get(i) {
-            Some(t) => t,
-            None => return false,
-        };
-        if !set.iter().any(|s| s == topic) {
-            return false;
-        }
-    }
-    true
-}
-
-fn collect_logs(
-    bc: &sentrix_core::blockchain::Blockchain,
-    from: u64,
-    to: u64,
-    addrs: &[[u8; 20]],
-    topics: &TopicFilter,
-) -> Vec<Value> {
-    let storage = match bc.mdbx_storage.as_ref() {
-        Some(s) => s,
-        None => return Vec::new(),
-    };
-    let all = match storage.iter(sentrix_storage::tables::TABLE_LOGS) {
-        Ok(v) => v,
-        Err(_) => return Vec::new(),
-    };
-    let mut out = Vec::new();
-    for (k, v) in all {
-        if k.len() < 16 {
-            continue;
-        }
-        let mut h_bytes = [0u8; 8];
-        h_bytes.copy_from_slice(&k[..8]);
-        let height = u64::from_be_bytes(h_bytes);
-        if height < from || height > to {
-            continue;
-        }
-        if let Some(bloom_bytes) = storage
-            .get(sentrix_storage::tables::TABLE_BLOOM, &h_bytes)
-            .ok()
-            .flatten()
-            && bloom_bytes.len() == 256
-            && !addrs.is_empty()
-        {
-            let mut bloom = [0u8; 256];
-            bloom.copy_from_slice(&bloom_bytes);
-            let any_hit = addrs.iter().any(|a| sentrix_evm::bloom_contains(&bloom, a));
-            if !any_hit {
-                continue;
-            }
-        }
-        let Ok(log) = bincode::deserialize::<sentrix_evm::StoredLog>(&v) else {
-            continue;
-        };
-        if log_matches(&log, addrs, topics) {
-            out.push(log.to_rpc_json());
-        }
-    }
-    out
-}
-
-fn load_logs_for_tx(
-    bc: &sentrix_core::blockchain::Blockchain,
-    block_height: u64,
-    txid: &str,
-) -> (Vec<Value>, String) {
-    let mut target_hash = [0u8; 32];
-    if let Ok(decoded) = hex::decode(txid.trim_start_matches("0x")) {
-        let n = decoded.len().min(32);
-        target_hash[..n].copy_from_slice(&decoded[..n]);
-    }
-    let storage = match bc.mdbx_storage.as_ref() {
-        Some(s) => s,
-        None => return (Vec::new(), "0x".to_string() + &"00".repeat(256)),
-    };
-    let prefix = block_height.to_be_bytes();
-    let entries = match storage.iter(sentrix_storage::tables::TABLE_LOGS) {
-        Ok(v) => v,
-        Err(_) => return (Vec::new(), "0x".to_string() + &"00".repeat(256)),
-    };
-    let mut logs = Vec::new();
-    let mut bloom = sentrix_evm::empty_bloom();
-    for (k, v) in entries {
-        if k.len() < 8 || k[..8] != prefix {
-            continue;
-        }
-        let Ok(log) = bincode::deserialize::<sentrix_evm::StoredLog>(&v) else {
-            continue;
-        };
-        if log.tx_hash == target_hash {
-            sentrix_evm::add_log_to_bloom(&mut bloom, &log.address, &log.topics);
-            logs.push(log.to_rpc_json());
-        }
-    }
-    (logs, format!("0x{}", hex::encode(bloom)))
-}
-
-fn block_gas_used_ratio(bc: &sentrix_core::blockchain::Blockchain, height: u64) -> f64 {
-    let block = match bc.chain.iter().find(|b| b.index == height) {
-        Some(b) => b,
-        None => return 0.0,
-    };
-    let total_gas: u64 = block
-        .transactions
-        .iter()
-        .filter(|t| t.is_evm_tx())
-        .map(|_| 21_000u64)
-        .sum();
-    (total_gas as f64) / (sentrix_evm::gas::BLOCK_GAS_LIMIT as f64)
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
Partial progress on backlog #11. Move `jsonrpc.rs` to `jsonrpc/mod.rs` and extract all shared helpers into a new `jsonrpc/helpers.rs` submodule.

## Scope
- **Extracted** (11 items): `to_hex`, `to_hex_u128`, `normalize_rpc_address`, `normalize_rpc_hash`, `parse_hex_u64`, `resolve_block_tag`, `parse_address_filter`, `parse_topic_filter`, `log_matches`, `collect_logs`, `load_logs_for_tx`, `block_gas_used_ratio`, `TopicFilter` type
- **Not extracted yet** (Phase 2): per-namespace handler split (`eth.rs`, `net.rs`, `web3.rs`, `sentrix.rs`) — queued for a follow-up
- **Not touched**: `rpc_dispatcher`, `jsonrpc_handler`, envelope types — behaviour-identical

## Impact
- `mod.rs`: 1302 → 1057 lines (−245)
- `helpers.rs`: 233 lines (new)
- No behaviour change, no API surface change

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` all pass (no new tests; existing `test_m03_max_batch_size_constant` + `test_m03_batch_too_large_rejected` validate the dispatcher path)
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [ ] CI green

## Follow-up
Phase 2 (the user-visible goal from the backlog) is the per-namespace handler split. I stopped here to keep this PR small and verifiable rather than bundle two large mechanical refactors in one review.