### PR TITLE
feat(rpc): eth_getBlockReceipts batch receipt query (backlog #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **feat(rpc): `eth_getBlockReceipts`** (backlog #8) — batch receipt
+  query matching the Ethereum JSON-RPC spec. Input: block tag
+  (`latest` / `earliest` / `pending` / `safe` / `finalized` / hex
+  number) OR block hash OR `{blockHash}` / `{blockNumber}` object.
+  Output: array of receipt objects in transaction order with
+  `transactionIndex`, `from`, `to`, and monotonic `cumulativeGasUsed`
+  on top of the existing `eth_getTransactionReceipt` shape (status,
+  logs, logsBloom, gasUsed). Non-existent block → `null`. Collapses
+  the N-round-trip receipt fan-out explorers used to do into one
+  call. 8 integration tests.
+
+### Refactored
+- **refactor(rpc): jsonrpc helpers extracted to submodule** (backlog
+  #11 phase 1, PR #152) — `jsonrpc.rs` → `jsonrpc/mod.rs` and all
+  shared helpers (to_hex, normalize_rpc_*, parse_hex_u64,
+  resolve_block_tag, parse_address_filter, parse_topic_filter,
+  log_matches, collect_logs, load_logs_for_tx, block_gas_used_ratio,
+  TopicFilter) moved to `jsonrpc/helpers.rs`. mod.rs 1302 → 1057 LOC.
+  No behaviour change. Phase 2 (per-namespace handler split) pending.
+
 ### Planned
 - Mainnet hard fork to Voyager (DPoS + BFT + EVM)
 - Parallel tx execution (rayon)

--- a/crates/sentrix-rpc/src/jsonrpc/mod.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/mod.rs
@@ -212,6 +212,90 @@ pub async fn jsonrpc_handler(
                 None => Ok(json!(null)),
             }
         }
+        "eth_getBlockReceipts" => {
+            // Batch receipt query. Input is a block tag (latest/earliest/
+            // 0x-hex) OR a block hash. Returns an array of receipt objects
+            // with the same shape as eth_getTransactionReceipt. Explorers
+            // that today fan out N single-receipt calls per block can
+            // collapse them to one round trip.
+            let bc = state.read().await;
+            let block = if let Some(s) = params[0].as_str() {
+                // Block hash path: 32-byte hex (with or without 0x).
+                if s.strip_prefix("0x").unwrap_or(s).len() == 64 {
+                    let hash = s.trim_start_matches("0x").to_lowercase();
+                    bc.get_block_by_hash(&hash).cloned()
+                } else {
+                    // Block tag path (latest / earliest / pending / hex).
+                    let latest = bc.height();
+                    let height = match resolve_block_tag(Some(&params[0]), latest) {
+                        Ok(h) => h,
+                        Err(e) => return Json(JsonRpcResponse::err(id, -32602, e)),
+                    };
+                    bc.get_block(height).cloned()
+                }
+            } else if let Some(obj) = params[0].as_object() {
+                // Object form: { "blockHash": "0x..." } OR
+                // { "blockNumber": "0x..." } (for geth-compat).
+                if let Some(h) = obj.get("blockHash").and_then(|v| v.as_str()) {
+                    let hash = h.trim_start_matches("0x").to_lowercase();
+                    bc.get_block_by_hash(&hash).cloned()
+                } else if let Some(n) = obj.get("blockNumber") {
+                    let latest = bc.height();
+                    let height = match resolve_block_tag(Some(n), latest) {
+                        Ok(h) => h,
+                        Err(e) => return Json(JsonRpcResponse::err(id, -32602, e)),
+                    };
+                    bc.get_block(height).cloned()
+                } else {
+                    return Json(JsonRpcResponse::err(
+                        id,
+                        -32602,
+                        "expected blockHash or blockNumber",
+                    ));
+                }
+            } else {
+                return Json(JsonRpcResponse::err(
+                    id,
+                    -32602,
+                    "expected block tag, block hash, or { blockHash | blockNumber } object",
+                ));
+            };
+
+            let block = match block {
+                Some(b) => b,
+                None => return Json(JsonRpcResponse::ok(id, json!(null))),
+            };
+
+            let mut receipts = Vec::with_capacity(block.transactions.len());
+            let mut cumulative: u64 = 0;
+            for (idx, tx) in block.transactions.iter().enumerate() {
+                let status = if bc.accounts.is_evm_tx_failed(&tx.txid) {
+                    "0x0"
+                } else {
+                    "0x1"
+                };
+                let (logs, bloom_hex) = load_logs_for_tx(&bc, block.index, &tx.txid);
+                // Flat 21k per tx matches eth_getTransactionReceipt today.
+                // Real gas accounting comes in with EIP-1559 dynamic fee
+                // (backlog #9).
+                let gas_used: u64 = 21_000;
+                cumulative = cumulative.saturating_add(gas_used);
+                receipts.push(json!({
+                    "transactionHash": format!("0x{}", tx.txid),
+                    "transactionIndex": to_hex(idx as u64),
+                    "blockNumber": to_hex(block.index),
+                    "blockHash": format!("0x{}", block.hash),
+                    "from": tx.from_address,
+                    "to": tx.to_address,
+                    "status": status,
+                    "gasUsed": to_hex(gas_used),
+                    "cumulativeGasUsed": to_hex(cumulative),
+                    "logs": logs,
+                    "logsBloom": bloom_hex,
+                }));
+            }
+            Ok(json!(receipts))
+        }
         "sentrix_sendTransaction" => {
             // JSON-RPC token operations accept signed transactions only — no private_key in params.
             // params[0] must be a pre-signed Transaction object (same fields as POST /transactions).

--- a/tests/integration_eth_block_receipts.rs
+++ b/tests/integration_eth_block_receipts.rs
@@ -1,0 +1,163 @@
+#![allow(missing_docs, clippy::expect_used, clippy::unwrap_used)]
+// integration_eth_block_receipts.rs — coverage for `eth_getBlockReceipts`
+// (backlog #8). Input shape supports: string block tag / hex number /
+// block hash / { blockHash | blockNumber } object. Output is an array of
+// receipt objects in transaction order with per-tx cumulativeGasUsed.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use sentrix::core::blockchain::Blockchain;
+use sentrix_rpc::jsonrpc::{JsonRpcRequest, jsonrpc_handler};
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+
+fn make_request(params: Value) -> JsonRpcRequest {
+    JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        method: "eth_getBlockReceipts".to_string(),
+        params: Some(params),
+        id: Some(json!(1)),
+    }
+}
+
+async fn call(state: Arc<RwLock<Blockchain>>, params: Value) -> Value {
+    let resp = jsonrpc_handler(State(state), Json(make_request(params))).await;
+    serde_json::to_value(&resp.0).expect("response → Value")
+}
+
+#[tokio::test]
+async fn latest_tag_returns_array() {
+    let (bc, _admin) = common::setup_single_validator();
+    let state = Arc::new(RwLock::new(bc));
+    let resp = call(state, json!(["latest"])).await;
+    assert!(
+        resp["error"].is_null(),
+        "latest tag must not error: {resp:?}"
+    );
+    assert!(
+        resp["result"].is_array(),
+        "result must be array, got {:?}",
+        resp["result"],
+    );
+}
+
+#[tokio::test]
+async fn earliest_tag_returns_genesis_receipts() {
+    let (bc, _admin) = common::setup_single_validator();
+    let state = Arc::new(RwLock::new(bc));
+    let resp = call(state, json!(["earliest"])).await;
+    let arr = resp["result"].as_array().expect("array");
+    // Genesis typically carries premine + coinbase. At minimum we expect
+    // the coinbase tx to produce a receipt.
+    assert!(
+        !arr.is_empty(),
+        "earliest block should have at least one receipt",
+    );
+    // Receipt shape — every entry must carry these keys.
+    for r in arr {
+        for key in [
+            "transactionHash",
+            "transactionIndex",
+            "blockNumber",
+            "blockHash",
+            "status",
+            "gasUsed",
+            "cumulativeGasUsed",
+            "logs",
+            "logsBloom",
+        ] {
+            assert!(
+                r.get(key).is_some(),
+                "missing field `{key}` in receipt: {r:?}",
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn cumulative_gas_used_is_monotonic() {
+    let (bc, _admin) = common::setup_single_validator();
+    let state = Arc::new(RwLock::new(bc));
+    let resp = call(state, json!(["earliest"])).await;
+    let arr = resp["result"].as_array().expect("array");
+    let mut prev: u64 = 0;
+    for r in arr {
+        let cur_hex = r["cumulativeGasUsed"]
+            .as_str()
+            .expect("cumulativeGasUsed hex");
+        let cur = u64::from_str_radix(cur_hex.trim_start_matches("0x"), 16)
+            .expect("u64 from hex");
+        assert!(
+            cur >= prev,
+            "cumulativeGasUsed must be non-decreasing ({prev} → {cur})",
+        );
+        prev = cur;
+    }
+}
+
+#[tokio::test]
+async fn hex_block_number_resolves() {
+    let (bc, _admin) = common::setup_single_validator();
+    let state = Arc::new(RwLock::new(bc));
+    let resp = call(state, json!(["0x0"])).await;
+    assert!(resp["error"].is_null(), "hex 0x0 must resolve: {resp:?}");
+    assert!(resp["result"].is_array());
+}
+
+#[tokio::test]
+async fn block_number_object_form() {
+    let (bc, _admin) = common::setup_single_validator();
+    let state = Arc::new(RwLock::new(bc));
+    let resp = call(state, json!([{"blockNumber": "latest"}])).await;
+    assert!(
+        resp["error"].is_null(),
+        "object form must resolve: {resp:?}"
+    );
+    assert!(resp["result"].is_array());
+}
+
+#[tokio::test]
+async fn missing_block_returns_null() {
+    let (bc, _admin) = common::setup_single_validator();
+    let state = Arc::new(RwLock::new(bc));
+    // Height 0xffffffff won't exist on a fresh chain.
+    let resp = call(state, json!(["0xffffffff"])).await;
+    assert!(
+        resp["error"].is_null(),
+        "non-existent block should return null, not error: {resp:?}",
+    );
+    assert!(
+        resp["result"].is_null(),
+        "non-existent block must return null result, got {:?}",
+        resp["result"],
+    );
+}
+
+#[tokio::test]
+async fn malformed_params_return_error() {
+    let (bc, _admin) = common::setup_single_validator();
+    let state = Arc::new(RwLock::new(bc));
+    let resp = call(state, json!([42])).await; // raw number — not supported
+    assert!(
+        !resp["error"].is_null(),
+        "malformed param should error: {resp:?}",
+    );
+}
+
+#[tokio::test]
+async fn block_hash_path_resolves() {
+    let (bc, _admin) = common::setup_single_validator();
+    // Grab genesis block hash.
+    let genesis_hash = bc.chain.first().map(|b| b.hash.clone()).expect("genesis");
+    let state = Arc::new(RwLock::new(bc));
+    let resp = call(state, json!([format!("0x{genesis_hash}")])).await;
+    assert!(
+        resp["error"].is_null(),
+        "block-hash lookup must succeed: {resp:?}",
+    );
+    assert!(resp["result"].is_array());
+}


### PR DESCRIPTION
## Summary
Adds Ethereum-spec `eth_getBlockReceipts` method. Explorers that today fan out N per-tx `eth_getTransactionReceipt` calls can collapse to one call.

## Input shapes
- block tag string: `latest` / `earliest` / `pending` / `safe` / `finalized` / hex number
- block hash string (`0x` + 64 hex)
- object form `{ blockHash: '0x...' }` OR `{ blockNumber: tag }` (geth-compat)

## Output
- Array of receipts in transaction order on block hit
- `null` on block miss
- `-32602` on malformed input

Each receipt: same fields as `eth_getTransactionReceipt` plus `transactionIndex`, `from`, `to`, and monotonic `cumulativeGasUsed`. `gasUsed` stays flat at 21k per tx — real gas accounting lands with #9 (EIP-1559 base fee).

## Tests
8 new integration tests:
1. `latest` tag returns array
2. `earliest` tag — genesis receipts have full field shape
3. Cumulative gas monotonicity
4. Hex block number resolves
5. Object form works
6. Non-existent block → `null` (not error)
7. Malformed params → `-32602`
8. Block-hash path resolves

## Test plan
- [x] `cargo test --test integration_eth_block_receipts` — 8/8 pass
- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [ ] CI green
- [ ] After merge: deploy + verify on live testnet/mainnet