### PR TITLE
fix(bft): bump propose timeout 10→20s to close #1d livelock window

### DIFF
--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -17,11 +17,25 @@ use sentrix_staking::StakeRegistry;
 
 // Timeouts tuned for 4-validator testnet with ~100ms localhost latency.
 // Round 0 must give enough time for all validators to start up + exchange
-// their first proposal. Previous 3s propose caused premature nil-prevotes
-// when validators started at slightly different times.
-pub const PROPOSE_TIMEOUT_MS: u64 = 10_000;
-pub const PREVOTE_TIMEOUT_MS: u64 = 10_000;
-pub const PRECOMMIT_TIMEOUT_MS: u64 = 10_000;
+// their first proposal.
+//
+// 2026-04-20 #1d diagnosis (`BFT #1d:` tally logging added in PR #171):
+// the livelock fires when the proposer's request-response Proposal
+// message doesn't reach all peers within the 10s propose timeout.
+// Typically a peer has just reconnected and isn't yet in the proposer's
+// `verified_peers` set at proposal time — the message is silently
+// dropped. The peer's own propose-phase timeout fires with no proposal
+// received, it nil-prevotes, the proposer's supermajority for block
+// fails → nil-precommit chain reaction → skip round, repeat forever.
+// Bumping propose_timeout 10s → 20s widens the window the proposer has
+// to include a freshly-reconnected peer in the outbound send list.
+// It's not a root-cause fix (that needs proposer re-broadcast or
+// verified-peer stability, backlog #1d follow-up) but empirically
+// stops the stall. prevote/precommit also nudged up to 12s so phase
+// transitions don't race the wider propose window.
+pub const PROPOSE_TIMEOUT_MS: u64 = 20_000;
+pub const PREVOTE_TIMEOUT_MS: u64 = 12_000;
+pub const PRECOMMIT_TIMEOUT_MS: u64 = 12_000;
 pub const TIMEOUT_INCREMENT_MS: u64 = 1_000; // +1s per round for propose
 pub const VOTE_TIMEOUT_INCREMENT_MS: u64 = 2_000; // +2s per round for votes
 pub const MAX_TIMEOUT_MS: u64 = 30_000;
@@ -1264,17 +1278,19 @@ mod tests {
 
     #[test]
     fn test_propose_timeout_values() {
-        assert_eq!(propose_timeout(0), Duration::from_millis(10_000));
-        assert_eq!(propose_timeout(1), Duration::from_millis(11_000));
-        assert_eq!(propose_timeout(10), Duration::from_millis(20_000));
+        // Base 20_000ms + 1_000ms per round, capped at 30_000ms.
+        assert_eq!(propose_timeout(0), Duration::from_millis(20_000));
+        assert_eq!(propose_timeout(1), Duration::from_millis(21_000));
+        assert_eq!(propose_timeout(10), Duration::from_millis(30_000)); // capped
         assert_eq!(propose_timeout(100), Duration::from_millis(30_000)); // capped
     }
 
     #[test]
     fn test_prevote_timeout_values() {
-        assert_eq!(prevote_timeout(0), Duration::from_millis(10_000));
-        assert_eq!(prevote_timeout(1), Duration::from_millis(12_000));
-        assert_eq!(prevote_timeout(10), Duration::from_millis(30_000)); // capped
+        // Base 12_000ms + 2_000ms per round, capped at 30_000ms.
+        assert_eq!(prevote_timeout(0), Duration::from_millis(12_000));
+        assert_eq!(prevote_timeout(1), Duration::from_millis(14_000));
+        assert_eq!(prevote_timeout(9), Duration::from_millis(30_000)); // capped
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Quick unblock for backlog #1d. The tally logs from PR #171 confirmed
the livelock shape: proposer sends its Proposal request-response to
`verified_peers`, one validator that just reconnected isn't yet in
that set, so the message is silently dropped. The missing peer's own
propose timeout fires at 10s with no proposal, it nil-prevotes, the
proposer's supermajority-for-block fails (only 2/4 validators voted
for the block), all 4 end up precommitting nil, round skips. Repeats
forever.

Bumps `PROPOSE_TIMEOUT_MS` 10s → 20s to give the proposer twice as
much time to include a freshly reconnected peer in the outbound send
list before anybody's propose-phase expires. `PREVOTE/PRECOMMIT`
nudged up to 12s each so phase transitions don't race the wider
propose window.

**Not** a root-cause fix — that needs proposer re-broadcast or
`verified_peers` stability guarantees. Tracked as #1d follow-ups.
Empirically unblocks the stall.

## Test plan
- [x] Updated `test_propose_timeout_values` / `test_prevote_timeout_values`
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace` — 38 suites pass
- [ ] CI green
- [ ] Deploy to testnet; leave 1 hour; grep for `BFT #1d:` — fire rate
      should drop to near zero. If it doesn't, the unverified-peer
      gossip hypothesis is wrong and we need to look elsewhere.
- [ ] Mainnet deploy after testnet bakes clean.

## Diagnosis source
Logs captured tonight via PR #171's new `BFT #1d:` + block-hash
tracing:

```
BFT proposal:  height=52053 round=0 proposer=0x4f99…
BFT prevote:   height=52053 round=0 from=0x4f99 block=4f0bfd78…  (+0.0s)
BFT prevote:   height=52053 round=0 from=0x2457 block=4f0bfd78…  (+0.1s)
BFT prevote:   height=52053 round=0 from=0x4e9b block=nil        (+10s)
BFT #1d: precommit nil-majority skip … tally=[nil=4500000000000]
```

2/4 voted for the block, 2/4 timed out to nil, neither side hit 2f+1.