### PR TITLE
docs: public specs for EIP-1559 + SRC-721 native NFTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   timeout, so the additional retries don't push past the round
   boundary.
 
-
+## [2.1.3] — 2026-04-20 — Runtime trie divergence guard (backlog #1e)
 
 ### Fixed
 - **fix(consensus): reject peer blocks with state_root=None past
@@ -50,7 +50,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   on both the None-from-peer and the `received_root != computed_root`
   branches so operators see trie divergence loud in journalctl.
 
-
+## [2.1.2] — 2026-04-20 — Trie-init hardening hotfix
 
 ### Fixed
 - **fix(consensus): hard-fail trie init above STATE_ROOT_FORK_HEIGHT**

--- a/docs/operations/EIP1559_SPEC.md
+++ b/docs/operations/EIP1559_SPEC.md
@@ -1,0 +1,279 @@
+# Sentrix EIP-1559 — Dynamic Base Fee Spec
+
+Sentrix is moving from a flat `INITIAL_BASE_FEE` to EIP-1559-style
+dynamic base fee, matching Ethereum's fee-pricing model. This doc
+specifies the mechanic, user-facing tx shape, and what it means for
+wallets / indexers / dApps.
+
+> Scope: behavior spec only. Implementation planning (rollout
+> sequencing, test strategy, migration risks) lives in the internal
+> companion doc.
+
+---
+
+## 1. Motivation
+
+Today every Sentrix transaction pays a fixed fee regardless of
+network load. That has two problems:
+
+1. **Fee discovery is manual.** Wallets can't auto-compute a
+   reasonable fee — they either over-pay or risk a queued tx if the
+   mempool spikes. MetaMask's "Market / Aggressive / Low" picker
+   relies on having a `baseFeePerGas` to compute against; without
+   it the wallet shows legacy fee fields that users don't understand.
+2. **No anti-spam pressure.** Under a sudden load (NFT mint, airdrop
+   claim, DEX incident), the mempool fills up and honest users can't
+   out-bid the spam because everyone pays the same flat fee. EIP-1559
+   raises the base fee as blocks fill, pricing out spam algorithmically.
+
+EIP-1559 also adds a deflationary pressure: the base fee is **burned**,
+reducing circulating supply under high load. Sentrix already has a
+50% fee burn (`block_executor.rs:611-617`); this formalises it as the
+base-fee mechanic.
+
+---
+
+## 2. Mechanic
+
+### 2.1 Base fee update rule
+
+Per-block:
+```
+base_fee_next = base_fee_current × (1 + (gas_used - gas_target) / gas_target / 8)
+              capped to [base_fee_current × 7/8, base_fee_current × 9/8]
+```
+
+- **Gas target** = 50% of block gas limit (= `BLOCK_GAS_LIMIT / 2`)
+- **Max adjustment per block** = ±12.5%
+- **Floor** = 1 sentri (never goes to zero)
+
+Identical to Ethereum's EIP-1559 formula (for wallet compatibility).
+
+### 2.2 Genesis base fee
+
+First post-fork block: `INITIAL_BASE_FEE` constant (same value as
+current flat fee, so there's no user-visible price shock at fork
+moment).
+
+### 2.3 Transaction fee model
+
+Two new fields on EVM transactions (already standard in Ethereum
+ecosystem):
+
+| Field | Meaning |
+|---|---|
+| `max_fee_per_gas` | Absolute ceiling the user is willing to pay per gas |
+| `max_priority_fee_per_gas` | Tip on top of base_fee that goes to the validator |
+
+Per-tx calculation on inclusion:
+```
+effective_gas_price = min(max_fee_per_gas, base_fee + max_priority_fee_per_gas)
+tx_fee = effective_gas_price × gas_used
+burn   = base_fee × gas_used
+tip    = tx_fee - burn
+```
+
+**Tip goes to the proposer's pending rewards** (via
+`distribute_reward`). **Burn is deducted from circulating supply**.
+
+### 2.4 Native Sentrix (non-EVM) transactions
+
+Legacy Sentrix tx shape (SRX transfer, SRC-20 ops, staking) continues
+to have a flat `fee` field for now. Rationale: native ops don't use
+gas metering — the fee is a simple flat anti-spam charge. Keeping
+them separate from EIP-1559 avoids forcing wallets to know two fee
+models for the same chain.
+
+A future release may bring native ops under a flat-but-dynamic fee
+adjusted per block (similar base-fee mechanic but without `gas_used`
+variability, using tx count instead). Out of scope for this spec.
+
+### 2.5 EVM transaction encoding
+
+Sentrix EVM txs are encoded as `EVM:gas_limit:calldata_hex` in the
+legacy Sentrix `data` field, with the original RLP-encoded Ethereum
+tx living in the `signature` field (see `crates/sentrix-evm/src/lib.rs`).
+
+After EIP-1559 activation:
+- **EIP-1559 txs (type 2)**: `max_fee_per_gas` + `max_priority_fee_per_gas`
+  are RLP-encoded in the signature field per standard. Sentrix
+  decodes them during `execute_evm_tx_in_block`.
+- **Legacy txs (type 0)**: still accepted. Treated as EIP-1559 with
+  `max_fee_per_gas = max_priority_fee_per_gas = gas_price`. This is
+  what Geth does.
+- **EIP-2930 txs (type 1)**: accepted, same treatment as legacy.
+
+---
+
+## 3. RPC surface
+
+### 3.1 `eth_getBlockByNumber` / `eth_getBlockByHash`
+
+Every returned block gains two new fields:
+```json
+{
+  "baseFeePerGas": "0x3b9aca00",     // base_fee at this block
+  ...
+}
+```
+
+### 3.2 `eth_feeHistory`
+
+New RPC method that returns recent base_fee history + percentile
+reward samples. Required for wallet fee estimation.
+
+```json
+{
+  "jsonrpc":"2.0","method":"eth_feeHistory",
+  "params":["0xa", "latest", [25, 50, 75]]
+}
+```
+
+Returns:
+```json
+{
+  "oldestBlock": "0x12a34",
+  "baseFeePerGas": ["0x3b9...", "0x3c0...", ...],   // baseFee for each block, +1 extrapolated
+  "gasUsedRatio": [0.43, 0.57, 0.81, ...],
+  "reward": [                                         // percentile tips per block
+    ["0x4b40", "0x9ca0", "0x13880"],
+    ...
+  ]
+}
+```
+
+### 3.3 `eth_gasPrice`
+
+Returns the current `base_fee + 1 gwei` as a sensible default for
+legacy-type callers. Not authoritative — EIP-1559 wallets should use
+`eth_feeHistory` instead.
+
+### 3.4 `eth_maxPriorityFeePerGas`
+
+Returns a suggested priority tip based on recent blocks (typically
+~1 gwei, bumps under load). Used by wallets to default the tip slider.
+
+### 3.5 `eth_getTransactionReceipt`
+
+Already returns `effectiveGasPrice`; no change. Now derived from
+base_fee at the receipt's block instead of being a constant.
+
+### 3.6 `sentrix_baseFee`
+
+New Sentrix-native method for simple base-fee lookup without
+EIP-1559 dev-tooling:
+```json
+{"jsonrpc":"2.0","method":"sentrix_baseFee","params":[]}
+→ "0x3b9aca00"
+```
+
+---
+
+## 4. Migration — what breaks, what doesn't
+
+### 4.1 Mainnet hard fork
+
+Base-fee activation **requires a hard fork** — block.base_fee is a
+new consensus-critical field affecting tx fee computation. The
+`VOYAGER_EVM_HEIGHT` env var (already used to gate EVM activation)
+is extended to also gate EIP-1559.
+
+- **Before fork height**: flat `INITIAL_BASE_FEE`, no base_fee field
+  in blocks.
+- **At/after fork height**: EIP-1559 active.
+
+A node running old binary past the fork height would reject the new
+base_fee field and fork the chain. Coordinate carefully.
+
+### 4.2 Wallet compatibility matrix
+
+| Wallet | Legacy tx | EIP-1559 tx | Notes |
+|---|---|---|---|
+| MetaMask | ✅ (auto-downgrade) | ✅ (default when detected) | Native support; uses `eth_feeHistory` |
+| Rabby | ✅ | ✅ | Same |
+| Rainbow | ✅ | ✅ | Same |
+| WalletConnect | transparent | transparent | Whatever the wallet speaks |
+| ethers.js v6 | ✅ | ✅ default | Automatic; uses provider's feeHistory |
+| viem | ✅ | ✅ default | Automatic |
+| web3.js v4 | ✅ | ✅ | Some dApps still on v1; v1 requires explicit config |
+
+All major Ethereum wallets + libraries are EIP-1559 compatible
+out-of-box. Legacy transactions keep working.
+
+### 4.3 dApp code changes
+
+Developers don't need to change anything — ethers / viem /
+web3.js v4 handle fee fields automatically. Contracts don't see
+base_fee at all (it's a block-level concern).
+
+The one change required: dApps that previously hard-coded a fee
+value should move to `provider.estimateFeesPerGas()` or equivalent.
+This is already common practice.
+
+### 4.4 Explorer (Sentrix Scan)
+
+Block pages need two new fields:
+- `baseFeePerGas` — shown prominently
+- `gasUsedRatio` — helps user understand why base_fee moved
+
+Tx pages need to distinguish:
+- `maxFeePerGas` (set by user)
+- `maxPriorityFeePerGas` (set by user)
+- `effectiveGasPrice` (actual, computed)
+- `baseFeeBurned` (base_fee × gas_used, separate line)
+- `tipPaid` (to validator)
+
+### 4.5 Indexer / subgraph
+
+Receipt data has always exposed `effectiveGasPrice`; indexers that
+use it continue to work. Indexers that summed fees as `gasPrice ×
+gasUsed` get slightly different numbers post-fork, because
+`effectiveGasPrice` now tracks base_fee. Not a breaking change —
+same interface, different numerical outputs.
+
+---
+
+## 5. Anti-abuse concerns
+
+### 5.1 Oscillation
+
+Max ±12.5% per block means a 10x price movement needs ~20 blocks.
+Prevents single-block shocks.
+
+### 5.2 Very low base_fee floor
+
+Floor of 1 sentri means attack-via-price-collapse (fill blocks to
+push fee to ~0 so validators earn nothing) costs the same as just
+spamming with paid txs. No free lunch.
+
+### 5.3 Validator tip capture
+
+Non-proposer signers under the reward-distribution-v2 proposal (PR
+pending) already share reward; tip is part of that pool, split same
+way. No special-case handling needed.
+
+---
+
+## 6. Out of scope for this spec
+
+- Fee adjustment for **native (non-EVM) ops**. Keep flat fee in v1.
+- Backdated base_fee for blocks before fork height (they don't have
+  one; explorers must handle `baseFeePerGas = null` for pre-fork
+  blocks gracefully).
+- Blob transactions (EIP-4844). Separate future spec.
+- Account abstraction (EIP-4337). Separate future spec.
+
+---
+
+## 7. Readiness checklist for activation
+
+Before setting `VOYAGER_EIP1559_HEIGHT` on mainnet:
+
+- [ ] Implementation merged + deployed to testnet, 7+ days of bake
+- [ ] `eth_feeHistory` works against at least 2 wallets end-to-end
+- [ ] Explorer displays baseFee + gasUsedRatio on block page
+- [ ] Wallet-web + mobile wallet updated to use EIP-1559 by default
+- [ ] A rollback plan documented (stop-the-world fork at fallback
+      height if EIP-1559 misbehaves in production)
+
+Ship as **v2.3 or later**; not bundled with Voyager-fork day.

--- a/docs/operations/SRC721_SPEC.md
+++ b/docs/operations/SRC721_SPEC.md
@@ -1,0 +1,347 @@
+# SRC-721 — Native NFT Spec
+
+Sentrix adds a native NFT module (`SRC-721`) as a first-class chain
+operation, mirroring the shape of the existing SRC-20 native tokens.
+Users pick between native (`SRC-721`) for simple collections and EVM
+(ERC-721 bytecode) for custom logic, same as the SRC-20 vs ERC-20
+choice.
+
+> Scope: behavior spec only. Implementation plan, risk analysis, and
+> sequencing live in the internal companion doc.
+
+---
+
+## 1. Why native NFTs
+
+Trade-off mirror of SRC-20:
+
+|  | Native SRC-721 | EVM ERC-721 |
+|---|---|---|
+| Deploy cost | Hardcoded in chain — no bytecode upload | Full contract deployment |
+| Per-op fee | Flat native fee (~50% cheaper than EVM) | EVM gas cost |
+| Customisable logic | No (fixed schema) | Yes |
+| Royalty / fee-on-transfer | Fixed policy per token at deploy | Arbitrary |
+| Compatibility | Sentrix-native APIs + explorer | Full Ethereum ecosystem |
+
+Target audience for native:
+- **Indonesian loyalty / membership NFTs** (KTP-linked kelas, gym
+  membership, event tickets) — simple, want low fees, don't need
+  custom code.
+- **In-app collectibles** (game, rewards, receipts) — tooling
+  handles everything, wallet just needs to own the token.
+- **Verifiable credentials** (certificates, diplomas).
+
+Target audience for EVM:
+- **OpenSea-style marketplaces** with complex royalty / auction
+  logic.
+- **Custom mint mechanics** (dutch auction, bonding curve, allow-list
+  with on-chain merkle proofs).
+
+---
+
+## 2. Data model
+
+### 2.1 Collection (one `SRC721_*` address per collection)
+
+```rust
+pub struct SRC721Collection {
+    pub address: String,             // "SRC721_<hash>"
+    pub name: String,                // 1..=64 chars
+    pub symbol: String,              // 1..=10 ASCII alphanumeric
+    pub max_supply: u64,             // 0 = unlimited
+    pub total_minted: u64,
+    pub total_burned: u64,
+    pub deployer: String,            // 0x-prefixed address
+    pub royalty_bps: u16,            // 0..=1000 (0-10%)
+    pub royalty_recipient: String,   // where royalty goes on transfer
+    pub base_uri: String,            // resolved per-token as `base_uri/{token_id}`
+    pub frozen: bool,                // once true, no more mint
+    pub created_height: u64,
+}
+```
+
+### 2.2 Token (one entry per minted NFT)
+
+```rust
+pub struct SRC721Token {
+    pub collection: String,          // SRC721 address
+    pub token_id: u64,               // serial within collection
+    pub owner: String,
+    pub token_uri_override: Option<String>,  // overrides `base_uri/{id}` if set
+    pub minted_height: u64,
+    pub last_transfer_height: u64,
+}
+```
+
+### 2.3 Approvals
+
+```rust
+pub struct SRC721Approval {
+    pub collection: String,
+    pub token_id: u64,       // specific token approval
+    pub spender: String,     // who can transfer on owner's behalf
+    pub expiry_height: u64,  // approval auto-expires
+}
+
+pub struct SRC721OperatorApproval {
+    pub collection: String,
+    pub owner: String,
+    pub operator: String,    // approved for ALL tokens in this collection
+}
+```
+
+---
+
+## 3. Operations
+
+### 3.1 Deploy collection
+
+```rust
+TokenOp::DeployNft {
+    name: String,
+    symbol: String,
+    max_supply: u64,       // 0 = unlimited
+    royalty_bps: u16,      // 0-1000
+    royalty_recipient: String,
+    base_uri: String,
+}
+```
+
+Fee: same flat fee as SRC-20 deploy.
+
+Emits: `NftCollectionDeployed { collection, deployer, name, symbol }`
+
+### 3.2 Mint
+
+```rust
+TokenOp::MintNft {
+    collection: String,
+    to: String,
+    token_id: u64,         // or None for auto-increment; see §4
+    token_uri_override: Option<String>,
+}
+```
+
+Only `deployer` or `operator` can mint until `frozen == true`.
+
+Emits: `NftMinted { collection, token_id, to }`
+
+### 3.3 Transfer
+
+```rust
+TokenOp::TransferNft {
+    collection: String,
+    token_id: u64,
+    to: String,
+}
+```
+
+Sender must be `owner`, approved spender, or operator. Royalty
+deducted from transfer amount (if the transfer is paired with a
+sale price in a future extension — v1 is a pure pointer change with
+no attached value transfer).
+
+Emits: `NftTransferred { collection, token_id, from, to }`
+
+### 3.4 Burn
+
+```rust
+TokenOp::BurnNft {
+    collection: String,
+    token_id: u64,
+}
+```
+
+Only `owner` can burn. Increments `total_burned`.
+
+Emits: `NftBurned { collection, token_id, owner }`
+
+### 3.5 Approve (single token)
+
+```rust
+TokenOp::ApproveNft {
+    collection: String,
+    token_id: u64,
+    spender: String,        // empty = revoke
+    expiry_height: u64,     // 0 = no expiry (valid until explicit revoke or transfer)
+}
+```
+
+### 3.6 Approve operator (all tokens)
+
+```rust
+TokenOp::ApproveNftOperator {
+    collection: String,
+    operator: String,
+    approved: bool,          // false = revoke
+}
+```
+
+### 3.7 Freeze (one-way lock)
+
+```rust
+TokenOp::FreezeNftCollection {
+    collection: String,
+}
+```
+
+Only deployer. Once called, `max_supply` becomes a hard cap and no
+new mints possible. Useful for final NFT drops where future mint
+introduces rug risk.
+
+### 3.8 Update `base_uri`
+
+```rust
+TokenOp::UpdateNftBaseUri {
+    collection: String,
+    base_uri: String,
+}
+```
+
+Only deployer, only if not frozen.
+
+---
+
+## 4. Token ID allocation
+
+Two modes:
+
+- **Explicit**: caller passes `token_id`. Must not already exist.
+  Fails otherwise.
+- **Auto-increment**: caller passes `token_id: None`. Chain assigns
+  next sequential `total_minted + 1`. Cheaper (no collision check),
+  recommended for most cases.
+
+Auto-increment is the default in the chain's deserialization —
+`None` cheaper to encode than a full `u64`.
+
+---
+
+## 5. RPC endpoints (REST)
+
+### 5.1 Collection queries
+
+```
+GET /nft/collections                       — list all SRC721 collections
+GET /nft/collection/{addr}                 — collection metadata
+GET /nft/collection/{addr}/tokens          — paginated tokens in collection
+GET /nft/collection/{addr}/holders         — paginated holders + count per address
+GET /nft/collection/{addr}/events          — paginated mint/transfer/burn events
+```
+
+### 5.2 Token queries
+
+```
+GET /nft/token/{collection_addr}/{token_id}            — token info
+GET /nft/token/{collection_addr}/{token_id}/history    — full transfer history
+```
+
+### 5.3 Holder queries
+
+```
+GET /nft/address/{addr}                    — all SRC721 tokens owned by addr
+GET /nft/address/{addr}/collections        — collections the addr holds
+```
+
+### 5.4 Approval queries
+
+```
+GET /nft/address/{addr}/approvals          — tokens addr has approved others to transfer
+GET /nft/address/{addr}/operator-approvals — operators addr has approved
+```
+
+---
+
+## 6. RPC endpoints (JSON-RPC, for tooling)
+
+Under the `sentrix_` namespace:
+
+- `sentrix_nftCollection(addr) → CollectionInfo`
+- `sentrix_nftToken(addr, token_id) → TokenInfo | null`
+- `sentrix_nftTokensOf(owner) → [Token]`
+- `sentrix_nftCollectionsOf(owner) → [{collection, token_count}]`
+
+These mirror the REST shape; exposed via JSON-RPC for indexers /
+dApps that prefer one connection pattern.
+
+---
+
+## 7. Event log (for indexers)
+
+Each op emits a structured event that goes into the block's event
+log (same infrastructure as SRC-20 events):
+
+```rust
+pub enum NftEvent {
+    CollectionDeployed { collection, deployer, name, symbol, base_uri },
+    Minted { collection, token_id, to, minter },
+    Transferred { collection, token_id, from, to },
+    Burned { collection, token_id, owner },
+    Approved { collection, token_id, owner, spender, expiry_height },
+    OperatorApprovalChanged { collection, owner, operator, approved },
+    CollectionFrozen { collection },
+    BaseUriUpdated { collection, new_base_uri },
+}
+```
+
+Indexers (Sentrix Scan NFT tab, subgraph-style services) consume
+these directly instead of having to parse tx payloads.
+
+---
+
+## 8. Compatibility with EVM ecosystem
+
+Native SRC-721 is **not** wire-compatible with ERC-721 tooling
+(OpenSea reads ERC-721 contracts on EVM chains). Two paths:
+
+1. **Native-only** — SRC-721 collection is only discoverable /
+   transferable via Sentrix tooling. Fine for loyalty / in-app /
+   Indonesia-native use cases.
+2. **EVM bridge contract** (optional follow-up) — a wrapper ERC-721
+   contract that holds native SRC-721 tokens in escrow and exposes
+   a standard ERC-721 surface for OpenSea-style marketplaces. Users
+   call `wrap(token_id)` to move a native token into the wrapper,
+   `unwrap(token_id)` to get it back. Not in v1 scope.
+
+For users who need OpenSea day-one, direct them to deploy ERC-721 on
+Sentrix EVM. That already works (post-Voyager fork).
+
+---
+
+## 9. Fee model
+
+Per-op flat fees (native-fee schedule, not gas):
+
+| Op | Fee |
+|---|---|
+| DeployNft | 10 × `MIN_TX_FEE` (same as SRC-20 deploy) |
+| MintNft | 1 × `MIN_TX_FEE` |
+| TransferNft | 1 × `MIN_TX_FEE` |
+| BurnNft | 1 × `MIN_TX_FEE` |
+| ApproveNft | 0.5 × `MIN_TX_FEE` (metadata-only ops cheaper) |
+| ApproveNftOperator | 0.5 × `MIN_TX_FEE` |
+| FreezeNftCollection | 0 |
+| UpdateNftBaseUri | 0.5 × `MIN_TX_FEE` |
+
+50% of each fee is burned (same policy as SRC-20), 50% to proposer.
+
+Royalties at transfer time: if the transfer includes attached value
+(future extension, v1 is pure pointer), `royalty_bps` of that value
+is sent to `royalty_recipient`. v1 doesn't attach value to transfers.
+
+---
+
+## 10. Rollout
+
+Target: **post-Voyager mainnet fork**, after EIP-1559 activation.
+Rationale:
+
+1. NFT launch on mainnet is a user-facing product moment. Don't
+   mix with consensus-critical work.
+2. EIP-1559 needs to land first so fee dynamics are predictable for
+   NFT mint events (avoid a pathological mint draining the mempool).
+3. Reward-distribution-v2 needs to land first so NFT op fees flow
+   through the new signer-proportional path.
+
+Estimated calendar: **~6 weeks after Voyager mainnet fork** before
+SRC-721 activates on mainnet.


### PR DESCRIPTION
Two parallel public specs for items on the post-Voyager roadmap:

- **EIP1559_SPEC.md** — dynamic base fee matching Ethereum's model. Gated on Voyager mainnet fork + reward-distribution-v2.
- **SRC721_SPEC.md** — native NFT module mirroring SRC-20 shape. 8 new TokenOp variants, REST + JSON-RPC endpoints.

Docs-only — no code. Implementation sequencing + effort estimates + risk analysis live in the internal companion docs. Ship these publicly so community can pre-comment on the API shape before code starts.