### PR TITLE
chore(release): 2.1.10 — network tuning + sentrix-wire split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.10] — 2026-04-23 — Network tuning + sentrix-wire split
+
+Patch release bundling three network-layer improvements. Zero consensus impact — all changes are network/observability config or pure refactors.
+
+### Added
+
+- **network: tune gossipsub + RR for small validator mesh** (`crates/sentrix-network/src/behaviour.rs`). Defaults retuned for Sentrix's current mesh sizes (3 mainnet, 4 testnet — separate meshes per chain_id). Heartbeat 5s→300ms, flood_publish true, mesh_n_low 5→2, history trimmed, RR request timeout 60s→15s. Addresses the #1d rebroadcast-livelock symptom. PR #219.
+- **network: env-var overrides for gossipsub + RR tunables** (`crates/sentrix-network/src/behaviour.rs`). Every tunable overridable via `SENTRIX_GOSSIP_*` / `SENTRIX_RR_REQUEST_TIMEOUT_SECS` env vars so operators can retune for mesh growth (hundreds-to-thousands of validators) WITHOUT rebuilding the binary. Defaults preserve PR #219 values; no behavior change today. PR #220.
+
+### Changed
+
+- **refactor(network): split sentrix-wire crate (Tier 1 #5)** (`crates/sentrix-wire/`, `crates/sentrix-network/src/behaviour.rs`). Extracts `SentrixRequest`, `SentrixResponse`, `GossipBlock`, `GossipTransaction`, `SENTRIX_PROTOCOL`, `BLOCKS_TOPIC`, `TXS_TOPIC`, `MAX_MESSAGE_BYTES` into their own crate so downstream tooling (future `sentrix-sdk`, monitoring, light clients) can reference canonical wire types without pulling the full libp2p stack. Back-compat shim keeps existing imports working. Pure refactor; bincode encoding unchanged. PR #221.
+
 ## [2.1.9] — 2026-04-23 — Divergence rate-alarm for silent state_root drift
 
 Patch release over v2.1.8. Single change: adds a rate-limited LOUD alarm when a validator rejects peer blocks at a sustained rate — motivated by the 2026-04-23 mainnet fork investigation, where VPS3 had been silently rejecting peer blocks for ≥4 hours (~4000 state_root mismatches per hour) without any operator signal. The existing per-event `CRITICAL #1e` log line was accurate but emitted at ~1/s during real divergence, filling journald rotation so the earliest mismatches were evicted before the operator checked.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "anyhow",
  "axum",
@@ -4892,14 +4892,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4942,14 +4942,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "bincode",
  "blake3",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Bundles PRs #219 + #220 + #221. Zero consensus impact. See CHANGELOG `[2.1.10]`.