### PR TITLE
refactor(evm): split sentrix-precompiles crate (Tier 2 #9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4846,6 +4846,7 @@ dependencies = [
  "alloy-primitives",
  "hex",
  "revm",
+ "sentrix-precompiles",
  "sentrix-primitives",
  "serde",
  "serde_json",
@@ -4886,6 +4887,13 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.23",
  "zeroize",
+]
+
+[[package]]
+name = "sentrix-precompiles"
+version = "2.1.6"
+dependencies = [
+ "alloy-primitives",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "bin/sentrix"]
+members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "bin/sentrix"]
 
 [package]
 name = "sentrix"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/sentrix-labs/sentrix"
 
 [dependencies]
 sentrix-primitives = { path = "../sentrix-primitives" }
+sentrix-precompiles = { path = "../sentrix-precompiles" }
 revm = { version = "37", default-features = false, features = ["std", "serde", "optional_balance_check", "optional_no_base_fee"] }
 alloy-primitives = "1.5"
 hex = "0.4"

--- a/crates/sentrix-evm/src/precompiles.rs
+++ b/crates/sentrix-evm/src/precompiles.rs
@@ -1,60 +1,9 @@
-// evm/precompiles.rs — Precompiled contracts for Sentrix EVM
+// evm/precompiles.rs — back-compat re-export shim.
 //
-// Standard Ethereum precompiles (0x01-0x09) are provided by revm's EthPrecompiles.
-// Sentrix-specific precompiles (0x100 staking, 0x101 slashing) will be added
-// when DPoS staking is integrated with EVM execution.
-//
-// Standard precompiles included automatically:
-//   0x01 ecRecover     — ECDSA public key recovery
-//   0x02 SHA256        — SHA-256 hash
-//   0x03 RIPEMD160     — RIPEMD-160 hash
-//   0x04 identity      — Data copy (returns input as output)
-//   0x05 modexp        — Modular exponentiation
-//   0x06 ecAdd         — BN256 elliptic curve addition
-//   0x07 ecMul         — BN256 elliptic curve scalar multiplication
-//   0x08 ecPairing     — BN256 elliptic curve pairing check
-//   0x09 blake2f       — BLAKE2 compression function F
+// Precompile address constants + `is_sentrix_precompile` moved to the
+// dedicated `sentrix-precompiles` crate (2026-04-22 per CRATE_SPLIT_PLAN.md
+// Tier 2 #9). This shim keeps existing `sentrix_evm::precompiles::*`
+// import paths working. Follow-up PR will migrate call sites to
+// `use sentrix_precompiles::*` directly and delete this file.
 
-use alloy_primitives::Address;
-
-/// Sentrix staking precompile address (0x0100).
-/// Allows smart contracts to interact with the DPoS staking system.
-pub const STAKING_PRECOMPILE: Address = Address::new([
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0x00,
-]);
-
-/// Sentrix slashing evidence precompile address (0x0101).
-/// Allows submitting double-sign evidence from smart contracts.
-pub const SLASHING_PRECOMPILE: Address = Address::new([
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0x01,
-]);
-
-/// Check if an address is a Sentrix-specific precompile.
-pub fn is_sentrix_precompile(address: &Address) -> bool {
-    *address == STAKING_PRECOMPILE || *address == SLASHING_PRECOMPILE
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_precompile_addresses() {
-        assert_eq!(
-            STAKING_PRECOMPILE,
-            Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0])
-        );
-        assert_eq!(
-            SLASHING_PRECOMPILE,
-            Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1])
-        );
-    }
-
-    #[test]
-    fn test_is_sentrix_precompile() {
-        assert!(is_sentrix_precompile(&STAKING_PRECOMPILE));
-        assert!(is_sentrix_precompile(&SLASHING_PRECOMPILE));
-        assert!(!is_sentrix_precompile(&Address::ZERO));
-        assert!(!is_sentrix_precompile(&Address::from([0x01u8; 20])));
-    }
-}
+pub use sentrix_precompiles::{SLASHING_PRECOMPILE, STAKING_PRECOMPILE, is_sentrix_precompile};

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sentrix-precompiles"
+version = "2.1.6"
+edition = "2024"
+license = "BUSL-1.1"
+description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"
+repository = "https://github.com/sentrix-labs/sentrix"
+
+[dependencies]
+alloy-primitives = "1.5"

