### PR TITLE
ops: testnet livelock watchdog (backlog #1d workaround)

### DIFF
--- a/scripts/install-testnet-watchdog.sh
+++ b/scripts/install-testnet-watchdog.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# install-testnet-watchdog.sh — One-shot installer for the testnet
+# livelock watchdog on VPS3.
+#
+# Run locally on VPS4 (or whoever has satya_master SSH). Copies the
+# watchdog script to VPS3, writes a systemd oneshot service + timer
+# pair, enables the timer. Idempotent — safe to re-run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHDOG_SCRIPT="$SCRIPT_DIR/testnet-livelock-watchdog.sh"
+VPS3_HOST="${VPS3_HOST:-}"
+if [[ -z "$VPS3_HOST" ]]; then
+    echo "VPS3_HOST not set — export VPS3_HOST=<user>@<ip> before running" >&2
+    exit 2
+fi
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/satya_master}"
+SSH="ssh -i $SSH_KEY -o StrictHostKeyChecking=accept-new $VPS3_HOST"
+
+[[ -f "$WATCHDOG_SCRIPT" ]] || { echo "missing $WATCHDOG_SCRIPT"; exit 1; }
+
+echo "==> Uploading watchdog script to VPS3"
+scp -i "$SSH_KEY" "$WATCHDOG_SCRIPT" "$VPS3_HOST:/tmp/testnet-livelock-watchdog.sh"
+
+echo "==> Installing watchdog to /usr/local/bin"
+$SSH 'sudo install -m 0755 /tmp/testnet-livelock-watchdog.sh /usr/local/bin/sentrix-testnet-livelock-watchdog && rm /tmp/testnet-livelock-watchdog.sh'
+
+echo "==> Writing systemd unit + timer"
+$SSH 'sudo tee /etc/systemd/system/sentrix-testnet-watchdog.service > /dev/null <<EOF
+[Unit]
+Description=Sentrix testnet livelock watchdog (backlog #1d workaround)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sentrix-testnet-livelock-watchdog
+# Watchdog itself should be cheap; generous timeout only in case
+# systemctl restart fans out slowly.
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF'
+
+$SSH 'sudo tee /etc/systemd/system/sentrix-testnet-watchdog.timer > /dev/null <<EOF
+[Unit]
+Description=Run Sentrix testnet watchdog every minute
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=5
+Unit=sentrix-testnet-watchdog.service
+
+[Install]
+WantedBy=timers.target
+EOF'
+
+echo "==> Enabling + starting timer"
+$SSH 'sudo systemctl daemon-reload && sudo systemctl enable --now sentrix-testnet-watchdog.timer'
+
+echo "==> Verification"
+$SSH 'sudo systemctl status sentrix-testnet-watchdog.timer --no-pager | head -10'
+echo
+echo "==> Tail logs with:"
+echo "    ssh $VPS3_HOST 'journalctl -t sentrix-livelock-watchdog -f'"

--- a/scripts/testnet-livelock-watchdog.sh
+++ b/scripts/testnet-livelock-watchdog.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# testnet-livelock-watchdog.sh — Workaround for BFT livelock #1d until the
+# proper fix lands.
+#
+# Polls the local testnet RPC every 60 s; if chain height hasn't advanced
+# for 5+ minutes, restart all 4 testnet validators in parallel. Logs
+# every action to syslog (journalctl -t sentrix-livelock-watchdog) and
+# keeps a short local state file under /run so the script is
+# stateless across reboots.
+#
+# Install on VPS3 (the only host running the testnet validator cluster)
+# as a systemd timer; see scripts/install-testnet-watchdog.sh for the
+# one-shot installer.
+
+set -euo pipefail
+
+RPC_URL="${RPC_URL:-http://localhost:9545/chain/info}"
+STATE_FILE="${STATE_FILE:-/run/sentrix-testnet-watchdog.state}"
+STALL_THRESHOLD_SECS="${STALL_THRESHOLD_SECS:-300}"   # 5 minutes
+COOLDOWN_SECS="${COOLDOWN_SECS:-180}"                 # don't restart more than once per 3 min
+VALIDATORS=(sentrix-testnet-val1 sentrix-testnet-val2 sentrix-testnet-val3 sentrix-testnet-val4)
+
+log() {
+    logger -t sentrix-livelock-watchdog "$*"
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+current_height() {
+    curl -sS --max-time 3 "$RPC_URL" 2>/dev/null \
+        | grep -oE '"height":[0-9]+' \
+        | grep -oE '[0-9]+' \
+        | head -1
+}
+
+read_state() {
+    [[ -f "$STATE_FILE" ]] || { echo "0 0 0"; return; }
+    cat "$STATE_FILE"
+}
+
+write_state() {
+    printf '%s %s %s\n' "$1" "$2" "$3" > "$STATE_FILE"
+}
+
+restart_validators() {
+    log "RESTART: chain stalled — restarting ${VALIDATORS[*]}"
+    for v in "${VALIDATORS[@]}"; do
+        systemctl restart "$v" &
+    done
+    wait
+    log "RESTART: completed"
+}
+
+main() {
+    local now last_seen_height last_seen_ts last_restart_ts
+    now=$(date +%s)
+    read -r last_seen_height last_seen_ts last_restart_ts < <(read_state)
+
+    local height
+    height=$(current_height || true)
+    if [[ -z "${height:-}" ]]; then
+        log "WARN: RPC unreachable ($RPC_URL) — skipping this tick"
+        return 0
+    fi
+
+    # First run or height advanced — just record.
+    if [[ "$height" != "$last_seen_height" ]]; then
+        log "OK: height $last_seen_height → $height (advancing)"
+        write_state "$height" "$now" "$last_restart_ts"
+        return 0
+    fi
+
+    # Same height as last tick — check stall duration.
+    local stalled_for=$(( now - last_seen_ts ))
+    local since_restart=$(( now - last_restart_ts ))
+
+    if (( stalled_for < STALL_THRESHOLD_SECS )); then
+        log "OK: height $height unchanged for ${stalled_for}s (<threshold=${STALL_THRESHOLD_SECS}s)"
+        return 0
+    fi
+
+    if (( since_restart < COOLDOWN_SECS )); then
+        log "COOLDOWN: height $height stalled ${stalled_for}s but last restart was ${since_restart}s ago (<cooldown=${COOLDOWN_SECS}s)"
+        return 0
+    fi
+
+    log "STALL: height $height stalled for ${stalled_for}s — triggering restart"
+    restart_validators
+    write_state "$height" "$now" "$now"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Stops the pager from firing every time testnet hits backlog #1d
(BFT livelock where rounds climb past 50 even though all 4 validators
vote). Proper engine fix is in flight; this is just a systemd timer
on VPS3 that restarts all 4 validators when chain height stalls.

- `scripts/testnet-livelock-watchdog.sh` — the poll loop itself.
  60s tick, 300s stall threshold, 180s restart cooldown.
- `scripts/install-testnet-watchdog.sh` — one-shot installer. Reads
  `VPS3_HOST` from env so the target isn't hard-coded (pre-commit
  hook flags hardcoded SSH user+host pairs).

Already deployed to VPS3 today (2026-04-20) and observed to tick
cleanly: two `OK: height X → Y (advancing)` entries with no
restarts fired. When the next #1d stall happens it'll kick in.

## Test plan
- [x] Installer runs cleanly on VPS3
- [x] Watchdog ticks every 60s with chain advancing
- [ ] Will verify restart path next time #1d fires in the wild
- [x] Pre-commit secret scan clean