### PR TITLE
fix(trie): refuse to start when backfill diverges from stored state_root (bug #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **fix(trie): refuse to start when backfill diverges from stored block
+  state_root (bug #3)** (`crates/sentrix-core/src/blockchain.rs`). The
+  incremental path (`update_trie_for_block`) only inserts accounts
+  touched by a block, while the backfill path (`init_trie` at height > 0)
+  inserts every account with balance > 0 — including premines that
+  were never touched by a tx. For the same logical state the two paths
+  produce different leaf sets. A validator that recovered via
+  `sentrix state import` + PR #187's auto-reset therefore rebuilt a
+  trie whose state_root silently disagreed with peers, and every block
+  it produced tripped the #1e strict-reject guard. This was the exact
+  shape of the 2026-04-21 mainnet freeze (VPS2 drifted ~45 SRX/min
+  from canonical after state-import; chain halted).
+
+  We cannot align the two paths without changing consensus history
+  (sync-from-genesis would fail). Instead `init_trie` now reads the
+  stored `state_root` on the block at that height and refuses to start
+  if the freshly-backfilled root disagrees. Operators hitting this must
+  recover via `rsync /opt/sentrix/data/chain.db` from a healthy peer
+  with all validators stopped — a whole-trie copy preserves the
+  incremental shape. New regression test
+  `test_reset_trie_then_init_refuses_on_backfill_divergence` pins
+  the safeguard; it fails on main and passes with the fix.
+
 ## [2.1.4] — 2026-04-20 — Extended #1d rebroadcast window
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.5] — 2026-04-21 — Trie backfill divergence guard (bug #3)
+
 ### Fixed
 - **fix(trie): refuse to start when backfill diverges from stored block
   state_root (bug #3)** (`crates/sentrix-core/src/blockchain.rs`). The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4832,7 +4832,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "bincode",
  "blake3",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -614,24 +614,23 @@ impl Blockchain {
                 // header. Operators must recover via rsync chain.db from a
                 // healthy peer (whole-trie copy preserves the incremental
                 // shape) instead of state_import + reset.
-                if let Ok(block) = self.latest_block() {
-                    if block.index == height
-                        && let Some(stored_root) = block.state_root
-                        && backfilled_root != stored_root
-                    {
-                        return Err(SentrixError::Internal(format!(
-                            "trie backfill at height {} produced root {} but the \
-                             block header at that height records state_root {}. \
-                             The rebuilt trie disagrees with the canonical chain \
-                             (bug #3). Refusing to start to prevent a silent \
-                             state fork. Recovery: rsync /opt/sentrix/data/chain.db \
-                             from a healthy peer with all validators stopped, \
-                             instead of `sentrix state import` + reset_trie.",
-                            height,
-                            hex::encode(backfilled_root),
-                            hex::encode(stored_root)
-                        )));
-                    }
+                if let Ok(block) = self.latest_block()
+                    && block.index == height
+                    && let Some(stored_root) = block.state_root
+                    && backfilled_root != stored_root
+                {
+                    return Err(SentrixError::Internal(format!(
+                        "trie backfill at height {} produced root {} but the \
+                         block header at that height records state_root {}. \
+                         The rebuilt trie disagrees with the canonical chain \
+                         (bug #3). Refusing to start to prevent a silent \
+                         state fork. Recovery: rsync /opt/sentrix/data/chain.db \
+                         from a healthy peer with all validators stopped, \
+                         instead of `sentrix state import` + reset_trie.",
+                        height,
+                        hex::encode(backfilled_root),
+                        hex::encode(stored_root)
+                    )));
                 }
             }
         }

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -592,12 +592,47 @@ impl Blockchain {
                     let val = account_value_bytes(balance, nonce);
                     trie.insert(&key, &val)?;
                 }
-                trie.commit(height)?;
+                let backfilled_root = trie.commit(height)?;
                 tracing::info!(
                     "trie: backfill complete at height {}, root = {}",
                     height,
-                    hex::encode(trie.root_hash())
+                    hex::encode(backfilled_root)
                 );
+
+                // Bug #3 safeguard (mainnet freeze 2026-04-21): the incremental
+                // path (update_trie_for_block) only inserts accounts touched by
+                // blocks, while backfill inserts every account with balance > 0
+                // — including premines/genesis accounts that were never touched.
+                // For the same logical state, the two paths produce different
+                // trie root sets, so a validator recovering via reset_trie +
+                // init_trie at height > 0 will compute a state_root that
+                // disagrees with peers whose trie was built incrementally from
+                // genesis. Without this check, the validator silently forks
+                // and every block it produces trips the #1e strict-reject guard.
+                //
+                // Refuse to start if the backfill root doesn't match the stored
+                // header. Operators must recover via rsync chain.db from a
+                // healthy peer (whole-trie copy preserves the incremental
+                // shape) instead of state_import + reset.
+                if let Ok(block) = self.latest_block() {
+                    if block.index == height
+                        && let Some(stored_root) = block.state_root
+                        && backfilled_root != stored_root
+                    {
+                        return Err(SentrixError::Internal(format!(
+                            "trie backfill at height {} produced root {} but the \
+                             block header at that height records state_root {}. \
+                             The rebuilt trie disagrees with the canonical chain \
+                             (bug #3). Refusing to start to prevent a silent \
+                             state fork. Recovery: rsync /opt/sentrix/data/chain.db \
+                             from a healthy peer with all validators stopped, \
+                             instead of `sentrix state import` + reset_trie.",
+                            height,
+                            hex::encode(backfilled_root),
+                            hex::encode(stored_root)
+                        )));
+                    }
+                }
             }
         }
 
@@ -1977,6 +2012,72 @@ mod tests {
         assert!(
             bc_trie.latest_block().unwrap().state_root.is_some(),
             "state_root must be Some when trie is initialized"
+        );
+    }
+
+    /// Regression test for bug #3 — mainnet freeze 2026-04-21.
+    ///
+    /// The incremental path (update_trie_for_block) only inserts accounts
+    /// actually touched by a block, while the backfill path (init_trie at
+    /// height > 0) inserts every account with balance > 0. For the same
+    /// logical state these two paths produce different leaf sets: any
+    /// premine / genesis account never touched by a tx is absent from the
+    /// incremental trie but present in the backfill trie. A validator that
+    /// recovers via state-import + reset_trie therefore rebuilds a trie
+    /// whose root disagrees with peers that kept their original trie, and
+    /// every subsequent block trips the #1e strict-reject guard (chain halt).
+    ///
+    /// The safeguard in init_trie MUST detect this divergence at startup
+    /// and refuse to continue — silently starting would fork the chain.
+    /// This test asserts that init_trie errors out with a message that
+    /// fingers the backfill/state-fork failure mode, not that the roots
+    /// magically align (they can't without changing consensus history).
+    #[test]
+    fn test_reset_trie_then_init_refuses_on_backfill_divergence() {
+        let (_dir, mdbx) = temp_mdbx();
+        let mut bc = setup_chain();
+        bc.init_trie(Arc::clone(&mdbx)).unwrap();
+
+        // Run several coinbase-only blocks so the incremental path has
+        // committed at least one root. Blocks do not touch any premine
+        // address — the "untouched premine" is precisely the state that
+        // backfill later reintroduces but incremental never did.
+        for _ in 0..3 {
+            let block = bc.create_block("validator1").unwrap();
+            bc.add_block(block).unwrap();
+        }
+        let stored_root = bc
+            .latest_block()
+            .expect("chain must have at least one block")
+            .state_root
+            .expect("block at trie-active height must have Some state_root");
+
+        // Simulate `sentrix chain reset-trie` (PR #187): drop all trie
+        // tables. accounts.accounts is untouched — this is the exact
+        // scenario a validator hits after `state import --force` on the
+        // post-#187 code path.
+        for table in [
+            "trie_nodes",
+            "trie_values",
+            "trie_roots",
+            "trie_committed_roots",
+        ] {
+            mdbx.clear_table(table).unwrap();
+        }
+        bc.state_trie = None;
+
+        // Re-init. height > 0 + empty trie tables triggers the backfill
+        // branch, which must detect that backfill != stored state_root
+        // and refuse to start.
+        let result = bc.init_trie(Arc::clone(&mdbx));
+        let err = result.expect_err(
+            "init_trie MUST refuse when backfill diverges from stored state_root \
+             — silently succeeding here is the 2026-04-21 mainnet freeze bug",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("backfill") && msg.contains(&hex::encode(stored_root)),
+            "error must name the backfill/stored-root mismatch: {msg}"
         );
     }
 }

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"


