### PR TITLE
hotfix(consensus): hard-fail trie init past fork height — v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.2] — 2026-04-20 — Trie-init hardening hotfix
+
+### Fixed
+- **fix(consensus): hard-fail trie init above STATE_ROOT_FORK_HEIGHT**
+  (`crates/sentrix-core/src/storage.rs`). Before: init_trie failure was
+  a tracing warn and the node continued, producing blocks with
+  `state_root = None` while peers with working tries produced
+  `state_root = Some(...)` — the hashes diverge and the chain forks.
+  Mainnet stalled at block 100,004 on 2026-04-20 via exactly this path:
+  VPS3's trie had a missing node (`24afba5f…`) so block 100,004 got
+  saved with `state_root = null`, VPS1 had a functional trie and block
+  100,004 with `state_root = Some(…)` → different block hashes → VPS1
+  rejected VPS3's block 100,005 as "invalid previous hash". Post-fix,
+  any node whose trie cannot init past fork height refuses to start —
+  a silently diverging validator is worse for the network than an
+  offline one. Below fork height the old hash format ignores
+  `state_root`, so the warn-only path is still safe there.
+
 ### Refactored
 - **refactor(rpc): transactions + epoch handlers out of
   `routes/mod.rs`** (backlog #12 phase 2f + 2g, final slices) — 5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4832,7 +4832,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "bincode",
  "blake3",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -843,18 +843,9 @@ fn cmd_validator_force_unjail(
     storage.save_blockchain(&bc)?;
     println!("Validator force-unjailed: {}", address);
     if let (Some(b), Some(a)) = (before, after) {
-        println!(
-            "  self_stake: {} → {}",
-            b.0, a.0,
-        );
-        println!(
-            "  is_jailed:  {} → {}",
-            b.1, a.1,
-        );
-        println!(
-            "  jail_until: {} → {}",
-            b.2, a.2,
-        );
+        println!("  self_stake: {} → {}", b.0, a.0,);
+        println!("  is_jailed:  {} → {}", b.1, a.1,);
+        println!("  jail_until: {} → {}", b.2, a.2,);
     }
     println!(
         "Active set: {} validators",
@@ -1063,8 +1054,8 @@ async fn cmd_start(
             // a consistent ~1s cadence without blocking the loop for 3s when
             // nothing is happening (previous 3s sleep made the effective
             // block time oscillate around 3s instead of the configured 1s).
-            let mut pioneer_last_block = tokio::time::Instant::now()
-                - tokio::time::Duration::from_secs(BLOCK_TIME_SECS);
+            let mut pioneer_last_block =
+                tokio::time::Instant::now() - tokio::time::Duration::from_secs(BLOCK_TIME_SECS);
 
             loop {
                 if shutdown_flag_clone.load(Ordering::Acquire) {
@@ -1339,8 +1330,7 @@ async fn cmd_start(
                                                 // signature verification + state lookups.
                                                 {
                                                     let bc_read = shared_clone.read().await;
-                                                    if let Err(e) = bc_read.validate_block(&blk)
-                                                    {
+                                                    if let Err(e) = bc_read.validate_block(&blk) {
                                                         drop(bc_read);
                                                         tracing::warn!(
                                                             "BFT finalize: pre-validate \
@@ -1450,8 +1440,7 @@ async fn cmd_start(
                                                                     "Block {} produced by {}",
                                                                     height, proposer
                                                                 );
-                                                                let bc =
-                                                                    shared_clone.read().await;
+                                                                let bc = shared_clone.read().await;
                                                                 if let Err(e) = storage_clone
                                                                     .save_blockchain(&bc)
                                                                 {
@@ -1487,8 +1476,7 @@ async fn cmd_start(
                                             // new round never emits a proposal, peers prevote
                                             // nil, precommit nil, skip-round, and loop.
                                             let bc_r = shared_clone.read().await;
-                                            let we_propose =
-                                                bft.is_proposer(&bc_r.stake_registry);
+                                            let we_propose = bft.is_proposer(&bc_r.stake_registry);
                                             drop(bc_r);
                                             if we_propose {
                                                 let mut bc = shared_clone.write().await;
@@ -1496,9 +1484,8 @@ async fn cmd_start(
                                                     bc.create_block_voyager(&wallet.address)
                                                 {
                                                     let block_hash = block.hash.clone();
-                                                    let block_data =
-                                                        bincode::serialize(&block)
-                                                            .unwrap_or_default();
+                                                    let block_data = bincode::serialize(&block)
+                                                        .unwrap_or_default();
                                                     let mut proposal = Proposal {
                                                         height: bft.height(),
                                                         round: bft.round(),
@@ -1534,8 +1521,7 @@ async fn cmd_start(
                                             // P1: re-propose on skip-round if we are the new
                                             // round's proposer. Same stall pattern as above.
                                             let bc_r = shared_clone.read().await;
-                                            let we_propose =
-                                                bft.is_proposer(&bc_r.stake_registry);
+                                            let we_propose = bft.is_proposer(&bc_r.stake_registry);
                                             drop(bc_r);
                                             if we_propose {
                                                 let mut bc = shared_clone.write().await;
@@ -1543,9 +1529,8 @@ async fn cmd_start(
                                                     bc.create_block_voyager(&wallet.address)
                                                 {
                                                     let block_hash = block.hash.clone();
-                                                    let block_data =
-                                                        bincode::serialize(&block)
-                                                            .unwrap_or_default();
+                                                    let block_data = bincode::serialize(&block)
+                                                        .unwrap_or_default();
                                                     let mut proposal = Proposal {
                                                         height: bft.height(),
                                                         round: bft.round(),
@@ -1625,8 +1610,8 @@ async fn cmd_start(
                                 }
                             }
                             // Messages reaching this point have already been
-                                // signature-verified AND membership-checked at the
-                                // libp2p network boundary (C-01 gaps 1/2/3).
+                            // signature-verified AND membership-checked at the
+                            // libp2p network boundary (C-01 gaps 1/2/3).
                             BftMessage::Prevote(prevote) => {
                                 let bc = shared_clone.read().await;
                                 let stake = bc
@@ -1972,12 +1957,11 @@ async fn cmd_start(
                                     drop(bc_r);
                                     if we_propose {
                                         let mut bc = shared_clone.write().await;
-                                        if let Ok(block) =
-                                            bc.create_block_voyager(&wallet.address)
+                                        if let Ok(block) = bc.create_block_voyager(&wallet.address)
                                         {
                                             let block_hash = block.hash.clone();
-                                            let block_data = bincode::serialize(&block)
-                                                .unwrap_or_default();
+                                            let block_data =
+                                                bincode::serialize(&block).unwrap_or_default();
                                             let mut proposal = Proposal {
                                                 height: bft.height(),
                                                 round: bft.round(),
@@ -1988,9 +1972,7 @@ async fn cmd_start(
                                             };
                                             proposal.sign(&validator_secret_key);
                                             drop(bc);
-                                            lp2p_clone
-                                                .broadcast_bft_proposal(&proposal)
-                                                .await;
+                                            lp2p_clone.broadcast_bft_proposal(&proposal).await;
                                             proposed_block = Some(block);
                                             let _ = bft.on_own_proposal(&block_hash);
                                             tracing::info!(
@@ -2017,12 +1999,11 @@ async fn cmd_start(
                                     drop(bc_r);
                                     if we_propose {
                                         let mut bc = shared_clone.write().await;
-                                        if let Ok(block) =
-                                            bc.create_block_voyager(&wallet.address)
+                                        if let Ok(block) = bc.create_block_voyager(&wallet.address)
                                         {
                                             let block_hash = block.hash.clone();
-                                            let block_data = bincode::serialize(&block)
-                                                .unwrap_or_default();
+                                            let block_data =
+                                                bincode::serialize(&block).unwrap_or_default();
                                             let mut proposal = Proposal {
                                                 height: bft.height(),
                                                 round: bft.round(),
@@ -2033,9 +2014,7 @@ async fn cmd_start(
                                             };
                                             proposal.sign(&validator_secret_key);
                                             drop(bc);
-                                            lp2p_clone
-                                                .broadcast_bft_proposal(&proposal)
-                                                .await;
+                                            lp2p_clone.broadcast_bft_proposal(&proposal).await;
                                             proposed_block = Some(block);
                                             let _ = bft.on_own_proposal(&block_hash);
                                             tracing::info!(
@@ -2264,17 +2243,11 @@ async fn cmd_start(
         //     lock.
         if let Some(handle) = validator_handle {
             tracing::info!("Graceful shutdown: awaiting validator task exit...");
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(10),
-                handle,
-            )
-            .await
-            {
+            match tokio::time::timeout(std::time::Duration::from_secs(10), handle).await {
                 Ok(Ok(())) => tracing::info!("Validator task exited cleanly"),
-                Ok(Err(join_err)) => tracing::warn!(
-                    "C-08: validator task joined with panic: {}",
-                    join_err
-                ),
+                Ok(Err(join_err)) => {
+                    tracing::warn!("C-08: validator task joined with panic: {}", join_err)
+                }
                 Err(_) => tracing::warn!(
                     "C-08: validator task did not exit within 10s; \
                      proceeding to save state snapshot anyway"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -1059,7 +1059,10 @@ mod tests {
         match action {
             BftAction::BroadcastPrevote(p) => {
                 assert_eq!(p.round, 4, "prevote must be for caught-up round");
-                assert_eq!(p.block_hash, None, "must be nil prevote — we have no proposal");
+                assert_eq!(
+                    p.block_hash, None,
+                    "must be nil prevote — we have no proposal"
+                );
             }
             other => panic!("expected BroadcastPrevote(nil), got {other:?}"),
         }
@@ -1078,7 +1081,10 @@ mod tests {
             signature: Vec::new(),
         };
         let _ = engine.on_round_status(&status);
-        assert!(engine.state.our_prevote_cast, "catch_up must mark our prevote cast");
+        assert!(
+            engine.state.our_prevote_cast,
+            "catch_up must mark our prevote cast"
+        );
         assert_eq!(engine.state.phase, BftPhase::Prevote);
 
         // Late proposal for the same round must NOT cause a second prevote.

--- a/crates/sentrix-bft/src/lib.rs
+++ b/crates/sentrix-bft/src/lib.rs
@@ -19,9 +19,9 @@
 pub mod engine;
 pub mod messages;
 
-pub use engine::{BftEngine, BftAction, BftPhase, BftRoundState, VoteCollector};
-pub use engine::{propose_timeout, prevote_timeout, precommit_timeout};
-pub use engine::{PROPOSE_TIMEOUT_MS, PREVOTE_TIMEOUT_MS, PRECOMMIT_TIMEOUT_MS, MAX_ROUND};
+pub use engine::{BftAction, BftEngine, BftPhase, BftRoundState, VoteCollector};
+pub use engine::{MAX_ROUND, PRECOMMIT_TIMEOUT_MS, PREVOTE_TIMEOUT_MS, PROPOSE_TIMEOUT_MS};
+pub use engine::{precommit_timeout, prevote_timeout, propose_timeout};
 pub use messages::{
     BftMessage, BlockJustification, Precommit, Prevote, Proposal, RoundStatus,
     supermajority_threshold,

--- a/crates/sentrix-bft/src/messages.rs
+++ b/crates/sentrix-bft/src/messages.rs
@@ -4,9 +4,9 @@
 // All serializable with bincode to match P2P wire format.
 // Signatures use secp256k1 ECDSA (same as transaction signing).
 
-use sentrix_primitives::{SentrixError, SentrixResult};
 use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 use secp256k1::{Message, Secp256k1, SecretKey};
+use sentrix_primitives::{SentrixError, SentrixResult};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -189,8 +189,8 @@ pub fn recover_signer(payload: &[u8], signature: &[u8]) -> SentrixResult<String>
     let secp = Secp256k1::verification_only();
     let hash: [u8; 32] = Sha256::digest(payload).into();
     let msg = Message::from_digest(hash);
-    let rec_id = RecoveryId::try_from(signature[64] as i32)
-        .map_err(|_| SentrixError::InvalidSignature)?;
+    let rec_id =
+        RecoveryId::try_from(signature[64] as i32).map_err(|_| SentrixError::InvalidSignature)?;
     let sig = RecoverableSignature::from_compact(&signature[..64], rec_id)
         .map_err(|_| SentrixError::InvalidSignature)?;
     let pubkey = secp

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/authority.rs
+++ b/crates/sentrix-core/src/authority.rs
@@ -1,7 +1,7 @@
 // authority.rs - Sentrix
 
-use sentrix_primitives::error::{SentrixError, SentrixResult};
 use secp256k1::PublicKey;
+use sentrix_primitives::error::{SentrixError, SentrixResult};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -114,9 +114,7 @@ impl AuthorityManager {
     /// boundary to reject consensus messages from non-validator peers
     /// (C-01 gap 2). Admin-toggled-off validators return `false`.
     pub fn is_active_validator(&self, address: &str) -> bool {
-        self.validators
-            .get(address)
-            .is_some_and(|v| v.is_active)
+        self.validators.get(address).is_some_and(|v| v.is_active)
     }
 
     // Admin operations

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -1,15 +1,15 @@
 // block_executor.rs - Sentrix — Block validation and commit (two-pass)
 
-use sentrix_primitives::account::AccountDB;
-use sentrix_primitives::block::{Block, STATE_ROOT_FORK_HEIGHT};
-use sentrix_primitives::error::{SentrixError, SentrixResult};
-use sentrix_primitives::transaction::{TokenOp, Transaction};
 use crate::authority::AuthorityManager;
 use crate::blockchain::{
     Blockchain, CHAIN_WINDOW_SIZE, is_spendable_sentrix_address, is_valid_sentrix_address,
 };
 use crate::vm::ContractRegistry;
 use hex;
+use sentrix_primitives::account::AccountDB;
+use sentrix_primitives::block::{Block, STATE_ROOT_FORK_HEIGHT};
+use sentrix_primitives::error::{SentrixError, SentrixResult};
+use sentrix_primitives::transaction::{TokenOp, Transaction};
 use std::collections::{HashMap, HashSet, VecDeque};
 
 /// C-03: snapshot of the mutable Blockchain state taken immediately
@@ -508,9 +508,9 @@ impl Blockchain {
             // in practice, but the guard is cheap and prevents a silent
             // wrap if MAX_TX_PER_BLOCK or MIN_TX_FEE are ever tuned
             // upward past the implicit ceiling.
-            total_fee = total_fee.checked_add(tx.fee).ok_or_else(|| {
-                SentrixError::Internal("block total_fee overflow".to_string())
-            })?;
+            total_fee = total_fee
+                .checked_add(tx.fee)
+                .ok_or_else(|| SentrixError::Internal("block total_fee overflow".to_string()))?;
 
             // Execute token operation if present in data field
             if let Some(token_op) = TokenOp::decode(&tx.data) {
@@ -575,7 +575,11 @@ impl Blockchain {
             // Execute EVM transaction if present (data field starts with "EVM:")
             // tx_index skips coinbase at slot 0 — first real tx is index 1.
             if tx.is_evm_tx() && Self::is_voyager_height(self.height()) {
-                let tx_index = (block.transactions.iter().position(|t| t.txid == tx.txid).unwrap_or(0)) as u32;
+                let tx_index = (block
+                    .transactions
+                    .iter()
+                    .position(|t| t.txid == tx.txid)
+                    .unwrap_or(0)) as u32;
                 self.execute_evm_tx_in_block(tx, block.index, &block.hash, tx_index)?;
             }
         }
@@ -584,7 +588,7 @@ impl Blockchain {
         // bounded; keeps the bloom exactly aligned with TABLE_LOGS without a
         // parallel in-memory accumulator.
         if let Some(storage) = self.mdbx_storage.as_ref() {
-            use sentrix_evm::{add_log_to_bloom, empty_bloom, StoredLog};
+            use sentrix_evm::{StoredLog, add_log_to_bloom, empty_bloom};
             let mut bloom = empty_bloom();
             let prefix = block.index.to_be_bytes();
             if let Ok(entries) = storage.iter(sentrix_storage::tables::TABLE_LOGS) {
@@ -722,14 +726,14 @@ impl Blockchain {
         let _sender = envelope.recover_signer().ok();
 
         // Build EVM tx
-        use sentrix_evm::database::parse_sentrix_address;
-        use sentrix_evm::executor::execute_tx;
-        use sentrix_evm::gas::INITIAL_BASE_FEE;
         use alloy_primitives::U256;
         use revm::context::TxEnv;
         use revm::database::InMemoryDB;
         use revm::primitives::{KECCAK_EMPTY, TxKind};
         use revm::state::AccountInfo;
+        use sentrix_evm::database::parse_sentrix_address;
+        use sentrix_evm::executor::execute_tx;
+        use sentrix_evm::gas::INITIAL_BASE_FEE;
 
         let from_addr =
             parse_sentrix_address(&tx.from_address).unwrap_or(alloy_primitives::Address::ZERO);
@@ -789,7 +793,7 @@ impl Blockchain {
                 // (height, tx_index, log_index) BE-packed so range scans
                 // return logs in canonical Ethereum order.
                 if let Some(storage) = self.mdbx_storage.as_ref() {
-                    use sentrix_evm::{log_key, StoredLog};
+                    use sentrix_evm::{StoredLog, log_key};
                     let mut block_hash_bytes = [0u8; 32];
                     if let Ok(decoded) = hex::decode(block_hash_hex.trim_start_matches("0x")) {
                         let n = decoded.len().min(32);
@@ -810,11 +814,8 @@ impl Blockchain {
                             log_idx as u32,
                         );
                         let key = log_key(block_height, tx_index, log_idx as u32);
-                        let _ = storage.put_bincode(
-                            sentrix_storage::tables::TABLE_LOGS,
-                            &key,
-                            &stored,
-                        );
+                        let _ =
+                            storage.put_bincode(sentrix_storage::tables::TABLE_LOGS, &key, &stored);
                     }
                 }
                 // Store contract RUNTIME code (not init code) if CREATE succeeded.
@@ -843,11 +844,9 @@ impl Blockchain {
                         );
                         self.accounts.mark_evm_tx_failed(&tx.txid);
                     } else {
-                        let addr_str =
-                            format!("0x{}", hex::encode(contract_addr.as_slice()));
+                        let addr_str = format!("0x{}", hex::encode(contract_addr.as_slice()));
                         use sha3::{Digest as _, Keccak256};
-                        let code_hash: [u8; 32] =
-                            Keccak256::digest(&receipt.output).into();
+                        let code_hash: [u8; 32] = Keccak256::digest(&receipt.output).into();
                         let code_hash_hex = hex::encode(code_hash);
                         self.accounts
                             .store_contract_code(&code_hash_hex, receipt.output.clone());
@@ -870,8 +869,8 @@ impl Blockchain {
 #[cfg(test)]
 mod tests {
     use crate::blockchain::{Blockchain, CHAIN_ID};
-    use sentrix_primitives::transaction::{MIN_TX_FEE, TOKEN_OP_ADDRESS, TokenOp, Transaction};
     use secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use sentrix_primitives::transaction::{MIN_TX_FEE, TOKEN_OP_ADDRESS, TokenOp, Transaction};
 
     fn make_keypair() -> (SecretKey, PublicKey) {
         let secp = Secp256k1::new();

--- a/crates/sentrix-core/src/block_producer.rs
+++ b/crates/sentrix-core/src/block_producer.rs
@@ -1,9 +1,9 @@
 // block_producer.rs - Sentrix — Block creation (validator side)
 
-use sentrix_primitives::block::Block;
 use crate::blockchain::{Blockchain, MAX_TX_PER_BLOCK};
-use sentrix_primitives::transaction::Transaction;
+use sentrix_primitives::block::Block;
 use sentrix_primitives::error::{SentrixError, SentrixResult};
+use sentrix_primitives::transaction::Transaction;
 
 impl Blockchain {
     // ── Block creation (validator calls this) ────────────
@@ -94,8 +94,8 @@ impl Blockchain {
 #[cfg(test)]
 mod tests {
     use crate::blockchain::{Blockchain, CHAIN_ID};
-    use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
     use secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
 
     fn make_keypair() -> (SecretKey, PublicKey) {
         let secp = Secp256k1::new();

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -1,17 +1,17 @@
 // blockchain.rs - Sentrix — Blockchain struct, constants, genesis, core state methods
 
-use sentrix_primitives::account::AccountDB;
 use crate::authority::AuthorityManager;
+use crate::vm::ContractRegistry;
+use hex;
+use sentrix_primitives::account::AccountDB;
 use sentrix_primitives::block::Block;
+use sentrix_primitives::error::{SentrixError, SentrixResult};
 use sentrix_primitives::merkle::merkle_root;
 use sentrix_primitives::transaction::TOKEN_OP_ADDRESS;
 use sentrix_primitives::transaction::Transaction;
+use sentrix_storage::{MdbxStorage, height_key, key_to_height, tables};
 use sentrix_trie::address::{account_value_bytes, address_to_key};
 use sentrix_trie::tree::SentrixTrie;
-use crate::vm::ContractRegistry;
-use sentrix_primitives::error::{SentrixError, SentrixResult};
-use sentrix_storage::{MdbxStorage, tables, height_key, key_to_height};
-use hex;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -161,8 +161,8 @@ impl Blockchain {
     /// a corrupt `include_str!` target; we fail loud rather than silently.
     pub fn new(admin_address: String) -> Self {
         #[allow(clippy::expect_used)]
-        let genesis = crate::Genesis::mainnet()
-            .expect("embedded mainnet genesis must parse and validate");
+        let genesis =
+            crate::Genesis::mainnet().expect("embedded mainnet genesis must parse and validate");
         Self::new_with_genesis(admin_address, &genesis)
     }
 
@@ -241,7 +241,11 @@ impl Blockchain {
     /// never called (e.g. unit tests with no storage backing).
     pub fn record_tx_in_index(&self, txid: &str, block_index: u64) {
         if let Some(mdbx) = &self.mdbx_storage {
-            let _ = mdbx.put(tables::TABLE_TX_INDEX, txid.as_bytes(), &height_key(block_index));
+            let _ = mdbx.put(
+                tables::TABLE_TX_INDEX,
+                txid.as_bytes(),
+                &height_key(block_index),
+            );
         }
     }
 
@@ -251,13 +255,19 @@ impl Blockchain {
     /// initialised.
     pub fn lookup_tx_in_storage(&self, txid: &str) -> Option<(Block, u64)> {
         let mdbx = self.mdbx_storage.as_ref()?;
-        let raw = mdbx.get(tables::TABLE_TX_INDEX, txid.as_bytes()).ok().flatten()?;
+        let raw = mdbx
+            .get(tables::TABLE_TX_INDEX, txid.as_bytes())
+            .ok()
+            .flatten()?;
         if raw.len() != 8 {
             return None;
         }
         let block_index = key_to_height(&raw);
         let key = format!("block:{}", block_index);
-        let bytes = mdbx.get(tables::TABLE_META, key.as_bytes()).ok().flatten()?;
+        let bytes = mdbx
+            .get(tables::TABLE_META, key.as_bytes())
+            .ok()
+            .flatten()?;
         let block: Block = serde_json::from_slice(&bytes).ok()?;
         Some((block, block_index))
     }
@@ -290,8 +300,12 @@ impl Blockchain {
                     .map_err(|e| SentrixError::StorageError(e.to_string()))?
                     .is_none()
                 {
-                    mdbx.put(tables::TABLE_TX_INDEX, tx.txid.as_bytes(), &height_key(block.index))
-                        .map_err(|e| SentrixError::StorageError(e.to_string()))?;
+                    mdbx.put(
+                        tables::TABLE_TX_INDEX,
+                        tx.txid.as_bytes(),
+                        &height_key(block.index),
+                    )
+                    .map_err(|e| SentrixError::StorageError(e.to_string()))?;
                     written += 1;
                 }
             }
@@ -419,7 +433,9 @@ impl Blockchain {
         // would crash the validator. checked_shr returns `None` at ≥64
         // so we clamp the reward to 0 (matching the intended "reward
         // halved to nothing" semantics).
-        let halvings: u32 = (self.height() / HALVING_INTERVAL).try_into().unwrap_or(u32::MAX);
+        let halvings: u32 = (self.height() / HALVING_INTERVAL)
+            .try_into()
+            .unwrap_or(u32::MAX);
         let reward = BLOCK_REWARD.checked_shr(halvings).unwrap_or(0);
 
         if reward == 0 {
@@ -659,8 +675,8 @@ impl Blockchain {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
     use secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
 
     fn make_keypair() -> (SecretKey, PublicKey) {
         let secp = Secp256k1::new();

--- a/crates/sentrix-core/src/chain_queries.rs
+++ b/crates/sentrix-core/src/chain_queries.rs
@@ -220,8 +220,8 @@ impl Blockchain {
 #[cfg(test)]
 mod tests {
     use crate::blockchain::{Blockchain, CHAIN_ID};
-    use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
     use secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
 
     fn make_keypair() -> (SecretKey, PublicKey) {
         let secp = Secp256k1::new();

--- a/crates/sentrix-core/src/genesis.rs
+++ b/crates/sentrix-core/src/genesis.rs
@@ -180,9 +180,9 @@ impl Genesis {
         // from hostile configs before hitting AccountDB.
         let mut total: u64 = 0;
         for b in &self.genesis.balances {
-            total = total.checked_add(b.amount).ok_or_else(|| {
-                GenesisError::Invalid("balance sum overflows u64".into())
-            })?;
+            total = total
+                .checked_add(b.amount)
+                .ok_or_else(|| GenesisError::Invalid("balance sum overflows u64".into()))?;
         }
         if total > crate::blockchain::MAX_SUPPLY {
             return Err(GenesisError::Invalid(format!(

--- a/crates/sentrix-core/src/mempool.rs
+++ b/crates/sentrix-core/src/mempool.rs
@@ -4,8 +4,8 @@ use crate::blockchain::{
     Blockchain, MAX_MEMPOOL_PER_SENDER, MAX_MEMPOOL_SIZE, MEMPOOL_MAX_AGE_SECS,
     is_valid_sentrix_address,
 };
-use sentrix_primitives::transaction::{TOKEN_OP_ADDRESS, TokenOp, Transaction};
 use sentrix_primitives::error::{SentrixError, SentrixResult};
+use sentrix_primitives::transaction::{TOKEN_OP_ADDRESS, TokenOp, Transaction};
 
 /// M-10: per-transaction size ceiling. Bounds worst-case memory impact
 /// of a single accepted mempool entry and caps block bloat from any
@@ -188,8 +188,8 @@ impl Blockchain {
 mod tests {
     use super::*;
     use crate::blockchain::{Blockchain, CHAIN_ID};
-    use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
     use secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
 
     fn make_keypair() -> (SecretKey, PublicKey) {
         let secp = Secp256k1::new();

--- a/crates/sentrix-core/src/storage.rs
+++ b/crates/sentrix-core/src/storage.rs
@@ -1,7 +1,7 @@
 // db.rs - Sentrix — Per-block persistent storage (MDBX backend)
 
-use sentrix_primitives::block::Block;
 use crate::blockchain::{Blockchain, CHAIN_WINDOW_SIZE};
+use sentrix_primitives::block::Block;
 use sentrix_primitives::error::{SentrixError, SentrixResult};
 use sentrix_storage::{ChainStorage, MdbxStorage};
 use std::sync::Arc;
@@ -12,13 +12,14 @@ pub struct Storage {
 
 impl Storage {
     pub fn open(path: &str) -> SentrixResult<Self> {
-        let chain = ChainStorage::open(path)
-            .map_err(|e| SentrixError::StorageError(e.to_string()))?;
+        let chain =
+            ChainStorage::open(path).map_err(|e| SentrixError::StorageError(e.to_string()))?;
         Ok(Self { chain })
     }
 
     pub fn ensure_hash_index(&self) -> SentrixResult<()> {
-        self.chain.ensure_hash_index()
+        self.chain
+            .ensure_hash_index()
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 
@@ -31,15 +32,19 @@ impl Storage {
     // ── Blockchain state (everything except blocks) ──────
 
     pub fn save_blockchain(&self, blockchain: &Blockchain) -> SentrixResult<()> {
-        self.chain.save_blockchain(blockchain, &blockchain.chain)
+        self.chain
+            .save_blockchain(blockchain, &blockchain.chain)
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
         Ok(())
     }
 
     pub fn load_blockchain(&self) -> SentrixResult<Option<Blockchain>> {
         // Try loading state
-        let mut bc: Blockchain = match self.chain.load_state()
-            .map_err(|e| SentrixError::StorageError(e.to_string()))? {
+        let mut bc: Blockchain = match self
+            .chain
+            .load_state()
+            .map_err(|e| SentrixError::StorageError(e.to_string()))?
+        {
             Some(bc) => bc,
             None => {
                 // Fallback: old "blockchain" key in meta table
@@ -49,7 +54,9 @@ impl Storage {
         };
 
         // Load only the sliding window (last CHAIN_WINDOW_SIZE blocks) into RAM.
-        let height = self.chain.load_height()
+        let height = self
+            .chain
+            .load_height()
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
         let window_start = height.saturating_sub(CHAIN_WINDOW_SIZE as u64 - 1);
         let mut blocks = Vec::with_capacity((height - window_start + 1) as usize);
@@ -79,7 +86,8 @@ impl Storage {
                         height,
                         effective
                     );
-                    self.chain.save_height(effective)
+                    self.chain
+                        .save_height(effective)
                         .map_err(|e| SentrixError::StorageError(e.to_string()))?;
                     break;
                 }
@@ -104,10 +112,35 @@ impl Storage {
             );
         }
 
-        // Restore state trie from MDBX
+        // Restore state trie from MDBX.
+        //
+        // HARD-FAIL on trie init failure above STATE_ROOT_FORK_HEIGHT: past the
+        // fork height, `state_root` is part of the block hash, so a node that
+        // silently fails trie init would produce blocks with `state_root = None`
+        // while peers with working tries produce `state_root = Some(...)`. The
+        // hashes diverge → chain fork. Mainnet stall on 2026-04-20 was caused
+        // by exactly this silent-warn path. Refusing to start surfaces broken
+        // trie state to operators immediately; the chain tolerates one
+        // validator offline better than a silently-diverging validator.
+        //
+        // Below fork height the old hash format ignores state_root entirely, so
+        // a failed trie init cannot cause consensus divergence — warn-only is
+        // still safe there.
         let mdbx = self.mdbx_arc();
         if let Err(e) = bc.init_trie(mdbx.clone()) {
-            tracing::warn!("trie init failed after blockchain load: {}", e);
+            let h = bc.height();
+            if h >= sentrix_primitives::block::STATE_ROOT_FORK_HEIGHT {
+                return Err(SentrixError::Internal(format!(
+                    "trie init failed at height {h}: {e}. Past STATE_ROOT_FORK_HEIGHT the trie \
+                     must be functional — state_root is part of the block hash and silent trie \
+                     failure causes chain forks. Resync from peers or wipe data dir to recover."
+                )));
+            }
+            tracing::warn!(
+                "trie init failed at height {} (below fork height — allowed): {}",
+                h,
+                e
+            );
         }
 
         // Bind storage handles for txid_index lookups
@@ -129,34 +162,40 @@ impl Storage {
     // ── Per-block operations ─────────────────────────────
 
     pub fn save_block(&self, block: &Block) -> SentrixResult<()> {
-        self.chain.save_block(block)
+        self.chain
+            .save_block(block)
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 
     pub fn load_block(&self, index: u64) -> SentrixResult<Option<Block>> {
-        self.chain.load_block(index)
+        self.chain
+            .load_block(index)
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 
     pub fn load_block_by_hash(&self, hash: &str) -> SentrixResult<Option<Block>> {
-        self.chain.load_block_by_hash(hash)
+        self.chain
+            .load_block_by_hash(hash)
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 
     pub fn load_blocks_range(&self, from: u64, to: u64) -> SentrixResult<Vec<Block>> {
-        self.chain.load_blocks_range(from, to)
+        self.chain
+            .load_blocks_range(from, to)
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 
     // ── Height ───────────────────────────────────────────
 
     pub fn save_height(&self, height: u64) -> SentrixResult<()> {
-        self.chain.save_height(height)
+        self.chain
+            .save_height(height)
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 
     pub fn load_height(&self) -> SentrixResult<u64> {
-        self.chain.load_height()
+        self.chain
+            .load_height()
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 
@@ -167,12 +206,14 @@ impl Storage {
     }
 
     pub fn clear(&self) -> SentrixResult<()> {
-        self.chain.clear()
+        self.chain
+            .clear()
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 
     pub fn reset_trie(&self) -> SentrixResult<()> {
-        self.chain.reset_trie()
+        self.chain
+            .reset_trie()
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-evm/src/database.rs
+++ b/crates/sentrix-evm/src/database.rs
@@ -3,11 +3,11 @@
 // Maps Sentrix account state to revm's Database trait, allowing the EVM
 // to read balances, nonces, contract code, and storage from our trie.
 
-use sentrix_primitives::{AccountDB, EMPTY_CODE_HASH};
 use alloy_primitives::{Address, B256, U256};
 use revm::database_interface::{DBErrorMarker, Database};
 use revm::primitives::KECCAK_EMPTY;
 use revm::state::{AccountInfo, Bytecode};
+use sentrix_primitives::{AccountDB, EMPTY_CODE_HASH};
 use std::collections::HashMap;
 
 /// Minimal EVM database error type that implements DBErrorMarker.
@@ -103,8 +103,7 @@ impl SentrixEvmDb {
                 .unwrap_or(KECCAK_EMPTY);
             let info = AccountInfo {
                 // P1: sentri → wei conversion (see `from_account_db`).
-                balance: U256::from(balance)
-                    .saturating_mul(U256::from(10_000_000_000u64)),
+                balance: U256::from(balance).saturating_mul(U256::from(10_000_000_000u64)),
                 nonce,
                 code_hash,
                 account_id: None,

--- a/crates/sentrix-evm/src/lib.rs
+++ b/crates/sentrix-evm/src/lib.rs
@@ -16,9 +16,9 @@ pub mod logs;
 pub mod precompiles;
 
 pub use database::{SentrixEvmDb, parse_sentrix_address};
-pub use executor::{execute_tx, execute_call, TxReceipt};
+pub use executor::{TxReceipt, execute_call, execute_tx};
 pub use gas::{BLOCK_GAS_LIMIT, INITIAL_BASE_FEE};
 pub use logs::{
-    add_log_to_bloom, bloom_contains, bloom_union, compute_logs_bloom, empty_bloom, log_key,
-    log_key_prefix, LogsBloom, StoredLog,
+    LogsBloom, StoredLog, add_log_to_bloom, bloom_contains, bloom_union, compute_logs_bloom,
+    empty_bloom, log_key, log_key_prefix,
 };

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/src/lib.rs
+++ b/crates/sentrix-network/src/lib.rs
@@ -12,4 +12,4 @@ pub mod sync;
 pub mod transport;
 
 pub use libp2p_node::{LibP2pNode, make_multiaddr};
-pub use node::{NodeEvent, SharedBlockchain, DEFAULT_PORT};
+pub use node::{DEFAULT_PORT, NodeEvent, SharedBlockchain};

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -30,14 +30,14 @@ use libp2p::{
 };
 use tokio::sync::mpsc;
 
-use sentrix_primitives::block::Block;
-use sentrix_primitives::transaction::Transaction;
 use crate::behaviour::{
     BLOCKS_TOPIC, GossipBlock, GossipTransaction, SentrixBehaviour, SentrixBehaviourEvent,
     SentrixRequest, SentrixResponse, TXS_TOPIC,
 };
 use crate::node::{NodeEvent, SharedBlockchain};
+use sentrix_primitives::block::Block;
 use sentrix_primitives::error::{SentrixError, SentrixResult};
+use sentrix_primitives::transaction::Transaction;
 
 // ── P2P protection constants ────────────────────────────
 /// Maximum number of verified (handshaked) peers.
@@ -166,10 +166,7 @@ impl LibP2pNode {
 
     /// Broadcast our current BFT round status so peers can sync rounds.
     /// Called periodically (~5s) by the validator loop.
-    pub async fn broadcast_bft_round_status(
-        &self,
-        status: &sentrix_bft::messages::RoundStatus,
-    ) {
+    pub async fn broadcast_bft_round_status(&self, status: &sentrix_bft::messages::RoundStatus) {
         let req = SentrixRequest::BftRoundStatus {
             status: status.clone(),
         };
@@ -1335,7 +1332,8 @@ mod tests {
 
         let node = LibP2pNode::new(keypair, bc, etx).expect("node");
         // No peers — broadcast should silently do nothing
-        let block = sentrix_primitives::block::Block::new(0, "0".to_string(), vec![], "v1".to_string());
+        let block =
+            sentrix_primitives::block::Block::new(0, "0".to_string(), vec![], "v1".to_string());
         node.broadcast_block(&block).await; // must not panic
     }
 }

--- a/crates/sentrix-network/src/node.rs
+++ b/crates/sentrix-network/src/node.rs
@@ -8,10 +8,10 @@
 // The TCP listener/handler functions below are NOT called by main.rs.
 // Do NOT re-enable raw TCP P2P without adding encryption.
 
-use sentrix_primitives::block::Block;
 use sentrix_core::blockchain::Blockchain;
-use sentrix_primitives::transaction::Transaction;
+use sentrix_primitives::block::Block;
 use sentrix_primitives::error::{SentrixError, SentrixResult};
+use sentrix_primitives::transaction::Transaction;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::IpAddr;

--- a/crates/sentrix-network/src/sync.rs
+++ b/crates/sentrix-network/src/sync.rs
@@ -1,8 +1,8 @@
 // sync.rs - Sentrix — Chain synchronization
 
-use sentrix_primitives::block::Block;
 use crate::node::{Message, Node, SharedBlockchain};
 use sentrix_core::storage::Storage;
+use sentrix_primitives::block::Block;
 use sentrix_primitives::error::{SentrixError, SentrixResult};
 use std::sync::Arc;
 use tokio::net::TcpStream;

--- a/crates/sentrix-network/src/transport.rs
+++ b/crates/sentrix-network/src/transport.rs
@@ -3,13 +3,13 @@
 // Builds a fully encrypted, multiplexed transport:
 //   TCP  →  Noise XX (mutual auth + forward secrecy)  →  Yamux (stream muxing)
 
-use sentrix_primitives::error::{SentrixError, SentrixResult};
 use libp2p::{
     PeerId, Transport,
     core::{muxing::StreamMuxerBox, transport::Boxed, upgrade},
     identity::Keypair,
     noise, tcp, yamux,
 };
+use sentrix_primitives::error::{SentrixError, SentrixResult};
 
 /// Fully assembled, boxed transport: TCP + Noise + Yamux.
 /// Ready to be handed to a libp2p `Swarm`.

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-primitives/src/block.rs
+++ b/crates/sentrix-primitives/src/block.rs
@@ -1,8 +1,8 @@
 // block.rs - Sentrix
 
+use crate::error::{SentrixError, SentrixResult};
 use crate::merkle::{merkle_root, sha256_hex};
 use crate::transaction::Transaction;
-use crate::error::{SentrixError, SentrixResult};
 use hex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -287,8 +287,7 @@ mod tests {
     #[test]
     fn test_c05_duplicate_txids_rejected_at_block_layer() {
         let genesis = Block::genesis();
-        let coinbase =
-            Transaction::new_coinbase("v1".to_string(), 100_000_000, 1, 1_712_620_800);
+        let coinbase = Transaction::new_coinbase("v1".to_string(), 100_000_000, 1, 1_712_620_800);
         // Two structurally-identical tx records share a txid by construction
         // (Transaction::new_coinbase is deterministic for given inputs).
         let dup_a = Transaction::new_coinbase("v2".to_string(), 1, 2, 1_712_620_800);
@@ -327,12 +326,7 @@ mod tests {
         let genesis = Block::genesis();
         let cb1 = Transaction::new_coinbase("v1".to_string(), 100_000_000, 1, 1_712_620_801);
         let cb2 = Transaction::new_coinbase("attacker".to_string(), 999_999_999, 1, 1_712_620_801);
-        let block1 = Block::new(
-            1,
-            genesis.hash.clone(),
-            vec![cb1, cb2],
-            "v1".to_string(),
-        );
+        let block1 = Block::new(1, genesis.hash.clone(), vec![cb1, cb2], "v1".to_string());
         let err = block1.validate_structure(1, &genesis.hash).unwrap_err();
         assert!(
             format!("{err:?}").contains("only the first transaction may be coinbase"),

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/explorer_api.rs
+++ b/crates/sentrix-rpc/src/explorer_api.rs
@@ -36,7 +36,11 @@ use std::collections::HashMap;
 const SENTRI_PER_SRX: f64 = 100_000_000.0;
 
 fn parse_page_limit(params: &HashMap<String, String>) -> (usize, usize) {
-    let page: usize = params.get("page").and_then(|p| p.parse().ok()).unwrap_or(1).max(1);
+    let page: usize = params
+        .get("page")
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(1)
+        .max(1);
     let limit: usize = params
         .get("limit")
         .and_then(|l| l.parse().ok())

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -17,11 +17,7 @@ use super::helpers::{
     to_hex, to_hex_u128,
 };
 
-pub(super) async fn dispatch(
-    method: &str,
-    params: &Value,
-    state: &SharedState,
-) -> DispatchResult {
+pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) -> DispatchResult {
     match method {
         "eth_chainId" => {
             let bc = state.read().await;
@@ -412,9 +408,8 @@ async fn eth_call(params: &Value, state: &SharedState) -> DispatchResult {
     {
         let code_hash_hex = hex::encode(target_account.code_hash);
         if let Some(code_bytes) = bc.accounts.get_contract_code(&code_hash_hex) {
-            let bytecode = revm::state::Bytecode::new_raw(alloy_primitives::Bytes::from(
-                code_bytes.clone(),
-            ));
+            let bytecode =
+                revm::state::Bytecode::new_raw(alloy_primitives::Bytes::from(code_bytes.clone()));
             let code_hash = alloy_primitives::B256::from(target_account.code_hash);
             in_mem_db.insert_account_info(
                 target,
@@ -471,11 +466,7 @@ async fn eth_get_logs(params: &Value, state: &SharedState) -> DispatchResult {
 }
 
 async fn eth_fee_history(params: &Value, state: &SharedState) -> DispatchResult {
-    let block_count = params
-        .get(0)
-        .and_then(parse_hex_u64)
-        .unwrap_or(1)
-        .min(1024);
+    let block_count = params.get(0).and_then(parse_hex_u64).unwrap_or(1).min(1024);
     let bc = state.read().await;
     let latest = bc.height();
     let newest = params

--- a/crates/sentrix-rpc/src/jsonrpc/mod.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/mod.rs
@@ -160,7 +160,6 @@ pub async fn rpc_dispatcher(
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sentrix-rpc/src/jsonrpc/net.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/net.rs
@@ -12,11 +12,7 @@ use serde_json::{Value, json};
 
 use super::DispatchResult;
 
-pub(super) async fn dispatch(
-    method: &str,
-    _params: &Value,
-    state: &SharedState,
-) -> DispatchResult {
+pub(super) async fn dispatch(method: &str, _params: &Value, state: &SharedState) -> DispatchResult {
     match method {
         "net_version" => {
             let bc = state.read().await;

--- a/crates/sentrix-rpc/src/jsonrpc/sentrix.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/sentrix.rs
@@ -15,11 +15,7 @@ use serde_json::{Value, json};
 use super::DispatchResult;
 use super::helpers::to_hex_u128;
 
-pub(super) async fn dispatch(
-    method: &str,
-    params: &Value,
-    state: &SharedState,
-) -> DispatchResult {
+pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) -> DispatchResult {
     match method {
         "sentrix_sendTransaction" => {
             // JSON-RPC token operations accept signed transactions only — no
@@ -30,10 +26,7 @@ pub(super) async fn dispatch(
             let tx: Transaction = match serde_json::from_value(params[0].clone()) {
                 Ok(t) => t,
                 Err(e) => {
-                    return Err((
-                        -32602,
-                        format!("invalid transaction object: {}", e),
-                    ));
+                    return Err((-32602, format!("invalid transaction object: {}", e)));
                 }
             };
             let txid = tx.txid.clone();
@@ -63,10 +56,7 @@ pub(super) async fn dispatch(
 async fn sentrix_get_validator_set(state: &SharedState) -> DispatchResult {
     let bc = state.read().await;
     let epoch = &bc.epoch_manager.current_epoch;
-    let epoch_span = epoch
-        .end_height
-        .saturating_sub(epoch.start_height)
-        .max(1);
+    let epoch_span = epoch.end_height.saturating_sub(epoch.start_height).max(1);
 
     // On a PoA chain (mainnet pre-Voyager) the DPoS stake_registry is
     // empty by design — validators live in AuthorityManager. Without the
@@ -229,8 +219,7 @@ async fn sentrix_get_delegations(params: &Value, state: &SharedState) -> Dispatc
         // delegator reward accounting lives in a staking sprint.
         let pending_reward_wei = match vstake {
             Some(v) if v.total_delegated > 0 => {
-                let share = (d.amount as u128)
-                    .saturating_mul(v.pending_rewards as u128)
+                let share = (d.amount as u128).saturating_mul(v.pending_rewards as u128)
                     / v.total_delegated as u128;
                 share.saturating_mul(10_000_000_000u128)
             }
@@ -306,8 +295,7 @@ async fn sentrix_get_staking_rewards(params: &Value, state: &SharedState) -> Dis
         if vstake.total_delegated == 0 {
             continue;
         }
-        let share_sentri = (d.amount as u128)
-            .saturating_mul(vstake.pending_rewards as u128)
+        let share_sentri = (d.amount as u128).saturating_mul(vstake.pending_rewards as u128)
             / vstake.total_delegated as u128;
         total_pending_sentri = total_pending_sentri.saturating_add(share_sentri);
         if cur >= from_epoch && cur <= to_epoch && share_sentri > 0 {

--- a/crates/sentrix-rpc/src/routes/auth.rs
+++ b/crates/sentrix-rpc/src/routes/auth.rs
@@ -65,4 +65,3 @@ pub fn constant_time_eq(a: &str, b: &str) -> bool {
     let content_eq: subtle::Choice = a_padded.ct_eq(&b_padded);
     (len_eq & content_eq).into()
 }
-

--- a/crates/sentrix-rpc/src/routes/mod.rs
+++ b/crates/sentrix-rpc/src/routes/mod.rs
@@ -22,8 +22,8 @@ pub use ratelimit::{GlobalIpLimiter, IpRateLimiter, WriteIpLimiter};
 pub use types::{ApiResponse, SendTxRequest, SignedTxRequest};
 
 use accounts::{
-    get_address_history, get_address_info, get_address_proof, get_balance, get_nonce,
-    get_richlist, get_state_root, get_wallet_info, list_transactions,
+    get_address_history, get_address_info, get_address_proof, get_balance, get_nonce, get_richlist,
+    get_state_root, get_wallet_info, list_transactions,
 };
 use chain::{chain_info, get_block, get_blocks, validate_chain};
 use epoch::{epoch_current, epoch_history};
@@ -31,8 +31,8 @@ use ops::{START_TIME, get_admin_log, health, metrics, root};
 use ratelimit::{ip_rate_limit_middleware, write_rate_limit_middleware};
 use staking::{get_validators, staking_delegations, staking_unbonding, staking_validators};
 use tokens::{
-    deploy_token, get_token_balance, get_token_holders_list, get_token_info,
-    get_token_trades_list, list_tokens, token_burn, token_transfer,
+    deploy_token, get_token_balance, get_token_holders_list, get_token_info, get_token_trades_list,
+    list_tokens, token_burn, token_transfer,
 };
 use transactions::{get_mempool, get_transaction, send_transaction};
 
@@ -57,10 +57,7 @@ use tokio::sync::RwLock;
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::cors::{Any, CorsLayer};
 
-
 pub type SharedState = Arc<RwLock<Blockchain>>;
-
-
 
 // ── Router ───────────────────────────────────────────────
 pub fn create_router(state: SharedState) -> Router {
@@ -190,10 +187,7 @@ pub fn create_router(state: SharedState) -> Router {
             "/accounts/{address}/history",
             get(crate::explorer_api::accounts_history),
         )
-        .route(
-            "/accounts/top",
-            get(crate::explorer_api::accounts_top),
-        )
+        .route("/accounts/top", get(crate::explorer_api::accounts_top))
         .route(
             "/accounts/{address}/tokens",
             get(crate::explorer_api::accounts_tokens),
@@ -273,19 +267,9 @@ fn explorer_router(_state: SharedState) -> Router<SharedState> {
 
 // ── Handlers ─────────────────────────────────────────────
 
-
-
-
-
 // ── Token handlers ───────────────────────────────────────
 
-
 // ── Short-form alias handlers ────────────────────────────
-
-
-
-
-
 
 // Helper for API error responses
 pub(super) fn api_err(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
@@ -351,7 +335,6 @@ mod tests {
         assert!(!constant_time_eq("", "a"));
         assert!(!constant_time_eq("a", ""));
     }
-
 
     // ── L-05: serde_json error propagation tests ──────────
 

--- a/crates/sentrix-rpc/src/routes/ops.rs
+++ b/crates/sentrix-rpc/src/routes/ops.rs
@@ -11,8 +11,7 @@ use axum::{Json, extract::State, response::IntoResponse};
 
 use super::{ApiKey, SharedState};
 
-pub(super) static START_TIME: std::sync::OnceLock<std::time::Instant> =
-    std::sync::OnceLock::new();
+pub(super) static START_TIME: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
 
 pub(super) async fn root() -> Json<serde_json::Value> {
     let chain_id = sentrix_core::blockchain::get_chain_id();

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-staking/src/staking.rs
+++ b/crates/sentrix-staking/src/staking.rs
@@ -278,10 +278,7 @@ impl StakeRegistry {
             .flat_map(|v| v.iter())
             .filter(|u| u.validator == validator)
             .fold((0usize, 0usize), |(per_pair, total), u| {
-                (
-                    per_pair + (u.delegator == delegator) as usize,
-                    total + 1,
-                )
+                (per_pair + (u.delegator == delegator) as usize, total + 1)
             });
         if existing_unbonding >= MAX_UNBONDING_ENTRIES {
             return Err(SentrixError::InvalidTransaction(format!(

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-storage/src/chain.rs
+++ b/crates/sentrix-storage/src/chain.rs
@@ -25,8 +25,7 @@ impl ChainStorage {
     /// Applies the same disk-encryption checks as the old sled Storage.
     pub fn open(path: &str) -> StorageResult<Self> {
         let encrypted = std::env::var("SENTRIX_ENCRYPTED_DISK").as_deref() == Ok("true");
-        let dev_override =
-            std::env::var("SENTRIX_ALLOW_UNENCRYPTED_DISK").as_deref() == Ok("true");
+        let dev_override = std::env::var("SENTRIX_ALLOW_UNENCRYPTED_DISK").as_deref() == Ok("true");
         if !encrypted {
             if dev_override {
                 tracing::warn!(
@@ -77,8 +76,11 @@ impl ChainStorage {
             if let Some(block) = self.load_block(i)? {
                 indexed_any = true;
                 if !self.mdbx.has(TABLE_BLOCK_HASHES, block.hash.as_bytes())? {
-                    self.mdbx
-                        .put(TABLE_BLOCK_HASHES, block.hash.as_bytes(), &height_key(block.index))?;
+                    self.mdbx.put(
+                        TABLE_BLOCK_HASHES,
+                        block.hash.as_bytes(),
+                        &height_key(block.index),
+                    )?;
                 }
             }
         }
@@ -91,7 +93,11 @@ impl ChainStorage {
 
     // ── Blockchain state ────────────────────────────────────
 
-    pub fn save_blockchain<T: Serialize>(&self, blockchain: &T, chain: &[Block]) -> StorageResult<()> {
+    pub fn save_blockchain<T: Serialize>(
+        &self,
+        blockchain: &T,
+        chain: &[Block],
+    ) -> StorageResult<()> {
         // Save state (accounts, authority, etc.)
         self.mdbx.put_json(TABLE_STATE, b"state", blockchain)?;
 
@@ -318,12 +324,21 @@ mod tests {
         let storage = ChainStorage::open(&path).unwrap();
 
         storage.save_block(&Block::genesis()).unwrap();
-        storage.mdbx().put(TABLE_TRIE_NODES, b"node1", b"data").unwrap();
+        storage
+            .mdbx()
+            .put(TABLE_TRIE_NODES, b"node1", b"data")
+            .unwrap();
         assert!(storage.load_block(0).unwrap().is_some());
 
         storage.reset_trie().unwrap();
         // Trie cleared but blocks still exist
-        assert!(storage.mdbx().get(TABLE_TRIE_NODES, b"node1").unwrap().is_none());
+        assert!(
+            storage
+                .mdbx()
+                .get(TABLE_TRIE_NODES, b"node1")
+                .unwrap()
+                .is_none()
+        );
         assert!(storage.load_block(0).unwrap().is_some());
 
         let _ = std::fs::remove_dir_all(&path);

--- a/crates/sentrix-storage/src/mdbx.rs
+++ b/crates/sentrix-storage/src/mdbx.rs
@@ -4,9 +4,7 @@
 
 use crate::error::{StorageError, StorageResult};
 use crate::tables::ALL_TABLES;
-use libmdbx::{
-    Database, DatabaseOptions, NoWriteMap, TableFlags, Transaction, WriteFlags, RW,
-};
+use libmdbx::{Database, DatabaseOptions, NoWriteMap, RW, TableFlags, Transaction, WriteFlags};
 use serde::{Serialize, de::DeserializeOwned};
 use std::path::Path;
 
@@ -30,11 +28,14 @@ impl MdbxStorage {
     pub fn open(path: &Path) -> StorageResult<Self> {
         std::fs::create_dir_all(path).map_err(|e| StorageError::Other(e.to_string()))?;
 
-        let db = Database::<NoWriteMap>::open_with_options(path, DatabaseOptions {
-            max_tables: Some(16),
-            ..Default::default()
-        })
-            .map_err(|e| StorageError::Mdbx(format!("open: {e}")))?;
+        let db = Database::<NoWriteMap>::open_with_options(
+            path,
+            DatabaseOptions {
+                max_tables: Some(16),
+                ..Default::default()
+            },
+        )
+        .map_err(|e| StorageError::Mdbx(format!("open: {e}")))?;
 
         // Pre-create all named tables
         {
@@ -45,7 +46,11 @@ impl MdbxStorage {
             tx.commit()?;
         }
 
-        tracing::info!("MDBX storage opened at {:?} ({} tables)", path, ALL_TABLES.len());
+        tracing::info!(
+            "MDBX storage opened at {:?} ({} tables)",
+            path,
+            ALL_TABLES.len()
+        );
         Ok(Self { db })
     }
 
@@ -89,13 +94,22 @@ impl MdbxStorage {
     // ── Typed operations (bincode encoding) ─────────────────
 
     /// Put a serializable value into the given table (bincode).
-    pub fn put_bincode<V: Serialize>(&self, table: &str, key: &[u8], value: &V) -> StorageResult<()> {
+    pub fn put_bincode<V: Serialize>(
+        &self,
+        table: &str,
+        key: &[u8],
+        value: &V,
+    ) -> StorageResult<()> {
         let encoded = bincode::serialize(value)?;
         self.put(table, key, &encoded)
     }
 
     /// Get a deserializable value from the given table (bincode).
-    pub fn get_bincode<V: DeserializeOwned>(&self, table: &str, key: &[u8]) -> StorageResult<Option<V>> {
+    pub fn get_bincode<V: DeserializeOwned>(
+        &self,
+        table: &str,
+        key: &[u8],
+    ) -> StorageResult<Option<V>> {
         match self.get(table, key)? {
             Some(bytes) => Ok(Some(bincode::deserialize(&bytes)?)),
             None => Ok(None),
@@ -109,7 +123,11 @@ impl MdbxStorage {
     }
 
     /// Get a JSON-deserializable value.
-    pub fn get_json<V: DeserializeOwned>(&self, table: &str, key: &[u8]) -> StorageResult<Option<V>> {
+    pub fn get_json<V: DeserializeOwned>(
+        &self,
+        table: &str,
+        key: &[u8],
+    ) -> StorageResult<Option<V>> {
         match self.get(table, key)? {
             Some(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
             None => Ok(None),
@@ -185,7 +203,12 @@ impl WriteBatch<'_> {
     }
 
     /// Put a bincode-encoded value.
-    pub fn put_bincode<V: Serialize>(&self, table: &str, key: &[u8], value: &V) -> StorageResult<()> {
+    pub fn put_bincode<V: Serialize>(
+        &self,
+        table: &str,
+        key: &[u8],
+        value: &V,
+    ) -> StorageResult<()> {
         let encoded = bincode::serialize(value)?;
         self.put(table, key, &encoded)
     }

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-trie/src/cache.rs
+++ b/crates/sentrix-trie/src/cache.rs
@@ -2,8 +2,8 @@
 
 use crate::node::{NodeHash, TrieNode};
 use crate::storage::TrieStorage;
-use sentrix_primitives::SentrixResult;
 use lru::LruCache;
+use sentrix_primitives::SentrixResult;
 use std::num::NonZeroUsize;
 use std::sync::Mutex;
 

--- a/crates/sentrix-trie/src/lib.rs
+++ b/crates/sentrix-trie/src/lib.rs
@@ -17,7 +17,7 @@ pub mod storage;
 pub mod tree;
 
 // Re-export commonly used types
-pub use tree::SentrixTrie;
 pub use address::{account_value_bytes, account_value_decode, address_to_key};
 pub use node::{NodeHash, TrieNode};
 pub use proof::MerkleProof;
+pub use tree::SentrixTrie;

--- a/crates/sentrix-trie/src/storage.rs
+++ b/crates/sentrix-trie/src/storage.rs
@@ -32,26 +32,33 @@ impl TrieStorage {
     /// O(n_blocks) one-time cost on migration; O(1) fast-path on all subsequent opens.
     fn ensure_committed_roots_index(&self) -> SentrixResult<()> {
         // Fast path: sentinel present means the index is already complete.
-        if self.mdbx.has(tables::TABLE_TRIE_COMMITTED, b"__ready__")
-            .map_err(|e| SentrixError::StorageError(e.to_string()))? {
+        if self
+            .mdbx
+            .has(tables::TABLE_TRIE_COMMITTED, b"__ready__")
+            .map_err(|e| SentrixError::StorageError(e.to_string()))?
+        {
             return Ok(());
         }
 
         // Slow path: scan trie_roots and populate the reverse index.
-        let entries = self.mdbx.iter(tables::TABLE_TRIE_ROOTS)
+        let entries = self
+            .mdbx
+            .iter(tables::TABLE_TRIE_ROOTS)
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
 
         let mut any = false;
         for (k, v) in &entries {
             if v.len() == 32 {
-                self.mdbx.put(tables::TABLE_TRIE_COMMITTED, v, k)
+                self.mdbx
+                    .put(tables::TABLE_TRIE_COMMITTED, v, k)
                     .map_err(|e| SentrixError::StorageError(e.to_string()))?;
                 any = true;
             }
         }
 
         if any {
-            self.mdbx.put(tables::TABLE_TRIE_COMMITTED, b"__ready__", b"1")
+            self.mdbx
+                .put(tables::TABLE_TRIE_COMMITTED, b"__ready__", b"1")
                 .map_err(|e| SentrixError::StorageError(e.to_string()))?;
         }
         Ok(())
@@ -62,14 +69,18 @@ impl TrieStorage {
     pub fn store_node(&self, hash: &NodeHash, node: &TrieNode) -> SentrixResult<()> {
         let bytes = bincode::serialize(node)
             .map_err(|e| SentrixError::SerializationError(e.to_string()))?;
-        self.mdbx.put(tables::TABLE_TRIE_NODES, hash, &bytes)
+        self.mdbx
+            .put(tables::TABLE_TRIE_NODES, hash, &bytes)
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
         Ok(())
     }
 
     pub fn load_node(&self, hash: &NodeHash) -> SentrixResult<Option<TrieNode>> {
-        match self.mdbx.get(tables::TABLE_TRIE_NODES, hash)
-            .map_err(|e| SentrixError::StorageError(e.to_string()))? {
+        match self
+            .mdbx
+            .get(tables::TABLE_TRIE_NODES, hash)
+            .map_err(|e| SentrixError::StorageError(e.to_string()))?
+        {
             Some(bytes) => {
                 let node = bincode::deserialize::<TrieNode>(&bytes)
                     .map_err(|e| SentrixError::SerializationError(e.to_string()))?;
@@ -81,7 +92,8 @@ impl TrieStorage {
 
     /// Remove a node entry from persistent storage (called when a leaf is replaced).
     pub fn delete_node(&self, hash: &NodeHash) -> SentrixResult<()> {
-        self.mdbx.delete(tables::TABLE_TRIE_NODES, hash)
+        self.mdbx
+            .delete(tables::TABLE_TRIE_NODES, hash)
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
         Ok(())
     }
@@ -89,19 +101,22 @@ impl TrieStorage {
     // ── Values ────────────────────────────────────────────
 
     pub fn store_value(&self, hash: &NodeHash, value: &[u8]) -> SentrixResult<()> {
-        self.mdbx.put(tables::TABLE_TRIE_VALUES, hash, value)
+        self.mdbx
+            .put(tables::TABLE_TRIE_VALUES, hash, value)
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
         Ok(())
     }
 
     pub fn load_value(&self, hash: &NodeHash) -> SentrixResult<Option<Vec<u8>>> {
-        self.mdbx.get(tables::TABLE_TRIE_VALUES, hash)
+        self.mdbx
+            .get(tables::TABLE_TRIE_VALUES, hash)
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 
     /// Remove a value blob from persistent storage (called when a leaf is replaced).
     pub fn delete_value(&self, hash: &NodeHash) -> SentrixResult<()> {
-        self.mdbx.delete(tables::TABLE_TRIE_VALUES, hash)
+        self.mdbx
+            .delete(tables::TABLE_TRIE_VALUES, hash)
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
         Ok(())
     }
@@ -109,23 +124,41 @@ impl TrieStorage {
     // ── Roots ─────────────────────────────────────────────
 
     pub fn store_root(&self, version: u64, root: &NodeHash) -> SentrixResult<()> {
-        self.mdbx.put(tables::TABLE_TRIE_ROOTS, &version.to_be_bytes(), root.as_slice())
+        self.mdbx
+            .put(
+                tables::TABLE_TRIE_ROOTS,
+                &version.to_be_bytes(),
+                root.as_slice(),
+            )
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
 
         // Maintain reverse index: NodeHash → version (O(1) is_committed_root lookups).
-        self.mdbx.put(tables::TABLE_TRIE_COMMITTED, root.as_slice(), &version.to_be_bytes())
+        self.mdbx
+            .put(
+                tables::TABLE_TRIE_COMMITTED,
+                root.as_slice(),
+                &version.to_be_bytes(),
+            )
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
 
-        if !self.mdbx.has(tables::TABLE_TRIE_COMMITTED, b"__ready__")
-            .unwrap_or(false) {
-            let _ = self.mdbx.put(tables::TABLE_TRIE_COMMITTED, b"__ready__", b"1");
+        if !self
+            .mdbx
+            .has(tables::TABLE_TRIE_COMMITTED, b"__ready__")
+            .unwrap_or(false)
+        {
+            let _ = self
+                .mdbx
+                .put(tables::TABLE_TRIE_COMMITTED, b"__ready__", b"1");
         }
         Ok(())
     }
 
     pub fn load_root(&self, version: u64) -> SentrixResult<Option<NodeHash>> {
-        match self.mdbx.get(tables::TABLE_TRIE_ROOTS, &version.to_be_bytes())
-            .map_err(|e| SentrixError::StorageError(e.to_string()))? {
+        match self
+            .mdbx
+            .get(tables::TABLE_TRIE_ROOTS, &version.to_be_bytes())
+            .map_err(|e| SentrixError::StorageError(e.to_string()))?
+        {
             Some(bytes) if bytes.len() == 32 => {
                 let mut arr = [0u8; 32];
                 arr.copy_from_slice(&bytes);
@@ -141,7 +174,8 @@ impl TrieStorage {
     /// Check whether `hash` is currently recorded as a committed root for any version.
     /// O(1) via `trie_committed_roots` reverse index.
     pub fn is_committed_root(&self, hash: &NodeHash) -> SentrixResult<bool> {
-        self.mdbx.has(tables::TABLE_TRIE_COMMITTED, hash.as_slice())
+        self.mdbx
+            .has(tables::TABLE_TRIE_COMMITTED, hash.as_slice())
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 
@@ -153,7 +187,9 @@ impl TrieStorage {
         let cutoff = latest_version - keep;
         let mut removed = 0usize;
 
-        let entries = self.mdbx.iter(tables::TABLE_TRIE_ROOTS)
+        let entries = self
+            .mdbx
+            .iter(tables::TABLE_TRIE_ROOTS)
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
 
         let mut to_delete: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
@@ -169,10 +205,12 @@ impl TrieStorage {
         }
 
         for (key, root_hash) in &to_delete {
-            self.mdbx.delete(tables::TABLE_TRIE_ROOTS, key.as_slice())
+            self.mdbx
+                .delete(tables::TABLE_TRIE_ROOTS, key.as_slice())
                 .map_err(|e| SentrixError::StorageError(e.to_string()))?;
             if root_hash.len() == 32 {
-                self.mdbx.delete(tables::TABLE_TRIE_COMMITTED, root_hash.as_slice())
+                self.mdbx
+                    .delete(tables::TABLE_TRIE_COMMITTED, root_hash.as_slice())
                     .map_err(|e| SentrixError::StorageError(e.to_string()))?;
             }
             removed += 1;
@@ -197,7 +235,9 @@ impl TrieStorage {
         table: &str,
         live_hashes: &std::collections::HashSet<NodeHash>,
     ) -> SentrixResult<usize> {
-        let entries = self.mdbx.iter(table)
+        let entries = self
+            .mdbx
+            .iter(table)
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
 
         let mut to_delete: Vec<NodeHash> = Vec::new();
@@ -212,7 +252,8 @@ impl TrieStorage {
         }
         let count = to_delete.len();
         for hash in &to_delete {
-            self.mdbx.delete(table, hash)
+            self.mdbx
+                .delete(table, hash)
                 .map_err(|e| SentrixError::StorageError(e.to_string()))?;
         }
         Ok(count)
@@ -220,7 +261,8 @@ impl TrieStorage {
 
     /// Count entries in a trie table. Used by tests.
     pub fn count(&self, table: &str) -> SentrixResult<usize> {
-        self.mdbx.count(table)
+        self.mdbx
+            .count(table)
             .map_err(|e| SentrixError::StorageError(e.to_string()))
     }
 }
@@ -403,7 +445,10 @@ mod tests {
         let root = dummy_hash(0x42);
         storage.store_root(7, &root).unwrap();
         assert!(
-            storage.mdbx.has(tables::TABLE_TRIE_COMMITTED, root.as_slice()).unwrap(),
+            storage
+                .mdbx
+                .has(tables::TABLE_TRIE_COMMITTED, root.as_slice())
+                .unwrap(),
             "trie_committed_roots must contain the hash after store_root()"
         );
     }
@@ -431,7 +476,8 @@ mod tests {
         let mdbx = Arc::new(MdbxStorage::open(dir.path()).unwrap());
 
         let root = dummy_hash(0xAA);
-        mdbx.put(tables::TABLE_TRIE_ROOTS, &1u64.to_be_bytes(), &root[..]).unwrap();
+        mdbx.put(tables::TABLE_TRIE_ROOTS, &1u64.to_be_bytes(), &root[..])
+            .unwrap();
 
         // Re-open via TrieStorage::new() — triggers ensure_committed_roots_index()
         let storage = TrieStorage::new(mdbx).unwrap();

--- a/crates/sentrix-trie/src/tree.rs
+++ b/crates/sentrix-trie/src/tree.rs
@@ -685,11 +685,15 @@ mod tests {
         let key = address_to_key("0xaaaa");
 
         trie.insert(&key, &account_value_bytes(100, 0)).unwrap();
-        let nodes_after_insert = mdbx.count(sentrix_storage::tables::TABLE_TRIE_NODES).unwrap();
+        let nodes_after_insert = mdbx
+            .count(sentrix_storage::tables::TABLE_TRIE_NODES)
+            .unwrap();
 
         // Update same key — node count must stay the same (old leaf removed, new leaf added)
         trie.insert(&key, &account_value_bytes(200, 1)).unwrap();
-        let nodes_after_update = mdbx.count(sentrix_storage::tables::TABLE_TRIE_NODES).unwrap();
+        let nodes_after_update = mdbx
+            .count(sentrix_storage::tables::TABLE_TRIE_NODES)
+            .unwrap();
 
         assert_eq!(
             nodes_after_insert, nodes_after_update,
@@ -759,12 +763,20 @@ mod tests {
         let val = account_value_bytes(500, 0);
 
         trie.insert(&key, &val).unwrap();
-        let nodes_after_insert = mdbx.count(sentrix_storage::tables::TABLE_TRIE_NODES).unwrap();
-        let values_after_insert = mdbx.count(sentrix_storage::tables::TABLE_TRIE_VALUES).unwrap();
+        let nodes_after_insert = mdbx
+            .count(sentrix_storage::tables::TABLE_TRIE_NODES)
+            .unwrap();
+        let values_after_insert = mdbx
+            .count(sentrix_storage::tables::TABLE_TRIE_VALUES)
+            .unwrap();
 
         trie.delete(&key).unwrap();
-        let nodes_after_delete = mdbx.count(sentrix_storage::tables::TABLE_TRIE_NODES).unwrap();
-        let values_after_delete = mdbx.count(sentrix_storage::tables::TABLE_TRIE_VALUES).unwrap();
+        let nodes_after_delete = mdbx
+            .count(sentrix_storage::tables::TABLE_TRIE_NODES)
+            .unwrap();
+        let values_after_delete = mdbx
+            .count(sentrix_storage::tables::TABLE_TRIE_VALUES)
+            .unwrap();
 
         assert!(
             nodes_after_delete < nodes_after_insert,
@@ -792,15 +804,21 @@ mod tests {
 
         // Insert first key (creates leaf at root)
         trie.insert(&k1, &account_value_bytes(100, 0)).unwrap();
-        let nodes_1 = mdbx.count(sentrix_storage::tables::TABLE_TRIE_NODES).unwrap();
+        let nodes_1 = mdbx
+            .count(sentrix_storage::tables::TABLE_TRIE_NODES)
+            .unwrap();
 
         // Insert second key (creates internal node, old root-leaf becomes sibling)
         trie.insert(&k2, &account_value_bytes(200, 0)).unwrap();
-        let nodes_2 = mdbx.count(sentrix_storage::tables::TABLE_TRIE_NODES).unwrap();
+        let nodes_2 = mdbx
+            .count(sentrix_storage::tables::TABLE_TRIE_NODES)
+            .unwrap();
 
         // Update k1 (causes structural change — old internal nodes replaced)
         trie.insert(&k1, &account_value_bytes(300, 1)).unwrap();
-        let nodes_3 = mdbx.count(sentrix_storage::tables::TABLE_TRIE_NODES).unwrap();
+        let nodes_3 = mdbx
+            .count(sentrix_storage::tables::TABLE_TRIE_NODES)
+            .unwrap();
 
         // Node count after update should not exceed count after two-key insert
         // (old internal nodes should be cleaned up)

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wallet/src/keystore.rs
+++ b/crates/sentrix-wallet/src/keystore.rs
@@ -1,6 +1,5 @@
 // keystore.rs - Sentrix
 
-use sentrix_primitives::{SentrixError, SentrixResult};
 use crate::wallet::Wallet;
 use aes_gcm::{
     Aes256Gcm, Key, Nonce,
@@ -9,6 +8,7 @@ use aes_gcm::{
 use argon2::{Algorithm, Argon2, Params, Version};
 use pbkdf2::pbkdf2_hmac;
 use rand::RngCore;
+use sentrix_primitives::{SentrixError, SentrixResult};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 

--- a/crates/sentrix-wallet/src/wallet.rs
+++ b/crates/sentrix-wallet/src/wallet.rs
@@ -1,7 +1,7 @@
 // wallet.rs - Sentrix
 
-use sentrix_primitives::{SentrixError, SentrixResult};
 use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use sentrix_primitives::{SentrixError, SentrixResult};
 use sha3::Digest;
 use sha3::Keccak256;
 use zeroize::Zeroizing;

--- a/src/core/trie/mod.rs
+++ b/src/core/trie/mod.rs
@@ -8,7 +8,7 @@ pub use sentrix_trie::storage;
 pub use sentrix_trie::tree;
 
 pub use sentrix_trie::address::{account_value_bytes, account_value_decode, address_to_key};
-pub use sentrix_trie::node::{NodeHash, TrieNode};
 pub use sentrix_trie::node::{NULL_HASH, empty_hash, get_bit, hash_internal, hash_leaf};
+pub use sentrix_trie::node::{NodeHash, TrieNode};
 pub use sentrix_trie::proof::MerkleProof;
 pub use sentrix_trie::tree::SentrixTrie;

--- a/tests/integration_eth_block_receipts.rs
+++ b/tests/integration_eth_block_receipts.rs
@@ -89,8 +89,7 @@ async fn cumulative_gas_used_is_monotonic() {
         let cur_hex = r["cumulativeGasUsed"]
             .as_str()
             .expect("cumulativeGasUsed hex");
-        let cur = u64::from_str_radix(cur_hex.trim_start_matches("0x"), 16)
-            .expect("u64 from hex");
+        let cur = u64::from_str_radix(cur_hex.trim_start_matches("0x"), 16).expect("u64 from hex");
         assert!(
             cur >= prev,
             "cumulativeGasUsed must be non-decreasing ({prev} → {cur})",

--- a/tests/integration_eth_logs_and_fees.rs
+++ b/tests/integration_eth_logs_and_fees.rs
@@ -79,11 +79,7 @@ async fn test_eth_get_logs_rejects_inverted_range() {
 #[tokio::test]
 async fn test_eth_get_logs_requires_filter_object() {
     let state = fresh_state();
-    let resp = jsonrpc_handler(
-        State(state),
-        Json(make_request("eth_getLogs", json!([]))),
-    )
-    .await;
+    let resp = jsonrpc_handler(State(state), Json(make_request("eth_getLogs", json!([])))).await;
     let err = resp.0.error.expect("should error");
     assert_eq!(err.code, -32602);
 }
@@ -101,13 +97,21 @@ async fn test_eth_fee_history_shape() {
     .await;
     let result = resp.0.result.expect("result");
     assert!(result["oldestBlock"].as_str().unwrap().starts_with("0x"));
-    let base_fees = result["baseFeePerGas"].as_array().expect("baseFeePerGas array");
-    let ratios = result["gasUsedRatio"].as_array().expect("gasUsedRatio array");
+    let base_fees = result["baseFeePerGas"]
+        .as_array()
+        .expect("baseFeePerGas array");
+    let ratios = result["gasUsedRatio"]
+        .as_array()
+        .expect("gasUsedRatio array");
     let rewards = result["reward"].as_array().expect("reward array");
     assert_eq!(base_fees.len(), 5, "baseFeePerGas always blockCount+1");
     assert_eq!(ratios.len(), rewards.len(), "ratios + rewards must align");
     if let Some(first_reward) = rewards.first() {
-        assert_eq!(first_reward.as_array().unwrap().len(), 3, "reward[i] len == percentiles len");
+        assert_eq!(
+            first_reward.as_array().unwrap().len(),
+            3,
+            "reward[i] len == percentiles len"
+        );
     }
 }
 

--- a/tests/integration_p2p.rs
+++ b/tests/integration_p2p.rs
@@ -144,9 +144,7 @@ async fn test_gossipsub_block_propagation() {
     // Create a valid block on chain A (so it has correct prev_hash, merkle root, etc.)
     let block = {
         let mut chain_a = bc_a.write().await;
-        let b = chain_a
-            .create_block(&val.address)
-            .expect("create_block");
+        let b = chain_a.create_block(&val.address).expect("create_block");
         chain_a.add_block(b.clone()).expect("add_block on A");
         b
     };

--- a/tests/integration_sentrix_native_rpc.rs
+++ b/tests/integration_sentrix_native_rpc.rs
@@ -67,8 +67,7 @@ fn setup_chain_with_dpos() -> (Arc<RwLock<Blockchain>>, String, String, String, 
     bc.stake_registry
         .delegate(&del2.address, &val2.address, 7_000_000_000, 12)
         .expect("delegate");
-    bc.stake_registry
-        .update_active_set();
+    bc.stake_registry.update_active_set();
 
     (
         Arc::new(RwLock::new(bc)),
@@ -82,14 +81,24 @@ fn setup_chain_with_dpos() -> (Arc<RwLock<Blockchain>>, String, String, String, 
 #[tokio::test]
 async fn test_sentrix_get_validator_set_shape() {
     let (state, _, _, _, _) = setup_chain_with_dpos();
-    let resp = jsonrpc_handler(State(state), Json(make_request("sentrix_getValidatorSet", json!([])))).await;
+    let resp = jsonrpc_handler(
+        State(state),
+        Json(make_request("sentrix_getValidatorSet", json!([]))),
+    )
+    .await;
     let result = resp.0.result.expect("result");
     assert_eq!(
         result["consensus"].as_str().unwrap(),
         "PoA",
         "default chain (no VOYAGER_FORK_HEIGHT env) is PoA — empty stake_registry must fall back to AuthorityManager"
     );
-    assert!(result.get("validators").and_then(|v| v.as_array()).is_some(), "validators array");
+    assert!(
+        result
+            .get("validators")
+            .and_then(|v| v.as_array())
+            .is_some(),
+        "validators array"
+    );
     assert!(result.get("active_count").is_some());
     assert!(result.get("total_count").is_some());
     assert!(result.get("total_active_stake").is_some());
@@ -157,7 +166,12 @@ async fn test_sentrix_get_staking_rewards_default_window() {
     .await;
     let result = resp.0.result.expect("result");
     assert!(result["total_lifetime"].as_str().unwrap().starts_with("0x"));
-    assert!(result["pending_claimable"].as_str().unwrap().starts_with("0x"));
+    assert!(
+        result["pending_claimable"]
+            .as_str()
+            .unwrap()
+            .starts_with("0x")
+    );
     assert!(result["by_epoch"].is_array());
     assert!(result["from_epoch"].is_number());
     assert!(result["to_epoch"].is_number());
@@ -179,7 +193,10 @@ async fn test_sentrix_get_bft_status_poa_mode() {
     assert!(result.get("last_finalized_height").is_some());
     assert!(result.get("last_finalized_hash").is_some());
     // PoA response does NOT include BFT-only fields.
-    assert!(result.get("current_round").is_none(), "PoA must omit current_round");
+    assert!(
+        result.get("current_round").is_none(),
+        "PoA must omit current_round"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Mainnet stalled today (2026-04-20) at block 100,004 due to a silent
trie init failure path: `init_trie` failure was a `tracing::warn!` and
the node continued, producing blocks with `state_root = null` while
peers with working tries produced `state_root = Some(...)`. Past
`STATE_ROOT_FORK_HEIGHT = 100_000` the state_root is included in the
block hash, so the two versions had different hashes for the same
block content — VPS1 rejected VPS3's block 100,005 with "invalid
previous hash". Chain halted.

This PR changes `load_blockchain()` in `crates/sentrix-core/src/storage.rs`
to return an error when `init_trie()` fails at a height past fork
height. Below fork height the old hash format ignores `state_root`, so
the warn-only path stays there.

Also bumps workspace version 2.1.1 → 2.1.2.

## Test plan
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace` all 38 suites pass
- [ ] CI green
- [ ] Deploy hotfix binary to mainnet VPS1/VPS3/VPS2.val5 one at a time
- [ ] Verify chain still producing blocks after each restart

## Deploy notes
- Mainnet currently at ~height 100,050+ and stable after today's
  recovery (DB copy from VPS3 → VPS1)
- Restarting each validator with v2.1.2 binary — if any one refuses to
  start, its trie is broken and needs data-dir wipe + peer resync
  before coming back online