### PR TITLE
hotfix(consensus): reject peer blocks with state_root=None past fork height — v2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,32 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [2.1.2] — 2026-04-20 — Trie-init hardening hotfix
+## [2.1.3] — 2026-04-20 — Runtime trie divergence guard (backlog #1e)
+
+### Fixed
+- **fix(consensus): reject peer blocks with state_root=None past
+  STATE_ROOT_FORK_HEIGHT** (`crates/sentrix-core/src/block_executor.rs`).
+  Root cause of the 2026-04-20 mainnet fork that recurred even after
+  v2.1.2: `apply_block_pass2` treated every block arriving with
+  `state_root = None` as self-produced and silently stamped its own
+  computed root + recomputed the block hash. When a peer with a broken
+  trie broadcast a block with `state_root = None`, local nodes accepted
+  it, stamped a different root, stored a different hash — the next
+  block's `previous_hash` check failed against the peer's view and the
+  chain forked.
+
+  Fix: admission path now threads a `BlockSource` enum. New
+  `Blockchain::add_block_from_peer` routes incoming P2P / BFT-finalized
+  blocks through a strict branch that returns
+  `ChainValidationFailed` on `state_root = None` past fork height.
+  `Blockchain::add_block` stays as the permissive self-proposed path
+  (used by `build_block` where `state_root = None` is legitimate
+  because Pass 2 stamps it). All `sentrix-network` sync/gossip call
+  sites updated to `add_block_from_peer`. CRITICAL-level logs emitted
+  on both the None-from-peer and the `received_root != computed_root`
+  branches so operators see trie divergence loud in journalctl.
+
+
 
 ### Fixed
 - **fix(consensus): hard-fail trie init above STATE_ROOT_FORK_HEIGHT**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -12,6 +12,22 @@ use sentrix_primitives::error::{SentrixError, SentrixResult};
 use sentrix_primitives::transaction::{TokenOp, Transaction};
 use std::collections::{HashMap, HashSet, VecDeque};
 
+/// Origin of a block being admitted to the chain. Distinguishes
+/// proposals this validator just produced locally (where `state_root`
+/// is legitimately `None` until `update_trie_for_block` stamps it)
+/// from blocks that arrived over the wire (where a `None` state_root
+/// past `STATE_ROOT_FORK_HEIGHT` means the sender's trie is broken
+/// and accepting would fork the chain). Backlog #1e.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockSource {
+    /// Produced by this validator (block_producer::build_block).
+    /// state_root starts None and is stamped in Pass 2.
+    SelfProduced,
+    /// Received from a peer via P2P sync or BFT finalize.
+    /// state_root must already be Some past STATE_ROOT_FORK_HEIGHT.
+    Peer,
+}
+
 /// C-03: snapshot of the mutable Blockchain state taken immediately
 /// before Pass 2 of `add_block`. If any step in Pass 2 returns `Err`,
 /// the snapshot is restored so the chain never observes a partial
@@ -232,7 +248,45 @@ impl Blockchain {
     }
 
     // ── Block application (two-pass atomic) ─────────────
