### PR TITLE
refactor(rpc): move staking handlers to routes/staking.rs (backlog #12 phase 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Refactored
+- **refactor(rpc): staking handlers out to `routes/staking.rs`**
+  (backlog #12 phase 2b) — 4 handlers moved: `get_validators`
+  (PoA authority set, `GET /validators`), `staking_validators`
+  (DPoS set, `GET /staking/validators`), `staking_delegations`
+  (`GET /staking/delegations/{addr}`), `staking_unbonding`
+  (`GET /staking/unbonding/{addr}`). Zero route / behaviour change.
 - **refactor(rpc): token handlers out to `routes/tokens.rs`** (backlog
   #12 phase 2a) — the 8 SRC-20 handlers (list / info / balance /
   holders / trades / deploy / transfer / burn) move to their own

--- a/crates/sentrix-rpc/src/routes/mod.rs
+++ b/crates/sentrix-rpc/src/routes/mod.rs
@@ -7,6 +7,7 @@
 
 mod auth;
 mod ratelimit;
+mod staking;
 mod tokens;
 mod types;
 
@@ -15,6 +16,7 @@ pub use ratelimit::{GlobalIpLimiter, IpRateLimiter, WriteIpLimiter};
 pub use types::{ApiResponse, SendTxRequest, SignedTxRequest};
 
 use ratelimit::{ip_rate_limit_middleware, write_rate_limit_middleware};
+use staking::{get_validators, staking_delegations, staking_unbonding, staking_validators};
 use tokens::{
     deploy_token, get_token_balance, get_token_holders_list, get_token_info,
     get_token_trades_list, list_tokens, token_burn, token_transfer,
@@ -623,28 +625,6 @@ async fn get_mempool(State(state): State<SharedState>) -> Json<serde_json::Value
     }))
 }
 
-async fn get_validators(State(state): State<SharedState>) -> Json<serde_json::Value> {
-    let bc = state.read().await;
-    let validators: Vec<serde_json::Value> = bc
-        .authority
-        .validators
-        .values()
-        .map(|v| {
-            serde_json::json!({
-                "address": v.address,
-                "name": v.name,
-                "is_active": v.is_active,
-                "blocks_produced": v.blocks_produced,
-                "registered_at": v.registered_at,
-            })
-        })
-        .collect();
-    Json(serde_json::json!({
-        "validators": validators,
-        "active": bc.authority.active_count(),
-        "total": bc.authority.validator_count(),
-    }))
-}
 
 // ── Token handlers ───────────────────────────────────────
 
@@ -733,84 +713,8 @@ async fn get_admin_log(_auth: ApiKey, State(state): State<SharedState>) -> Json<
 
 // ── Staking + Epoch handlers (Voyager Phase 2a) ─────────
 
-async fn staking_validators(State(state): State<SharedState>) -> Json<serde_json::Value> {
-    let bc = state.read().await;
-    let validators: Vec<serde_json::Value> = bc
-        .stake_registry
-        .validators
-        .values()
-        .map(|v| {
-            serde_json::json!({
-                "address": v.address,
-                "self_stake": v.self_stake,
-                "total_delegated": v.total_delegated,
-                "total_stake": v.total_stake(),
-                "commission_rate": v.commission_rate,
-                "is_jailed": v.is_jailed,
-                "is_tombstoned": v.is_tombstoned,
-                "is_active": bc.stake_registry.is_active(&v.address),
-                "blocks_signed": v.blocks_signed,
-                "blocks_missed": v.blocks_missed,
-                "pending_rewards": v.pending_rewards,
-            })
-        })
-        .collect();
-    Json(serde_json::json!({
-        "validators": validators,
-        "active_count": bc.stake_registry.active_count(),
-        "total_count": bc.stake_registry.validators.len(),
-    }))
-}
 
-async fn staking_delegations(
-    State(state): State<SharedState>,
-    axum::extract::Path(address): axum::extract::Path<String>,
-) -> Json<serde_json::Value> {
-    let bc = state.read().await;
-    let addr = address.to_lowercase();
-    let delegations: Vec<serde_json::Value> = bc
-        .stake_registry
-        .get_delegations(&addr)
-        .iter()
-        .map(|d| {
-            serde_json::json!({
-                "validator": d.validator,
-                "amount": d.amount,
-                "height": d.height,
-            })
-        })
-        .collect();
-    Json(serde_json::json!({
-        "delegator": addr,
-        "delegations": delegations,
-        "count": delegations.len(),
-    }))
-}
 
