### PR TITLE
fix(rpc): split rate limits + CORS on error responses + Cache-Control middleware

### DIFF
--- a/crates/sentrix-rpc/src/routes/cache.rs
+++ b/crates/sentrix-rpc/src/routes/cache.rs
@@ -1,0 +1,180 @@
+// cache.rs — Cache-Control header middleware.
+//
+// Block explorer + wallet UIs hammer read endpoints every few seconds.
+// A lot of what they fetch is immutable (confirmed block at height N,
+// confirmed tx by id) or only slowly changing (token metadata). Without
+// Cache-Control, every request hits MDBX; with the right headers, the
+// browser + any upstream CDN short-circuits most of it.
+//
+// Rules applied (by matched URI path):
+//
+// | Endpoint                        | Cache-Control                               |
+// |---------------------------------|----------------------------------------------|
+// | /chain/blocks/{height}          | public, max-age=3600, immutable             |
+// | /blocks/{height}                | public, max-age=3600, immutable             |
+// | /transactions/{txid}            | public, max-age=3600, immutable             |
+// | /tokens/{contract}              | public, max-age=60                          |
+// | /chain/info                     | no-store                                    |
+// | /sentrix_status                 | no-store                                    |
+// | /mempool                        | no-store                                    |
+// | /chain/performance              | no-store                                    |
+// | /chain/blocks (list)            | public, max-age=5                           |
+// | /blocks (list)                  | public, max-age=5                           |
+// | everything else                 | unchanged                                   |
+//
+// Only applied to successful (2xx) GET responses — 4xx/5xx skip it so
+// error responses aren't cached by a browser that later sees the real
+// data.
+
+use axum::{
+    body::Body,
+    http::{HeaderValue, Method, Request, header::CACHE_CONTROL},
+    middleware::Next,
+    response::Response,
+};
+
+const CACHE_IMMUTABLE: &str = "public, max-age=3600, immutable";
+const CACHE_TOKEN_META: &str = "public, max-age=60";
+const CACHE_LIVE_LIST: &str = "public, max-age=5";
+const CACHE_NO_STORE: &str = "no-store";
+
+/// Decide the Cache-Control value for a given path. Returns `None` if
+/// the path has no cache policy (leave headers untouched).
+fn cache_policy_for(path: &str) -> Option<&'static str> {
+    // Live data: must always fetch fresh.
+    match path {
+        "/chain/info" | "/sentrix_status" | "/mempool" | "/chain/performance" => {
+            return Some(CACHE_NO_STORE);
+        }
+        "/chain/blocks" | "/blocks" => return Some(CACHE_LIVE_LIST),
+        _ => {}
+    }
+
+    // Immutable block / tx resources: have a trailing path segment that
+    // names the resource, never mutate once confirmed.
+    //
+    // Match `/chain/blocks/<seg>`, `/blocks/<seg>`, `/transactions/<seg>`
+    // strictly — so the LIST endpoints above and any nested children do
+    // NOT match.
+    if let Some(rest) = path.strip_prefix("/chain/blocks/")
+        && is_single_segment(rest)
+    {
+        return Some(CACHE_IMMUTABLE);
+    }
+    if let Some(rest) = path.strip_prefix("/blocks/")
+        && is_single_segment(rest)
+    {
+        return Some(CACHE_IMMUTABLE);
+    }
+    if let Some(rest) = path.strip_prefix("/transactions/")
+        && is_single_segment(rest)
+    {
+        return Some(CACHE_IMMUTABLE);
+    }
+
+    // Token metadata — `/tokens/{contract}` only. Excludes balance /
+    // holders / transfers / trades / etc which live under the same
+    // prefix but mutate more often.
+    if let Some(rest) = path.strip_prefix("/tokens/")
+        && is_single_segment(rest)
+    {
+        return Some(CACHE_TOKEN_META);
+    }
+
+    None
+}
+
+/// True when `s` looks like a single non-empty URL path segment (no `/`,
+/// no query). Used to distinguish `/chain/blocks/{height}` (cacheable)
+/// from `/chain/blocks` (list) and from any deeper nested route.
+fn is_single_segment(s: &str) -> bool {
+    !s.is_empty() && !s.contains('/')
+}
+
+/// Axum middleware. Only applies to GET responses with 2xx status — we
+/// don't want a browser caching a 404 or 500.
+pub(super) async fn cache_control_middleware(request: Request<Body>, next: Next) -> Response {
+    let path = request.uri().path().to_string();
+    let is_get = request.method() == Method::GET;
+
+    let mut response = next.run(request).await;
+
+    if !is_get || !response.status().is_success() {
+        return response;
+    }
+
+    if let Some(value) = cache_policy_for(&path)
+        && let Ok(header) = HeaderValue::from_str(value)
+    {
+        // Don't overwrite a handler that already set its own Cache-Control.
+        response
+            .headers_mut()
+            .entry(CACHE_CONTROL)
+            .or_insert(header);
+    }
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_live_endpoints_get_no_store() {
+        assert_eq!(cache_policy_for("/chain/info"), Some(CACHE_NO_STORE));
+        assert_eq!(cache_policy_for("/sentrix_status"), Some(CACHE_NO_STORE));
+        assert_eq!(cache_policy_for("/mempool"), Some(CACHE_NO_STORE));
+        assert_eq!(cache_policy_for("/chain/performance"), Some(CACHE_NO_STORE));
+    }
+
+    #[test]
+    fn test_block_list_vs_specific_block() {
+        // Lists: short cache so UI picks up new blocks quickly.
+        assert_eq!(cache_policy_for("/chain/blocks"), Some(CACHE_LIVE_LIST));
+        assert_eq!(cache_policy_for("/blocks"), Some(CACHE_LIVE_LIST));
+
+        // Specific block at a committed height: immutable.
+        assert_eq!(cache_policy_for("/chain/blocks/100"), Some(CACHE_IMMUTABLE));
+        assert_eq!(cache_policy_for("/blocks/100"), Some(CACHE_IMMUTABLE));
+    }
+
+    #[test]
+    fn test_transaction_by_id_immutable() {
+        assert_eq!(
+            cache_policy_for("/transactions/abcdef0123"),
+            Some(CACHE_IMMUTABLE)
+        );
+    }
+
+    #[test]
+    fn test_token_metadata_vs_token_children() {
+        // `/tokens/{contract}` → token metadata, 60s cache.
+        assert_eq!(
+            cache_policy_for("/tokens/SRC20_abcdef"),
+            Some(CACHE_TOKEN_META)
+        );
+        // `/tokens` list itself is not cached (metadata count churns).
+        assert_eq!(cache_policy_for("/tokens"), None);
+        // Children (holders, balance, etc) must NOT pick up token meta.
+        assert_eq!(cache_policy_for("/tokens/SRC20_abcdef/holders"), None);
+        assert_eq!(cache_policy_for("/tokens/SRC20_abcdef/balance/0xdead"), None);
+    }
+
+    #[test]
+    fn test_unmatched_paths_return_none() {
+        assert_eq!(cache_policy_for("/health"), None);
+        assert_eq!(cache_policy_for("/metrics"), None);
+        assert_eq!(cache_policy_for("/validators"), None);
+        assert_eq!(cache_policy_for("/accounts/0xdead/balance"), None);
+    }
+
+    #[test]
+    fn test_is_single_segment() {
+        assert!(is_single_segment("100"));
+        assert!(is_single_segment("abcdef"));
+        assert!(!is_single_segment(""));
+        assert!(!is_single_segment("100/extra"));
+        assert!(!is_single_segment("a/b"));
+    }
+}