+    /// Admit a block produced locally. Preserves existing call sites that
+    /// don't care about origin (tests, legacy integrations). For blocks
+    /// arriving from peers past `STATE_ROOT_FORK_HEIGHT`, use
+    /// [`add_block_from_peer`](Self::add_block_from_peer) instead — it
+    /// rejects state_root=None rather than stamping it locally (which
+    /// would silently fork the chain when the peer's trie is broken,
+    /// backlog #1e / 2026-04-20 mainnet incident).
     pub fn add_block(&mut self, block: Block) -> SentrixResult<()> {
+        self.add_block_with_source(block, BlockSource::SelfProduced)
+    }
+
+    /// Admit a block received from a peer. Past fork height, the block
+    /// must carry `state_root = Some(root)` — a `None` from a peer
+    /// indicates the peer's trie failed to commit (backlog #1e) and
+    /// accepting it would cause us to stamp our own root and recompute
+    /// the block hash, diverging from the peer's persisted hash →
+    /// "invalid previous hash" fork on the next block.
+    pub fn add_block_from_peer(&mut self, block: Block) -> SentrixResult<()> {
+        self.add_block_with_source(block, BlockSource::Peer)
+    }
+
+    /// Core admit path. `source` is consulted only in the state_root
+    /// stamping branch — everything else is identical for self-produced
+    /// and peer-received blocks.
+    pub fn add_block_with_source(
+        &mut self,
+        block: Block,
+        source: BlockSource,
+    ) -> SentrixResult<()> {
+        self.source_for_current_add = source;
+        let result = self.add_block_impl(block);
+        // Clear the source marker so stale state can't leak into a later
+        // unrelated call (e.g. if apply_block_pass2 were ever called
+        // directly from tests).
+        self.source_for_current_add = BlockSource::SelfProduced;
+        result
+    }
+
+    fn add_block_impl(&mut self, block: Block) -> SentrixResult<()> {
         let expected_index = self.height() + 1;
         let expected_prev = self.latest_block()?.hash.clone();
 
@@ -663,8 +717,31 @@ impl Blockchain {
             if last.index >= STATE_ROOT_FORK_HEIGHT {
                 match last.state_root {
                     None => {
-                        // Self-produced block: set state_root and recompute hash so that
-                        // state_root is committed into the block header (V7-C-01).
+                        // state_root=None past fork height is only legitimate
+                        // when WE just produced this block — build_block creates
+                        // fresh blocks with state_root=None and add_block is
+                        // expected to stamp it here. A peer-sent block with
+                        // state_root=None means the peer's trie is broken
+                        // (backlog #1e / 2026-04-20 mainnet incident) — if we
+                        // stamp it ourselves we silently recompute the block
+                        // hash, diverging from what the peer persisted, and
+                        // the next block's previous_hash check fails → fork.
+                        //
+                        // Peer blocks with None get rejected loud, not stamped.
+                        if self.source_for_current_add == BlockSource::Peer {
+                            tracing::error!(
+                                "CRITICAL #1e: peer block {} arrived with state_root=None past \
+                                 STATE_ROOT_FORK_HEIGHT — sender's trie is broken. Rejecting to \
+                                 prevent silent fork. Expected local trie root: {}",
+                                last.index,
+                                hex::encode(computed_root)
+                            );
+                            return Err(SentrixError::ChainValidationFailed(format!(
+                                "peer block {} has state_root=None past fork height (#1e)",
+                                last.index
+                            )));
+                        }
+                        // Self-produced: stamp and recompute hash (V7-C-01).
                         last.state_root = Some(computed_root);
                         last.hash = last.calculate_hash();
                     }
@@ -672,6 +749,14 @@ impl Blockchain {
                         // Received block: verify peer's state_root matches ours (V7-C-01).
                         // State root mismatch is fatal — reject the block to prevent accepting a diverged chain state
                         if received_root != computed_root {
+                            tracing::error!(
+                                "CRITICAL #1e: state_root mismatch at block {} — received {} \
+                                 vs computed {}. Local trie and peer's trie disagree on the \
+                                 post-block state. Rejecting.",
+                                last.index,
+                                hex::encode(received_root),
+                                hex::encode(computed_root),
+                            );
                             return Err(SentrixError::ChainValidationFailed(format!(
                                 "state_root mismatch at block {}: received {}, computed {}",
                                 last.index,

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -149,6 +149,18 @@ pub struct Blockchain {
     /// Slashing engine for liveness + double-sign tracking
     #[serde(default)]
     pub slashing: sentrix_staking::slashing::SlashingEngine,
+
+    /// Origin of the block currently being admitted. Set by the
+    /// `add_block*` family before calling `apply_block_pass2` and
+    /// cleared after. Peer blocks trigger strict state_root checks;
+    /// self-produced blocks are allowed to stamp state_root in
+    /// Pass 2. Backlog #1e. Not persisted.
+    #[serde(skip, default = "default_block_source")]
+    pub(crate) source_for_current_add: crate::block_executor::BlockSource,
+}
+
+fn default_block_source() -> crate::block_executor::BlockSource {
+    crate::block_executor::BlockSource::SelfProduced
 }
 
 impl Blockchain {
@@ -189,6 +201,7 @@ impl Blockchain {
             stake_registry: sentrix_staking::staking::StakeRegistry::new(),
             epoch_manager: sentrix_staking::epoch::EpochManager::new(),
             slashing: sentrix_staking::slashing::SlashingEngine::new(),
+            source_for_current_add: crate::block_executor::BlockSource::SelfProduced,
         };
         bc.initialize_genesis(genesis);
         bc

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -586,7 +586,7 @@ async fn on_swarm_event(
                         let peer = propagation_source;
                         tokio::spawn(async move {
                             let mut chain = bc.write().await;
-                            match chain.add_block(gossip.block.clone()) {
+                            match chain.add_block_from_peer(gossip.block.clone()) {
                                 Ok(()) => {
                                     let updated =
                                         chain.latest_block().ok().cloned().unwrap_or(gossip.block);
@@ -837,7 +837,7 @@ async fn on_inbound_request(
             let etx = event_tx.clone();
             tokio::spawn(async move {
                 let mut chain = bc.write().await;
-                match chain.add_block(*block.clone()) {
+                match chain.add_block_from_peer(*block.clone()) {
                     Ok(()) => {
                         tracing::info!("libp2p: applied block {} from {}", block.index, peer);
                         // Capture H2 (with state_root + recomputed hash) before releasing
@@ -1056,7 +1056,7 @@ async fn on_inbound_response(
             let mut chain = bc.write().await;
             let mut synced = 0u64;
             for block in &blocks_owned {
-                match chain.add_block(block.clone()) {
+                match chain.add_block_from_peer(block.clone()) {
                     Ok(()) => {
                         // Use H2 (post-add_block state_root hash) — not the raw peer block (PR #78).
                         let updated = chain

--- a/crates/sentrix-network/src/node.rs
+++ b/crates/sentrix-network/src/node.rs
@@ -339,7 +339,7 @@ impl Node {
 
                 Message::NewBlock { block } => {
                     let mut bc = blockchain.write().await;
-                    match bc.add_block(block.clone()) {
+                    match bc.add_block_from_peer(block.clone()) {
                         Ok(()) => {
                             tracing::info!("Received block {} from peer", block.index);
                             // Send the canonically committed block (with state_root set) rather than the pre-commit version
@@ -376,7 +376,7 @@ impl Node {
                     let mut bc = blockchain.write().await;
                     let mut applied = 0;
                     for block in blocks {
-                        match bc.add_block(block) {
+                        match bc.add_block_from_peer(block) {
                             Ok(()) => applied += 1,
                             Err(_) => break, // stop on first invalid
                         }
@@ -482,7 +482,7 @@ impl Node {
                         let mut bc = self.blockchain.write().await;
                         let mut applied = 0;
                         for block in blocks {
-                            match bc.add_block(block) {
+                            match bc.add_block_from_peer(block) {
                                 Ok(()) => applied += 1,
                                 Err(_) => break,
                             }

--- a/crates/sentrix-network/src/sync.rs
+++ b/crates/sentrix-network/src/sync.rs
@@ -80,7 +80,7 @@ impl ChainSync {
                             );
                             return Ok(total_synced);
                         }
-                        match bc.add_block(block.clone()) {
+                        match bc.add_block_from_peer(block.clone()) {
                             Ok(()) => {
                                 // Persist each synced block to sled immediately rather than batching
                                 if let Err(e) = storage.save_block(block) {

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"


### PR DESCRIPTION
## Summary

Root cause of the mainnet fork that came back minutes after the v2.1.2
deploy today. `apply_block_pass2` had a branch that treated every
block arriving with `state_root = None` as self-produced — it stamped
our own trie-computed root and then **recomputed the block hash**.
When a peer with a broken trie broadcast a block with
`state_root = None`, local nodes silently swapped the hash. The
peer's next block carried a `previous_hash` that pointed at its own
version, our validation rejected it as "invalid previous hash", and
the chain forked.

v2.1.2 covered *startup* trie init failures. This PR covers the
*runtime* path.

## Change

New `BlockSource` enum threaded through the admission path:

- `Blockchain::add_block` — permissive, used by `block_producer::build_block`
  where `state_root = None` is legitimate because Pass 2 stamps it.
- `Blockchain::add_block_from_peer` — strict, returns
  `ChainValidationFailed` on `state_root = None` past
  `STATE_ROOT_FORK_HEIGHT` (a peer producing such a block has a broken
  trie and accepting would fork).

Every `sentrix-network` call site that applies blocks arriving over
the wire (gossip receive, `BlocksResponse` sync, legacy `sync.rs`,
libp2p new-block handler) switches to `add_block_from_peer`. Block
production + existing tests keep using `add_block`.

CRITICAL-level `tracing::error!` logs on both the None-from-peer and
`received_root != computed_root` branches so operators see trie
divergence loud in journalctl.

Workspace bumped 2.1.2 → 2.1.3.

## Test plan
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace` — all 38 suites pass
- [ ] CI green
- [ ] Deploy to testnet first; leave 1-2 hours; look for any
      `CRITICAL #1e:` log lines — each one is a chain health signal
      that either validates the fix (peer block correctly rejected) or
      surfaces a different trie bug we still need to chase.
- [ ] Mainnet deploy after testnet bakes clean.

## Follow-ups
- Ideally we'd unit-test the fork-height branch, but getting a test
  chain to `STATE_ROOT_FORK_HEIGHT = 100_000` is expensive. Integration
  test on testnet after deploy will cover it.
- `add_block_from_peer` does not yet verify the peer's `state_root`
  hash against our committed trie root *before* Pass 2 runs — the
  check still happens after the trie update. Future hardening:
  compute a cheap pre-check so we reject faster and don't spend the
  trie commit on a doomed block.