### PR TITLE
p2p: unhardcode integration test ports via new listen_addrs() API

### DIFF
--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -66,6 +66,10 @@ enum SwarmCommand {
     /// Trigger a Kademlia bootstrap (random walk).
     KadBootstrap,
     GetPeerCount(tokio::sync::oneshot::Sender<usize>),
+    /// Query the swarm's current listen addresses. Useful for tests that
+    /// bind on port 0 (OS-assigned) and need the actual port back, and
+    /// for ops who want to know the node's externally-reachable addrs.
+    GetListenAddrs(tokio::sync::oneshot::Sender<Vec<Multiaddr>>),
     /// Re-dial bootstrap peers that are no longer connected.
     ReconnectPeers(Vec<Multiaddr>),
     /// Trigger an out-of-band block sync from the first verified peer.
@@ -219,6 +223,28 @@ impl LibP2pNode {
             rx.await.unwrap_or(0)
         } else {
             0
+        }
+    }
+
+    /// Returns the swarm's current listen addresses (after bind completes).
+    ///
+    /// Useful for:
+    /// - Tests that bind on port 0 (OS-assigned) and need the actual port
+    ///   back for peer-dialing instead of hardcoding a fragile port number.
+    /// - Ops tooling that wants to know what the node is reachable on.
+    ///
+    /// Returns an empty Vec if the swarm task has exited.
+    pub async fn listen_addrs(&self) -> Vec<Multiaddr> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if self
+            .cmd_tx
+            .send(SwarmCommand::GetListenAddrs(tx))
+            .await
+            .is_ok()
+        {
+            rx.await.unwrap_or_default()
+        } else {
+            Vec::new()
         }
     }
 }
@@ -413,6 +439,10 @@ async fn run_swarm(
                     }
                     Some(SwarmCommand::GetPeerCount(reply)) => {
                         let _ = reply.send(verified_peers.len());
+                    }
+                    Some(SwarmCommand::GetListenAddrs(reply)) => {
+                        let addrs: Vec<Multiaddr> = swarm.listeners().cloned().collect();
+                        let _ = reply.send(addrs);
                     }
                     Some(SwarmCommand::ReconnectPeers(addrs)) => {
                         for addr in addrs {

--- a/tests/integration_p2p.rs
+++ b/tests/integration_p2p.rs
@@ -9,7 +9,7 @@
 // This test prevents v1.3.0-style regressions where compilation and unit
 // tests pass but runtime P2P networking is broken.
 
-#![allow(clippy::expect_used, clippy::unwrap_used, missing_docs)]
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic, missing_docs)]
 
 use sentrix::core::blockchain::Blockchain;
 use sentrix::network::libp2p_node::{LibP2pNode, make_multiaddr};
@@ -23,6 +23,40 @@ fn make_blockchain() -> SharedBlockchain {
     Arc::new(RwLock::new(Blockchain::new(
         "0x4f3319a747fd564136209cd5d9e7d1a1e4d142be".to_string(),
     )))
+}
+
+/// Bind a node on `127.0.0.1:0` (OS-assigned port) and return the actual
+/// port number the kernel assigned. Replaces the old pattern of hardcoding
+/// ports like 39101-39104 which collided when tests ran in parallel.
+///
+/// Polls `listen_addrs()` every 25ms (up to 2s) until the listener has
+/// bound — the `listen_on` call returns immediately but the swarm task
+/// needs a moment to actually bind the socket.
+async fn bind_random_port(node: &Arc<LibP2pNode>) -> u16 {
+    node.listen_on(make_multiaddr("127.0.0.1", 0).expect("make addr"))
+        .await
+        .expect("listen");
+
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(2);
+    while tokio::time::Instant::now() < deadline {
+        let addrs = node.listen_addrs().await;
+        for a in addrs {
+            if let Some(port) = multiaddr_tcp_port(&a) {
+                return port;
+            }
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(25)).await;
+    }
+    panic!("bind_random_port: listener never reported a bound TCP address within 2s");
+}
+
+/// Extract the TCP port component from a multiaddr like `/ip4/127.0.0.1/tcp/39101`.
+fn multiaddr_tcp_port(addr: &libp2p::Multiaddr) -> Option<u16> {
+    use libp2p::multiaddr::Protocol;
+    addr.iter().find_map(|p| match p {
+        Protocol::Tcp(port) => Some(port),
+        _ => None,
+    })
 }
 
 /// Spawn a libp2p node listening on 127.0.0.1 with a random port.