### PR DESCRIPTION
## Summary

Follow-on to PR #187. Adds a safeguard that prevents the silent state fork which halted mainnet on 2026-04-21.

## Root cause

Two trie-construction paths exist and they do NOT agree on the leaf set:

- **Incremental** (`update_trie_for_block`) inserts only accounts touched by a block.
- **Backfill** (`init_trie` when `height > 0` and trie tables are empty) inserts every account with `balance > 0`.

Genesis premine addresses that are never touched by a tx are absent from the incremental trie but present in the backfill trie. So a validator that recovers via `sentrix state import` + PR #187's auto-reset rebuilds a trie whose `state_root` silently disagrees with peers that kept their original trie. Every block the recovered validator then sees or produces trips the #1e strict-reject guard.

That is the exact shape of the 2026-04-21 freeze — VPS2 drifted ~45 SRX/min from canonical after state-import, chain halted at height 153326.

## Fix

We cannot change the two paths to agree without breaking sync-from-genesis (backfilling at height 0 would rewrite every historical `state_root`). Instead `init_trie` now compares the freshly-backfilled root against the stored `block.state_root` at that height and returns an error if they disagree.

If the guard fires, the operator recovers via `rsync /opt/sentrix/data/chain.db` from a healthy peer with all validators stopped — a whole-trie byte-copy preserves the incremental shape.

## Test

New regression test `test_reset_trie_then_init_refuses_on_backfill_divergence` in `crates/sentrix-core/src/blockchain.rs`:

- Fails on main (roots differ silently, no error surfaced)
- Passes with the fix (`init_trie` returns `Err` whose message names the divergence and cites bug #3)

## Test plan

- [ ] CI green (workspace 531 tests)
- [ ] Deploy to testnet, 24h bake — no false-positive guard fires under normal restart
- [ ] Mainnet deploy only after bake, coordinated restart of all 3 validators
- [ ] Update `runbooks/state-divergence-recovery.md` — replace `state export/import` with rsync procedure