### PR TITLE
chore(deps): ignore RUSTSEC-2026-0097 (rand 0.8 via yamux 0.12)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,16 @@ ignore = [
     # the 0.12.1 package disappears from Cargo.lock.
     # Dependabot alert: https://github.com/sentrix-labs/sentrix/security/dependabot/3
     "GHSA-vxx9-2994-q338",
+
+    # RUSTSEC-2026-0097 — `rand 0.8.5` unsound with a custom logger when
+    # `rand::rng()` is called from inside a `log!()` macro. Reaches us
+    # only transitively via `yamux 0.12.1` → `libp2p-yamux 0.47.0`, the
+    # same crate path whose 0.12 decoder we've already demonstrated is
+    # never wired up at runtime (see GHSA-vxx9-2994-q338 note above).
+    # We don't call into yamux 0.12 at all, so the advisory code path is
+    # unreachable. Remove this ignore together with the GHSA one once
+    # libp2p-yamux 0.48+ drops v0.12 compat.
+    "RUSTSEC-2026-0097",
 ]
 
 # ── Licenses ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Adds `RUSTSEC-2026-0097` to `deny.toml` ignore list, alongside the existing `GHSA-vxx9-2994-q338` entry.

## Context
2026-04-19 audit turned up a new advisory:

- **RUSTSEC-2026-0097** — `rand 0.8.5` unsoundness when `rand::rng()` is called from inside a custom log macro
- Dep path: `rand 0.8.5` ← `yamux 0.12.1` ← `libp2p-yamux 0.47.0` ← `libp2p 0.56`
- Same reachability story as the existing `GHSA-vxx9-2994-q338` yamux 0.12 ignore: `libp2p-yamux` pulls both 0.12.1 and 0.13.10, and `yamux::Config::default()` constructs the 0.13 variant, so nothing actually talks to the 0.12 decoder at runtime

Non-reachable → safe to ignore until libp2p-yamux 0.48+ drops v0.12 compat.

## Scope
`deny.toml` only. Documented inline with the same reachability note as the existing yamux ignore so future auditors don't have to re-derive it.

## Test plan
- [x] `cargo deny check advisories` — pre-existing bincode/paste unmaintained errors unchanged; my ignore adds no new errors
- [ ] CI green