### PR TITLE
refactor(network): split sentrix-wire crate (Tier 1 #5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4865,6 +4865,7 @@ dependencies = [
  "sentrix-bft",
  "sentrix-core",
  "sentrix-primitives",
+ "sentrix-wire",
  "serde",
  "serde_json",
  "tokio",
@@ -5003,6 +5004,16 @@ dependencies = [
  "sha2",
  "sha3 0.11.0",
  "zeroize",
+]
+
+[[package]]
+name = "sentrix-wire"
+version = "2.1.9"
+dependencies = [
+ "bincode",
+ "sentrix-bft",
+ "sentrix-primitives",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "bin/sentrix"]
+members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "crates/sentrix-wire", "bin/sentrix"]
 
 [package]
 name = "sentrix"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 sentrix-primitives = { path = "../sentrix-primitives" }
 sentrix-bft = { path = "../sentrix-bft" }
 sentrix-core = { path = "../sentrix-core" }
+sentrix-wire = { path = "../sentrix-wire" }
 
 libp2p = { version = "0.56", features = ["tcp", "noise", "yamux", "gossipsub", "kad", "identify", "tokio", "request-response", "macros"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/crates/sentrix-network/src/behaviour.rs
+++ b/crates/sentrix-network/src/behaviour.rs
@@ -22,22 +22,18 @@ use libp2p::{
 };
 use serde::{Deserialize, Serialize};
 
-use sentrix_bft::messages::{Precommit, Prevote, Proposal};
-use sentrix_primitives::block::Block;
-use sentrix_primitives::transaction::Transaction;
+// Wire types (SentrixRequest/SentrixResponse/GossipBlock/GossipTransaction)
+// moved to `sentrix-wire`; their associated primitives imports live there
+// too. Anything still needed here comes through the re-exports below.
 
-// ── Protocol identifier ──────────────────────────────────
-/// Protocol version string — bumped to 2.0.0 for bincode wire format.
-pub const SENTRIX_PROTOCOL: &str = "/sentrix/2.0.0";
-
-// ── Gossipsub topic names ────────────────────────────────
-/// Topic for block propagation via gossipsub.
-pub const BLOCKS_TOPIC: &str = "sentrix/blocks/1";
-/// Topic for transaction propagation via gossipsub.
-pub const TXS_TOPIC: &str = "sentrix/txs/1";
-
-/// Hard cap on a single message (10 MiB) — matches `MAX_MESSAGE_SIZE` in node.rs.
-const MAX_MESSAGE_BYTES: usize = 10 * 1024 * 1024;
+// ── Protocol identifier + topic names + size cap ─────────
+//
+// These were moved to the `sentrix-wire` crate 2026-04-23 (Tier 1 split #5
+// per `founder-private/architecture/CRATE_SPLIT_PLAN.md`). Re-exported here
+// so existing call sites (`use sentrix_network::behaviour::BLOCKS_TOPIC`)
+// keep working during the migration window. Follow-up PR will switch all
+// imports to the canonical `sentrix_wire::*` path and drop these shims.
+pub use sentrix_wire::{BLOCKS_TOPIC, MAX_MESSAGE_BYTES, SENTRIX_PROTOCOL, TXS_TOPIC};
 
 // ── Tunable gossipsub + RR parameters ─────────────────────────
 //
@@ -143,61 +139,10 @@ fn rr_request_timeout_secs() -> u64 {
 }
 
 // ── Request / Response enums ─────────────────────────────
-
-/// Messages a node sends to a peer (requests).
-///
-/// Mirrors [`crate::network::node::Message`] but split into request/response
-/// halves so libp2p's `RequestResponse` behaviour can track correlation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum SentrixRequest {
-    /// Initial handshake — carries chain_id for network partitioning.
-    Handshake {
-        host: String,
-        port: u16,
-        height: u64,
-        chain_id: u64,
-    },
-    /// Push a freshly mined block.
-    NewBlock { block: Box<Block> },
-    /// Push a new mempool transaction.
-    NewTransaction { transaction: Transaction },
-    /// Ask for blocks starting at `from_height`.
-    GetBlocks { from_height: u64 },
-    /// Ask for the peer's current chain height.
-    GetHeight,
-    /// Liveness probe.
-    Ping,
-    /// BFT: block proposal from the round proposer
-    BftProposal { proposal: Box<Proposal> },
-    /// BFT: prevote for a block (or nil)
-    BftPrevote { prevote: Prevote },
-    /// BFT: precommit for a block (or nil)
-    BftPrecommit { precommit: Precommit },
-    /// BFT: periodic round status announcement for round synchronization
-    BftRoundStatus {
-        status: sentrix_bft::messages::RoundStatus,
-    },
-}
-
-/// Responses returned by a peer for the above requests.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum SentrixResponse {
-    /// Handshake acknowledgement — peer echoes their own chain state.
-    Handshake {
-        host: String,
-        port: u16,
-        height: u64,
-        chain_id: u64,
-    },
-    /// Batch of blocks answering a `GetBlocks` request.
-    BlocksResponse { blocks: Vec<Block> },
-    /// Answer to `GetHeight`.
-    HeightResponse { height: u64 },
-    /// Answer to `Ping`.
-    Pong { height: u64 },
-    /// Generic acknowledgement for fire-and-forget messages (NewBlock, NewTx, BFT).
-    Ack,
-}
+//
+// Moved to `sentrix-wire` 2026-04-23. Re-exported for back-compat; the
+// codec impls below still need them as `Self::Request` / `Self::Response`.
+pub use sentrix_wire::{SentrixRequest, SentrixResponse};
 
 // ── Wire codec ───────────────────────────────────────────
 //
