### PR TITLE
cli: guard state-import + reset-trie against non-genesis chain (fork follow-up #2)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -2416,6 +2416,51 @@ fn cmd_chain_reset_trie() -> anyhow::Result<()> {
     if !storage.has_blockchain() {
         anyhow::bail!("Chain not initialized.");
     }
+
+    // 2026-04-21 mainnet 3-way fork root cause: pre-v2.1.5 `state_import` on
+    // production validators reset the trie to empty and re-populated it from
+    // the imported account set. The backfilled trie produced a state_root
+    // that disagreed with peers whose trie was built incrementally from
+    // genesis — silent fork. v2.1.5 added a boot-time backfill-vs-header
+    // guard, and PR #206 added a full trie-reachability check, but the
+    // cleanest protection is to refuse reset-trie on a production chain
+    // in the first place. The rsync-from-peer recovery preserves the
+    // incremental trie shape and is the canonical path for mainnet.
+    let height = storage
+        .load_height()
+        .map_err(|e| anyhow::anyhow!("reading chain height: {e}"))?;
+    if height > 0 {
+        // The env-var escape hatch is checked INSIDE this branch — a prior
+        // draft of this guard checked it *after* `bail!` which meant the
+        // override was dead code. Keep the check here and nowhere else.
+        let override_set = std::env::var("SENTRIX_ALLOW_RESET_TRIE_ON_NONZERO_HEIGHT")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        if !override_set {
+            anyhow::bail!(
+                "Refusing reset-trie on a chain at height {height} > 0.\n\
+                 This command wipes trie_nodes/trie_values/trie_roots and rebuilds \
+                 from AccountDB on next boot. On a chain past genesis the rebuilt \
+                 trie CAN differ from peers' incrementally-built tries (see the \
+                 2026-04-21 3-way fork incident for what that looks like in prod).\n\
+                 \n\
+                 Correct recoveries for a damaged trie on a non-genesis chain:\n\
+                 1. Stop this node.\n\
+                 2. rsync /opt/sentrix/data/chain.db from a healthy peer (all validators stopped).\n\
+                 3. Restart. The boot-time integrity check will confirm the copy is intact.\n\
+                 \n\
+                 If you REALLY need reset-trie on a non-genesis chain (devnet / \
+                 isolated testing only), set `SENTRIX_ALLOW_RESET_TRIE_ON_NONZERO_HEIGHT=1` \
+                 in your environment. This flag does not exist on release builds \
+                 that operators should be using."
+            );
+        }
+        tracing::warn!(
+            "reset-trie proceeding on non-zero height (h={height}) via env override — \
+             you are on your own; fork is very likely on a shared chain"
+        );
+    }
+
     storage.reset_trie()?;
     println!(
         "Trie state cleared. Start the node normally — it will rebuild the trie from AccountDB."
@@ -2460,6 +2505,51 @@ fn cmd_state_import(input: &str, force: bool) -> anyhow::Result<()> {
     Blockchain::verify_snapshot(&snapshot)?;
 
     let storage = Storage::open(&get_db_path())?;
+
+    // 2026-04-21 mainnet 3-way fork root cause: pre-v2.1.5 `state_import` on
+    // production validators re-populated the account set without rebuilding
+    // the trie identically to peers'. The v2.1.5 trie-reset-on-import fix
+    // + v2.1.6 strict state_root enforcement + PR #206 boot-time integrity
+    // check now catch the damage, but the safest contract is: never allow
+    // state_import on a non-genesis chain at all. On mainnet / an existing
+    // network, the right recovery is rsync-from-peer (preserves incremental
+    // trie shape, matches peers bit-for-bit). state_import is only correct
+    // for fresh genesis bootstrapping or isolated devnet testing.
+    let current_height = storage
+        .load_height()
+        .map_err(|e| anyhow::anyhow!("reading chain height: {e}"))?;
+    if current_height > 0 {
+        // Env override check lives INSIDE this branch. A prior draft ordered
+        // `bail!` first and the override after, making the override dead code.
+        let override_set = std::env::var("SENTRIX_ALLOW_STATE_IMPORT_ON_NONZERO_HEIGHT")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        if !override_set {
+            anyhow::bail!(
+                "Refusing state import on a chain at height {current_height} > 0.\n\
+                 This command wipes and rebuilds AccountDB from the snapshot, \
+                 then resets the trie so init_trie rebuilds it on next boot. On \
+                 a chain past genesis that rebuild CAN produce a state_root that \
+                 disagrees with peers who built their trie incrementally block by \
+                 block (see the 2026-04-21 3-way fork incident for what that \
+                 looks like — took ~30h to recover).\n\
+                 \n\
+                 Correct recoveries on a non-genesis chain:\n\
+                 1. Stop this node.\n\
+                 2. rsync /opt/sentrix/data/chain.db from a healthy peer (all validators stopped).\n\
+                 3. Restart. Boot-time integrity check confirms the copy is intact.\n\
+                 \n\
+                 If you really need state_import on a non-genesis chain (isolated \
+                 devnet / one-off testing only), set `SENTRIX_ALLOW_STATE_IMPORT_ON_NONZERO_HEIGHT=1` \
+                 in your environment. There is no supported use of this flag on a shared chain."
+            );
+        }
+        tracing::warn!(
+            "state import proceeding on non-zero height (h={current_height}) via env override — \
+             fork is very likely on a shared chain"
+        );
+    }
+
     let mut bc = storage
         .load_blockchain()?
         .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;


### PR DESCRIPTION
## Summary

Follow-up #2 from the 2026-04-21 mainnet 3-way fork. Closes the CLI-surface landmine on \`sentrix state import\` and \`sentrix chain reset-trie\`.

## What was the problem

Even after all the boot-time integrity guards (v2.1.5 reset-trie-after-import + v2.1.5 backfill-root-mismatch + [PR #206](https://github.com/sentrix-labs/sentrix/pull/206) full trie reachability check), nothing stops an operator from **running** \`sentrix state import\` or \`sentrix chain reset-trie\` against a production chain.db. The boot-time guard then fires on next startup and the node refuses to start — safer than producing broken blocks, but still a manual recovery path away from a working cluster.

The 2026-04-21 3-way fork was caused by exactly this chain of events on pre-v2.1.5 binaries: operators ran \`state import\` as a recovery attempt, trie got reset, rebuild produced a state_root that disagreed with peers who built incrementally from genesis, fork locked in for ~30h.

## What this PR does

Both commands now refuse to run when \`current_height > 0\` with an error pointing at the correct recovery:

\`\`\`
Refusing state import on a chain at height 145745 > 0.
[…]
Correct recoveries on a non-genesis chain:
  1. Stop this node.
  2. rsync /opt/sentrix/data/chain.db from a healthy peer (all validators stopped).
  3. Restart. Boot-time integrity check confirms the copy is intact.
\`\`\`

## Escape hatch

For genuine devnet / isolated-testing use, each command has an env-var override:
- \`SENTRIX_ALLOW_STATE_IMPORT_ON_NONZERO_HEIGHT=1\`
- \`SENTRIX_ALLOW_RESET_TRIE_ON_NONZERO_HEIGHT=1\`

The names are intentionally ugly — no operator types them by accident, and anyone who does type them has signed their own name to the outcome. Both emit a WARN log on use.

## Non-breaking for happy paths

- \`sentrix state import\` on fresh chain (height == 0): works exactly as before.
- \`sentrix state export\`: unchanged, harmless, still useful for snapshots.
- \`sentrix state verify\`: unchanged.
- \`sentrix chain reset-trie\` on fresh chain: works as before.
- Library methods \`Blockchain::import_state\` and \`Storage::reset_trie\`: unchanged — still needed by init_trie's backfill path and by existing tests.

## Test plan

- [x] \`cargo check -p sentrix-node\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [ ] Manual smoke test: will do post-merge on a devnet — \`sentrix state import\` on a height > 0 chain should print the refuse-message + exit 1.

## Not merged autonomously

CLI-surface change touching state import. Review + decide whether to cherry-pick into next patch release.