### PR TITLE
core: divergence rate-alarm for silent state_root drift

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -749,17 +749,27 @@ impl Blockchain {
                         // Received block: verify peer's state_root matches ours (V7-C-01).
                         // State root mismatch is fatal — reject the block to prevent accepting a diverged chain state
                         if received_root != computed_root {
+                            let block_index = last.index;
                             tracing::error!(
                                 "CRITICAL #1e: state_root mismatch at block {} — received {} \
                                  vs computed {}. Local trie and peer's trie disagree on the \
                                  post-block state. Rejecting.",
-                                last.index,
+                                block_index,
                                 hex::encode(received_root),
                                 hex::encode(computed_root),
                             );
+                            // 2026-04-23 divergence rate-alarm: per-event ERROR
+                            // line above is truthful but gets lost in log noise
+                            // during a real divergence (~1/s). Record the
+                            // rejection in the rolling tracker, which emits a
+                            // LOUD rate-limited alarm pointing at the rsync
+                            // recovery playbook when the rate crosses threshold.
+                            // See `DivergenceTracker` in blockchain.rs for the
+                            // full rationale.
+                            self.divergence_tracker.record_rejection(block_index);
                             return Err(SentrixError::ChainValidationFailed(format!(
                                 "state_root mismatch at block {}: received {}, computed {}",
-                                last.index,
+                                block_index,
                                 hex::encode(received_root),
                                 hex::encode(computed_root),
                             )));

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -157,6 +157,105 @@ pub struct Blockchain {
     /// Pass 2. Backlog #1e. Not persisted.
     #[serde(skip, default = "default_block_source")]
     pub(crate) source_for_current_add: crate::block_executor::BlockSource,
+
+    /// Rolling tracker for state_root divergences from peers.
+    ///
+    /// Added 2026-04-23 after the second mainnet fork where VPS3 was
+    /// silently rejecting peer blocks for 4+ hours (4000+ state_root
+    /// mismatches per hour) without any operator alert. The existing
+    /// per-event ERROR log was lost in log noise. This tracker emits
+    /// a rate-limited LOUD alarm when the rejection rate crosses a
+    /// threshold, pointing operators at the rsync-from-peer recovery.
+    /// Not persisted (rebuilds from scratch on every boot, which is
+    /// the correct behavior — a validator that was diverging 6h ago
+    /// but is clean now shouldn't keep alarming).
+    #[serde(skip, default)]
+    pub(crate) divergence_tracker: DivergenceTracker,
+}
+
+/// Rate-threshold detector for "this validator has diverged from peers".
+///
+/// Why not just rely on the per-event ERROR log:
+///   The existing `CRITICAL #1e: state_root mismatch at block N` line is
+///   correct but emits once PER rejected block. During a real divergence
+///   that's ~1 line/s. Journald rotation evicts the first occurrences
+///   within hours, so by the time an operator checks, they see only the
+///   tail end and don't realize the validator has been rejecting
+///   everything from peers for the entire time.
+///
+/// What this adds:
+///   One ERROR-level alarm when the rolling rejection rate exceeds the
+///   threshold, rate-limited so subsequent rejections within the
+///   cooldown don't spam. The alarm message names the recovery playbook
+///   explicitly (rsync chain.db from a healthy peer) so the operator
+///   can act without having to look anything up.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct DivergenceTracker {
+    /// Timestamps of recent state_root-mismatch rejections.
+    recent_rejections: VecDeque<std::time::Instant>,
+    /// Total rejections observed since process boot (monotonic).
+    total_rejections: u64,
+    /// Last alarm emission timestamp (for rate-limiting).
+    last_alarm_at: Option<std::time::Instant>,
+}
+
+impl DivergenceTracker {
+    /// Rolling window for rate calculation.
+    const WINDOW_SECS: u64 = 300; // 5 minutes
+    /// Alarm fires when recent_rejections.len() reaches this within the window.
+    const ALARM_THRESHOLD: usize = 100;
+    /// Minimum seconds between alarm emissions (prevents spam).
+    const ALARM_COOLDOWN_SECS: u64 = 60;
+
+    /// Record one state_root-mismatch rejection and maybe emit an alarm.
+    /// Call this from the rejection path in `apply_block_pass2` (or
+    /// wherever state_root mismatch is detected).
+    pub fn record_rejection(&mut self, block_index: u64) {
+        let now = std::time::Instant::now();
+
+        // Evict entries older than the window.
+        while let Some(front) = self.recent_rejections.front() {
+            if now.duration_since(*front).as_secs() > Self::WINDOW_SECS {
+                self.recent_rejections.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        self.recent_rejections.push_back(now);
+        self.total_rejections = self.total_rejections.saturating_add(1);
+
+        // Check alarm threshold + cooldown.
+        if self.recent_rejections.len() >= Self::ALARM_THRESHOLD {
+            let should_alarm = self
+                .last_alarm_at
+                .map(|t| now.duration_since(t).as_secs() >= Self::ALARM_COOLDOWN_SECS)
+                .unwrap_or(true);
+            if should_alarm {
+                tracing::error!(
+                    "🚨 DIVERGENCE ALERT: this validator has rejected {} peer blocks with \
+                     state_root mismatch in the last {}s (total since boot: {}, current block {}). \
+                     This strongly suggests the local chain.db has diverged from the network. \
+                     RECOVERY: stop this validator, rsync /opt/sentrix/data/chain.db from a \
+                     healthy peer with all validators briefly stopped, then restart. See \
+                     `founder-private/incidents/2026-04-21-mainnet-3way-fork.md` for the full \
+                     playbook. If ≥2 validators are flagging this, the OTHER validator(s) may \
+                     be canonical — investigate before rsync'ing the wrong direction.",
+                    self.recent_rejections.len(),
+                    Self::WINDOW_SECS,
+                    self.total_rejections,
+                    block_index,
+                );
+                self.last_alarm_at = Some(now);
+            }
+        }
+    }
+
+    /// Read-only view of counters, for RPC exposure (future) and tests.
+    #[allow(dead_code)] // surfaced via RPC in a follow-up PR (`/chain/divergence`)
+    pub fn stats(&self) -> (usize, u64) {
+        (self.recent_rejections.len(), self.total_rejections)
+    }
 }
 
 fn default_block_source() -> crate::block_executor::BlockSource {
@@ -202,6 +301,7 @@ impl Blockchain {
             epoch_manager: sentrix_staking::epoch::EpochManager::new(),
             slashing: sentrix_staking::slashing::SlashingEngine::new(),
             source_for_current_add: crate::block_executor::BlockSource::SelfProduced,
+            divergence_tracker: DivergenceTracker::default(),
         };
         bc.initialize_genesis(genesis);
         bc
@@ -802,6 +902,50 @@ mod tests {
 
     fn derive_addr(pk: &PublicKey) -> String {
         sentrix_wallet::Wallet::derive_address(pk)
+    }
+
+    // ── DivergenceTracker tests ──────────────────────────────
+
+    /// Counter monotonicity + threshold behavior. We can't test the
+    /// rolling eviction in real-time without waiting 5 minutes, so we
+    /// test the linear count path which is what actually fires the
+    /// alarm under real divergence conditions.
+    #[test]
+    fn test_divergence_tracker_counts() {
+        let mut t = DivergenceTracker::default();
+        assert_eq!(t.stats(), (0, 0));
+
+        for i in 0..50u64 {
+            t.record_rejection(1_000 + i);
+        }
+        let (recent, total) = t.stats();
+        assert_eq!(recent, 50, "all 50 rejections should be within the 5-min window");
+        assert_eq!(total, 50);
+    }
+
+    /// Alarm cooldown — after the threshold is crossed, subsequent
+    /// rejections within the cooldown must not re-emit. We can't
+    /// assert the log output directly without an observer; we assert
+    /// the internal `last_alarm_at` state instead.
+    #[test]
+    fn test_divergence_alarm_cooldown() {
+        let mut t = DivergenceTracker::default();
+        // Push enough rejections to cross the threshold.
+        for i in 0..DivergenceTracker::ALARM_THRESHOLD as u64 {
+            t.record_rejection(2_000 + i);
+        }
+        assert!(
+            t.last_alarm_at.is_some(),
+            "alarm must fire once threshold crossed"
+        );
+
+        // Subsequent rejection within the cooldown window doesn't
+        // update `last_alarm_at` (since the current alarm is still
+        // within cooldown). Hard to assert without mocking time;
+        // just verify no panic + tracker continues accepting records.
+        t.record_rejection(2_999);
+        let (_recent, total) = t.stats();
+        assert_eq!(total, DivergenceTracker::ALARM_THRESHOLD as u64 + 1);
     }
 
     // Valid-format test address for use as to_address in tests


### PR DESCRIPTION
Follow-up from the 2026-04-23 mainnet fork investigation. Pure observability — no consensus/validation change.

## Problem

The existing `CRITICAL #1e: state_root mismatch` log line is correct but emits once per rejected peer block. During a real divergence (~1/s) it fills journald rotation inside hours, so by the time an operator checks, the earliest occurrences are gone and they only see the tail end. Result observed today: VPS3 was silently on its own chain for ~4 hours with 4000+ mismatches/hour, and nobody noticed until the v2.1.8 deploy restart cascade made it impossible to miss.

## Fix

`DivergenceTracker` in `Blockchain` + a hook in the state_root mismatch rejection path. Tracks a rolling window of rejection timestamps; when the count crosses the threshold, emits one LOUD ERROR-level alarm pointing at the rsync recovery playbook. Rate-limited so subsequent rejections within the cooldown don't spam.

- Window: 5 minutes
- Threshold: 100 rejections
- Cooldown: 60 s between alarms
- Not persisted (rebuilds on boot — a validator that was diverging 6h ago but is clean now shouldn't keep alarming)

## Alarm text

> 🚨 DIVERGENCE ALERT: this validator has rejected N peer blocks with state_root mismatch in the last 300s (total since boot: M, current block X). This strongly suggests the local chain.db has diverged from the network. RECOVERY: stop this validator, rsync /opt/sentrix/data/chain.db from a healthy peer with all validators briefly stopped, then restart. See `founder-private/incidents/2026-04-21-mainnet-3way-fork.md` for the full playbook. If ≥2 validators are flagging this, the OTHER validator(s) may be canonical — investigate before rsync'ing the wrong direction.

## Tests

- `test_divergence_tracker_counts` — linear count path
- `test_divergence_alarm_cooldown` — threshold + alarm state

`cargo test -p sentrix-core --lib` — 178 pass (176 + 2 new)
`cargo clippy --workspace --all-targets -- -D warnings` — clean

## Consensus impact

**Zero.** No change to block validation, block acceptance, or state transitions. Alarm is a log line, not an action. If the threshold is wrong (too noisy or too quiet), tuning is a one-line constant change with no compat concern.

## Follow-up

RPC endpoint `/chain/divergence` surfacing the counters is marked with `#[allow(dead_code)] // surfaced via RPC in a follow-up PR` so operators can query programmatically instead of grepping journalctl. Separate PR.
