### PR TITLE
fix(evm): state persistence across transactions (Bug #1 + #2)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -817,14 +817,14 @@ impl Blockchain {
         let _sender = envelope.recover_signer().ok();
 
         // Build EVM tx
-        use alloy_primitives::U256;
+        use alloy_primitives::{B256, U256};
         use revm::context::TxEnv;
-        use revm::database::InMemoryDB;
-        use revm::primitives::{KECCAK_EMPTY, TxKind};
-        use revm::state::AccountInfo;
-        use sentrix_evm::database::parse_sentrix_address;
-        use sentrix_evm::executor::execute_tx;
+        use revm::primitives::TxKind;
+        use revm::state::Bytecode;
+        use sentrix_evm::database::{SentrixEvmDb, parse_sentrix_address};
+        use sentrix_evm::executor::execute_tx_with_state;
         use sentrix_evm::gas::INITIAL_BASE_FEE;
+        use sentrix_evm::writeback::commit_state_to_account_db;
 
         let from_addr =
             parse_sentrix_address(&tx.from_address).unwrap_or(alloy_primitives::Address::ZERO);
@@ -838,20 +838,57 @@ impl Blockchain {
             None => TxKind::Create,
         };
 
-        // Populate InMemoryDB with sender (gas + value) and target if contract
-        let mut in_mem_db = InMemoryDB::default();
-        let sender_balance = self.accounts.get_balance(&tx.from_address);
+        // Build EVM db from CURRENT AccountDB so the EVM sees real balances,
+        // nonces, and contract code pointers — not a fresh InMemoryDB as pre-fix.
+        // from_account_db handles sentri → wei scaling for all accounts.
+        let mut evm_db = SentrixEvmDb::from_account_db(&self.accounts);
         let sender_nonce = self.accounts.get_nonce(&tx.from_address);
-        in_mem_db.insert_account_info(
-            from_addr,
-            AccountInfo {
-                balance: U256::from(sender_balance).saturating_mul(U256::from(10_000_000_000u64)),
-                nonce: sender_nonce.saturating_sub(1), // already incremented by .transfer() above
-                code_hash: KECCAK_EMPTY,
-                account_id: None,
-                code: None,
-            },
-        );
+
+        // For Call txs, pre-load the target contract's bytecode + existing
+        // storage slots. Without this, revm sees an empty-code address and
+        // executes nothing useful. CREATE txs don't need pre-load — code
+        // comes from tx data and gets deployed by revm itself.
+        if let TxKind::Call(target_addr) = tx_kind {
+            let target_str = format!("0x{}", hex::encode(target_addr.as_slice()));
+            if let Some(target_account) = self.accounts.accounts.get(&target_str)
+                && target_account.code_hash != sentrix_primitives::EMPTY_CODE_HASH
+            {
+                let code_hash_hex = hex::encode(target_account.code_hash);
+                if let Some(bytecode) = self.accounts.get_contract_code(&code_hash_hex) {
+                    let code = Bytecode::new_raw(alloy_primitives::Bytes::from(bytecode.clone()));
+                    evm_db.insert_code(B256::from(target_account.code_hash), code);
+                }
+                // Pre-load storage slots whose key starts with "{target_addr}:".
+                // Sorted by slot_hex so the insertion order is deterministic
+                // across validator processes (HashMap iteration otherwise is
+                // non-deterministic; same pattern as init_trie backfill).
+                let prefix = format!("{}:", target_str);
+                let mut slots: Vec<(String, Vec<u8>)> = self
+                    .accounts
+                    .contract_storage
+                    .iter()
+                    .filter(|(k, _)| k.starts_with(&prefix))
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                slots.sort_by(|a, b| a.0.cmp(&b.0));
+                for (key, value) in slots {
+                    if let Some(slot_hex) = key.strip_prefix(&prefix)
+                        && let Ok(slot) = U256::from_str_radix(slot_hex, 16)
+                    {
+                        // Left-pad short values with leading zeros to 32 bytes
+                        // (big-endian high bits on the left). Note: normally
+                        // values ARE already 32 bytes because we always store
+                        // them that way in writeback, but defensive for any
+                        // legacy entries or state-imports with short blobs.
+                        let mut val_bytes = [0u8; 32];
+                        let n = value.len().min(32);
+                        val_bytes[32 - n..].copy_from_slice(&value[..n]);
+                        let val = U256::from_be_slice(&val_bytes);
+                        evm_db.insert_storage(target_addr, slot, val);
+                    }
+                }
+            }
+        }
 
         let evm_tx = TxEnv::builder()
             .caller(from_addr)
@@ -864,8 +901,8 @@ impl Blockchain {
             .build()
             .unwrap_or_default();
 
-        match execute_tx(in_mem_db, evm_tx, INITIAL_BASE_FEE, self.chain_id) {
-            Ok(receipt) => {
+        match execute_tx_with_state(evm_db, evm_tx, INITIAL_BASE_FEE, self.chain_id) {
+            Ok((receipt, state)) => {
                 tracing::info!(
                     "EVM tx {}: success={} gas_used={} contract={:?}",
                     &tx.txid[..16.min(tx.txid.len())],
@@ -943,6 +980,24 @@ impl Blockchain {
                             .store_contract_code(&code_hash_hex, receipt.output.clone());
                         self.accounts.set_contract(&addr_str, code_hash);
                     }
+                }
+
+                // ── EVM state writeback (closes Bug #1) ─────────────
+                // On success, commit every touched account's balance,
+                // nonce, storage slots, and (for CREATE) bytecode back
+                // to AccountDB so the next tx / next block sees them.
+                // Skip on revert — EVM spec requires state changes to
+                // be discarded on revert; the gas fee was already
+                // debited by the native Pass-1 .transfer() call above,
+                // so there's nothing else to do.
+                //
+                // The EIP-170 guard above may flip the tx to failed
+                // even for a successful revm receipt — in that case
+                // we skip the writeback too. Check mark AFTER the
+                // EIP-170 block ran so "was marked failed" is
+                // authoritative.
+                if receipt.success && !self.accounts.is_evm_tx_failed(&tx.txid) {
+                    commit_state_to_account_db(&state, &mut self.accounts)?;
                 }
             }
             Err(e) => {

--- a/crates/sentrix-evm/src/executor.rs
+++ b/crates/sentrix-evm/src/executor.rs
@@ -9,6 +9,8 @@ use alloy_primitives::Address;
 use revm::context::TxEnv;
 use revm::context::result::ExecutionResult;
 use revm::database::InMemoryDB;
+use revm::database_interface::Database;
+use revm::state::EvmState;
 use revm::{ExecuteEvm, MainBuilder, MainContext};
 
 /// Result of executing a single EVM transaction.
@@ -28,7 +30,9 @@ pub struct TxReceipt {
 
 /// Execute a single EVM transaction against an in-memory database.
 ///
-/// The db is consumed. Returns the receipt and the accumulated state changes.
+/// Back-compat wrapper that preserves the original signature — discards the
+/// state diff from revm and returns the receipt only. New callers that need
+/// to persist state changes to AccountDB should use [`execute_tx_with_state`].
 ///
 /// # Arguments
 /// * `chain_id` — active chain ID for EIP-155 replay protection. If the tx
@@ -41,10 +45,11 @@ pub fn execute_tx(
     block_base_fee: u64,
     chain_id: u64,
 ) -> Result<TxReceipt, String> {
-    execute_tx_inner(db, tx, block_base_fee, false, chain_id)
+    execute_tx_with_state(db, tx, block_base_fee, chain_id).map(|(receipt, _state)| receipt)
 }
 
 /// Read-only variant — disables balance/nonce checks for eth_call.
+/// Back-compat wrapper that discards the state diff; see [`execute_call_with_state`].
 ///
 /// # Arguments
 /// * `chain_id` — active chain ID for EIP-155 replay protection (see
@@ -55,16 +60,63 @@ pub fn execute_call(
     block_base_fee: u64,
     chain_id: u64,
 ) -> Result<TxReceipt, String> {
+    execute_call_with_state(db, tx, block_base_fee, chain_id).map(|(receipt, _state)| receipt)
+}
+
+/// Execute a transaction AND return the revm state diff.
+///
+/// The state diff (an `EvmState` = `HashMap<Address, Account>` of touched
+/// accounts with balance/nonce/storage/code changes) is what the block
+/// executor needs to persist back to AccountDB. Prior to this variant the
+/// diff was being dropped on the floor — see
+/// `founder-private/audits/evm-fix-analysis-2026-04-22.md`.
+///
+/// Generic over any `D: Database` so callers can pass either `InMemoryDB`
+/// (the original path, kept for the #[cfg(test)] unit tests) or
+/// `SentrixEvmDb` (the block-apply path that needs to pre-load target
+/// contract code + storage). The DB's associated error type must convert
+/// to `String` to fit the existing Result shape.
+pub fn execute_tx_with_state<D>(
+    db: D,
+    tx: TxEnv,
+    block_base_fee: u64,
+    chain_id: u64,
+) -> Result<(TxReceipt, EvmState), String>
+where
+    D: Database,
+    D::Error: std::fmt::Debug,
+{
+    execute_tx_inner(db, tx, block_base_fee, false, chain_id)
+}
+
+/// Read-only variant of [`execute_tx_with_state`] — disables balance/nonce
+/// checks and base-fee enforcement for `eth_call` / `debug_traceCall` paths
+/// that want to introspect the state diff without requiring the caller to
+/// be funded.
+pub fn execute_call_with_state<D>(
+    db: D,
+    tx: TxEnv,
+    block_base_fee: u64,
+    chain_id: u64,
+) -> Result<(TxReceipt, EvmState), String>
+where
+    D: Database,
+    D::Error: std::fmt::Debug,
+{
     execute_tx_inner(db, tx, block_base_fee, true, chain_id)
 }
 
-fn execute_tx_inner(
-    db: InMemoryDB,
+fn execute_tx_inner<D>(
+    db: D,
     tx: TxEnv,
     block_base_fee: u64,
     read_only: bool,
     chain_id: u64,
-) -> Result<TxReceipt, String> {
+) -> Result<(TxReceipt, EvmState), String>
+where
+    D: Database,
+    D::Error: std::fmt::Debug,
+{
     use revm::Context;
 
     // EIP-155 replay protection: reject tx whose embedded chain_id doesn't
@@ -99,6 +151,7 @@ fn execute_tx_inner(
 
     match result {
         Ok(result_and_state) => {
+            let state = result_and_state.state;
             let exec_result = result_and_state.result;
             let (contract_address, output) = match &exec_result {
                 ExecutionResult::Success {
@@ -118,7 +171,7 @@ fn execute_tx_inner(
                 logs: exec_result.into_logs(),
                 output,
             };
-            Ok(receipt)
+            Ok((receipt, state))
         }
         Err(e) => Err(format!("EVM execution error: {:?}", e)),
     }
@@ -281,5 +334,73 @@ mod tests {
                 e
             );
         }
+    }
+
+    // The new *_with_state variant must expose the revm state diff so the
+    // block executor can persist balance/nonce/storage changes back to
+    // AccountDB. Without this the whole fix is pointless — assert the
+    // HashMap is returned and contains the sender (whose balance changed
+    // due to gas + value transfer).
+    #[test]
+    fn test_execute_tx_with_state_returns_state_diff() {
+        let (db, sender) = funded_sender_db();
+        let receiver = Address::from([0x02u8; 20]);
+
+        let tx = TxEnv::builder()
+            .caller(sender)
+            .kind(TxKind::Call(receiver))
+            .value(U256::from(100_000u64))
+            .gas_limit(21_000)
+            .gas_price((INITIAL_BASE_FEE + 1_000) as u128)
+            .nonce(0)
+            .chain_id(Some(7119))
+            .build()
+            .unwrap_or_default();
+
+        let result = execute_tx_with_state(db, tx, INITIAL_BASE_FEE, 7119);
+        assert!(result.is_ok(), "execute_tx_with_state failed: {:?}", result.err());
+        let (receipt, state) = result.unwrap();
+        assert!(receipt.success);
+        assert!(
+            state.contains_key(&sender),
+            "state diff must contain the sender address"
+        );
+        let sender_acct = state.get(&sender).unwrap();
+        // Sender's post-tx balance should be less than the starting 1 ETH
+        // (gas + value both debited).
+        assert!(
+            sender_acct.info.balance < U256::from(1_000_000_000_000_000_000u128),
+            "sender balance should have decreased"
+        );
+        // Receiver should also be in the state (received value), but
+        // we only assert on sender here because receiver was zero-loaded
+        // and its presence depends on revm's touched-account semantics.
+    }
+
+    // Reverted tx still returns a state diff — caller is responsible for
+    // NOT applying it when receipt.success == false. This test pins that
+    // the executor doesn't silently eat the state on failure.
+    #[test]
+    fn test_execute_tx_with_state_returns_state_even_on_noop() {
+        let (db, sender) = funded_sender_db();
+        // Call with no calldata to a non-contract address — no-op, success=true
+        let receiver = Address::from([0x02u8; 20]);
+
+        let tx = TxEnv::builder()
+            .caller(sender)
+            .kind(TxKind::Call(receiver))
+            .value(U256::ZERO)
+            .gas_limit(21_000)
+            .gas_price((INITIAL_BASE_FEE + 1_000) as u128)
+            .nonce(0)
+            .chain_id(Some(7119))
+            .build()
+            .unwrap_or_default();
+
+        let result = execute_tx_with_state(db, tx, INITIAL_BASE_FEE, 7119);
+        let (_receipt, state) = result.expect("no-op call should succeed");
+        // State map is returned even for trivial txs — sender is touched
+        // by gas deduction at minimum.
+        assert!(!state.is_empty(), "state diff must not be empty even for no-op");
     }
 }

--- a/crates/sentrix-evm/src/lib.rs
+++ b/crates/sentrix-evm/src/lib.rs
@@ -16,7 +16,9 @@ pub mod logs;
 pub mod precompiles;
 
 pub use database::{SentrixEvmDb, parse_sentrix_address};
-pub use executor::{TxReceipt, execute_call, execute_tx};
+pub use executor::{
+    TxReceipt, execute_call, execute_call_with_state, execute_tx, execute_tx_with_state,
+};
 pub use gas::{BLOCK_GAS_LIMIT, INITIAL_BASE_FEE};
 pub use logs::{
     LogsBloom, StoredLog, add_log_to_bloom, bloom_contains, bloom_union, compute_logs_bloom,

--- a/crates/sentrix-evm/src/lib.rs
+++ b/crates/sentrix-evm/src/lib.rs
@@ -14,11 +14,13 @@ pub mod executor;
 pub mod gas;
 pub mod logs;
 pub mod precompiles;
+pub mod writeback;
 
 pub use database::{SentrixEvmDb, parse_sentrix_address};
 pub use executor::{
     TxReceipt, execute_call, execute_call_with_state, execute_tx, execute_tx_with_state,
 };
+pub use writeback::commit_state_to_account_db;
 pub use gas::{BLOCK_GAS_LIMIT, INITIAL_BASE_FEE};
 pub use logs::{
     LogsBloom, StoredLog, add_log_to_bloom, bloom_contains, bloom_union, compute_logs_bloom,

--- a/crates/sentrix-evm/src/writeback.rs
+++ b/crates/sentrix-evm/src/writeback.rs
@@ -1,0 +1,360 @@
+//! evm/writeback.rs — Apply a revm EvmState diff back to Sentrix's AccountDB.
+//!
+//! Called by the block-apply path after a SUCCESSFUL EVM tx execution.
+//! Skipped when the tx reverted (caller checks `receipt.success` first);
+//! on revert the gas fee is already debited by the native Pass-1 transfer
+//! and the EVM state diff is dropped per EVM spec.
+//!
+//! Rules enforced by this module:
+//!
+//!   1. Balance wei → sentri: round DOWN. EVM gas accounting at
+//!      INITIAL_BASE_FEE = 1e9 wei/unit produces sub-sentri remainders
+//!      (e.g. `gas_used=21001 × 1e9 = 2.1001e13 wei`), so the RPC-ingress
+//!      rule `!value.is_multiple_of(1e10) → Err` (rpc/jsonrpc/eth.rs:313,
+//!      shipped v2.1.6) CANNOT apply here — it'd reject every tx with odd
+//!      gas usage. Max precision loss per account per tx: 9_999_999_999
+//!      wei = ~1e-9 SRX, which is negligible at any realistic SRX price.
+//!
+//!   2. Storage slot key: U256 → 64-char lowercase hex via `format!("{:064x}")`.
+//!      AccountDB's `store_contract_storage` keys as `"{address}:{slot_hex}"`;
+//!      the 64-char padding keeps string comparisons sortable and matches
+//!      existing SRC-20 key format.
+//!
+//!   3. Storage value: U256 → 32-byte big-endian `Vec<u8>`. Reversible with
+//!      `U256::from_be_bytes(&value_bytes)` on read. Padding is always 32
+//!      bytes so downstream readers can slice without length checks.
+//!
+//!   4. Only process accounts where `status.is_touched() == true`.
+//!      SentrixEvmDb::from_account_db loads ALL accounts into revm's map,
+//!      but revm only marks the ones execution actually reads/writes. This
+//!      filter prevents spurious AccountDB rewrites.
+//!
+//!   5. SELFDESTRUCT: observed via `is_selfdestructed()` flag. Writeback
+//!      zeros the balance and clears code_hash to EMPTY_CODE_HASH. The
+//!      beneficiary's funds transfer is reflected in the beneficiary's
+//!      OWN state diff (revm already moved them). Storage slots of the
+//!      destroyed contract are not explicitly purged — they become
+//!      unreachable because the code pointer is gone; a future prune pass
+//!      reclaims. Also emits a `tracing::warn!` for ops visibility.
+//!
+//!   6. New contract code: present on CREATE txs as `account.info.code = Some(bytecode)`.
+//!      Stored via `store_contract_code(code_hash_hex, bytes)` + account
+//!      marked as contract via `set_contract(addr, code_hash)`.
+//!      Existing contracts whose code didn't change have `code = None`
+//!      post-execution (revm doesn't re-load code into the state diff) —
+//!      nothing to persist.
+//!
+//! Determinism: iteration order is NOT the bit-for-bit identity of the
+//! output (AccountDB reads are by-key), but sorted iteration prevents
+//! log/trace output divergence across validators and matches the pattern
+//! used elsewhere (`init_trie` backfill at blockchain.rs:583).
+//!
+//! Performance note: this function is O(touched_accounts × avg_slots_per_account)
+//! per tx. Acceptable at current testnet scale. Future optimization: batch
+//! writes through WriteBatch instead of per-call HashMap inserts.
+
+use alloy_primitives::{Address, U256};
+use revm::state::EvmState;
+use sentrix_primitives::{AccountDB, EMPTY_CODE_HASH, SentrixResult};
+
+use crate::database::address_to_sentrix;
+
+/// Commit a revm `EvmState` diff back to Sentrix's `AccountDB`.
+///
+/// **Caller must check `receipt.success == true` BEFORE calling this.**
+/// On revert, the diff must be dropped per EVM spec; this function applies
+/// unconditionally whatever is passed in.
+///
+/// Returns `Err` only if the AccountDB setters fail (currently they don't,
+/// but the return type is `SentrixResult<()>` to preserve the option for
+/// future overflow / validation checks).
+pub fn commit_state_to_account_db(
+    state: &EvmState,
+    account_db: &mut AccountDB,
+) -> SentrixResult<()> {
+    // Sort touched addresses for deterministic iteration order. HashMap
+    // iteration is non-deterministic across processes; sorting removes a
+    // potential source of cross-validator log divergence. Matches the
+    // init_trie backfill pattern at blockchain.rs:583.
+    let mut touched: Vec<(&Address, &revm::state::Account)> = state
+        .iter()
+        .filter(|(_, acc)| acc.is_touched())
+        .collect();
+    touched.sort_by_key(|(addr, _)| *addr);
+
+    for (addr, evm_account) in touched {
+        let addr_str = address_to_sentrix(addr);
+
+        // ── SELFDESTRUCT fast-path ───────────────────────────────────
+        // Post-Cancun (EIP-6780), SELFDESTRUCT only destroys the contract
+        // if invoked in the same tx that CREATED it. revm already enforces
+        // that; when we see is_selfdestructed() == true it IS a legitimate
+        // destroy. See founder-private/security/SECURITY_NOTES.md for
+        // partial-support scope (balance zero + code clear; storage slots
+        // linger but are unreachable).
+        if evm_account.is_selfdestructed() {
+            tracing::warn!(
+                "evm/writeback: SELFDESTRUCT observed on {} — zeroing balance + code_hash. \
+                 Beneficiary transfer is reflected in their own state diff.",
+                addr_str
+            );
+            account_db.set_balance(&addr_str, 0);
+            account_db.set_contract(&addr_str, EMPTY_CODE_HASH);
+            continue;
+        }
+
+        // ── Balance ─────────────────────────────────────────────────
+        // Rule: wei → sentri, round DOWN. See module-doc rule (1) for why
+        // the v2.1.6 RPC-ingress `is_multiple_of(1e10)` cannot apply here.
+        let balance_wei: U256 = evm_account.info.balance;
+        let balance_sentri = (balance_wei / U256::from(10_000_000_000u64))
+            .try_into()
+            .unwrap_or(u64::MAX); // U256→u64 saturation — u64::MAX sentri is 184B SRX, far above any realistic balance
+        account_db.set_balance(&addr_str, balance_sentri);
+
+        // ── Nonce ──────────────────────────────────────────────────
+        // Direct copy. revm returns the post-execution nonce; for the
+        // sender this is `pre_execute_nonce + 1`, which equals the value
+        // AccountDB already has (native Pass-1 already incremented, then
+        // the block_executor shim subtracts 1 before passing to revm).
+        // For the sender this is effectively a no-op; for CREATEd
+        // contracts revm sets nonce=1 (EIP-161).
+        account_db.set_nonce(&addr_str, evm_account.info.nonce);
+
+        // ── Contract code (new deployments only) ──────────────────
+        // revm populates `info.code = Some(bytecode)` on CREATE; None
+        // for existing-contract calls (code was loaded from DB, not
+        // re-materialised into the state diff). Only persist when
+        // actually new. EIP-170 24KB cap is enforced at block_executor
+        // level BEFORE this commit — oversized CREATE flips the tx to
+        // failed and this writeback is skipped entirely.
+        if let Some(bytecode) = &evm_account.info.code {
+            let code_bytes = bytecode.original_byte_slice();
+            if !code_bytes.is_empty() {
+                let code_hash_bytes: [u8; 32] = evm_account.info.code_hash.into();
+                let code_hash_hex = hex::encode(code_hash_bytes);
+                account_db.store_contract_code(&code_hash_hex, code_bytes.to_vec());
+                account_db.set_contract(&addr_str, code_hash_bytes);
+            }
+        }
+
+        // ── Storage slots ──────────────────────────────────────────
+        // Only persist slots where is_changed() == true (original_value
+        // != present_value). Collect + sort by slot for deterministic
+        // output ordering even though downstream reads are by-key.
+        let mut changed_slots: Vec<(U256, U256)> = evm_account
+            .storage
+            .iter()
+            .filter(|(_, slot)| slot.is_changed())
+            .map(|(key, slot)| (*key, slot.present_value))
+            .collect();
+        changed_slots.sort_by_key(|(k, _)| *k);
+
+        for (slot, value) in changed_slots {
+            // 64-char lowercase hex, zero-padded. Left-pads with leading
+            // zeros (big-endian high bits on the left, same convention as
+            // Ethereum storage slot addressing).
+            let slot_hex = format!("{slot:064x}");
+            let value_bytes = value.to_be_bytes::<32>().to_vec();
+            account_db.store_contract_storage(&addr_str, &slot_hex, value_bytes);
+        }
+    }
+
+    Ok(())
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use revm::primitives::KECCAK_EMPTY;
+    use revm::state::{Account, AccountInfo, AccountStatus, EvmStorageSlot};
+    use std::collections::HashMap;
+
+    fn addr(b: u8) -> Address {
+        Address::from([b; 20])
+    }
+
+    fn touched_account(balance_wei: U256, nonce: u64) -> Account {
+        let info = AccountInfo {
+            balance: balance_wei,
+            nonce,
+            code_hash: KECCAK_EMPTY,
+            account_id: None,
+            code: None,
+        };
+        Account {
+            original_info: Box::new(info.clone()),
+            info,
+            storage: HashMap::default(),
+            transaction_id: 0,
+            status: AccountStatus::Touched,
+        }
+    }
+
+    #[test]
+    fn test_commit_balance_rounds_down() {
+        let mut state = EvmState::default();
+        // 2.1001e13 wei = 21001 × 1e9 — legitimate gas×base_fee remainder
+        // that must NOT be rejected. 2.1001e13 / 1e10 = 2100 (floor).
+        state.insert(
+            addr(0x01),
+            touched_account(U256::from(21_001_000_000_000u128), 1),
+        );
+        let mut db = AccountDB::new();
+        commit_state_to_account_db(&state, &mut db).unwrap();
+        assert_eq!(db.get_balance("0x0101010101010101010101010101010101010101"), 2100);
+    }
+
+    #[test]
+    fn test_commit_nonce_direct() {
+        let mut state = EvmState::default();
+        state.insert(addr(0x02), touched_account(U256::ZERO, 7));
+        let mut db = AccountDB::new();
+        commit_state_to_account_db(&state, &mut db).unwrap();
+        assert_eq!(db.get_nonce("0x0202020202020202020202020202020202020202"), 7);
+    }
+
+    #[test]
+    fn test_commit_single_storage_slot() {
+        let mut state = EvmState::default();
+        let mut account = touched_account(U256::from(10_000_000_000u64), 1);
+        // slot 0 → 42
+        account.storage.insert(
+            U256::ZERO,
+            EvmStorageSlot::new_changed(U256::ZERO, U256::from(42u64), 0),
+        );
+        state.insert(addr(0x03), account);
+
+        let mut db = AccountDB::new();
+        commit_state_to_account_db(&state, &mut db).unwrap();
+
+        let addr_str = "0x0303030303030303030303030303030303030303";
+        let slot_hex = format!("{:064x}", 0);
+        let stored = db.get_contract_storage(addr_str, &slot_hex);
+        assert!(stored.is_some(), "slot 0 must be persisted");
+        // 42 big-endian in 32 bytes: 31 zeros then 0x2a.
+        let bytes = stored.unwrap();
+        assert_eq!(bytes.len(), 32);
+        assert_eq!(bytes[31], 42);
+        assert!(bytes[..31].iter().all(|b| *b == 0));
+    }
+
+    #[test]
+    fn test_commit_new_contract_code_persists() {
+        use revm::state::Bytecode;
+        let mut state = EvmState::default();
+        let runtime = vec![0x60, 0x00, 0x60, 0x00, 0xf3]; // dummy RETURN 0x00
+        let bytecode = Bytecode::new_raw(alloy_primitives::Bytes::from(runtime.clone()));
+        let code_hash = bytecode.hash_slow();
+
+        let mut account = touched_account(U256::ZERO, 1);
+        account.info.code = Some(bytecode);
+        account.info.code_hash = code_hash;
+        state.insert(addr(0x04), account);
+
+        let mut db = AccountDB::new();
+        commit_state_to_account_db(&state, &mut db).unwrap();
+
+        let code_hash_bytes: [u8; 32] = code_hash.into();
+        let code_hash_hex = hex::encode(code_hash_bytes);
+        assert_eq!(
+            db.get_contract_code(&code_hash_hex).map(|v| v.as_slice()),
+            Some(runtime.as_slice()),
+            "new contract bytecode must be persisted"
+        );
+        let addr_str = "0x0404040404040404040404040404040404040404";
+        let acct = db.accounts.get(addr_str).expect("contract account must exist");
+        assert_eq!(acct.code_hash, code_hash_bytes, "set_contract must mark account");
+        assert!(acct.is_contract());
+    }
+
+    #[test]
+    fn test_commit_selfdestruct_zeroes_account() {
+        let mut state = EvmState::default();
+        let mut account = touched_account(U256::from(1_000_000_000_000u64), 5);
+        account.status |= AccountStatus::SelfDestructed;
+        account.info.code_hash = alloy_primitives::B256::from([0xAA; 32]);
+        state.insert(addr(0x05), account);
+
+        let mut db = AccountDB::new();
+        // Pre-populate so we can see the zero-out.
+        db.credit("0x0505050505050505050505050505050505050505", 100).unwrap();
+        db.set_contract("0x0505050505050505050505050505050505050505", [0xBB; 32]);
+
+        commit_state_to_account_db(&state, &mut db).unwrap();
+
+        let addr_str = "0x0505050505050505050505050505050505050505";
+        assert_eq!(db.get_balance(addr_str), 0, "selfdestructed balance must be zeroed");
+        let acct = db.accounts.get(addr_str).unwrap();
+        assert_eq!(acct.code_hash, EMPTY_CODE_HASH, "selfdestructed code_hash must be EMPTY");
+    }
+
+    #[test]
+    fn test_commit_skips_untouched() {
+        let mut state = EvmState::default();
+        // Un-touched account should NOT influence AccountDB.
+        let info = AccountInfo {
+            balance: U256::from(999_999u128),
+            nonce: 42,
+            code_hash: KECCAK_EMPTY,
+            account_id: None,
+            code: None,
+        };
+        let account = Account {
+            original_info: Box::new(info.clone()),
+            info,
+            storage: HashMap::default(),
+            transaction_id: 0,
+            status: AccountStatus::default(), // NOT touched
+        };
+        state.insert(addr(0x06), account);
+
+        let mut db = AccountDB::new();
+        commit_state_to_account_db(&state, &mut db).unwrap();
+
+        // Account should not even exist in AccountDB since we never touched it.
+        assert!(!db.accounts.contains_key("0x0606060606060606060606060606060606060606"));
+    }
+
+    #[test]
+    fn test_commit_deterministic_across_runs() {
+        // Two runs over the same logical state must produce bit-identical
+        // AccountDB contents, regardless of HashMap iteration order.
+        let mut state_a = EvmState::default();
+        let mut state_b = EvmState::default();
+
+        for i in 0u8..5 {
+            let mut acc_a = touched_account(U256::from((i as u64 + 1) * 10_000_000_000u64), i as u64);
+            let mut acc_b = touched_account(U256::from((i as u64 + 1) * 10_000_000_000u64), i as u64);
+            acc_a.storage.insert(
+                U256::ZERO,
+                EvmStorageSlot::new_changed(U256::ZERO, U256::from(i as u64 + 100), 0),
+            );
+            acc_b.storage.insert(
+                U256::ZERO,
+                EvmStorageSlot::new_changed(U256::ZERO, U256::from(i as u64 + 100), 0),
+            );
+            state_a.insert(addr(i + 1), acc_a);
+            state_b.insert(addr(i + 1), acc_b);
+        }
+
+        let mut db_a = AccountDB::new();
+        let mut db_b = AccountDB::new();
+        commit_state_to_account_db(&state_a, &mut db_a).unwrap();
+        commit_state_to_account_db(&state_b, &mut db_b).unwrap();
+
+        // Same 5 addresses committed either order → AccountDB contents match.
+        for i in 0u8..5 {
+            let addr_str = format!("0x{}", hex::encode([i + 1; 20]));
+            assert_eq!(db_a.get_balance(&addr_str), db_b.get_balance(&addr_str));
+            assert_eq!(db_a.get_nonce(&addr_str), db_b.get_nonce(&addr_str));
+            let slot_hex = format!("{:064x}", 0);
+            assert_eq!(
+                db_a.get_contract_storage(&addr_str, &slot_hex),
+                db_b.get_contract_storage(&addr_str, &slot_hex)
+            );
+        }
+    }
+}

--- a/crates/sentrix-primitives/src/account.rs
+++ b/crates/sentrix-primitives/src/account.rs
@@ -221,6 +221,28 @@ impl AccountDB {
         account.code_hash = code_hash;
     }
 
+    /// Set an account's balance to an absolute value in sentri. Used by the
+    /// EVM state writeback path (`sentrix_evm::writeback::commit_state_to_account_db`)
+    /// where revm returns the post-execution balance as an absolute U256 in
+    /// wei, which the caller converts to u64 sentri before calling here.
+    ///
+    /// Native paths (`transfer`, `credit`) continue to compute deltas — they
+    /// must NOT migrate to this setter or they'd lose the overflow/underflow
+    /// guards on the delta arithmetic.
+    pub fn set_balance(&mut self, address: &str, balance: u64) {
+        let account = self.get_or_create(address);
+        account.balance = balance;
+    }
+
+    /// Set an account's nonce to an absolute value. Used by the EVM state
+    /// writeback path where revm returns the post-execution nonce directly.
+    /// Native paths (`transfer`) continue to increment via `checked_add` —
+    /// they must NOT migrate to this setter or they'd lose the overflow guard.
+    pub fn set_nonce(&mut self, address: &str, nonce: u64) {
+        let account = self.get_or_create(address);
+        account.nonce = nonce;
+    }
+
     /// A2: Mark an EVM tx hash as failed (reverted). Bounded FIFO — evicts
     /// the oldest entry once the set hits `MAX_FAILED_EVM_TXS` so the
     /// structure cannot grow unbounded.
@@ -390,6 +412,34 @@ mod tests {
                 .map(|a| a.is_contract())
                 .unwrap_or(false)
         );
+    }
+
+    #[test]
+    fn test_set_balance_overrides_existing() {
+        let mut db = AccountDB::new();
+        db.credit("alice", 1_000).unwrap();
+        assert_eq!(db.get_balance("alice"), 1_000);
+
+        db.set_balance("alice", 42);
+        assert_eq!(db.get_balance("alice"), 42);
+
+        // On a fresh address (no prior credit) set_balance auto-creates.
+        db.set_balance("bob", 999);
+        assert_eq!(db.get_balance("bob"), 999);
+    }
+
+    #[test]
+    fn test_set_nonce_direct() {
+        let mut db = AccountDB::new();
+        // Fresh address: starts at 0, setter bumps to N.
+        db.set_nonce("alice", 5);
+        assert_eq!(db.get_nonce("alice"), 5);
+
+        // Overwrite is allowed (EVM writeback may set to a lower value
+        // only in pathological rollback-ish scenarios; setter itself
+        // enforces no policy).
+        db.set_nonce("alice", 3);
+        assert_eq!(db.get_nonce("alice"), 3);
     }
 
     #[test]

--- a/tests/integration_evm_state_persistence.rs
+++ b/tests/integration_evm_state_persistence.rs
@@ -1,0 +1,320 @@
+//! integration_evm_state_persistence.rs — end-to-end proof that EVM state
+//! persists across executions via execute_tx_with_state + commit_state_to_account_db.
+//!
+//! These tests exercise the **executor + writeback** boundary directly
+//! (not the full `apply_block_pass2` → `execute_evm_tx_in_block` Sentrix tx
+//! wrapping). Building a valid sentrix_primitives::Transaction with a
+//! correctly-RLP-signed Ethereum inner envelope is substantial scaffolding
+//! and is orthogonal to the bug fix itself.
+//!
+//! End-to-end validation through the full Sentrix block-apply path
+//! (eth_sendRawTransaction → mempool → create_block → add_block → state)
+//! happens on testnet during the 48h bake, where real signed Ethereum
+//! transactions from `cast` / hardhat produce the same EvmState that these
+//! tests exercise synthetically.
+//!
+//! What these tests DO prove:
+//!   - SSTORE writes survive and reach AccountDB.contract_storage.
+//!   - Balance changes (gas + value) round-trip wei ↔ sentri correctly.
+//!   - Nonce increments persist.
+//!   - Contract CREATE deploys bytecode and marks the account as contract.
+//!   - Reverted txs leave AccountDB unchanged.
+//!   - Within-"block" multi-tx: each subsequent execute sees the prior's
+//!     committed state (via freshly-rebuilt SentrixEvmDb from AccountDB).
+//!
+//! What remains for testnet bake:
+//!   - Full mempool → create_block path (EVM tx encoding into sentrix.data)
+//!   - RPC boundary (eth_sendRawTransaction)
+//!   - Gas fee distribution (coinbase reward + burn) at block level
+//!   - Multi-validator state_root agreement
+
+#![allow(missing_docs, clippy::expect_used, clippy::unwrap_used)]
+
+use alloy_primitives::{Address, U256};
+use revm::context::TxEnv;
+use revm::primitives::TxKind;
+use sentrix_evm::database::{SentrixEvmDb, address_to_sentrix};
+use sentrix_evm::executor::execute_tx_with_state;
+use sentrix_evm::gas::INITIAL_BASE_FEE;
+use sentrix_evm::writeback::commit_state_to_account_db;
+use sentrix_primitives::{AccountDB, EMPTY_CODE_HASH};
+
+const CHAIN_ID: u64 = 7119;
+
+/// Fund a sender in AccountDB so execute_tx_with_state has budget for gas.
+/// 100 SRX = 1e10 sentri. from_account_db scales to 1e20 wei which covers
+/// `gas_limit × gas_price` many times over.
+fn fund_sender(db: &mut AccountDB, addr: &Address, sentri: u64) {
+    let addr_str = address_to_sentrix(addr);
+    db.credit(&addr_str, sentri).expect("credit");
+}
+
+/// SimpleStorage bytecode: constructor stores nothing, runtime supports
+/// `set(uint)` via calldata at offset 0 → SSTORE slot 0, and `get()` via
+/// returning slot 0.
+///
+/// Runtime bytecode (hex):
+///   6004600c60003960046000f3      — constructor: copy 4 bytes of runtime
+///                                   starting at offset 0x0c into memory
+///                                   offset 0x00, then RETURN
+///   60003554                      — runtime: PUSH1 0x00 CALLDATALOAD
+///                                   PUSH1 0x00 SSTORE (set slot 0 = calldata[0..32])
+///
+/// For SET: send calldata = 32 bytes of value (no selector; minimalist).
+/// For GET: there's no "get" opcode path; reads are verified via AccountDB
+/// directly post-commit (the test doesn't need the GET return path to
+/// prove persistence).
+fn simple_storage_init_code() -> Vec<u8> {
+    // Deploy: runtime is exactly the 5 bytes `6000355560` hex (PUSH1 0x00
+    // CALLDATALOAD PUSH1 0x00 SSTORE STOP). Constructor:
+    //   PUSH1 0x05  (length of runtime = 5)
+    //   PUSH1 0x0c  (runtime offset = 12)
+    //   PUSH1 0x00  (dest offset in memory)
+    //   CODECOPY
+    //   PUSH1 0x05  (return length)
+    //   PUSH1 0x00  (return offset)
+    //   RETURN
+    //
+    //   runtime follows at byte 12: 60 00 35 60 00 55 00
+    //
+    // Full init code (constructor = exactly 12 bytes, runtime starts at byte 12):
+    //   bytes 0-1:  60 07    PUSH1 7 (runtime length)
+    //   bytes 2-3:  60 0c    PUSH1 12 (runtime offset in code)
+    //   bytes 4-5:  60 00    PUSH1 0 (memory dest)
+    //   byte  6:    39       CODECOPY
+    //   bytes 7-8:  60 07    PUSH1 7 (return length)
+    //   bytes 9-10: 60 00    PUSH1 0 (return offset)
+    //   byte  11:   f3       RETURN
+    //   bytes 12-18: 60 00 35 60 00 55 00  (runtime: STORE calldata[0..32] at slot 0; STOP)
+    //
+    // 12 constructor bytes + 7 runtime bytes = 19 total (38 hex chars).
+    hex::decode("6007600c60003960076000f360003560005500").unwrap()
+}
+
+// Hash the init code via revm::primitives::keccak256 used by revm when
+// computing contract addresses, so we can round-trip.
+fn deploy_bytecode(db: &mut AccountDB, deployer: Address, init_code: Vec<u8>) -> Address {
+    let evm_db = SentrixEvmDb::from_account_db(db);
+    let tx = TxEnv::builder()
+        .caller(deployer)
+        .kind(TxKind::Create)
+        .value(U256::ZERO)
+        .gas_limit(500_000)
+        .gas_price((INITIAL_BASE_FEE + 1_000) as u128)
+        .nonce(db.get_nonce(&address_to_sentrix(&deployer)))
+        .data(alloy_primitives::Bytes::from(init_code))
+        .chain_id(Some(CHAIN_ID))
+        .build()
+        .unwrap_or_default();
+    let (receipt, state) = execute_tx_with_state(evm_db, tx, INITIAL_BASE_FEE, CHAIN_ID)
+        .expect("deploy must succeed");
+    assert!(receipt.success, "deploy reverted");
+    let contract_addr = receipt.contract_address.expect("CREATE must produce address");
+    // Commit + also manually persist the runtime bytecode via set_contract,
+    // because revm's state diff contains info.code = Some(runtime) from the
+    // CREATE and commit_state_to_account_db will store + mark it.
+    commit_state_to_account_db(&state, db).expect("commit");
+    contract_addr
+}
+
+fn call_contract(
+    db: &mut AccountDB,
+    caller: Address,
+    target: Address,
+    calldata: Vec<u8>,
+    gas_limit: u64,
+) -> (bool, u64) {
+    // Build SentrixEvmDb from current AccountDB + pre-load target's code
+    // and any existing storage (exactly the pattern block_executor uses).
+    let mut evm_db = SentrixEvmDb::from_account_db(db);
+    let target_str = address_to_sentrix(&target);
+    if let Some(target_account) = db.accounts.get(&target_str)
+        && target_account.code_hash != EMPTY_CODE_HASH
+    {
+        let code_hash_hex = hex::encode(target_account.code_hash);
+        if let Some(bytecode) = db.get_contract_code(&code_hash_hex) {
+            let code = revm::state::Bytecode::new_raw(alloy_primitives::Bytes::from(bytecode.clone()));
+            evm_db.insert_code(alloy_primitives::B256::from(target_account.code_hash), code);
+        }
+        let prefix = format!("{}:", target_str);
+        let mut slots: Vec<(String, Vec<u8>)> = db
+            .contract_storage
+            .iter()
+            .filter(|(k, _)| k.starts_with(&prefix))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        slots.sort_by(|a, b| a.0.cmp(&b.0));
+        for (key, value) in slots {
+            if let Some(slot_hex) = key.strip_prefix(&prefix)
+                && let Ok(slot) = U256::from_str_radix(slot_hex, 16)
+            {
+                let mut val_bytes = [0u8; 32];
+                let n = value.len().min(32);
+                val_bytes[32 - n..].copy_from_slice(&value[..n]);
+                let val = U256::from_be_slice(&val_bytes);
+                evm_db.insert_storage(target, slot, val);
+            }
+        }
+    }
+    let tx = TxEnv::builder()
+        .caller(caller)
+        .kind(TxKind::Call(target))
+        .value(U256::ZERO)
+        .gas_limit(gas_limit)
+        .gas_price((INITIAL_BASE_FEE + 1_000) as u128)
+        .nonce(db.get_nonce(&address_to_sentrix(&caller)))
+        .data(alloy_primitives::Bytes::from(calldata))
+        .chain_id(Some(CHAIN_ID))
+        .build()
+        .unwrap_or_default();
+    let (receipt, state) = execute_tx_with_state(evm_db, tx, INITIAL_BASE_FEE, CHAIN_ID)
+        .expect("execute must not hard-error");
+    if receipt.success {
+        commit_state_to_account_db(&state, db).expect("commit");
+    }
+    (receipt.success, receipt.gas_used)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+// Test 1 (headline): SimpleStorage SSTORE persists to AccountDB.
+// Deploy → call set(42) → assert contract_storage slot 0 == 42.
+#[test]
+fn test_1_simple_storage_persists_after_set() {
+    let mut db = AccountDB::new();
+    let deployer = Address::from([0x01; 20]);
+    fund_sender(&mut db, &deployer, 100_000_000); // 1 SRX in sentri
+
+    let contract = deploy_bytecode(&mut db, deployer, simple_storage_init_code());
+
+    // Sanity: contract is now recorded.
+    let contract_str = address_to_sentrix(&contract);
+    assert!(
+        db.accounts.get(&contract_str).map(|a| a.is_contract()).unwrap_or(false),
+        "contract account must be marked is_contract() post-deploy"
+    );
+
+    // set(42): calldata is 32 bytes of value (0x000...002a).
+    let mut calldata = vec![0u8; 32];
+    calldata[31] = 42;
+    let (ok, _gas) = call_contract(&mut db, deployer, contract, calldata, 100_000);
+    assert!(ok, "set(42) call must succeed");
+
+    // Verify slot 0 == 42.
+    let slot_hex = format!("{:064x}", 0);
+    let stored = db.get_contract_storage(&contract_str, &slot_hex)
+        .expect("slot 0 must be persisted to AccountDB");
+    assert_eq!(stored.len(), 32, "slot value is 32 bytes");
+    assert_eq!(stored[31], 42, "low byte == 42");
+    assert!(stored[..31].iter().all(|b| *b == 0), "high bytes == 0");
+}
+
+// Test 3 (multi-call same contract): set(10) → set(20) → final slot == 20.
+// Proves subsequent calls in sequence see the prior commit (via
+// re-read AccountDB in the test helper).
+#[test]
+fn test_3_multiple_sets_see_prior_write() {
+    let mut db = AccountDB::new();
+    let deployer = Address::from([0x01; 20]);
+    fund_sender(&mut db, &deployer, 100_000_000);
+    let contract = deploy_bytecode(&mut db, deployer, simple_storage_init_code());
+
+    let mut calldata10 = vec![0u8; 32]; calldata10[31] = 10;
+    let mut calldata20 = vec![0u8; 32]; calldata20[31] = 20;
+
+    call_contract(&mut db, deployer, contract, calldata10, 100_000);
+    call_contract(&mut db, deployer, contract, calldata20, 100_000);
+
+    let contract_str = address_to_sentrix(&contract);
+    let slot_hex = format!("{:064x}", 0);
+    let stored = db.get_contract_storage(&contract_str, &slot_hex).unwrap();
+    assert_eq!(stored[31], 20, "second set must win");
+}
+
+// Test 5 (reverted tx): deploy a contract that REVERTs on input != 0,
+// call with nonzero → assert storage UNCHANGED.
+#[test]
+fn test_5_revert_leaves_state_unchanged() {
+    // Bytecode: if calldata[0..32] != 0, REVERT. Otherwise SSTORE slot 0 = 1.
+    //   60 00 35               PUSH1 0 CALLDATALOAD  — stack: input
+    //   80                     DUP1                   — stack: input, input
+    //   15                     ISZERO                 — stack: input, isZero
+    //   60 0c                  PUSH1 0x0c             — stack: input, isZero, jumpdest
+    //   57                     JUMPI                  — if isZero jump
+    //   60 00 60 00 fd          PUSH1 0 PUSH1 0 REVERT — pops 2, revert
+    //   5b                     JUMPDEST (byte 12)
+    //   50                     POP                   — discard input
+    //   60 01 60 00 55          PUSH1 1 PUSH1 0 SSTORE
+    //   00                     STOP
+    //
+    // Runtime: 6000358015600c57600060 00fd5b50600160 005500  (17 bytes? let's just hand-assemble safely)
+    //
+    // Simpler: use a bytecode that ALWAYS reverts regardless. Enough to
+    // prove the commit-skip path. We already proved "success commits" in
+    // test 1 and test 3.
+    //
+    // ALWAYS-REVERT runtime:
+    //   60 00 60 00 fd    PUSH1 0 PUSH1 0 REVERT
+    //
+    // Constructor copying 5 bytes of runtime:
+    //   60 05 60 0c 60 00 39 60 05 60 00 f3 60 00 60 00 fd
+    let mut db = AccountDB::new();
+    let deployer = Address::from([0x01; 20]);
+    fund_sender(&mut db, &deployer, 100_000_000);
+    let init_code = hex::decode("6005600c60003960056000f3600060 00fd".replace(' ', "")).unwrap();
+    let contract = deploy_bytecode(&mut db, deployer, init_code);
+
+    // First set a known storage value directly (simulating prior success).
+    let contract_str = address_to_sentrix(&contract);
+    let slot_hex = format!("{:064x}", 0);
+    db.store_contract_storage(&contract_str, &slot_hex, vec![42u8; 32]);
+
+    // Now invoke the always-revert contract.
+    let (ok, _gas) = call_contract(&mut db, deployer, contract, vec![], 100_000);
+    assert!(!ok, "revert must return success=false");
+
+    // Storage slot 0 must STILL be 42 (revert did not commit).
+    let stored = db.get_contract_storage(&contract_str, &slot_hex).unwrap();
+    assert_eq!(stored, &vec![42u8; 32], "reverted tx must NOT overwrite storage");
+}
+
+// Tests 2 (ERC-20 mock), 4 (contract-to-contract), 6 (SELFDESTRUCT) are
+// scaffolded below with #[ignore]. Implementing them requires more bytecode
+// vendoring (ERC-20 is ~1KB of EVM, not hand-assemblable). They are
+// explicitly NOT blocking this PR — unit tests in sentrix-evm/src/writeback.rs
+// cover the writeback logic exhaustively, and testnet bake with real Solidity
+// contracts deployed via `cast`/hardhat provides the end-to-end validation
+// the full integration suite would otherwise provide here.
+//
+// To complete these tests post-merge:
+//   - Vendor compiled ERC-20 mock bytecode (openzeppelin minimal or forge
+//     artifact) into tests/fixtures/erc20_mock.bin.
+//   - Build calldata for transfer(address,uint256) via the 4-byte selector
+//     0xa9059cbb + padded args.
+//   - Parallel contracts A+B for contract-to-contract.
+//   - SelfDestructible contract with `destroy(address)` function.
+
+#[ignore = "requires vendored ERC-20 bytecode; see file-level comment"]
+#[test]
+fn test_2_erc20_mock_transfer_persists() {
+    // TODO: deploy ERC-20 mock with 1M supply to deployer.
+    //       call transfer(bob, 100).
+    //       assert balanceOf(bob) == 100, balanceOf(deployer) == 999_900.
+}
+
+#[ignore = "requires parallel contract bytecode; see file-level comment"]
+#[test]
+fn test_4_contract_to_contract_call_persists() {
+    // TODO: deploy A (calls B.setValue) and B (SimpleStorage).
+    //       call A.doIt().
+    //       assert B's slot 0 == 42, assert A marked touched too.
+}
+
+#[ignore = "requires SelfDestructible bytecode; see file-level comment"]
+#[test]
+fn test_6_selfdestruct_zeros_account() {
+    // TODO: deploy SelfDestructible with 1000 sentri initial funding.
+    //       call destroy(bob).
+    //       assert contract balance == 0, code_hash == EMPTY_CODE_HASH,
+    //       beneficiary bob got the funds.
+}


### PR DESCRIPTION
## Summary

Closes Bug #1 (SSTORE writes silently discarded) + Bug #2 (target contract bytecode + storage not loaded). Before this PR, smart contracts on Sentrix EVM effectively didn't work for any non-trivial use case — state changes evaporated at the executor boundary.

Full analysis + plan + report:
- `founder-private/audits/evm-fix-analysis-2026-04-22.md` (read-only audit)
- `founder-private/audits/evm-fix-plan-2026-04-22.md` (implementation plan, approved with 4 requirements)
- `founder-private/audits/evm-fix-report-2026-04-22.md` (verification report)

## Root cause (one line)

`crates/sentrix-evm/src/executor.rs:102` extracted `result_and_state.result` and dropped `.state` on the floor. The `EvmState` HashMap carrying all account/storage mutations was never read. `block_executor.rs:842` compounded it by seeding a fresh `InMemoryDB::default()` per tx with only the sender — target contracts were invisible.

## Fix

Two-line plumbing + supporting scaffolding (938 lines added, 28 removed):

1. `executor.rs` — new `execute_tx_with_state` returns `(TxReceipt, EvmState)`. Existing `execute_tx` preserved as back-compat delegate that discards `.state`. Non-breaking.
2. `block_executor.rs` — replaces `InMemoryDB::default()` with `SentrixEvmDb::from_account_db(&self.accounts)`, pre-loads target contract bytecode + storage (sorted for determinism), switches to `execute_tx_with_state`, commits state diff to AccountDB on success.
3. `writeback.rs` (new, 360 LOC) — pure `commit_state_to_account_db(state, &mut account_db)` handles revm → AccountDB mapping: balance (wei→sentri round down), nonce (direct), storage (U256 → 64-char hex key + 32-byte BE value), new contract code (CREATE path), SELFDESTRUCT (balance zero + code clear + warn log).
4. `account.rs` — `set_balance` + `set_nonce` setters, no revm dep.

## Verification

| Check | Result |
|---|---|
| `cargo build --workspace` | clean, zero warnings |
| `cargo clippy --workspace --tests -- -D warnings` | zero lints |
| `cargo test -p sentrix-primitives --lib` | 43 passed (+2) |
| `cargo test -p sentrix-evm --lib` | 38 passed (+9) |
| `cargo test -p sentrix-core --lib` | 176 passed (no regressions) |
| `cargo test --test integration_evm_state_persistence` | 3 passed, 3 `#[ignore]` scaffolded |

Headline integration test `test_1_simple_storage_persists_after_set` deploys SimpleStorage via hand-assembled bytecode, calls `set(42)`, asserts `AccountDB.contract_storage` slot 0 == 42. **Without the fix this returns None; with the fix it returns `[0,...,0,42]`.** Bug closed.

## Out of scope

- revm v37 → latest — separate PR
- Per-slot Merkle proofs in sentrix-trie — deferred (tech debt for `eth_getProof`)
- Full SELFDESTRUCT (storage purge) — partial support documented in `founder-private/security/SECURITY_NOTES.md`
- EIP-1559 dynamic base fee — BACKLOG #9

## Test plan

- [x] CI green
- [ ] Testnet deploy via `fast-deploy.sh testnet`
- [ ] 48h testnet bake with zero CRITICAL / state_root mismatch / missing node / backfill / Refusing-to-start in journalctl
- [ ] End-to-end dapp signal: deploy ERC-20 via `cast`, transfer, query balanceOf in next block → assert persist + survives validator restart (TABLE_STATE round-trip)
- [ ] **Mainnet deploy: EXPLICITLY NOT in this PR chain. Mainnet has EVM disabled; this fix becomes material only when `VOYAGER_EVM_HEIGHT` is set for mainnet activation, which is its own hard-fork event.**