@@ -424,23 +369,19 @@ impl SentrixBehaviour {
 // ── Gossipsub message types ─────────────────────────────
 // Gossipsub carries bincode-encoded envelopes on the two topics.
 
-/// Envelope for gossipsub block messages.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GossipBlock {
-    pub block: Block,
-}
-
-/// Envelope for gossipsub transaction messages.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GossipTransaction {
-    pub transaction: Transaction,
-}
+// Gossipsub envelopes moved to `sentrix-wire` 2026-04-23. Re-exported for
+// back-compat.
+pub use sentrix_wire::{GossipBlock, GossipTransaction};
 
 // ── Tests ────────────────────────────────────────────────
 #[cfg(test)]
 mod tests {
     use super::*;
     use libp2p::identity;
+    // Primitives needed by the roundtrip tests below — not used at top
+    // level of the module anymore (wire types moved to sentrix-wire).
+    use sentrix_primitives::block::Block;
+    use sentrix_primitives::transaction::Transaction;
     use libp2p::request_response::Codec;
 
     fn make_keypair() -> identity::Keypair {

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "sentrix-wire"
+version = "2.1.9"
+edition = "2024"
+license = "BUSL-1.1"
+description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."
+repository = "https://github.com/sentrix-labs/sentrix"
+
+# Why this crate exists
+# -------------------------
+# Extracted from `sentrix-network::behaviour` during the 45-crate split (Tier 1
+# template #5 per `founder-private/architecture/CRATE_SPLIT_PLAN.md`). Lives
+# separately so other crates (e.g. future `sentrix-sdk`, monitoring tools)
+# can reference the canonical wire types WITHOUT pulling the full libp2p
+# network stack as a transitive dep. The framing codec (`SentrixCodec`) and
+# all libp2p-specific machinery stay in `sentrix-network`.
+#
+# Breaking-change policy: wire types are part of the on-network protocol
+# surface. Any additive variant must be rolled out testnet-first with a
+# version bump on `SENTRIX_PROTOCOL`. Removing a variant requires a hard
+# fork at a pinned height — never just drop it.
+
+[dependencies]
+sentrix-primitives = { path = "../sentrix-primitives" }
+sentrix-bft = { path = "../sentrix-bft" }
+
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+bincode = "1.3"

--- a/crates/sentrix-wire/src/lib.rs
+++ b/crates/sentrix-wire/src/lib.rs
@@ -1,0 +1,195 @@
+//! Sentrix libp2p wire protocol types.
+//!
+//! Pure data types for the on-network protocol surface — no libp2p, no
+//! async runtime, no framing. The actual codec + behaviour lives in
+//! `sentrix-network`; this crate exists so downstream tooling (future SDKs,
+//! monitoring tools, light clients) can reference the canonical wire types
+//! without pulling the full libp2p stack.
+//!
+//! # Stability
+//!
+//! These types are part of the on-network protocol surface. Rules:
+//! - **Adding a new variant** (new `SentrixRequest` case, new `SentrixResponse` case):
+//!   bump `SENTRIX_PROTOCOL`, roll out testnet-first so peers can negotiate.
+//! - **Renaming or reordering existing variants**: bincode encoding is
+//!   position-dependent. Reordering = immediate wire break. NEVER.
+//! - **Removing a variant**: requires a hard fork at a pinned height, not a
+//!   drop-in upgrade. Most of the time you want to deprecate-but-keep.
+//! - **Changing a field type or adding a field**: same rule as reordering —
+//!   bincode layout change is a wire break.
+//!
+//! # History
+//!
+//! Extracted from `sentrix-network::behaviour` 2026-04-23 as Tier 1 crate
+//! split #5 per `founder-private/architecture/CRATE_SPLIT_PLAN.md`. The
+//! enum definitions + constants were moved verbatim; the framing codec
+//! `SentrixCodec` stays in `sentrix-network` because it pulls libp2p traits.
+
+use sentrix_bft::messages::{Precommit, Prevote, Proposal, RoundStatus};
+use sentrix_primitives::block::Block;
+use sentrix_primitives::transaction::Transaction;
+use serde::{Deserialize, Serialize};
+
+// ── Protocol identifier ──────────────────────────────────
+
+/// Protocol version string. Bump when adding / removing request or response
+/// variants so peers can negotiate compatible versions. Currently 2.0.0 —
+/// same as the sentrix binary major.minor, but intentionally tracked
+/// separately so we don't have to bump the binary to bump the wire version.
+pub const SENTRIX_PROTOCOL: &str = "/sentrix/2.0.0";
+
+// ── Gossipsub topic names ────────────────────────────────
+
+/// Topic for block propagation via gossipsub.
+pub const BLOCKS_TOPIC: &str = "sentrix/blocks/1";
+/// Topic for transaction propagation via gossipsub.
+pub const TXS_TOPIC: &str = "sentrix/txs/1";
+
+/// Hard cap on a single wire message (10 MiB). Callers doing their own
+/// framing should enforce this too.
+pub const MAX_MESSAGE_BYTES: usize = 10 * 1024 * 1024;
+
+// ── Request / Response enums ─────────────────────────────
+
+/// Messages a node sends to a peer (requests).
+///
+/// Mirrors the pre-2.0 raw-TCP `Message` enum but split into request /
+/// response halves so libp2p's `RequestResponse` can correlate replies.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SentrixRequest {
+    /// Initial handshake — carries chain_id for network partitioning.
+    Handshake {
+        host: String,
+        port: u16,
+        height: u64,
+        chain_id: u64,
+    },
+    /// Push a freshly mined block.
+    NewBlock { block: Box<Block> },
+    /// Push a new mempool transaction.
+    NewTransaction { transaction: Transaction },
+    /// Ask for blocks starting at `from_height`.
+    GetBlocks { from_height: u64 },
+    /// Ask for the peer's current chain height.
+    GetHeight,
+    /// Liveness probe.
+    Ping,
+    /// BFT: block proposal from the round proposer.
+    BftProposal { proposal: Box<Proposal> },
+    /// BFT: prevote for a block (or nil).
+    BftPrevote { prevote: Prevote },
+    /// BFT: precommit for a block (or nil).
+    BftPrecommit { precommit: Precommit },
+    /// BFT: periodic round status announcement for round synchronization.
+    BftRoundStatus { status: RoundStatus },
+}
+
+/// Responses returned by a peer for the above requests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SentrixResponse {
+    /// Handshake acknowledgement — peer echoes their own chain state.
+    Handshake {
+        host: String,
+        port: u16,
+        height: u64,
+        chain_id: u64,
+    },
+    /// Batch of blocks answering a `GetBlocks` request.
+    BlocksResponse { blocks: Vec<Block> },
+    /// Answer to `GetHeight`.
+    HeightResponse { height: u64 },
+    /// Answer to `Ping`.
+    Pong { height: u64 },
+    /// Generic acknowledgement for fire-and-forget messages (NewBlock, NewTx, BFT).
+    Ack,
+}
+
+// ── Gossipsub envelopes ──────────────────────────────────
+
+/// Envelope for gossipsub block messages — bincode encoded on
+/// [`BLOCKS_TOPIC`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GossipBlock {
+    pub block: Block,
+}
+
+/// Envelope for gossipsub transaction messages — bincode encoded on
+/// [`TXS_TOPIC`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GossipTransaction {
+    pub transaction: Transaction,
+}
+
+// ── Tests ────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin the protocol version string — change requires deliberate bump.
+    #[test]
+    fn test_protocol_version_is_2_0_0() {
+        assert_eq!(SENTRIX_PROTOCOL, "/sentrix/2.0.0");
+    }
+
+    /// Pin the topic names — callers (explorers, dApps) subscribe by string.
+    #[test]
+    fn test_topic_names_stable() {
+        assert_eq!(BLOCKS_TOPIC, "sentrix/blocks/1");
+        assert_eq!(TXS_TOPIC, "sentrix/txs/1");
+    }
+
+    /// Pin the message size cap so callers doing their own framing
+    /// (non-libp2p transports) agree on the limit.
+    #[test]
+    fn test_max_message_bytes_is_10_mib() {
+        assert_eq!(MAX_MESSAGE_BYTES, 10 * 1024 * 1024);
+    }
+
+    /// Handshake round-trip — bincode must preserve every field.
+    #[test]
+    fn test_handshake_roundtrip() {
+        let req = SentrixRequest::Handshake {
+            host: "127.0.0.1".to_string(),
+            port: 30303,
+            height: 42,
+            chain_id: 7119,
+        };
+        let bytes = bincode::serialize(&req).expect("encode");
+        let decoded: SentrixRequest = bincode::deserialize(&bytes).expect("decode");
+        match decoded {
+            SentrixRequest::Handshake {
+                host,
+                port,
+                height,
+                chain_id,
+            } => {
+                assert_eq!(host, "127.0.0.1");
+                assert_eq!(port, 30303);
+                assert_eq!(height, 42);
+                assert_eq!(chain_id, 7119);
+            }
+            _ => panic!("wrong variant after roundtrip"),
+        }
+    }
+
+    /// Pong response round-trip.
+    #[test]
+    fn test_pong_roundtrip() {
+        let res = SentrixResponse::Pong { height: 999 };
+        let bytes = bincode::serialize(&res).expect("encode");
+        let decoded: SentrixResponse = bincode::deserialize(&bytes).expect("decode");
+        match decoded {
+            SentrixResponse::Pong { height } => assert_eq!(height, 999),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    /// Ack round-trip — unit-like variant.
+    #[test]
+    fn test_ack_roundtrip() {
+        let res = SentrixResponse::Ack;
+        let bytes = bincode::serialize(&res).expect("encode");
+        let decoded: SentrixResponse = bincode::deserialize(&bytes).expect("decode");
+        assert!(matches!(decoded, SentrixResponse::Ack));
+    }
+}


### PR DESCRIPTION
Fifth Tier 1 crate split per `founder-private/architecture/CRATE_SPLIT_PLAN.md`. Pure refactor — bincode encoding unchanged, same bytes on the wire.

## What's in the new crate

Moved to `crates/sentrix-wire/`:
- `SENTRIX_PROTOCOL`, `BLOCKS_TOPIC`, `TXS_TOPIC` constants
- `MAX_MESSAGE_BYTES` (10 MiB hard cap)
- `SentrixRequest` enum (all 10 variants)
- `SentrixResponse` enum (all 5 variants)
- `GossipBlock`, `GossipTransaction` envelopes

## What stayed in sentrix-network

libp2p-bound machinery:
- `SentrixCodec` + `lp_read`/`lp_write` framing
- `SentrixBehaviour` + all libp2p wiring
- Config builders + tuning constants from PR #219 / #220

## Why this shape

Downstream tooling (future `sentrix-sdk`, monitoring tools, light clients) can reference the canonical wire types WITHOUT pulling the full libp2p stack as a transitive dep. `sentrix-network` keeps all libp2p surface; `sentrix-wire` is pure `serde::{Serialize, Deserialize}` + bincode.

## Back-compat

`sentrix-network::behaviour` re-exports all moved symbols via `pub use sentrix_wire::{...}`. Existing call sites like `use sentrix_network::behaviour::BLOCKS_TOPIC` keep compiling. Follow-up PR migrates call sites to canonical `sentrix_wire::*` path and drops the shims.

## Stability policy

Documented inline in `sentrix-wire/src/lib.rs`:
- Adding a variant: bump `SENTRIX_PROTOCOL`, testnet-first rollout
- Reordering variants: NEVER (bincode is position-dependent)
- Removing a variant: hard fork at pinned height

## Test plan

- [x] `cargo test -p sentrix-wire --lib` — 6 pass (new crate)
- [x] `cargo test -p sentrix-network --lib` — 35 pass (unchanged via shim)
- [x] `cargo test --test integration_p2p` — 4 pass (real gossipsub roundtrip via shim)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

## Consensus impact

**Zero.** Pure refactor. Bincode encoding layout unchanged — same bytes go on the wire. Verified by integration_p2p test_gossipsub_block_propagation which exercises the full encode→libp2p-transport→decode path.
