### PR TITLE
fix(cli): mainnet gate on validator force-unjail (phantom-stake guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   every peer's chain DB before BFT resumes so all peers agree on
   the recovered state. Backed by `StakeRegistry::force_unjail` +
   4 unit tests (stake restore, stake preservation when already
-  above min, tombstone refusal, cooldown skip).
+  above min, tombstone refusal, cooldown skip). **Mainnet gate**
+  (PR #157): on `chain_id == 7119` the command refuses unless
+  `--i-understand-phantom-stake` is passed — restoring `self_stake`
+  via direct DB edit creates phantom stake (SRX is not minted, but
+  the stake counter goes up) and violates the supply invariant.
+  Safe on testnet; break-glass on mainnet.
 - **feat(rpc): `eth_getBlockReceipts`** (backlog #8) — batch receipt
   query matching the Ethereum JSON-RPC spec. Input: block tag
   (`latest` / `earliest` / `pending` / `safe` / `finalized` / hex

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -227,6 +227,16 @@ enum ValidatorCommands {
     /// MIN_SELF_STAKE when slashing has knocked the validator below
     /// the eligibility floor. Skips the jail-period cooldown.
     ///
+    /// PHANTOM STAKE WARNING: restoring self_stake via direct DB edit
+    /// does NOT mint SRX. The supply invariant
+    /// `sum(balances) + sum(stakes + delegations) == circulating_supply`
+    /// gets violated by the shortfall. Safe on testnet (no real value);
+    /// on mainnet (chain_id 7119) this command refuses to run unless
+    /// `--i-understand-phantom-stake` is passed. Mainnet operators
+    /// should prefer a real self-delegate TX from the validator's own
+    /// wallet whenever possible, and use this break-glass only when
+    /// the chain is so stuck that no TX can be mined.
+    ///
     /// Use this when the chain is stuck because all validators were
     /// auto-slashed (BFT `active_set` empty → can't mine blocks →
     /// can't submit unjail/stake TXs). Run while the node is STOPPED,
@@ -235,6 +245,11 @@ enum ValidatorCommands {
     ForceUnjail {
         /// Validator address to force-unjail
         address: String,
+        /// Required on mainnet to acknowledge the supply-invariant
+        /// violation this command introduces. Testnet does not require
+        /// the flag.
+        #[arg(long)]
+        i_understand_phantom_stake: bool,
     },
     /// Transfer the admin role to a new address (admin only).
     /// Use to rotate out a compromised admin key without a hard fork.
@@ -445,8 +460,11 @@ async fn main() -> anyhow::Result<()> {
                 let key = resolve_key(admin_key, "SENTRIX_ADMIN_KEY", "admin key")?;
                 cmd_validator_rename(&address, &new_name, &key)?;
             }
-            ValidatorCommands::ForceUnjail { address } => {
-                cmd_validator_force_unjail(&address)?;
+            ValidatorCommands::ForceUnjail {
+                address,
+                i_understand_phantom_stake,
+            } => {
+                cmd_validator_force_unjail(&address, i_understand_phantom_stake)?;
             }
             ValidatorCommands::Unjail { address } => {
                 cmd_validator_unjail(&address)?;
@@ -784,11 +802,32 @@ fn cmd_validator_unjail(address: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn cmd_validator_force_unjail(address: &str) -> anyhow::Result<()> {
+fn cmd_validator_force_unjail(
+    address: &str,
+    acknowledged_phantom_stake: bool,
+) -> anyhow::Result<()> {
     let storage = Storage::open(&get_db_path())?;
     let mut bc = storage
         .load_blockchain()?
         .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+
+    const MAINNET_CHAIN_ID: u64 = 7119;
+    if bc.chain_id == MAINNET_CHAIN_ID && !acknowledged_phantom_stake {
+        anyhow::bail!(
+            "mainnet (chain_id 7119) detected: force-unjail creates phantom \
+             stake (restores self_stake without minting SRX), which violates \
+             the supply invariant. Prefer a real self-delegate TX from the \
+             validator's wallet. If the chain is genuinely stuck and this is \
+             the last option, re-run with `--i-understand-phantom-stake`."
+        );
+    }
+    if bc.chain_id == MAINNET_CHAIN_ID {
+        eprintln!(
+            "WARNING: force-unjail on mainnet. Phantom stake will be created \
+             if self_stake < MIN_SELF_STAKE. Document the recovery decision \
+             before proceeding."
+        );
+    }
 
     let before = bc
         .stake_registry


### PR DESCRIPTION
## Summary
Locks the `force-unjail` break-glass against accidental mainnet misuse. On `chain_id == 7119` the command now refuses unless `--i-understand-phantom-stake` is explicitly passed. Testnet is unchanged.

## Why
`force-unjail` bumps `self_stake` directly in the DB to get jailed validators back into the active set without a consensus tx. On testnet where SRX has no value that's fine. On mainnet it creates **phantom stake**:

- Stake counter goes up
- No SRX is minted
- No wallet balance moves
- Supply invariant `sum(balances) + sum(stakes + delegations) == circulating_supply` breaks

Long-term consequences on mainnet:
- Validator earns rewards proportional to inflated stake (SRX created from nothing over time)
- On unbond, the phantom SRX becomes real circulating supply — silent inflation
- Audit trail has no mint event to explain the delta

## Guard
```
$ sentrix validator force-unjail 0xval1
Error: mainnet (chain_id 7119) detected: force-unjail creates phantom
stake (restores self_stake without minting SRX), which violates the
supply invariant. Prefer a real self-delegate TX from the validator's
wallet. If the chain is genuinely stuck and this is the last option,
re-run with `--i-understand-phantom-stake`.

$ sentrix validator force-unjail 0xval1 --i-understand-phantom-stake
WARNING: force-unjail on mainnet. Phantom stake will be created if
self_stake < MIN_SELF_STAKE. Document the recovery decision before
proceeding.
Validator force-unjailed: 0xval1
  self_stake: 12345 → 1500000000000
  …
```

Testnet path is unchanged — no flag needed, no warning printed.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] Existing 4 `force_unjail` unit tests still pass (logic unchanged)
- [ ] CI green