### PR TITLE
chore(release): 2.1.6 — RPC validation hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.6] — 2026-04-21 — RPC validation hardening
+
+### Fixed
+- **fix(rpc): reject wei values not divisible by 1e10 in eth_sendRawTransaction**
+  (`crates/sentrix-rpc/src/jsonrpc/eth.rs`). Sentrix's on-chain unit is sentri
+  (1 SRX = 1e8 sentri = 1e18 wei), so values below 1e10 wei are sub-sentri
+  dust. Truncating them silently meant a caller sending 10_000_000_001 wei
+  saw 1 sentri transferred and 9 wei unaccounted — neither burned, refunded,
+  nor credited. The handler now returns JSON-RPC `-32602` if
+  `value_wei % 1e10 != 0`, surfacing the mismatch at the boundary.
+- **fix(rpc): eth_getBlockByNumber returns -32602 on invalid hex**
+  (`crates/sentrix-rpc/src/jsonrpc/eth.rs`). Previously a typo like `0xZZ`
+  or a non-hex string silently mapped to block 0 (genesis), so clients
+  took genesis data at face value for broken inputs. Now the parse error
+  is propagated with the offending value quoted.
+- **fix(rpc): panic at startup when SENTRIX_CORS_ORIGIN is unparseable**
+  (`crates/sentrix-rpc/src/routes/mod.rs`). A malformed env value used to
+  silently fall back to the literal "null" header, producing a router
+  that rejected every browser request without any signal to the operator.
+  Now an invalid value aborts `create_router` with a clear panic message
+  naming the offending string — fail-fast at config validation time.
+
 ## [2.1.5] — 2026-04-21 — Trie backfill divergence guard (bug #3)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4832,7 +4832,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "bincode",
  "blake3",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -77,12 +77,23 @@ pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) 
 async fn eth_get_block_by_number(params: &Value, state: &SharedState) -> DispatchResult {
     let bc = state.read().await;
     let block_param = params[0].as_str().unwrap_or("latest");
+    // Silently mapping invalid hex to block 0 returned genesis on typos like
+    // `0xZZ` or `"not a number"`, which users then took at face value. Reject
+    // the parse error so the caller sees the mistake instead of genesis data.
     let index = if block_param == "latest" {
         bc.height()
     } else if block_param == "earliest" {
         0
     } else {
-        u64::from_str_radix(block_param.trim_start_matches("0x"), 16).unwrap_or(0)
+        match u64::from_str_radix(block_param.trim_start_matches("0x"), 16) {
+            Ok(n) => n,
+            Err(_) => {
+                return Err((
+                    -32602,
+                    format!("invalid block number: {block_param:?}").into(),
+                ));
+            }
+        }
     };
     match bc.get_block(index) {
         Some(block) => Ok(json!({
@@ -296,6 +307,18 @@ async fn eth_send_raw_transaction(params: &Value, state: &SharedState) -> Dispat
             ));
         }
     };
+    // Sentrix's on-chain unit is sentri (1 SRX = 1e8 sentri = 1e18 wei), so
+    // values below 1e10 wei are sub-sentri dust. Truncating them silently
+    // meant a caller sending 10_000_000_001 wei saw 1 sentri transferred
+    // and 9 wei unaccounted — the 9 wei was neither burned, refunded, nor
+    // credited. Reject non-divisible amounts so the mismatch surfaces at
+    // the boundary instead of becoming phantom loss.
+    if value_wei % 10_000_000_000u128 != 0 {
+        return Err((
+            -32602,
+            "tx value is not a whole number of sentri (must be divisible by 1e10 wei)".into(),
+        ));
+    }
     let amount_sentri = (value_wei / 10_000_000_000u128) as u64;
 
     use sha3::{Digest as _, Keccak256};

--- a/crates/sentrix-rpc/src/routes/mod.rs
+++ b/crates/sentrix-rpc/src/routes/mod.rs
@@ -87,13 +87,18 @@ pub fn create_router(state: SharedState) -> Router {
                 ])
         }
         Some(origin) if !origin.is_empty() => {
-            // Specific origin (production)
-            CorsLayer::new()
-                .allow_origin(
-                    origin
-                        .parse::<axum::http::HeaderValue>()
-                        .unwrap_or(axum::http::HeaderValue::from_static("null")),
+            // Specific origin (production). Silently falling back to the
+            // literal "null" header on parse failure meant a typo in
+            // SENTRIX_CORS_ORIGIN produced a router that rejected every
+            // browser request without surfacing the misconfig. Panic at
+            // startup instead so operators see the problem immediately.
+            let header = origin.parse::<axum::http::HeaderValue>().unwrap_or_else(|e| {
+                panic!(
+                    "SENTRIX_CORS_ORIGIN={origin:?} is not a valid HTTP header value: {e}"
                 )
+            });
+            CorsLayer::new()
+                .allow_origin(header)
                 .allow_methods([
                     axum::http::Method::GET,
                     axum::http::Method::POST,

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"


### PR DESCRIPTION
## Summary

Three independent boundary fixes in the RPC layer. No consensus change, no on-chain behavior change — only the error surface visible to RPC callers.

### Fixes

1. **`eth_sendRawTransaction` wei↔sentri truncation** (`crates/sentrix-rpc/src/jsonrpc/eth.rs`)
   Sentrix's on-chain unit is sentri (1 SRX = 1e8 sentri = 1e18 wei). Values below 1e10 wei are sub-sentri dust. Truncating them silently produced phantom loss — 9 wei unaccounted on a 10_000_000_001-wei tx. Now returns `-32602` when `value_wei % 1e10 != 0`.

2. **`eth_getBlockByNumber` invalid hex → genesis** (`crates/sentrix-rpc/src/jsonrpc/eth.rs`)
   A typo like `0xZZ` silently mapped to block 0 and returned genesis, which clients then took at face value. Now the parse error propagates with the offending value quoted.

3. **`SENTRIX_CORS_ORIGIN` silent fallback to "null"** (`crates/sentrix-rpc/src/routes/mod.rs`)
   Malformed env var used to silently fall back to the literal "null" header, producing a router that rejected every browser request without any operator signal. Now `create_router` panics at startup with a clear message naming the offending value — fail-fast at config-validation time.

## Test plan

- [x] `cargo test --workspace --lib` → 532 tests pass (+1 from v2.1.5)
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [ ] CI green
- [ ] Mainnet rolling restart — RPC error surface only, no consensus impact