@@ -69,13 +103,9 @@ async fn test_two_nodes_connect_and_verify_peers() {
     let node_a = Arc::new(LibP2pNode::new(kp_a, bc_a, etx_a).expect("node A"));
     let node_b = Arc::new(LibP2pNode::new(kp_b, bc_b, etx_b).expect("node B"));
 
-    // A listens on port 39101
-    let addr_a = make_multiaddr("127.0.0.1", 39101).expect("addr");
-    node_a.listen_on(addr_a).await.expect("A listen");
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-
-    // B connects to A
-    let dial_addr = make_multiaddr("127.0.0.1", 39101).expect("dial addr");
+    // A listens on an OS-assigned port; B dials whatever port A got.
+    let port_a = bind_random_port(&node_a).await;
+    let dial_addr = make_multiaddr("127.0.0.1", port_a).expect("dial addr");
     node_b.connect_peer(dial_addr).await.expect("B connect");
 
     // Wait for handshake events (up to 5 seconds)
@@ -155,16 +185,10 @@ async fn test_gossipsub_block_propagation() {
     let node_a = Arc::new(LibP2pNode::new(kp_a, bc_a, etx_a).expect("node A"));
     let node_b = Arc::new(LibP2pNode::new(kp_b, bc_b, etx_b).expect("node B"));
 
-    // A listens on port 39102
-    node_a
-        .listen_on(make_multiaddr("127.0.0.1", 39102).unwrap())
-        .await
-        .unwrap();
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-
-    // B connects to A
+    // A listens on an OS-assigned port; B dials whatever port A got.
+    let port_a = bind_random_port(&node_a).await;
     node_b
-        .connect_peer(make_multiaddr("127.0.0.1", 39102).unwrap())
+        .connect_peer(make_multiaddr("127.0.0.1", port_a).unwrap())
         .await
         .unwrap();
 
@@ -219,20 +243,14 @@ async fn test_three_node_mesh() {
     let node_b = Arc::new(LibP2pNode::new(kp_b, bc_b, etx_b).expect("B"));
     let node_c = Arc::new(LibP2pNode::new(kp_c, bc_c, etx_c).expect("C"));
 
-    // A listens on 39103
-    node_a
-        .listen_on(make_multiaddr("127.0.0.1", 39103).unwrap())
-        .await
-        .unwrap();
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-
-    // B and C connect to A
+    // A listens on an OS-assigned port; B and C both dial whatever port A got.
+    let port_a = bind_random_port(&node_a).await;
     node_b
-        .connect_peer(make_multiaddr("127.0.0.1", 39103).unwrap())
+        .connect_peer(make_multiaddr("127.0.0.1", port_a).unwrap())
         .await
         .unwrap();
     node_c
-        .connect_peer(make_multiaddr("127.0.0.1", 39103).unwrap())
+        .connect_peer(make_multiaddr("127.0.0.1", port_a).unwrap())
         .await
         .unwrap();
 
@@ -299,14 +317,9 @@ async fn test_chain_id_mismatch_rejected() {
     let node_a = Arc::new(LibP2pNode::new(kp_a, bc_a, etx_a).expect("A"));
     let _node_b = Arc::new(LibP2pNode::new(kp_b, bc_b, etx_b).expect("B"));
 
-    node_a
-        .listen_on(make_multiaddr("127.0.0.1", 39104).unwrap())
-        .await
-        .unwrap();
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-
+    let port_a = bind_random_port(&node_a).await;
     _node_b
-        .connect_peer(make_multiaddr("127.0.0.1", 39104).unwrap())
+        .connect_peer(make_multiaddr("127.0.0.1", port_a).unwrap())
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary

Removes the last four hardcoded ports from the P2P integration test suite. Parallel CI runs or repeated local runs no longer collide on ports 39101-39104.

## Changes

### New public API: `LibP2pNode::listen_addrs()`

Returns the swarm's current bound addresses as `Vec<Multiaddr>`. Wired through a new `SwarmCommand::GetListenAddrs` oneshot roundtrip. Useful for:

- **Tests** — bind on port 0 (OS-assigned), poll `listen_addrs()` for the actual port, dial it.
- **Ops tooling** — query a node for the addresses it's externally reachable on.

### New test helper: `bind_random_port(node)`

Binds on `127.0.0.1:0`, polls `listen_addrs()` every 25ms for up to 2s until the swarm task reports a bound TCP address, returns the port.

### Updated 4 tests to use the helper

- `test_two_nodes_connect_and_verify_peers` (was 39101)
- `test_gossipsub_block_propagation` (was 39102)
- `test_three_node_mesh` (was 39103)
- `test_chain_id_mismatch_rejected` (was 39104)

## Test plan

- [x] `cargo test --test integration_p2p` — 4 pass (no behavior change, just no more port collisions)
- [x] `cargo build -p sentrix-network` — clean (new `SwarmCommand::GetListenAddrs` variant handled in swarm task match)
- [x] `cargo clippy --tests -p sentrix --all-targets -- -D warnings` — clean

## Risk

Zero runtime risk. The new API is additive (new method, new enum variant) and only called by tests today. The 200ms pre-dial sleep in the old tests is replaced by active polling which is at worst the same duration and at best faster.