### PR TITLE
chore(release): 2.1.9 — divergence rate-alarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.9] — 2026-04-23 — Divergence rate-alarm for silent state_root drift
+
+Patch release over v2.1.8. Single change: adds a rate-limited LOUD alarm when a validator rejects peer blocks at a sustained rate — motivated by the 2026-04-23 mainnet fork investigation, where VPS3 had been silently rejecting peer blocks for ≥4 hours (~4000 state_root mismatches per hour) without any operator signal. The existing per-event `CRITICAL #1e` log line was accurate but emitted at ~1/s during real divergence, filling journald rotation so the earliest mismatches were evicted before the operator checked.
+
+### Added
+
+- **core: divergence rate-alarm** (`crates/sentrix-core/src/blockchain.rs`, `crates/sentrix-core/src/block_executor.rs`). New `DivergenceTracker` records state_root-mismatch rejections in a rolling 5-minute window; when the count crosses 100 within the window, emits one `ERROR`-level alarm with the rsync-from-peer recovery playbook inline. Rate-limited to one alarm per 60 seconds so the signal stays punchy rather than spamming. Counter is in-memory only (resets on restart — a validator that diverged 6h ago but is clean now shouldn't keep alarming). Not a consensus change; pure observability. PR #217.
+
 ## [2.1.8] — 2026-04-22 — Sentrix-style liveness thresholds
 
 Patch release over v2.1.7. Adds exactly one change: retuned the validator liveness-slashing thresholds from Tendermint's demo defaults to Sentrix-style values calibrated for 1-second block time + solo-operator ops. Config-only; no algorithm change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -4891,14 +4891,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4941,14 +4941,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "bincode",
  "blake3",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"


### PR DESCRIPTION
Version bump + CHANGELOG for v2.1.9. Single change: PR #217 DivergenceTracker. Pure observability, no consensus change.