### PR TITLE
chore(release): 2.1.7 — post-fork hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.7] — 2026-04-22 — Post-fork hardening (3-way state_root fork follow-up)
+
+Post-mortem release after the 2026-04-21 mainnet 3-way state_root fork. The fork itself was recovered ops-side via frozen-rsync of VPS1 canonical chain.db to VPS2 + VPS3 (see `founder-private/incidents/2026-04-21-mainnet-3way-fork.md`). This release closes the code-level gaps that let the incident develop silently on the v2.1.6 binary after a pre-v2.1.5 `state_import` had already damaged VPS3's trie.
+
+### Fork follow-ups
+
+- **fix(trie): boot-time integrity check — refuse to start on orphan trie references** (`crates/sentrix-trie/src/tree.rs`, `crates/sentrix-core/src/blockchain.rs`). New `SentrixTrie::verify_integrity()` walks the current root and fails fast if any referenced node or leaf-value is missing from `trie_nodes` / `trie_values`. Wired into `Blockchain::init_trie`: hard-fail past `STATE_ROOT_FORK_HEIGHT`, warn-only below. In the 2026-04-21 incident, VPS3's chain.db had a top-level root that existed but referenced an orphaned subtree, so the existing backfill-mismatch and missing-root-node guards didn't fire — it just produced `state_root=None` blocks that strict peers then rejected. PR #206.
+- **fix(cli): guard `sentrix state import` and `sentrix chain reset-trie` against non-genesis chain** (`bin/sentrix/src/main.rs`). Both commands now refuse on `height > 0` with an error pointing at rsync-from-peer as the correct recovery. Env-var escape hatch for devnet (`SENTRIX_ALLOW_STATE_IMPORT_ON_NONZERO_HEIGHT=1` / `SENTRIX_ALLOW_RESET_TRIE_ON_NONZERO_HEIGHT=1`), intentionally ugly names. PR #207.
+- **fix(network): boundary-reject state_root=None blocks past fork height** (`crates/sentrix-network/src/libp2p_node.rs`). New `block_boundary_reject_reason()` helper rejects obvious-bad blocks at network ingest (both RequestResponse and Gossipsub paths) before spawning an apply task. Moves the existing v2.1.5 execution-time state_root guard earlier in the pipeline — same blocks rejected, just without contending for the chain write lock and without the flood of CRITICAL logs that previously filled the journald cap within hours during an incident. PR #208.
+
+### Added
+
+- **feat(rpc): real gas estimation via EVM dry-run** (`crates/sentrix-rpc/src/jsonrpc/eth.rs`). `eth_estimateGas` now delegates to a shared `run_evm_dry_run()` helper that executes the call through `execute_call`, replacing the flat 21_000 / 100_000 heuristic with `receipt.gas_used`. Reverting transactions surface `-32000` with revert-data hex (Geth-compatible — a reverting tx has no meaningful gas estimate). PR #210.
+- **feat(rpc): add `effectiveGasPrice` + `type` to EVM tx receipts** (`crates/sentrix-rpc/src/jsonrpc/eth.rs`). MetaMask / ethers.js / web3.js now see `type = 0x2` for EVM-envelope txs, `0x0` for native, and `effectiveGasPrice = INITIAL_BASE_FEE` for EVM. `gasUsed` remains a flat `21_000` pending a per-tx schema change. PR #211.
+
+### Changed
+
+- **chore(rpc): tighten RPC input validation** (`crates/sentrix-rpc/src/jsonrpc/eth.rs`). `eth_estimateGas` rejects non-object params[0] with `-32602` instead of silently defaulting to `21_000`. `eth_getCode` and `eth_getStorageAt` now call `normalize_rpc_address` like the balance/nonce endpoints, rejecting malformed addresses at ingress. `eth_getStorageAt` also validates the storage slot is valid hex ≤ 32 bytes. PR #205.
+- **test(staking): add delegation-sum invariant proptest** (`crates/sentrix-staking/src/staking.rs`). Runs 500 random delegate/undelegate/redelegate/slash ops against 4 validators × 6 delegators and asserts `Σ per-delegator entries to V == validators[V].total_delegated` after each op. Fixed-seed LCG keeps it reproducible. 74 staking tests pass (was 73). PR #205.
+- **test(p2p): unhardcode integration-test ports via new `listen_addrs()` API** (`crates/sentrix-network/src/libp2p_node.rs`, `tests/integration_p2p.rs`). New `LibP2pNode::listen_addrs()` method + `bind_random_port()` test helper. All 4 P2P integration tests now bind on port 0 (OS-assigned) and dial the reported port, removing the parallel-run port collisions that used to happen on 39101-39104. PR #209.
+
+### Dependencies
+
+- **chore(deps): audit + clean deny.toml skip[] list** (`deny.toml`). Removed 4 stale skip entries whose duplicates have resolved (`bitflags`, `parking_lot`, `parking_lot_core`, `redox_syscall`). Kept 11 entries with per-entry justification comments explaining the upstream split + what needs to happen for the skip to drop. PR #212.
+- **deps: sweep open security advisories (2026-04-22)** (`deny.toml`, `Cargo.lock`). One real vulnerability fixed: `RUSTSEC-2026-0104` (rustls-webpki 0.103.12 CRL parsing panic) bumped to 0.103.13 via `cargo update`. Five informational / unmaintained advisories documented + ignored with per-advisory reachability analysis: `RUSTSEC-2025-0055` (tracing-subscriber 0.2 ANSI — never `.init()`ed), `RUSTSEC-2026-0105` (core2 yanked — no security surface), `RUSTSEC-2025-0141` (bincode unmaintained — sentrix-codec wraps v1 API pending migration), `RUSTSEC-2024-0388` + `RUSTSEC-2024-0436` (derivative / paste — proc-macro only). `cargo deny check` now passes all four sections. PR #213.
+
 ## [2.1.6] — 2026-04-21 — RPC validation hardening
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -4891,14 +4891,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4941,14 +4941,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -35,7 +35,7 @@ use crate::behaviour::{
     SentrixRequest, SentrixResponse, TXS_TOPIC,
 };
 use crate::node::{NodeEvent, SharedBlockchain};
