### PR TITLE
refactor(rpc): move chain handlers to routes/chain.rs (backlog #12 phase 2d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Refactored
+- **refactor(rpc): chain handlers out to `routes/chain.rs`** (backlog
+  #12 phase 2d) — 4 handlers moved: `chain_info` (`GET /chain/info`),
+  `get_blocks` (paginated listing), `get_block` (by index),
+  `validate_chain` (full-chain scan, auth-gated with result cache).
+  The `VALIDATE_CACHE_HEIGHT` / `VALIDATE_CACHE_RESULT` statics +
+  their M-07 cache tests moved with the handler. Zero route /
+  behaviour change.
 - **refactor(rpc): ops handlers out to `routes/ops.rs`** (backlog #12
   phase 2c) — five handlers moved: `root` (`GET /`), `health`
   (`GET /health`), `sentrix_status` (`GET /sentrix_status`, re-exported

--- a/crates/sentrix-rpc/src/routes/chain.rs
+++ b/crates/sentrix-rpc/src/routes/chain.rs
@@ -1,0 +1,174 @@
+// chain.rs — chain-wide read endpoints: `/chain/info`, paginated blocks
+// list, block-by-height, and the authenticated full-chain validate. The
+// validate handler caches its last result per block height to keep the
+// O(n) scan from running on every hit.
+//
+// Extracted from `routes/mod.rs` as part of backlog #12 phase 2d.
+
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use super::{ApiKey, SharedState};
+
+pub(super) async fn chain_info(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let bc = state.read().await;
+    Json(bc.chain_stats())
+}
+
+// Paginated block listing — default 20, max 100, newest first
+pub(super) async fn get_blocks(
+    State(state): State<SharedState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Json<serde_json::Value> {
+    let bc = state.read().await;
+    let page: u64 = params.get("page").and_then(|p| p.parse().ok()).unwrap_or(0);
+    let limit: u64 = params
+        .get("limit")
+        .and_then(|l| l.parse().ok())
+        .unwrap_or(20)
+        .min(100); // hard cap at 100
+
+    let total = bc.height() + 1; // true height from last block's index, not window size
+    let start_skip = (page * limit) as usize;
+
+    let blocks: Vec<serde_json::Value> = bc
+        .chain
+        .iter()
+        .rev() // newest first (window only — last CHAIN_WINDOW_SIZE blocks)
+        .skip(start_skip)
+        .take(limit as usize)
+        .map(|b| {
+            serde_json::json!({
+                "index": b.index,
+                "hash": b.hash,
+                "previous_hash": b.previous_hash,
+                "timestamp": b.timestamp,
+                "tx_count": b.tx_count(),
+                "validator": b.validator,
+                "merkle_root": b.merkle_root,
+                "round": b.round,
+                "has_justification": b.justification.is_some(),
+            })
+        })
+        .collect();
+
+    let has_more = (start_skip + blocks.len()) < total as usize;
+
+    Json(serde_json::json!({
+        "blocks": blocks,
+        "pagination": {
+            "page": page,
+            "limit": limit,
+            "total": total,
+            "has_more": has_more
+        }
+    }))
+}
+
+pub(super) async fn get_block(
+    State(state): State<SharedState>,
+    Path(index): Path<u64>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let bc = state.read().await;
+    match bc.get_block(index) {
+        Some(block) => serde_json::to_value(block)
+            .map(Json)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR),
+        None => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+// Cache last validation result per block height to avoid O(n) recompute
+// on every call.
+static VALIDATE_CACHE_HEIGHT: AtomicU64 = AtomicU64::new(u64::MAX);
+static VALIDATE_CACHE_RESULT: AtomicBool = AtomicBool::new(false);
+
+// validate_chain requires X-API-Key authentication — an O(n) full chain
+// scan per unauthenticated request would be a viable DoS vector on a
+// long chain.
+pub(super) async fn validate_chain(
+    _auth: ApiKey,
+    State(state): State<SharedState>,
+) -> Json<serde_json::Value> {
+    let bc = state.read().await;
+    let height = bc.height();
+
+    // Return cached result if chain height hasn't changed since last run
+    if VALIDATE_CACHE_HEIGHT.load(Ordering::Relaxed) == height {
+        let cached_valid = VALIDATE_CACHE_RESULT.load(Ordering::Relaxed);
+        return Json(serde_json::json!({
+            "valid": cached_valid,
+            "height": height,
+            "total_blocks": bc.height() + 1, // true total from block index, not window length
+            "cached": true,
+        }));
+    }
+
+    // Full O(n) chain scan — only runs when height has changed
+    let valid = bc.is_valid_chain_window();
+    VALIDATE_CACHE_HEIGHT.store(height, Ordering::Relaxed);
+    VALIDATE_CACHE_RESULT.store(valid, Ordering::Relaxed);
+
+    Json(serde_json::json!({
+        "valid": valid,
+        "height": height,
+        "total_blocks": bc.chain.len(),
+        "cached": false,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── M-07: validate_chain cache logic ──────────────────
+
+    #[test]
+    fn test_m07_validate_cache_statics_initialized() {
+        // VALIDATE_CACHE_HEIGHT starts at u64::MAX (sentinel = never cached)
+        // VALIDATE_CACHE_RESULT starts at false
+        // After a fresh start, loading the statics should not panic.
+        let h = VALIDATE_CACHE_HEIGHT.load(std::sync::atomic::Ordering::Relaxed);
+        let r = VALIDATE_CACHE_RESULT.load(std::sync::atomic::Ordering::Relaxed);
+        // Height is either u64::MAX (never run) or a valid height from a previous test.
+        // Either way, the atomics must be readable without panic.
+        let _ = h;
+        let _ = r;
+    }
+
+    #[test]
+    fn test_m07_validate_cache_update() {
+        // Simulate the cache update logic used by validate_chain handler.
+        let test_height: u64 = 12_345;
+        let test_valid = true;
+
+        VALIDATE_CACHE_HEIGHT.store(test_height, std::sync::atomic::Ordering::Relaxed);
+        VALIDATE_CACHE_RESULT.store(test_valid, std::sync::atomic::Ordering::Relaxed);
+
+        // Reading back should match
+        assert_eq!(
+            VALIDATE_CACHE_HEIGHT.load(std::sync::atomic::Ordering::Relaxed),
+            test_height
+        );
+        assert_eq!(
+            VALIDATE_CACHE_RESULT.load(std::sync::atomic::Ordering::Relaxed),
+            test_valid
+        );
+
+        // Different height means cache miss (simulate)
+        let different_height = test_height + 1;
+        let is_cache_hit =
+            VALIDATE_CACHE_HEIGHT.load(std::sync::atomic::Ordering::Relaxed) == different_height;
+        assert!(!is_cache_hit);
+
+        // Same height is a cache hit
+        let is_same_hit =
+            VALIDATE_CACHE_HEIGHT.load(std::sync::atomic::Ordering::Relaxed) == test_height;
+        assert!(is_same_hit);
+    }
+}

--- a/crates/sentrix-rpc/src/routes/mod.rs
+++ b/crates/sentrix-rpc/src/routes/mod.rs
@@ -6,6 +6,7 @@
 // dedicated modules. (backlog #12 phase 1)
 
 mod auth;
+mod chain;
 mod ops;
 mod ratelimit;
 mod staking;
@@ -17,6 +18,7 @@ pub use ops::sentrix_status;
 pub use ratelimit::{GlobalIpLimiter, IpRateLimiter, WriteIpLimiter};
 pub use types::{ApiResponse, SendTxRequest, SignedTxRequest};
 
+use chain::{chain_info, get_block, get_blocks, validate_chain};
 use ops::{START_TIME, get_admin_log, health, metrics, root};
 use ratelimit::{ip_rate_limit_middleware, write_rate_limit_middleware};
 use staking::{get_validators, staking_delegations, staking_unbonding, staking_validators};
@@ -33,7 +35,7 @@ use axum::{
     routing::{get, post},
 };
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
 // tokio::sync::Mutex is async-safe — does not block Tokio worker threads.
 // std::sync::Mutex::lock() is a blocking syscall; holding it in async context
 // starves other tasks on the same thread under high load.
@@ -266,110 +268,6 @@ fn explorer_router(_state: SharedState) -> Router<SharedState> {
 // ── Handlers ─────────────────────────────────────────────
 
 
-async fn chain_info(State(state): State<SharedState>) -> Json<serde_json::Value> {
-    let bc = state.read().await;
-    Json(bc.chain_stats())
-}
-
-// Paginated block listing — default 20, max 100, newest first
-async fn get_blocks(
-    State(state): State<SharedState>,
-    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
-) -> Json<serde_json::Value> {
-    let bc = state.read().await;
-    let page: u64 = params.get("page").and_then(|p| p.parse().ok()).unwrap_or(0);
-    let limit: u64 = params
-        .get("limit")
-        .and_then(|l| l.parse().ok())
-        .unwrap_or(20)
-        .min(100); // hard cap at 100
-
-    let total = bc.height() + 1; // true height from last block's index, not window size
-    let start_skip = (page * limit) as usize;
-
-    let blocks: Vec<serde_json::Value> = bc
-        .chain
-        .iter()
-        .rev() // newest first (window only — last CHAIN_WINDOW_SIZE blocks)
-        .skip(start_skip)
-        .take(limit as usize)
-        .map(|b| {
-            serde_json::json!({
-                "index": b.index,
-                "hash": b.hash,
-                "previous_hash": b.previous_hash,
-                "timestamp": b.timestamp,
-                "tx_count": b.tx_count(),
-                "validator": b.validator,
-                "merkle_root": b.merkle_root,
-                "round": b.round,
-                "has_justification": b.justification.is_some(),
-            })
-        })
-        .collect();
-
-    let has_more = (start_skip + blocks.len()) < total as usize;
-
-    Json(serde_json::json!({
-        "blocks": blocks,
-        "pagination": {
-            "page": page,
-            "limit": limit,
-            "total": total,
-            "has_more": has_more
-        }
-    }))
-}
-
-async fn get_block(
-    State(state): State<SharedState>,
-    Path(index): Path<u64>,
-) -> Result<Json<serde_json::Value>, StatusCode> {
-    let bc = state.read().await;
-    match bc.get_block(index) {
-        Some(block) => serde_json::to_value(block)
-            .map(Json)
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR),
-        None => Err(StatusCode::NOT_FOUND),
-    }
-}
-
-// Cache last validation result per block height to avoid O(n) recompute on every call.
-static VALIDATE_CACHE_HEIGHT: AtomicU64 = AtomicU64::new(u64::MAX);
-static VALIDATE_CACHE_RESULT: AtomicBool = AtomicBool::new(false);
-
-// validate_chain requires X-API-Key authentication — an O(n) full chain scan per
-// unauthenticated request would be a viable DoS vector on a long chain.
-async fn validate_chain(
-    _auth: ApiKey,
-    State(state): State<SharedState>,
-) -> Json<serde_json::Value> {
-    let bc = state.read().await;
-    let height = bc.height();
-
-    // Return cached result if chain height hasn't changed since last run
-    if VALIDATE_CACHE_HEIGHT.load(Ordering::Relaxed) == height {
-        let cached_valid = VALIDATE_CACHE_RESULT.load(Ordering::Relaxed);
-        return Json(serde_json::json!({
-            "valid": cached_valid,
-            "height": height,
-            "total_blocks": bc.height() + 1, // true total from block index, not window length
-            "cached": true,
-        }));
-    }
-
-    // Full O(n) chain scan — only runs when height has changed
-    let valid = bc.is_valid_chain_window();
-    VALIDATE_CACHE_HEIGHT.store(height, Ordering::Relaxed);
-    VALIDATE_CACHE_RESULT.store(valid, Ordering::Relaxed);
-
-    Json(serde_json::json!({
-        "valid": valid,
-        "height": height,
-        "total_blocks": bc.chain.len(),
-        "cached": false,
-    }))
-}
 
 async fn get_balance(
     State(state): State<SharedState>,
@@ -786,51 +684,6 @@ mod tests {
         assert!(!constant_time_eq("a", ""));
     }
 
-    // ── M-07: validate_chain cache logic ──────────────────
-
-    #[test]
-    fn test_m07_validate_cache_statics_initialized() {
-        // VALIDATE_CACHE_HEIGHT starts at u64::MAX (sentinel = never cached)
-        // VALIDATE_CACHE_RESULT starts at false
-        // After a fresh start, loading the statics should not panic.
-        let h = VALIDATE_CACHE_HEIGHT.load(std::sync::atomic::Ordering::Relaxed);
-        let r = VALIDATE_CACHE_RESULT.load(std::sync::atomic::Ordering::Relaxed);
-        // Height is either u64::MAX (never run) or a valid height from a previous test.
-        // Either way, the atomics must be readable without panic.
-        let _ = h;
-        let _ = r;
-    }
-
-    #[test]
-    fn test_m07_validate_cache_update() {
-        // Simulate the cache update logic used by validate_chain handler.
-        let test_height: u64 = 12_345;
-        let test_valid = true;
-
-        VALIDATE_CACHE_HEIGHT.store(test_height, std::sync::atomic::Ordering::Relaxed);
-        VALIDATE_CACHE_RESULT.store(test_valid, std::sync::atomic::Ordering::Relaxed);
-
-        // Reading back should match
-        assert_eq!(
-            VALIDATE_CACHE_HEIGHT.load(std::sync::atomic::Ordering::Relaxed),
-            test_height
-        );
-        assert_eq!(
-            VALIDATE_CACHE_RESULT.load(std::sync::atomic::Ordering::Relaxed),
-            test_valid
-        );
-
-        // Different height means cache miss (simulate)
-        let different_height = test_height + 1;
-        let is_cache_hit =
-            VALIDATE_CACHE_HEIGHT.load(std::sync::atomic::Ordering::Relaxed) == different_height;
-        assert!(!is_cache_hit);
-
-        // Same height is a cache hit
-        let is_same_hit =
-            VALIDATE_CACHE_HEIGHT.load(std::sync::atomic::Ordering::Relaxed) == test_height;
-        assert!(is_same_hit);
-    }
 
     // ── L-05: serde_json error propagation tests ──────────
 


### PR DESCRIPTION
Fourth routes slice. Four chain-wide endpoints out of mod.rs:

- `chain_info`        — `GET /chain/info`
- `get_blocks`        — `GET /chain/blocks` (paginated)
- `get_block`         — `GET /chain/blocks/{index}`
- `validate_chain`    — `GET /chain/validate` (auth-gated, O(n) cached scan)

The validate_chain result cache (`VALIDATE_CACHE_HEIGHT` + `VALIDATE_CACHE_RESULT` atomics) moves with the handler, along with the two M-07 cache tests.

Zero route / behaviour change. Remaining slices: accounts, transactions, epoch.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` all pass (38 suites)
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [ ] CI green