### PR TITLE
fix(bft): extend #1d rebroadcast 3×3s → 7×2s + cover Prevote — v2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,23 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [2.1.3] — 2026-04-20 — Runtime trie divergence guard (backlog #1e)
+## [2.1.4] — 2026-04-20 — Extended #1d rebroadcast window
+
+### Fixed
+- **fix(bft): widen proposer rebroadcast window 9s → 14s + cover Prevote
+  phase too** (`bin/sentrix/src/main.rs`). v2.1.3's 3 retries × 3s
+  helped but didn't fully close #1d on testnet — bake logs showed the
+  4th validator (often after restart) still missed the proposal during
+  the 9s window because it took ~10s+ to enter the proposer's
+  `verified_peers` set. v2.1.4 bumps the retry budget to 7 attempts at
+  2s each (= 14s of live retry) and lets the proposer keep
+  rebroadcasting after it has moved into Prevote phase, so a peer that
+  finally appears mid-prevote can still validate the prevotes it's
+  receiving from the proposer. 14s fits inside the 20s propose
+  timeout, so the additional retries don't push past the round
+  boundary.
+
+
 
 ### Fixed
 - **fix(consensus): reject peer blocks with state_root=None past

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4832,7 +4832,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1936,20 +1936,26 @@ async fn cmd_start(
                         }
                     }
 
-                    // #1d rebroadcast: if we're the proposer, still in Propose
-                    // phase, and our initial proposal broadcast hasn't yet pulled
-                    // supermajority prevote, resend the proposal every ~3s up to
-                    // 3 times. Covers the libp2p case where the Proposal got
-                    // dropped for a peer that wasn't in verified_peers at the
-                    // moment of the initial broadcast (reconnect lag, handshake
-                    // still in progress). Without this the peer times out to
-                    // nil-prevote, supermajority for our block never forms, round
-                    // skips — the core #1d livelock shape from the 2026-04-20 logs.
+                    // #1d rebroadcast (v2.1.4 — extended after first round of
+                    // testnet bake showed 3 attempts × 3s = 9s isn't enough to
+                    // catch persistently-late peers). The shape we kept seeing:
+                    // proposer fires the proposal, 2 of 4 peers prevote it in
+                    // time, 1 peer takes ~10s before it shows up in
+                    // `verified_peers` post-restart, by which time the
+                    // already-fast peers have already nil-precommit'd because
+                    // their prevote window closed. v2.1.4 widens the retry
+                    // window to 14s (7 × 2s) so a slow peer has a real chance
+                    // to enter `verified_peers` during the proposer's send loop
+                    // before the proposer's own propose timeout fires (20s).
+                    // Stays in Propose AND Prevote phases — sometimes peers
+                    // need the proposal even after we've moved to prevote
+                    // collection so they can validate the prevotes they're
+                    // receiving from us.
                     const REBROADCAST_INTERVAL: std::time::Duration =
-                        std::time::Duration::from_secs(3);
-                    const MAX_REBROADCASTS: u32 = 3;
+                        std::time::Duration::from_secs(2);
+                    const MAX_REBROADCASTS: u32 = 7;
                     if let Some(ref block) = proposed_block
-                        && bft.phase() == BftPhase::Propose
+                        && matches!(bft.phase(), BftPhase::Propose | BftPhase::Prevote)
                         && proposal_rebroadcast_count < MAX_REBROADCASTS
                         && proposal_broadcast_at
                             .is_some_and(|t| t.elapsed() >= REBROADCAST_INTERVAL)

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"


### PR DESCRIPTION
## Summary
v2.1.3's rebroadcast (#175) closed only part of the gap — testnet
bake logs from the 2026-04-20 deploy showed the proposer was firing
all 3 rebroadcasts within 9s but the late peer was still missing the
proposal because it took ~10s+ post-restart before entering the
proposer's `verified_peers` set. Result: chain still stalled at the
restart-recovery boundary.

v2.1.4 widens the retry budget to actually fit the slow-handshake case:

| Knob | v2.1.3 | v2.1.4 |
|---|---|---|
| `MAX_REBROADCASTS` | 3 | 7 |
| `REBROADCAST_INTERVAL` | 3s | 2s |
| Total retry window | 9s | **14s** |
| Phases covered | Propose only | Propose + **Prevote** |

14s fits inside the v2.1.3 `PROPOSE_TIMEOUT_MS = 20_000`, so we don't
push past the round boundary. Covering Prevote too means a peer that
appears mid-prevote can still validate the prevotes we're sending it
— without that, it nil-prevotes anyway and supermajority for the
block fails.

## Test plan
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace` — all 38 suites pass
- [ ] CI green
- [ ] Deploy to testnet; verify `BFT #1d: rebroadcast proposal
      attempt=N/7` lines now go beyond 3 in slow-recovery scenarios
- [ ] Bake testnet 30+ minutes; confirm height advances continuously
      with #1d nil-skip count near zero
- [ ] If clean → mainnet deploy