### PR TITLE
feat(network): trigger_sync on BFT SyncNeeded event (backlog #4)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -2120,6 +2120,7 @@ async fn cmd_start(
     // Sync is handled inside the libp2p swarm task (Step 3d).
     let storage_for_p2p = storage.clone();
     let bft_tx_clone = bft_tx;
+    let lp2p_for_events = lp2p.clone();
     tokio::spawn(async move {
         while let Some(event) = event_rx.recv().await {
             match event {
@@ -2137,6 +2138,13 @@ async fn cmd_start(
                     peer_height,
                 } => {
                     tracing::info!("Sync needed from {} (height: {})", peer_addr, peer_height);
+                    // Backlog #4 auto-resync: BFT RoundStatus gossip told us a
+                    // peer is at a higher height. Request blocks right now
+                    // instead of waiting up to 30s for the periodic
+                    // sync_interval tick. If the trigger is dropped (channel
+                    // closed), we simply fall back to the periodic path —
+                    // no error surfacing needed for that case.
+                    lp2p_for_events.trigger_sync().await;
                 }
                 // BFT events — forward to validator loop for multi-validator consensus.
                 //

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -68,6 +68,13 @@ enum SwarmCommand {
     GetPeerCount(tokio::sync::oneshot::Sender<usize>),
     /// Re-dial bootstrap peers that are no longer connected.
     ReconnectPeers(Vec<Multiaddr>),
+    /// Trigger an out-of-band block sync from the first verified peer.
+    /// Fired by the validator loop when BFT sees a peer at a higher
+    /// height and we need to catch up before we can vote (backlog #4
+    /// auto-resync). Unlike the periodic 30s sync_interval tick, this
+    /// fires *immediately* so the chain doesn't wait up to 30s to
+    /// discover it's behind.
+    TriggerSync,
 }
 
 // ── Public handle ────────────────────────────────────────
@@ -176,6 +183,15 @@ impl LibP2pNode {
     /// Re-dial bootstrap peers that may have disconnected.
     pub async fn reconnect_peers(&self, addrs: Vec<Multiaddr>) {
         let _ = self.cmd_tx.send(SwarmCommand::ReconnectPeers(addrs)).await;
+    }
+
+    /// Ask the swarm to immediately issue a `GetBlocks` to the first
+    /// verified peer. Backlog #4 auto-resync trigger: when BFT detects
+    /// a peer at a higher height (via RoundStatus gossip) we want to
+    /// catch up before the next round starts, not wait up to 30s for
+    /// the periodic sync interval to fire.
+    pub async fn trigger_sync(&self) {
+        let _ = self.cmd_tx.send(SwarmCommand::TriggerSync).await;
     }
 
     /// Add a known peer to the Kademlia routing table (bootstrap node).
@@ -402,6 +418,31 @@ async fn run_swarm(
                         for addr in addrs {
                             if let Err(e) = swarm.dial(addr.clone()) {
                                 tracing::warn!("libp2p reconnect dial {} failed: {}", addr, e);
+                            }
+                        }
+                    }
+                    Some(SwarmCommand::TriggerSync) => {
+                        // Backlog #4 auto-resync: ask the first verified peer
+                        // for blocks from our current height + 1. Fires
+                        // immediately instead of waiting for the 30s periodic
+                        // sync_interval tick.
+                        if verified_peers.is_empty() {
+                            tracing::debug!("libp2p trigger_sync: no verified peers");
+                        } else {
+                            let our_height = blockchain.read().await.height();
+                            if let Some(&peer_id) = verified_peers.iter().next() {
+                                let req_id = swarm.behaviour_mut().rr.send_request(
+                                    &peer_id,
+                                    SentrixRequest::GetBlocks {
+                                        from_height: our_height + 1,
+                                    },
+                                );
+                                pending_syncs.insert(req_id, peer_id);
+                                tracing::info!(
+                                    "libp2p trigger_sync: requested blocks from {} starting at {}",
+                                    peer_id,
+                                    our_height + 1
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

First step on the auto-resync track (backlog #4). Today the
`NodeEvent::SyncNeeded` handler in main.rs only logged the event —
it didn't actually request any blocks. BFT RoundStatus gossip would
tell us a peer was at a higher height, and we'd wait up to 30s for
the periodic `sync_interval` tick to do anything about it. Exactly
the gap we hit on testnet all day today when a validator fell behind
post-restart: chain stalled while the lagged peer slowly trickled
blocks in via the 30s tick.

Changes:
- `SwarmCommand::TriggerSync` — new command; fires an immediate
  `GetBlocks { from_height: our_height + 1 }` to the first verified
  peer.
- `LibP2pNode::trigger_sync()` — public handle.
- main.rs — event handler now calls it. Needed an extra
  `lp2p.clone()` so the handle survives into the spawned event-loop
  closure.

## Scope

This closes the "peer restarted and is a few blocks behind" case.
Still **doesn't** close the deeper state-divergence case (rogue
blocks, trie mismatches) — those need the manual chain.db rsync
workaround documented in the session handoff. True auto-resync
(fallback-reconnect when peer blocks fail `add_block_from_peer`
validation) is the follow-up.

## Test plan
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace` — 38 suites pass
- [ ] CI green
- [ ] Deploy on testnet; restart one validator deliberately; observe
      `libp2p trigger_sync: requested blocks from ... starting at N`
      log within 1s of SyncNeeded, not 30s.