### PR TITLE
refactor(rpc): split sentrix-rpc-types crate (Tier 1 #1)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -77,6 +77,7 @@ ADDR_ALLOW_PATHS=(
   "^crates/sentrix-primitives/src/"    # primitives: TOKEN_OP_ADDRESS/STAKING_ADDRESS constants + test addrs
   "^crates/sentrix-trie/src/"          # trie crate: test address_to_key patterns
   "^crates/sentrix-rpc/src/"           # RPC crate: route tests with addresses
+  "^crates/sentrix-rpc-types/src/"     # RPC type-conversion helpers: tests use v1 founder addr as fixed vector
   "^crates/sentrix-evm/src/"           # EVM crate: sentri→wei conversion tests use fixed addrs
   "^genesis/"                          # externalised genesis TOML (validators + premine allocations)
   "^tests/"                            # integration tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,6 +4909,7 @@ dependencies = [
  "sentrix-core",
  "sentrix-evm",
  "sentrix-primitives",
+ "sentrix-rpc-types",
  "sentrix-storage",
  "sentrix-trie",
  "serde",
@@ -4919,6 +4920,13 @@ dependencies = [
  "tower 0.4.13",
  "tower-http",
  "tracing",
+]
+
+[[package]]
+name = "sentrix-rpc-types"
+version = "2.1.6"
+dependencies = [
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-rpc", "crates/sentrix-storage", "bin/sentrix"]
+members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "bin/sentrix"]
 
 [package]
 name = "sentrix"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sentrix-rpc-types"
+version = "2.1.6"
+edition = "2024"
+license = "BUSL-1.1"
+description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"
+repository = "https://github.com/sentrix-labs/sentrix"
+
+[dependencies]
+serde_json = "1.0"

--- a/crates/sentrix-rpc-types/src/lib.rs
+++ b/crates/sentrix-rpc-types/src/lib.rs
@@ -1,0 +1,169 @@
+//! sentrix-rpc-types — ETH ↔ Sentrix JSON-RPC type conversions + hex /
+//! address validation helpers.
+//!
+//! Extracted from `crates/sentrix-rpc/src/jsonrpc/helpers.rs` during the
+//! 45-crate split (see `founder-private/architecture/CRATE_SPLIT_PLAN.md`).
+//! Lives outside `sentrix-rpc` so a future `sentrix-sdk` (JSON-RPC client)
+//! can depend on the type conversions without pulling the axum/tokio
+//! server stack.
+//!
+//! All helpers here are PURE — they operate on strings and primitive
+//! numeric types, not on `Blockchain` or any node-state reference. Any
+//! helper that needs node state (e.g. `resolve_block_tag`, `log_matches`,
+//! `load_logs_for_tx`) stays in the consuming crate.
+
+#![allow(missing_docs)]
+
+use serde_json::Value;
+
+/// Format a `u64` as an Ethereum JSON-RPC hex string: `"0x<lower-hex>"`.
+///
+/// Matches `web3.toHex` / `ethers.js utils.hexValue` behaviour. No leading
+/// zeros beyond a single `0` for zero: `0x0`, not `0x00`.
+pub fn to_hex(n: u64) -> String {
+    format!("0x{:x}", n)
+}
+
+/// Format a `u128` as an Ethereum JSON-RPC hex string. Same format as
+/// [`to_hex`] but for wider integers (wei balances, gas prices).
+pub fn to_hex_u128(n: u128) -> String {
+    format!("0x{:x}", n)
+}
+
+/// M-11: validate a JSON-RPC address parameter before it is used as a
+/// trie/DB lookup key. Accepts exactly `0x` + 40 hex lowercase and
+/// returns the normalised string, or `Err` with an error message suitable
+/// for JSON-RPC -32602 (Invalid params). Prevents oddly-shaped strings
+/// (empty, too-long, non-hex) from reaching the account store where
+/// they are merely a silent miss, wasting compute per malformed request
+/// under adversarial load.
+pub fn normalize_rpc_address(s: &str) -> Result<String, &'static str> {
+    if s.len() != 42 {
+        return Err("address must be 42 chars (0x + 40 hex)");
+    }
+    let lower = s.to_lowercase();
+    if !lower.starts_with("0x") {
+        return Err("address must start with 0x");
+    }
+    if !lower[2..].chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("address must be lowercase hex after 0x");
+    }
+    Ok(lower)
+}
+
+/// M-11: validate a JSON-RPC 32-byte hash parameter (tx hash, block
+/// hash). Same rationale as [`normalize_rpc_address`] — keeps malformed
+/// hex out of DB lookups.
+pub fn normalize_rpc_hash(s: &str) -> Result<String, &'static str> {
+    let stripped = s.strip_prefix("0x").unwrap_or(s);
+    if stripped.len() != 64 {
+        return Err("hash must be 32 bytes (64 hex chars)");
+    }
+    if !stripped.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("hash must be hex");
+    }
+    Ok(stripped.to_lowercase())
+}
+
+/// Accept either a `String` (hex-encoded) or a JSON `Number` and return
+/// it as `u64`. Used for the many JSON-RPC parameters that accept both
+/// `"0x..."` hex strings AND plain numbers (`block tag`, gas limits).
+pub fn parse_hex_u64(v: &Value) -> Option<u64> {
+    match v {
+        Value::String(s) => {
+            let s = s.trim_start_matches("0x");
+            u64::from_str_radix(s, 16).ok()
+        }
+        Value::Number(n) => n.as_u64(),
+        _ => None,
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_to_hex_zero() {
+        assert_eq!(to_hex(0), "0x0");
+    }
+
+    #[test]
+    fn test_to_hex_nonzero() {
+        assert_eq!(to_hex(255), "0xff");
+        assert_eq!(to_hex(42), "0x2a");
+    }
+
+    #[test]
+    fn test_to_hex_u128() {
+        assert_eq!(
+            to_hex_u128(u128::from(u64::MAX) + 1),
+            "0x10000000000000000"
+        );
+    }
+
+    #[test]
+    fn test_normalize_address_valid() {
+        let s = "0x4f3319a747fd564136209cd5d9e7d1a1e4d142be";
+        assert_eq!(normalize_rpc_address(s).unwrap(), s);
+    }
+
+    #[test]
+    fn test_normalize_address_uppercase_lowered() {
+        let got = normalize_rpc_address("0x4F3319A747FD564136209CD5D9E7D1A1E4D142BE").unwrap();
+        assert_eq!(got, "0x4f3319a747fd564136209cd5d9e7d1a1e4d142be");
+    }
+
+    #[test]
+    fn test_normalize_address_too_short() {
+        assert!(normalize_rpc_address("0x123").is_err());
+    }
+
+    #[test]
+    fn test_normalize_address_no_prefix() {
+        assert!(normalize_rpc_address("4f3319a747fd564136209cd5d9e7d1a1e4d142be").is_err());
+    }
+
+    #[test]
+    fn test_normalize_address_bad_hex() {
+        assert!(normalize_rpc_address("0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ").is_err());
+    }
+
+    #[test]
+    fn test_normalize_hash_valid() {
+        let s = "0x".to_string() + &"a".repeat(64);
+        assert_eq!(normalize_rpc_hash(&s).unwrap(), "a".repeat(64));
+    }
+
+    #[test]
+    fn test_normalize_hash_no_prefix() {
+        // Stripping 0x is optional on input; output is always lowercase hex without prefix
+        let s = "A".repeat(64);
+        assert_eq!(normalize_rpc_hash(&s).unwrap(), "a".repeat(64));
+    }
+
+    #[test]
+    fn test_normalize_hash_wrong_length() {
+        assert!(normalize_rpc_hash("0xabcd").is_err());
+    }
+
+    #[test]
+    fn test_parse_hex_u64_string() {
+        assert_eq!(parse_hex_u64(&json!("0x2a")), Some(42));
+        assert_eq!(parse_hex_u64(&json!("2a")), Some(42)); // prefix optional
+    }
+
+    #[test]
+    fn test_parse_hex_u64_number() {
+        assert_eq!(parse_hex_u64(&json!(42)), Some(42));
+    }
+
+    #[test]
+    fn test_parse_hex_u64_invalid() {
+        assert!(parse_hex_u64(&json!("0xZZ")).is_none());
+        assert!(parse_hex_u64(&json!(null)).is_none());
+    }
+}

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 sentrix-primitives = { path = "../sentrix-primitives" }
 sentrix-core = { path = "../sentrix-core" }
 sentrix-evm = { path = "../sentrix-evm" }
+sentrix-rpc-types = { path = "../sentrix-rpc-types" }
 sentrix-trie = { path = "../sentrix-trie" }
 sentrix-storage = { path = "../sentrix-storage" }
 bincode = "1.3"

--- a/crates/sentrix-rpc/src/jsonrpc/helpers.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/helpers.rs
@@ -2,62 +2,19 @@
 // (eth / net / web3 / sentrix). Pulled out of the monolithic
 // `jsonrpc.rs` during the backlog #11 refactor so each namespace file
 // can stay focused on its handlers.
+//
+// Pure hex / address / number conversion helpers moved to the new
+// `sentrix-rpc-types` crate (2026-04-22 split per CRATE_SPLIT_PLAN.md
+// Tier 1). Re-exported here as pub(super) shims so the existing
+// callers in eth.rs / sentrix.rs / net.rs / web3.rs don't need their
+// import paths changed in this PR. A follow-up PR will migrate call
+// sites to `use sentrix_rpc_types::*` directly and delete the shims.
 
 use serde_json::Value;
 
-pub(super) fn to_hex(n: u64) -> String {
-    format!("0x{:x}", n)
-}
-
-pub(super) fn to_hex_u128(n: u128) -> String {
-    format!("0x{:x}", n)
-}
-
-/// M-11: validate a JSON-RPC address parameter before it is used as a
-/// trie/DB lookup key. Accepts exactly `0x` + 40 hex lowercase and
-/// returns the normalised string, or `Err` with an error message suitable
-/// for JSON-RPC -32602 (Invalid params). Prevents oddly-shaped strings
-/// (empty, too-long, non-hex) from reaching the account store where
-/// they are merely a silent miss, wasting compute per malformed request
-/// under adversarial load.
-pub(super) fn normalize_rpc_address(s: &str) -> Result<String, &'static str> {
-    if s.len() != 42 {
-        return Err("address must be 42 chars (0x + 40 hex)");
-    }
-    let lower = s.to_lowercase();
-    if !lower.starts_with("0x") {
-        return Err("address must start with 0x");
-    }
-    if !lower[2..].chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err("address must be lowercase hex after 0x");
-    }
-    Ok(lower)
-}
-
-/// M-11: validate a JSON-RPC 32-byte hash parameter (tx hash, block
-/// hash). Same rationale as `normalize_rpc_address` — keeps malformed
-/// hex out of DB lookups.
-pub(super) fn normalize_rpc_hash(s: &str) -> Result<String, &'static str> {
-    let stripped = s.strip_prefix("0x").unwrap_or(s);
-    if stripped.len() != 64 {
-        return Err("hash must be 32 bytes (64 hex chars)");
-    }
-    if !stripped.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err("hash must be hex");
-    }
-    Ok(stripped.to_lowercase())
-}
-
-pub(super) fn parse_hex_u64(v: &Value) -> Option<u64> {
-    match v {
-        Value::String(s) => {
-            let s = s.trim_start_matches("0x");
-            u64::from_str_radix(s, 16).ok()
-        }
-        Value::Number(n) => n.as_u64(),
-        _ => None,
-    }
-}
+pub(super) use sentrix_rpc_types::{
+    normalize_rpc_address, normalize_rpc_hash, parse_hex_u64, to_hex, to_hex_u128,
+};
 
 pub(super) fn resolve_block_tag(v: Option<&Value>, latest: u64) -> Result<u64, &'static str> {
     match v {


### PR DESCRIPTION
First of 35 crate splits per \`founder-private/architecture/CRATE_SPLIT_PLAN.md\`. Tier 1 = pure utility, no consensus touch.

## Changes

New crate \`crates/sentrix-rpc-types/\` with 5 pure helpers moved from \`jsonrpc/helpers.rs\`:
- \`to_hex(u64)\`, \`to_hex_u128(u128)\`
- \`normalize_rpc_address\`, \`normalize_rpc_hash\`
- \`parse_hex_u64\`

All pure string/int conversions. No Blockchain refs, no revm types, no consensus path.

## Back-compat

\`helpers.rs\` keeps \`pub(super) use sentrix_rpc_types::*\` so 4 call sites in the \`sentrix-rpc\` crate (eth.rs, sentrix.rs, net.rs, web3.rs) don't need touching. Future PR migrates call sites + removes shim.

## Non-moved

These stay in sentrix-rpc because they reference Blockchain or revm types (not pure):
\`resolve_block_tag\`, \`parse_address_filter\`, \`parse_topic_filter\`, \`log_matches\`, \`collect_logs\`, \`load_logs_for_tx\`, \`block_gas_used_ratio\`

## Tests

14 new unit tests in \`sentrix-rpc-types\` covering every exported function. 22 existing \`sentrix-rpc\` tests pass unchanged.

## Follow-on

Template for Tier 1 items #2-5: \`sentrix-codec\`, \`sentrix-metrics\`, \`sentrix-tracing\`, \`sentrix-wire\`.