### PR TITLE
rpc+staking: tighten param validation + delegation-sum invariant test

### DIFF
--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -29,7 +29,14 @@ pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) 
         }
         "eth_gasPrice" => Ok(json!(to_hex(1_000_000_000))),
         "eth_estimateGas" => {
-            let call_obj = &params[0];
+            // params[0] must be a call object. Before this check, passing a
+            // non-object (null, string, number) silently defaulted to 21_000
+            // via `Value::Null["data"].as_str() -> None`. That was safe but
+            // ambiguous; caller couldn't tell a malformed param from an empty
+            // calldata. Reject non-object params so the client sees the mistake.
+            let Some(call_obj) = params.get(0).filter(|v| v.is_object()) else {
+                return Err((-32602, "expected call object as first param".into()));
+            };
             let data_hex = call_obj["data"].as_str().unwrap_or("0x");
             if data_hex.len() > 2 {
                 Ok(json!(to_hex(100_000)))
@@ -520,7 +527,10 @@ async fn eth_fee_history(params: &Value, state: &SharedState) -> DispatchResult 
 }
 
 async fn eth_get_code(params: &Value, state: &SharedState) -> DispatchResult {
-    let address = params[0].as_str().unwrap_or("").to_lowercase();
+    let address = match normalize_rpc_address(params[0].as_str().unwrap_or("")) {
+        Ok(a) => a,
+        Err(e) => return Err((-32602, e.into())),
+    };
     let bc = state.read().await;
     if let Some(account) = bc.accounts.accounts.get(&address) {
         if account.is_contract() {
@@ -539,9 +549,19 @@ async fn eth_get_code(params: &Value, state: &SharedState) -> DispatchResult {
 }
 
 async fn eth_get_storage_at(params: &Value, state: &SharedState) -> DispatchResult {
-    let address = params[0].as_str().unwrap_or("").to_lowercase();
+    let address = match normalize_rpc_address(params[0].as_str().unwrap_or("")) {
+        Ok(a) => a,
+        Err(e) => return Err((-32602, e.into())),
+    };
     let slot = params[1].as_str().unwrap_or("0x0");
+    // Storage slot must be valid hex (≤ 64 chars = 32 bytes). Rejecting
+    // junk here keeps the downstream storage lookup from querying with
+    // a malformed key that quietly returns zero.
     let slot_hex = slot.trim_start_matches("0x");
+    if slot_hex.is_empty() || slot_hex.len() > 64 || !slot_hex.chars().all(|c| c.is_ascii_hexdigit())
+    {
+        return Err((-32602, "invalid storage slot (must be hex, ≤ 32 bytes)".into()));
+    }
     let bc = state.read().await;
     if let Some(value) = bc.accounts.get_contract_storage(&address, slot_hex) {
         Ok(json!(format!("0x{}", hex::encode(value))))

--- a/crates/sentrix-staking/src/staking.rs
+++ b/crates/sentrix-staking/src/staking.rs
@@ -1304,4 +1304,89 @@ mod tests {
         let pending = reg.get_pending_unbonding("0xdel1");
         assert_eq!(pending.len(), 2);
     }
+
+    /// Invariant: for every validator V, the sum of live delegation-entry
+    /// amounts to V across all delegators equals `validators[V].total_delegated`.
+    ///
+    /// `delegate` / `undelegate` / `redelegate` / `slash` each maintain this by
+    /// construction (checked_add on both sides in delegate, saturating_sub on
+    /// both sides in undelegate, atomic pair in redelegate, proportional in
+    /// slash). This test hammers a random mix of those ops and asserts the
+    /// invariant after every step, so a future refactor that breaks the
+    /// coupling is caught at test time instead of at a mainnet fork.
+    fn assert_delegation_sum_invariant(reg: &StakeRegistry) {
+        use std::collections::HashMap;
+        let mut sum_per_val: HashMap<&str, u128> = HashMap::new();
+        for entries in reg.delegations.values() {
+            for e in entries {
+                *sum_per_val.entry(e.validator.as_str()).or_insert(0) += e.amount as u128;
+            }
+        }
+        for (addr, val) in &reg.validators {
+            let expected = val.total_delegated as u128;
+            let actual = sum_per_val.get(addr.as_str()).copied().unwrap_or(0);
+            assert_eq!(
+                expected, actual,
+                "delegation sum invariant broken for validator {addr}: \
+                 total_delegated = {expected}, actual Σ entries = {actual}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_delegation_sum_invariant_under_random_ops() {
+        // Seed is fixed so the test is reproducible. If this fails in CI the
+        // seed + op-trace can be replayed locally.
+        //
+        // Using a tiny self-rolled LCG instead of pulling in `rand` as a
+        // dev-dep. Quality of randomness doesn't matter here — we just need
+        // cheap reproducible "whichever op next".
+        struct Lcg(u64);
+        impl Lcg {
+            fn next(&mut self) -> u64 {
+                self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                self.0 >> 33
+            }
+            fn pick<'a, T>(&mut self, xs: &'a [T]) -> &'a T {
+                &xs[self.next() as usize % xs.len()]
+            }
+        }
+
+        let mut rng = Lcg(0xdeadbeef_cafef00d);
+        let mut reg = new_registry();
+
+        // Seed 4 validators + 6 candidate delegators
+        let vals = ["0xv1", "0xv2", "0xv3", "0xv4"];
+        let dels = ["0xd1", "0xd2", "0xd3", "0xd4", "0xd5", "0xd6"];
+        for v in &vals {
+            register_val(&mut reg, v, MIN_SELF_STAKE);
+        }
+        assert_delegation_sum_invariant(&reg);
+
+        for height in 100u64..600u64 {
+            let op = rng.next() % 4;
+            let del = *rng.pick(&dels);
+            let val = *rng.pick(&vals);
+            // Bounded amounts so we don't overflow u64::MAX in sums but big
+            // enough to hit the non-trivial bookkeeping paths.
+            let amount: u64 = (rng.next() % 10_000 + 1) * 1_000;
+
+            let _ = match op {
+                0 => reg.delegate(del, val, amount, height),
+                1 => reg.undelegate(del, val, amount, height),
+                2 => {
+                    let val_to = *rng.pick(&vals);
+                    reg.redelegate(del, val, val_to, amount, height)
+                }
+                _ => {
+                    let bp: u16 = (rng.next() % 1001) as u16; // 0..=1000 bp
+                    reg.slash(val, bp).map(|_| ())
+                }
+            };
+
+            // Invariant must hold whether the op succeeded (state changed
+            // consistently) or failed (state unchanged).
+            assert_delegation_sum_invariant(&reg);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Two independent non-consensus improvements flagged in the 2026-04-22 TODO audit, bundled as a single PR since both are small, test-backed, and non-consensus.

### sentrix-rpc: RPC input validation hardening

Three holes in \`crates/sentrix-rpc/src/jsonrpc/eth.rs\`:

- **\`eth_estimateGas\`** (line 31-39): params[0] must be a call object. Before this PR, passing \`null\` / a string / a number silently defaulted to 21_000 via \`Value::Null[\"data\"].as_str() -> None\`. Behaviour was safe but ambiguous; callers couldn't tell 'malformed param' from 'empty calldata'. Now returns \`-32602\` with a descriptive message.
- **\`eth_getCode\`** (line 522): was \`params[0].as_str().unwrap_or(\"\").to_lowercase()\` — accepted any string. Now calls \`normalize_rpc_address\` so malformed addresses are rejected at ingress instead of returning \`0x\` that looks like 'no such contract'.
- **\`eth_getStorageAt\`** (line 541): same address normalization + new validation that the slot is valid hex and ≤ 32 bytes.

All three are info endpoints with no state mutation, so severity is low — but the new error paths surface malformed calls instead of returning lookalikes.

### sentrix-staking: delegation-sum invariant proptest

Adds \`test_delegation_sum_invariant_under_random_ops\` in \`crates/sentrix-staking/src/staking.rs\`. The invariant \`Σ per-delegator entries to V == validators[V].total_delegated\` is maintained by construction in \`delegate\` / \`undelegate\` / \`redelegate\` / \`slash\` (checked_add both sides / saturating_sub both sides / atomic pair / proportional), but wasn't asserted anywhere.

Now asserted after every op in a 500-step random walk across 4 validators × 6 delegators. Fixed-seed LCG (no new dev-dep) keeps the test reproducible. Any future refactor that breaks the coupling — e.g. adding an async checkpoint between the two sides of delegate — is caught at test time instead of at a mainnet fork.

## Test plan

- [x] \`cargo test -p sentrix-staking --lib\` — 74 pass (was 73 + 1 new proptest)
- [x] \`cargo test -p sentrix-rpc --lib\` — 22 pass (unchanged; RPC changes are defensive, behaviour on valid inputs unchanged)
- [x] \`cargo clippy -p sentrix-rpc -p sentrix-staking --all-targets -- -D warnings\` — clean

No consensus path touched. No mainnet deploy required; RPC-only changes would be picked up on next rolling restart whenever convenient.