--- a/crates/sentrix-precompiles/src/lib.rs
+++ b/crates/sentrix-precompiles/src/lib.rs
@@ -1,0 +1,74 @@
+//! sentrix-precompiles — Sentrix-specific EVM precompile addresses.
+//!
+//! Standard Ethereum precompiles (0x01-0x09) are provided by revm's
+//! EthPrecompiles at the EVM execution layer. This crate defines the
+//! Sentrix-reserved precompile addresses that chain-specific features
+//! (DPoS staking, slashing evidence, ...) will be wired to when EVM
+//! execution integrates with those subsystems.
+//!
+//! Extracted from `crates/sentrix-evm/src/precompiles.rs` during the
+//! 45-crate split (Tier 2 per CRATE_SPLIT_PLAN.md). Isolated so a
+//! future `sentrix-sdk` or governance tooling can reference the canonical
+//! precompile addresses without pulling the whole `sentrix-evm` stack.
+//!
+//! **Consensus note:** the numeric addresses defined here are part of
+//! Sentrix's contract surface post-Voyager-EVM activation. Smart
+//! contracts that encode these addresses as constants rely on them being
+//! stable. NEVER change an address — introduce a new one.
+//!
+//! Standard precompiles included automatically by revm:
+//!   0x01 ecRecover     — ECDSA public key recovery
+//!   0x02 SHA256        — SHA-256 hash
+//!   0x03 RIPEMD160     — RIPEMD-160 hash
+//!   0x04 identity      — Data copy (returns input as output)
+//!   0x05 modexp        — Modular exponentiation
+//!   0x06 ecAdd         — BN256 elliptic curve addition
+//!   0x07 ecMul         — BN256 elliptic curve scalar multiplication
+//!   0x08 ecPairing     — BN256 elliptic curve pairing check
+//!   0x09 blake2f       — BLAKE2 compression function F
+
+#![allow(missing_docs)]
+
+use alloy_primitives::Address;
+
+/// Sentrix staking precompile address (0x0100).
+/// Allows smart contracts to interact with the DPoS staking system.
+pub const STAKING_PRECOMPILE: Address = Address::new([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0x00,
+]);
+
+/// Sentrix slashing evidence precompile address (0x0101).
+/// Allows submitting double-sign evidence from smart contracts.
+pub const SLASHING_PRECOMPILE: Address = Address::new([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0x01,
+]);
+
+/// Check if an address is a Sentrix-specific precompile.
+pub fn is_sentrix_precompile(address: &Address) -> bool {
+    *address == STAKING_PRECOMPILE || *address == SLASHING_PRECOMPILE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_precompile_addresses() {
+        assert_eq!(
+            STAKING_PRECOMPILE,
+            Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0])
+        );
+        assert_eq!(
+            SLASHING_PRECOMPILE,
+            Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1])
+        );
+    }
+
+    #[test]
+    fn test_is_sentrix_precompile() {
+        assert!(is_sentrix_precompile(&STAKING_PRECOMPILE));
+        assert!(is_sentrix_precompile(&SLASHING_PRECOMPILE));
+        assert!(!is_sentrix_precompile(&Address::ZERO));
+        assert!(!is_sentrix_precompile(&Address::from([0x01u8; 20])));
+    }
+}


### PR DESCRIPTION
Third crate split overnight per CRATE_SPLIT_PLAN.md. Tier 2 pure-data extraction, zero consensus impact.

## Changes

New crate \`crates/sentrix-precompiles/\` with Sentrix-reserved EVM precompile addresses:
- \`STAKING_PRECOMPILE\` (0x0100)
- \`SLASHING_PRECOMPILE\` (0x0101)
- \`is_sentrix_precompile(addr)\`

## Rationale

Future \`sentrix-sdk\` + governance tooling can reference these canonical addresses without pulling the full \`sentrix-evm\` stack (revm 37 + 10+ alloy transitive crates).

## Consensus

The address VALUES are part of Sentrix's post-Voyager-EVM contract surface — smart contracts encode these constants. Pure \`git mv\` preserves bytes exactly, zero consensus impact.

## Back-compat

\`crates/sentrix-evm/src/precompiles.rs\` now re-exports the three items from the new crate so existing \`sentrix_evm::precompiles::*\` imports keep working. Follow-up PR migrates direct call sites + deletes shim.

## Tests

2 existing unit tests pass unchanged. Workspace build + clippy clean.