### PR TITLE
feat(cli): validator force-unjail for operator chain recovery (backlog #1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **feat(cli): `validator force-unjail` operator-recovery command**
+  (backlog #1b) — unlocks the chicken-and-egg state where every
+  validator has been auto-slashed below `MIN_SELF_STAKE` and the
+  normal `unjail` refuses. Bumps `self_stake` back to
+  `MIN_SELF_STAKE` if below, clears `is_jailed` + `jail_until`,
+  skips the cooldown. Tombstoned validators are still rejected.
+  Operator-only: bypasses consensus, so operator must run it on
+  every peer's chain DB before BFT resumes so all peers agree on
+  the recovered state. Backed by `StakeRegistry::force_unjail` +
+  4 unit tests (stake restore, stake preservation when already
+  above min, tombstone refusal, cooldown skip).
 - **feat(rpc): `eth_getBlockReceipts`** (backlog #8) — batch receipt
   query matching the Ethereum JSON-RPC spec. Input: block tag
   (`latest` / `earliest` / `pending` / `safe` / `finalized` / hex

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -223,6 +223,19 @@ enum ValidatorCommands {
         /// Validator address to unjail
         address: String,
     },
+    /// Operator-only recovery: unjail + restore self_stake to
+    /// MIN_SELF_STAKE when slashing has knocked the validator below
+    /// the eligibility floor. Skips the jail-period cooldown.
+    ///
+    /// Use this when the chain is stuck because all validators were
+    /// auto-slashed (BFT `active_set` empty → can't mine blocks →
+    /// can't submit unjail/stake TXs). Run while the node is STOPPED,
+    /// and run on EACH validator's chain DB for every jailed address
+    /// so all peers agree on the recovered state before BFT resumes.
+    ForceUnjail {
+        /// Validator address to force-unjail
+        address: String,
+    },
     /// Transfer the admin role to a new address (admin only).
     /// Use to rotate out a compromised admin key without a hard fork.
     /// Run on EACH validator's chain DB — the admin field is local node
@@ -431,6 +444,9 @@ async fn main() -> anyhow::Result<()> {
             } => {
                 let key = resolve_key(admin_key, "SENTRIX_ADMIN_KEY", "admin key")?;
                 cmd_validator_rename(&address, &new_name, &key)?;
+            }
+            ValidatorCommands::ForceUnjail { address } => {
+                cmd_validator_force_unjail(&address)?;
             }
             ValidatorCommands::Unjail { address } => {
                 cmd_validator_unjail(&address)?;
@@ -761,6 +777,46 @@ fn cmd_validator_unjail(address: &str) -> anyhow::Result<()> {
 
     storage.save_blockchain(&bc)?;
     println!("Validator unjailed: {}", address);
+    println!(
+        "Active set: {} validators",
+        bc.stake_registry.active_count()
+    );
+    Ok(())
+}
+
+fn cmd_validator_force_unjail(address: &str) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+
+    let before = bc
+        .stake_registry
+        .get_validator(address)
+        .map(|v| (v.self_stake, v.is_jailed, v.jail_until));
+    bc.stake_registry.force_unjail(address)?;
+    bc.stake_registry.update_active_set();
+    let after = bc
+        .stake_registry
+        .get_validator(address)
+        .map(|v| (v.self_stake, v.is_jailed, v.jail_until));
+
+    storage.save_blockchain(&bc)?;
+    println!("Validator force-unjailed: {}", address);
+    if let (Some(b), Some(a)) = (before, after) {
+        println!(
+            "  self_stake: {} → {}",
+            b.0, a.0,
+        );
+        println!(
+            "  is_jailed:  {} → {}",
+            b.1, a.1,
+        );
+        println!(
+            "  jail_until: {} → {}",
+            b.2, a.2,
+        );
+    }
     println!(
         "Active set: {} validators",
         bc.stake_registry.active_count()

--- a/crates/sentrix-staking/src/staking.rs
+++ b/crates/sentrix-staking/src/staking.rs
@@ -542,6 +542,43 @@ impl StakeRegistry {
         Ok(())
     }
 
+    /// Operator-only recovery path for validators that have been jailed
+    /// AND slashed below `MIN_SELF_STAKE`, leaving them unable to clear
+    /// the jail via the normal `unjail()` path and unable to stake up
+    /// because the chain is stuck (BFT refuses to start while
+    /// `active_set` is empty). This is the chicken-and-egg case observed
+    /// on testnet after the pre-#147 BFT livelock auto-slashed all 4
+    /// validators.
+    ///
+    /// Semantics differ from `unjail()` in two places: the jail-period
+    /// cooldown (`jail_until`) is skipped, and if the validator's
+    /// `self_stake` is below `MIN_SELF_STAKE` it is bumped back up to
+    /// exactly `MIN_SELF_STAKE` so they clear the eligibility check.
+    /// Tombstoned validators are still rejected — tombstone is
+    /// permanent by design.
+    ///
+    /// Callers are responsible for running this only on an operator-
+    /// owned chain DB (it bypasses consensus) and then propagating the
+    /// same edit to every peer's DB before consensus resumes, otherwise
+    /// peers will disagree on the stake_registry state.
+    pub fn force_unjail(&mut self, validator: &str) -> SentrixResult<()> {
+        let val = self
+            .validators
+            .get_mut(validator)
+            .ok_or_else(|| SentrixError::InvalidTransaction("validator not found".into()))?;
+        if val.is_tombstoned {
+            return Err(SentrixError::InvalidTransaction(
+                "tombstoned validators cannot unjail".into(),
+            ));
+        }
+        if val.self_stake < MIN_SELF_STAKE {
+            val.self_stake = MIN_SELF_STAKE;
+        }
+        val.is_jailed = false;
+        val.jail_until = 0;
+        Ok(())
+    }
+
     // ── Active Set ───────────────────────────────────────────
 
     pub fn compute_active_set(&self) -> Vec<String> {
@@ -1203,6 +1240,75 @@ mod tests {
         reg.slash("0xval1", 5000).unwrap(); // 50%
         // Can't unjail because self-stake below minimum
         assert!(reg.unjail("0xval1", 200).is_err());
+    }
+
+    #[test]
+    fn test_force_unjail_restores_stake_and_clears_flags() {
+        // Operator-only recovery for the chicken-and-egg state the
+        // testnet hit on 2026-04-19: pre-#147 livelock auto-slashed
+        // every validator below MIN_SELF_STAKE, so the normal
+        // `unjail()` path refused and BFT could not restart.
+        let mut reg = new_registry();
+        register_val(&mut reg, "0xval1", MIN_SELF_STAKE);
+        reg.jail("0xval1", 100, 1000).unwrap();
+        reg.slash("0xval1", 5000).unwrap(); // 50%, drops below min
+
+        assert!(reg.validators["0xval1"].is_jailed);
+        assert!(reg.validators["0xval1"].self_stake < MIN_SELF_STAKE);
+        // Sanity: the normal path can't recover this one.
+        assert!(reg.unjail("0xval1", 200).is_err());
+
+        reg.force_unjail("0xval1").unwrap();
+
+        let v = &reg.validators["0xval1"];
+        assert!(!v.is_jailed, "force_unjail must clear is_jailed");
+        assert_eq!(v.jail_until, 0, "force_unjail must clear jail_until");
+        assert_eq!(
+            v.self_stake, MIN_SELF_STAKE,
+            "force_unjail must restore self_stake to MIN_SELF_STAKE",
+        );
+    }
+
+    #[test]
+    fn test_force_unjail_preserves_stake_when_already_above_min() {
+        // If stake is already ≥ MIN_SELF_STAKE, force_unjail must not
+        // overwrite it — only jail flags are cleared.
+        let mut reg = new_registry();
+        let bigger = MIN_SELF_STAKE.saturating_add(12_345);
+        register_val(&mut reg, "0xval1", bigger);
+        reg.jail("0xval1", 100, 9999).unwrap();
+
+        reg.force_unjail("0xval1").unwrap();
+
+        let v = &reg.validators["0xval1"];
+        assert!(!v.is_jailed);
+        assert_eq!(v.jail_until, 0);
+        assert_eq!(v.self_stake, bigger, "stake should not be touched");
+    }
+
+    #[test]
+    fn test_force_unjail_rejects_tombstoned() {
+        // Tombstone is permanent by design — force_unjail must still
+        // refuse, same as `unjail`.
+        let mut reg = new_registry();
+        register_val(&mut reg, "0xval1", MIN_SELF_STAKE);
+        reg.validators.get_mut("0xval1").unwrap().is_tombstoned = true;
+
+        assert!(reg.force_unjail("0xval1").is_err());
+    }
+
+    #[test]
+    fn test_force_unjail_skips_cooldown() {
+        // Unlike `unjail`, `force_unjail` does not honor the
+        // jail_until cooldown — operator override is the whole point.
+        let mut reg = new_registry();
+        register_val(&mut reg, "0xval1", MIN_SELF_STAKE);
+        reg.jail("0xval1", 100, 50_000).unwrap();
+
+        reg.force_unjail("0xval1").unwrap();
+        let v = &reg.validators["0xval1"];
+        assert!(!v.is_jailed);
+        assert_eq!(v.jail_until, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Closes backlog #1b. Adds a `sentrix validator force-unjail <address>` CLI command so the testnet stall can be recovered without a full chain reset.

## The stall
Pre-#147 BFT livelock auto-slashed every testnet validator below `MIN_SELF_STAKE`. That created chicken-and-egg state:

- Normal `unjail` refuses: `self-stake below minimum after slashing — add more stake first`
- Can't submit a stake TX: BFT refuses to mine (`active_set = 0`, all eligible filters fail)
- So the stall persists even though #147 fixed the BFT root cause

## Fix
`StakeRegistry::force_unjail(addr)` sits alongside the existing `unjail`:

- Clears `is_jailed` + `jail_until`
- **Bumps `self_stake` to `MIN_SELF_STAKE` if below** (key difference)
- Skips the `jail_until` cooldown (operator override is the point)
- Tombstoned validators still rejected (permanence preserved)

CLI wrapper loads the chain DB, calls `force_unjail`, updates the active set, persists. Same operator discipline as the existing `unjail` / `transfer-admin` commands — run on every peer's DB while nodes are STOPPED so the stake registries converge before BFT resumes.

## Tests
4 new unit tests in `sentrix-staking`:
1. Stake restore: slashed below min → force_unjail → self_stake = MIN_SELF_STAKE, flags cleared
2. Stake preservation: already above min → stake untouched, only flags cleared
3. Tombstone refusal
4. Cooldown skip (jail_until honored by unjail, ignored by force_unjail)

## Recovery plan after merge
Ssh to VPS3, stop all 4 testnet validators, run:
```bash
for dir in data data2 data3 data4; do
  for addr in 0x682126... 0x4f9988... 0x245785... 0x4e9b3c...; do
    SENTRIX_ENCRYPTED_DISK=true \
    SENTRIX_DATA_DIR=/opt/sentrix-testnet/$dir \
      /opt/sentrix/sentrix validator force-unjail $addr
  done
done
```
Then restart all 4 — BFT should resume from height 30978.

## Test plan
- [x] `cargo test --package sentrix-staking` — 73 pass (4 new)
- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [ ] CI green
- [ ] After merge: deploy to VPS3, run recovery script, verify testnet advances past 30978