-async fn staking_unbonding(
-    State(state): State<SharedState>,
-    axum::extract::Path(address): axum::extract::Path<String>,
-) -> Json<serde_json::Value> {
-    let bc = state.read().await;
-    let addr = address.to_lowercase();
-    let entries: Vec<serde_json::Value> = bc
-        .stake_registry
-        .get_pending_unbonding(&addr)
-        .iter()
-        .map(|u| {
-            serde_json::json!({
-                "validator": u.validator,
-                "amount": u.amount,
-                "completion_height": u.completion_height,
-            })
-        })
-        .collect();
-    Json(serde_json::json!({
-        "delegator": addr,
-        "unbonding": entries,
-        "count": entries.len(),
-    }))
-}
 
 async fn epoch_current(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let bc = state.read().await;

--- a/crates/sentrix-rpc/src/routes/staking.rs
+++ b/crates/sentrix-rpc/src/routes/staking.rs
@@ -1,0 +1,119 @@
+// staking.rs — validator + staking (DPoS) REST endpoints. Four handlers:
+// the PoA authority set (`/validators`) and the three Voyager DPoS views
+// (`/staking/validators`, `/staking/delegations/{addr}`,
+// `/staking/unbonding/{addr}`).
+//
+// Extracted from `routes/mod.rs` as part of backlog #12 phase 2b. Paired
+// with the `sentrix_getValidatorSet` / `sentrix_getDelegations` JSON-RPC
+// methods — wallets / explorers can take either path.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+
+use super::SharedState;
+
+pub(super) async fn get_validators(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let bc = state.read().await;
+    let validators: Vec<serde_json::Value> = bc
+        .authority
+        .validators
+        .values()
+        .map(|v| {
+            serde_json::json!({
+                "address": v.address,
+                "name": v.name,
+                "is_active": v.is_active,
+                "blocks_produced": v.blocks_produced,
+                "registered_at": v.registered_at,
+            })
+        })
+        .collect();
+    Json(serde_json::json!({
+        "validators": validators,
+        "active": bc.authority.active_count(),
+        "total": bc.authority.validator_count(),
+    }))
+}
+
+pub(super) async fn staking_validators(
+    State(state): State<SharedState>,
+) -> Json<serde_json::Value> {
+    let bc = state.read().await;
+    let validators: Vec<serde_json::Value> = bc
+        .stake_registry
+        .validators
+        .values()
+        .map(|v| {
+            serde_json::json!({
+                "address": v.address,
+                "self_stake": v.self_stake,
+                "total_delegated": v.total_delegated,
+                "total_stake": v.total_stake(),
+                "commission_rate": v.commission_rate,
+                "is_jailed": v.is_jailed,
+                "is_tombstoned": v.is_tombstoned,
+                "is_active": bc.stake_registry.is_active(&v.address),
+                "blocks_signed": v.blocks_signed,
+                "blocks_missed": v.blocks_missed,
+                "pending_rewards": v.pending_rewards,
+            })
+        })
+        .collect();
+    Json(serde_json::json!({
+        "validators": validators,
+        "active_count": bc.stake_registry.active_count(),
+        "total_count": bc.stake_registry.validators.len(),
+    }))
+}
+
+pub(super) async fn staking_delegations(
+    State(state): State<SharedState>,
+    Path(address): Path<String>,
+) -> Json<serde_json::Value> {
+    let bc = state.read().await;
+    let addr = address.to_lowercase();
+    let delegations: Vec<serde_json::Value> = bc
+        .stake_registry
+        .get_delegations(&addr)
+        .iter()
+        .map(|d| {
+            serde_json::json!({
+                "validator": d.validator,
+                "amount": d.amount,
+                "height": d.height,
+            })
+        })
+        .collect();
+    Json(serde_json::json!({
+        "delegator": addr,
+        "delegations": delegations,
+        "count": delegations.len(),
+    }))
+}
+
+pub(super) async fn staking_unbonding(
+    State(state): State<SharedState>,
+    Path(address): Path<String>,
+) -> Json<serde_json::Value> {
+    let bc = state.read().await;
+    let addr = address.to_lowercase();
+    let entries: Vec<serde_json::Value> = bc
+        .stake_registry
+        .get_pending_unbonding(&addr)
+        .iter()
+        .map(|u| {
+            serde_json::json!({
+                "validator": u.validator,
+                "amount": u.amount,
+                "completion_height": u.completion_height,
+            })
+        })
+        .collect();
+    Json(serde_json::json!({
+        "delegator": addr,
+        "unbonding": entries,
+        "count": entries.len(),
+    }))
+}


### PR DESCRIPTION
Next slice of the #12 phase-2 routes split. Four staking/validator handlers come out of mod.rs:

- `get_validators`       — `GET /validators` (PoA authority set)
- `staking_validators`   — `GET /staking/validators` (DPoS active set)
- `staking_delegations`  — `GET /staking/delegations/{addr}`
- `staking_unbonding`    — `GET /staking/unbonding/{addr}`

Zero route path change, zero behaviour change. Same pattern as #162 (tokens).

Remaining slices: ops, chain, accounts, transactions, epoch. One PR each.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [ ] CI green