### PR TITLE
rpc: add effectiveGasPrice + type to EVM tx receipts

### DIFF
--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -163,6 +163,21 @@ async fn eth_get_transaction_receipt(params: &Value, state: &SharedState) -> Dis
                 "0x1"
             };
             let (logs, bloom_hex) = load_logs_for_tx(&bc, block_index, &txid);
+            // EVM tx vs native tx: `data` starts with "EVM:" for alloy-decoded
+            // envelopes (see primitives/transaction.rs:198). Sentrix's EVM
+            // txs go through the EIP-1559 base_fee pipeline, so we surface
+            // type 0x2 + effectiveGasPrice = INITIAL_BASE_FEE for those. Native
+            // txs have no EIP-1559 semantics — type 0x0 + effectiveGasPrice 0.
+            let is_evm = tx_data["transaction"]["data"]
+                .as_str()
+                .map(|d| d.starts_with("EVM:"))
+                .unwrap_or(false);
+            let tx_type = if is_evm { "0x2" } else { "0x0" };
+            let effective_gas_price = if is_evm {
+                to_hex(sentrix_evm::gas::INITIAL_BASE_FEE)
+            } else {
+                "0x0".to_string()
+            };
             Ok(json!({
                 "transactionHash": format!("0x{}", txid),
                 "blockNumber": to_hex(block_index),
@@ -170,6 +185,8 @@ async fn eth_get_transaction_receipt(params: &Value, state: &SharedState) -> Dis
                 "status": status,
                 "gasUsed": to_hex(21_000),
                 "cumulativeGasUsed": to_hex(21_000),
+                "effectiveGasPrice": effective_gas_price,
+                "type": tx_type,
                 "logs": logs,
                 "logsBloom": bloom_hex,
             }))
@@ -233,6 +250,15 @@ async fn eth_get_block_receipts(params: &Value, state: &SharedState) -> Dispatch
         let (logs, bloom_hex) = load_logs_for_tx(&bc, block.index, &tx.txid);
         let gas_used: u64 = 21_000;
         cumulative = cumulative.saturating_add(gas_used);
+        // See eth_get_transaction_receipt above for the EVM-vs-native
+        // `type` + `effectiveGasPrice` rationale.
+        let is_evm = tx.is_evm_tx();
+        let tx_type = if is_evm { "0x2" } else { "0x0" };
+        let effective_gas_price = if is_evm {
+            to_hex(sentrix_evm::gas::INITIAL_BASE_FEE)
+        } else {
+            "0x0".to_string()
+        };
         receipts.push(json!({
             "transactionHash": format!("0x{}", tx.txid),
             "transactionIndex": to_hex(idx as u64),
@@ -243,6 +269,8 @@ async fn eth_get_block_receipts(params: &Value, state: &SharedState) -> Dispatch
             "status": status,
             "gasUsed": to_hex(gas_used),
             "cumulativeGasUsed": to_hex(cumulative),
+            "effectiveGasPrice": effective_gas_price,
+            "type": tx_type,
             "logs": logs,
             "logsBloom": bloom_hex,
         }));


### PR DESCRIPTION
## Summary

Fills in two missing receipt fields that MetaMask / ethers.js / web3.js expect: \`effectiveGasPrice\` and \`type\`. Closes the non-schema half of the 'Complete EVM receipts' TODO.

## What's added

For each receipt (both \`eth_getTransactionReceipt\` and \`eth_getBlockReceipts\`):

- **\`type\`**: \`0x2\` for EVM-envelope txs (they go through Sentrix's EIP-1559 base_fee pipeline), \`0x0\` for native txs.
- **\`effectiveGasPrice\`**: \`INITIAL_BASE_FEE\` for EVM txs, \`0x0\` for native txs (native txs don't have EIP-1559 pricing semantics).

## EVM-vs-native detection

EVM txs are identified by \`tx.data.starts_with(\"EVM:\")\` — set in \`eth_sendRawTransaction\` when alloy decodes the envelope. See \`primitives/transaction.rs:198\` (\`is_evm_tx()\`).

## Not changed

- \`gasUsed\` still returns a flat 21000 everywhere. Fixing that needs per-tx gas to be stored at block-execute time, which is a schema change out of scope for this PR. Filed as a follow-up in the TODO.
- \`cumulativeGasUsed\`, \`logsBloom\`, \`status\` — already wired in prior work, unchanged.

## Test plan

- [x] \`cargo test -p sentrix-rpc --lib\` — 22 pass (the shape tests don't check the new fields; full integration test comes with MetaMask/ethers smoke-test post-merge).
- [x] \`cargo clippy -p sentrix-rpc --all-targets -- -D warnings\` — clean.

## Compatibility

Additive — new fields appear on all receipts, no existing field changed or removed. Any client that ignores unknown fields (all well-behaved ones) is unaffected. Clients that rely on the new fields now work where they didn't before.