-use sentrix_primitives::block::Block;
+use sentrix_primitives::block::{Block, STATE_ROOT_FORK_HEIGHT};
 use sentrix_primitives::error::{SentrixError, SentrixResult};
 use sentrix_primitives::transaction::Transaction;
 
@@ -652,6 +652,21 @@ async fn on_swarm_event(
             if topic == BLOCKS_TOPIC {
                 match bincode::deserialize::<GossipBlock>(&message.data) {
                     Ok(gossip) => {
+                        // Mirror the boundary-reject the RequestResponse path
+                        // uses — reject obvious-bad blocks before spawning an
+                        // apply task. See `block_boundary_reject_reason` for
+                        // the 2026-04-21 state_root=None fork rationale.
+                        if let Some(reason) =
+                            block_boundary_reject_reason(&gossip.block, our_chain_id)
+                        {
+                            tracing::warn!(
+                                "gossip: dropping block {} from {}: {}",
+                                gossip.block.index,
+                                propagation_source,
+                                reason
+                            );
+                            return;
+                        }
                         let bc = blockchain.clone();
                         let etx = event_tx.clone();
                         let peer = propagation_source;
@@ -883,24 +898,23 @@ async fn on_inbound_request(
         }
 
         // ── NewBlock — apply to chain (spawned to avoid blocking swarm) ──
-        // H-01: fast-reject cross-chain blocks at the network boundary.
-        // The transaction-level `tx.validate(.., chain_id)` inside add_block
-        // still catches this downstream, but rejecting up front avoids
-        // acquiring the chain write lock and spawning a doomed task.
+        // Fast-reject at the network boundary: H-01 cross-chain + 2026-04-21
+        // state_root=None. The transaction-level validate() / execution-time
+        // state_root guard still catch these downstream, but rejecting up
+        // front avoids acquiring the chain write lock and spawning a doomed
+        // task, and it emits ONE clean WARN at ingest instead of a flood of
+        // execution-path errors across every peer.
         SentrixRequest::NewBlock { block } => {
             let _ = swarm
                 .behaviour_mut()
                 .rr
                 .send_response(channel, SentrixResponse::Ack);
-            if let Some(tx) = block.transactions.iter().find(|t| !t.is_coinbase())
-                && tx.chain_id != our_chain_id
-            {
+            if let Some(reason) = block_boundary_reject_reason(&block, our_chain_id) {
                 tracing::warn!(
-                    "libp2p: dropping block {} from {}: chain_id mismatch ({} vs {})",
+                    "libp2p: dropping block {} from {}: {}",
                     block.index,
                     peer,
-                    tx.chain_id,
-                    our_chain_id
+                    reason
                 );
                 return;
             }
@@ -1094,6 +1108,47 @@ async fn is_active_bft_signer(blockchain: &SharedBlockchain, addr: &str) -> bool
     bc.authority.is_active_validator(addr)
 }
 
+/// Fast-reject a block at the network boundary if it fails cheap sanity
+/// checks that don't need the chain write lock. Returns `Some(reason)` if the
+/// block should be dropped on the floor, `None` if it's worth forwarding to
+/// `add_block_from_peer`.
+///
+/// Cheap checks only — expensive ones (signature, state-root math, trie
+/// apply) still run inside `add_block_from_peer` under the write lock.
+/// The purpose here is to kill the obvious-bad blocks before they
+/// contend for the lock or spawn a doomed apply task.
+///
+/// Added 2026-04-22 after the 3-way state_root fork: a validator running on
+/// a damaged chain.db was producing blocks with `state_root=None` above
+/// `STATE_ROOT_FORK_HEIGHT`, and peers were accepting them into the ingest
+/// pipeline before the execution-time guard caught and rejected them. With
+/// this check, bad blocks are rejected *before* propagation/apply so the
+/// signal reaches operators ~instantly instead of waiting for an execution
+/// failure that may be hidden by log noise.
+fn block_boundary_reject_reason(block: &Block, our_chain_id: u64) -> Option<&'static str> {
+    // H-01: cross-chain block. find the first non-coinbase tx and check its
+    // chain_id. (If every tx is coinbase, skip this check — coinbase has
+    // no chain_id-bound semantics.)
+    if let Some(tx) = block.transactions.iter().find(|t| !t.is_coinbase())
+        && tx.chain_id != our_chain_id
+    {
+        return Some("chain_id mismatch");
+    }
+
+    // 2026-04-21 3-way fork guard: past STATE_ROOT_FORK_HEIGHT, every valid
+    // block must carry a state_root; missing = producer's trie is broken.
+    // The execution-time guard in block_executor.rs also catches this, but
+    // gating at the network boundary means we never spend a write lock or
+    // apply-task on the bad block — and, more importantly, we don't log it
+    // at ERROR from every peer's execution path. One clean WARN at ingest
+    // is easier to spot than a flood of mismatches.
+    if block.index >= STATE_ROOT_FORK_HEIGHT && block.state_root.is_none() {
+        return Some("missing state_root past STATE_ROOT_FORK_HEIGHT (sender's trie is broken)");
+    }
+
+    None
+}
+
 // ── Inbound response handler ─────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
@@ -1226,6 +1281,59 @@ mod tests {
     fn test_make_multiaddr_invalid_ip_fails() {
         let result = make_multiaddr("not_an_ip", 30303);
         assert!(result.is_err(), "invalid IP should fail");
+    }
+
+    // ── block_boundary_reject_reason ─────────────────────
+    // 2026-04-22 fork follow-up tests.
+
+    fn make_test_block(index: u64, state_root: Option<[u8; 32]>) -> Block {
+        Block {
+            index,
+            timestamp: 1_700_000_000,
+            transactions: vec![],
+            previous_hash: "0".to_string(),
+            hash: "h".to_string(),
+            merkle_root: "m".to_string(),
+            validator: "v".to_string(),
+            state_root,
+            round: 0,
+            justification: None,
+        }
+    }
+
+    #[test]
+    fn test_block_boundary_valid_above_fork_with_state_root() {
+        let block = make_test_block(STATE_ROOT_FORK_HEIGHT + 1, Some([0u8; 32]));
+        assert_eq!(block_boundary_reject_reason(&block, 7119), None);
+    }
+
+    #[test]
+    fn test_block_boundary_rejects_missing_state_root_above_fork() {
+        let block = make_test_block(STATE_ROOT_FORK_HEIGHT + 1, None);
+        let reason = block_boundary_reject_reason(&block, 7119);
+        assert!(reason.is_some(), "must reject above fork when state_root None");
+        assert!(
+            reason.unwrap().contains("state_root"),
+            "reason should mention state_root; got: {:?}",
+            reason
+        );
+    }
+
+    #[test]
+    fn test_block_boundary_allows_missing_state_root_below_fork() {
+        // Below fork height, state_root=None is the old hash format — valid.
+        let block = make_test_block(STATE_ROOT_FORK_HEIGHT - 1, None);
+        assert_eq!(block_boundary_reject_reason(&block, 7119), None);
+    }
+
+    #[test]
+    fn test_block_boundary_at_exact_fork_height_requires_state_root() {
+        // Boundary case: fork height itself requires state_root.
+        let block = make_test_block(STATE_ROOT_FORK_HEIGHT, None);
+        assert!(
+            block_boundary_reject_reason(&block, 7119).is_some(),
+            "fork-height block with None state_root must reject"
+        );
     }
 
     // ── LibP2pNode creation ──────────────────────────────

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"


### PR DESCRIPTION
## Summary

Prep PR for **v2.1.7** — bundles the 9 post-incident hardening merges from 2026-04-22 into a patch release. No new code; just version bumps (2.1.6 → 2.1.7 across workspace) + CHANGELOG entry.

## What's in this release

### Fork follow-ups (2026-04-21 3-way state_root fork)
- #206 — trie+core: boot-time trie integrity check (refuses to start on orphan node/value past STATE_ROOT_FORK_HEIGHT)
- #207 — cli: guard \`state import\` + \`reset-trie\` against non-genesis chain
- #208 — network: boundary-reject state_root=None blocks past fork height

### EVM compat
- #210 — rpc: eth_estimateGas real EVM dry-run (Geth-compatible revert semantics)
- #211 — rpc: receipt \`effectiveGasPrice\` + \`type\` fields

### Hardening
- #205 — rpc+staking: RPC param validation tighten + delegation-sum invariant proptest
- #209 — p2p: unhardcode integration-test ports via \`listen_addrs()\` API

### Deps
- #212 — deny.toml skip[] audit + cleanup
- #213 — security advisories sweep (rustls-webpki CRL panic fixed)

## Consensus-safety note

No consensus-code behavior change. v2.1.7 on a clean chain.db produces the same state_root path as v2.1.6. The trie-integrity guard (#206) only triggers on chain.dbs that were ALREADY damaged by a pre-v2.1.5 state_import (the actual 2026-04-21 fork trigger). Safe to deploy alongside v2.1.6 peers during a rolling upgrade — no flag day needed.

## Release ritual (per \`feedback_release_cadence.md\`)

Still pending — this PR is just the version bump + changelog. After merge:
1. Tag \`v2.1.7\` on the merge commit.
2. Build binary; MD5 this one should be different from \`0e496fc5f6bed7e2\` (v2.1.6).
3. Testnet bake ≥ 24h. Watch for: CRITICAL / state_root mismatch / missing node / writeback / SELFDESTRUCT errors (none expected).
4. Rolling mainnet deploy: VPS1 → wait ≥ 1 min → VPS2 → wait ≥ 1 min → VPS3. Verify cluster heights converge after each step.
5. Publish GitHub release with CHANGELOG excerpt.

## Test plan

- [x] \`cargo check --workspace\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [ ] Testnet bake (post-merge)