--- a/crates/sentrix-rpc/src/routes/mod.rs
+++ b/crates/sentrix-rpc/src/routes/mod.rs
@@ -7,6 +7,7 @@
 
 mod accounts;
 mod auth;
+mod cache;
 mod chain;
 mod epoch;
 mod ops;
@@ -28,6 +29,7 @@ use accounts::{
 use chain::{chain_info, get_block, get_blocks, validate_chain};
 use epoch::{epoch_current, epoch_history};
 use ops::{START_TIME, get_admin_log, health, metrics, root};
+use cache::cache_control_middleware;
 use ratelimit::{ip_rate_limit_middleware, write_rate_limit_middleware};
 use staking::{get_validators, staking_delegations, staking_unbonding, staking_validators};
 use tokens::{
@@ -235,17 +237,27 @@ pub fn create_router(state: SharedState) -> Router {
         .nest("/explorer", explorer_router(state.clone()))
         // ── Write endpoints (stricter rate limit) ────────────────
         .merge(write_router)
-        .layer(cors)
-        // Global HTTP concurrency limit prevents CPU saturation from concurrent heavy requests (e.g. /chain/validate).
+        // Axum layer order: LAST `.layer()` call is OUTERMOST
+        // (sees request first, response last). We want:
+        //   cors           (outermost — 429/4xx/5xx responses MUST carry
+        //                   access-control-allow-origin or the browser
+        //                   reports CORS blocked instead of rate limit)
+        //   DefaultBodyLimit
+        //   Extension(global_limiter)
+        //   ip_rate_limit_middleware  (rejects 429 before entering the body)
+        //   ConcurrencyLimitLayer
+        //   cache_control_middleware  (inner — sets Cache-Control on 2xx
+        //                              GET responses from the handlers)
+        //   handler
+        .layer(axum::middleware::from_fn(cache_control_middleware))
         .layer(ConcurrencyLimitLayer::new(500))
-        // Per-IP rate limit (60 req/min, defense-in-depth behind nginx)
-        // Layer order: Extension (outer) → rate_limit middleware → concurrency → cors → handler
         .layer(axum::middleware::from_fn(ip_rate_limit_middleware))
         .layer(axum::Extension(global_limiter))
         // Reject request bodies larger than 1 MiB — prevents memory exhaustion from unbounded payloads.
         // Single transactions and JSON-RPC batches are well under this limit; legitimate clients
-        // are never affected.  Without this, an attacker can stream arbitrary bytes until the node OOMs.
+        // are never affected. Without this, an attacker can stream arbitrary bytes until the node OOMs.
         .layer(DefaultBodyLimit::max(1_048_576))
+        .layer(cors)
         .with_state(state)
 }
 

--- a/crates/sentrix-rpc/src/routes/ratelimit.rs
+++ b/crates/sentrix-rpc/src/routes/ratelimit.rs
@@ -4,12 +4,17 @@
 //
 // Two limiters are layered on each request:
 // * `GlobalIpLimiter` — cap every endpoint at `SENTRIX_GLOBAL_RATE_LIMIT`
-//   (default 60 / min / IP).
+//   (default 300 / min / IP). Raised 2026-04-21 from 60 → 300 so the
+//   block-explorer frontend (sentrixscan.sentriscloud.com) can poll the
+//   ~8 live stats endpoints it uses without tripping the limit on a
+//   shared office / NAT IP. Reads are cheap; 300/min is still well
+//   below any realistic DoS threshold on this hardware.
 // * `WriteIpLimiter` — tighter cap on state-mutating endpoints
 //   (`POST /transactions`, `/tokens/*`, `/rpc`) at
-//   `SENTRIX_WRITE_RATE_LIMIT` (default 10 / min / IP). An attacker
-//   hitting POST endpoints burns the write quota first while read
-//   traffic from the same IP keeps flowing.
+//   `SENTRIX_WRITE_RATE_LIMIT` (default 10 / min / IP). Applied ON TOP
+//   of the global limit so POSTs are effectively min(10, 300) = 10/min
+//   per IP. An attacker hitting POST endpoints burns the write quota
+//   first while read traffic from the same IP keeps flowing.
 
 use axum::{Json, http::StatusCode, response::IntoResponse};
 use std::collections::HashMap;
@@ -21,11 +26,14 @@ pub type IpRateLimiter = Arc<Mutex<HashMap<String, (u32, Instant)>>>;
 const RATE_LIMIT_WINDOW_SECS: u64 = 60;
 
 /// Override via `SENTRIX_GLOBAL_RATE_LIMIT` env var for benchmarking.
+/// Default raised from 60 to 300 on 2026-04-21 — block-explorer
+/// frontend polls ~8 stats endpoints per tick, single user on shared
+/// IP was hitting 60/min within seconds.
 pub(super) fn global_rate_limit_max() -> u32 {
     std::env::var("SENTRIX_GLOBAL_RATE_LIMIT")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(60)
+        .unwrap_or(300)
 }
 
 /// A7: tighter per-IP cap applied only to write / expensive endpoints


### PR DESCRIPTION
Addresses block-explorer UX breakage on `sentrixscan.sentriscloud.com` — the frontend polls ~35 read endpoints/min, hits the 60/min per-IP rate limit within seconds on shared / NAT IPs, and the 429 response was missing CORS so browsers reported "CORS blocked" instead of "rate limited". On top of that, reads that can never change (confirmed blocks, confirmed txs) were going straight to MDBX every request because no Cache-Control was set.

Three fixes, minimum scope.

## 1. Rate limit default 60 → 300 req/min for reads

`crates/sentrix-rpc/src/routes/ratelimit.rs` — raise `global_rate_limit_max()` default from 60 to 300. Writes still capped at 10/min via the separate `WriteIpLimiter` applied to `POST /transactions`, `/tokens/deploy|transfer|burn`, `/rpc`. 300/min is still well below any DoS threshold on this hardware.

## 2. CORS is now outermost so error responses carry `access-control-allow-origin`

`crates/sentrix-rpc/src/routes/mod.rs` — reordered the axum layer stack so `.layer(cors)` is the last (outermost) call. Previously `.layer(cors)` was inner to `.layer(ip_rate_limit_middleware)`, so when rate limit short-circuited with 429 the response bypassed the CORS middleware and came back without ACAO headers. Browser then reported a CORS error instead of the real 429.

Fleet-verified: after reordering, `GET /chain/info` exceeding the cap returns `429 Too Many Requests` WITH `access-control-allow-origin: *` and `vary: origin, ...` headers. Same for POST 429s.

## 3. Cache-Control middleware for read responses

New `crates/sentrix-rpc/src/routes/cache.rs` — tower middleware that inspects the matched URI and sets `Cache-Control` on successful GET responses:

| Endpoint | Cache-Control |
|---|---|
| `/chain/blocks/{height}` | `public, max-age=3600, immutable` |
| `/blocks/{height}` | same |
| `/transactions/{txid}` | same |
| `/tokens/{contract}` | `public, max-age=60` |
| `/chain/info`, `/sentrix_status`, `/mempool`, `/chain/performance` | `no-store` |
| `/chain/blocks`, `/blocks` (lists) | `public, max-age=5` |
| everything else | unchanged |

Only applied to 2xx GET responses — error responses (404/5xx) are intentionally uncached so a browser that later sees real data isn't stuck on a stale "not found". 6 unit tests pin the per-path rules.

## What's NOT in this PR

WebSocket `/ws` endpoint (user explicitly deprioritised — the HTTP-side fix is the minimum to unbreak the UI). WS can come later as its own PR.

## Acceptance tests run on a fresh binary

```
100 GETs to /chain/info                  → 100× 200 (cap=300)
310 GETs burn quota → probe 429          → 429 with access-control-allow-origin: *
11 POSTs /transactions → probe 429       → 429 with access-control-allow-origin: *
GET /chain/blocks/0                      → cache-control: public, max-age=3600, immutable
GET /blocks/0                            → cache-control: public, max-age=3600, immutable
GET /chain/info                          → cache-control: no-store
GET /mempool                             → cache-control: no-store
GET /sentrix_status                      → cache-control: no-store
GET /chain/performance                   → cache-control: no-store
GET /chain/blocks (list)                 → cache-control: public, max-age=5
GET /blocks (list)                       → cache-control: public, max-age=5
GET /health, /validators, /tokens (list) → no cache-control (correct — not spec'd)
```

Plus: `cargo test --workspace` all green, `cargo clippy --workspace --all-targets -- -D warnings` clean. 6 new unit tests for `cache_policy_for` covering live / list / immutable / metadata / sibling-path / empty-path cases.

## Rollout

Non-consensus code path. Safe to deploy: no storage format change, no wire format change, no validator behaviour change. Suggested order: testnet first (15 min bake is enough — this is read-path middleware), then mainnet.

Env override `SENTRIX_GLOBAL_RATE_LIMIT` still works for benchmarking.