### PR TITLE
fix(rpc): satisfy clippy useless_conversion + manual_is_multiple_of

### DIFF
--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -88,10 +88,7 @@ async fn eth_get_block_by_number(params: &Value, state: &SharedState) -> Dispatc
         match u64::from_str_radix(block_param.trim_start_matches("0x"), 16) {
             Ok(n) => n,
             Err(_) => {
-                return Err((
-                    -32602,
-                    format!("invalid block number: {block_param:?}").into(),
-                ));
+                return Err((-32602, format!("invalid block number: {block_param:?}")));
             }
         }
     };
@@ -313,7 +310,7 @@ async fn eth_send_raw_transaction(params: &Value, state: &SharedState) -> Dispat
     // and 9 wei unaccounted — the 9 wei was neither burned, refunded, nor
     // credited. Reject non-divisible amounts so the mismatch surfaces at
     // the boundary instead of becoming phantom loss.
-    if value_wei % 10_000_000_000u128 != 0 {
+    if !value_wei.is_multiple_of(10_000_000_000u128) {
         return Err((
             -32602,
             "tx value is not a whole number of sentri (must be divisible by 1e10 wei)".into(),


### PR DESCRIPTION
Two clippy 1.95 lints surfaced after #191 merged, aborting the v2.1.6 mainnet fast-deploy at preflight. No behaviour change.

## Test plan
- [x] `cargo clippy -p sentrix-rpc --tests --release -- -D warnings` clean
- [x] `cargo test -p sentrix-rpc --lib` passes
- [ ] Re-run `fast-deploy.sh mainnet`