### PR TITLE
fix(network): GetBlocks serves evicted blocks from MDBX (BACKLOG #14)

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -532,6 +532,35 @@ impl Blockchain {
         self.chain.iter().find(|b| b.hash == hash)
     }
 
+    /// Block lookup that transparently falls back to MDBX storage for
+    /// blocks evicted from the in-memory sliding window. Returns an
+    /// owned `Block` (cloning in the window case, fresh deserialise in
+    /// the storage case).
+    ///
+    /// Added for BACKLOG #14: the `GetBlocks` request-response handler
+    /// used to call `get_block` directly and silently dropped every
+    /// request for blocks older than `CHAIN_WINDOW_SIZE`, stranding
+    /// fresh or forensic-restored peers that needed a deep history
+    /// back-fill. Live validators keep full history in MDBX, so this
+    /// fallback just serves what already exists on disk.
+    ///
+    /// Returns None only when both the in-memory window misses AND the
+    /// MDBX store has no block at that index (i.e. the block was never
+    /// produced or the storage handle was never bound — fresh test
+    /// Blockchains with no `mdbx_storage` hit the latter).
+    pub fn get_block_any(&self, index: u64) -> Option<Block> {
+        if let Some(b) = self.get_block(index) {
+            return Some(b.clone());
+        }
+        let mdbx = self.mdbx_storage.as_ref()?;
+        let key = format!("block:{}", index);
+        let bytes = mdbx
+            .get(tables::TABLE_META, key.as_bytes())
+            .ok()
+            .flatten()?;
+        serde_json::from_slice(&bytes).ok()
+    }
+
     // ── Supply & reward ──────────────────────────────────
     pub fn get_block_reward(&self) -> u64 {
         let remaining = MAX_SUPPLY.saturating_sub(self.total_minted);
@@ -2282,6 +2311,71 @@ mod tests {
                  applying the same blocks — if this diverges, consensus is broken"
             );
         }
+    }
+
+    /// BACKLOG #14 regression: `get_block_any` must fall back to MDBX
+    /// once a block is evicted from the in-memory sliding window.
+    /// Without this fallback the `GetBlocks` network handler silently
+    /// drops requests for deep history, so any fresh or forensic-
+    /// restored peer stalls indefinitely on sync.
+    ///
+    /// Strategy: bump CHAIN_WINDOW_SIZE-adjacent behaviour by producing
+    /// `WINDOW + 5` blocks on a chain bound to a real MdbxStorage, save
+    /// each block via the same save_block call `add_block`'s caller
+    /// uses in production, then assert that:
+    ///   - the oldest block is NOT in the in-memory window any more,
+    ///     so `get_block` returns None,
+    ///   - `get_block_any` returns Some(_) for that same height (served
+    ///     from MDBX),
+    ///   - the fetched block's index matches what was produced.
+    #[test]
+    fn test_get_block_any_falls_back_to_mdbx_for_evicted_blocks() {
+        let (_dir, mdbx) = temp_mdbx();
+        let mut bc = setup_chain();
+        bc.init_trie(Arc::clone(&mdbx)).unwrap();
+        bc.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+
+        // Produce CHAIN_WINDOW_SIZE + 5 blocks so the earliest blocks
+        // get evicted from self.chain. Persist each one to MDBX (what
+        // the `save_block` hook does in production via main.rs).
+        let produce_count = CHAIN_WINDOW_SIZE + 5;
+        for _ in 0..produce_count {
+            let block = bc.create_block("validator1").unwrap();
+            // Save to MDBX before add_block evicts the window — this
+            // matches the order main.rs uses.
+            mdbx.put(
+                sentrix_storage::tables::TABLE_META,
+                format!("block:{}", block.index).as_bytes(),
+                &serde_json::to_vec(&block).unwrap(),
+            )
+            .unwrap();
+            bc.add_block(block).unwrap();
+        }
+
+        // Block 1 should be evicted (we produced WINDOW + 5 on top of
+        // genesis, so the window now covers roughly [6 .. WINDOW+5]).
+        let evicted_height = 1u64;
+        assert!(
+            bc.get_block(evicted_height).is_none(),
+            "test setup expected block {evicted_height} to be outside the window \
+             — {CHAIN_WINDOW_SIZE}-block window should have evicted it"
+        );
+        let fetched = bc.get_block_any(evicted_height).unwrap_or_else(|| {
+            panic!(
+                "get_block_any should have fetched evicted block {evicted_height} from MDBX"
+            )
+        });
+        assert_eq!(
+            fetched.index, evicted_height,
+            "MDBX fallback returned a block at the wrong index"
+        );
+
+        // In-memory path still works for recent blocks.
+        let recent_height = bc.height();
+        let in_window = bc
+            .get_block_any(recent_height)
+            .expect("recent block must be returned");
+        assert_eq!(in_window.index, recent_height);
     }
 }
 // fake addr 0x1234567890abcdef1234567890abcdef12345678

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -966,11 +966,19 @@ async fn on_inbound_request(
         }
 
         // ── GetBlocks — respond with up to 50 blocks (reduced from 100 to stay under 10MB) ──
+        //
+        // BACKLOG #14: use get_block_any so evicted blocks (older than
+        // CHAIN_WINDOW_SIZE) are served from MDBX instead of silently
+        // dropped. The previous `get_block(i).cloned()` path returned
+        // an empty BlocksResponse for any fresh or forensic-restored
+        // peer requesting a deep history back-fill — those peers
+        // stalled indefinitely because gossipsub only delivers new
+        // blocks to in-mesh subscribers.
         SentrixRequest::GetBlocks { from_height } => {
             let bc = blockchain.read().await;
             let to = bc.height().min(from_height.saturating_add(49));
             let blocks: Vec<Block> = (from_height..=to)
-                .filter_map(|i| bc.get_block(i).cloned())
+                .filter_map(|i| bc.get_block_any(i))
                 .collect();
             drop(bc);
             let _ = swarm


### PR DESCRIPTION
## Why

The \`GetBlocks\` request-response handler at \`libp2p_node.rs:972\`
called \`bc.get_block(i).cloned()\`, which returns None for any block
older than \`CHAIN_WINDOW_SIZE\` (~1000 blocks). Any peer requesting
deep history got back an empty \`BlocksResponse\` and stalled —
gossipsub only delivers new blocks to in-mesh subscribers, so without
a back-fill path a fresh node can never catch up.

Discovered during the VPS3 RCA env-repro attempt: a fresh sentrix
node on VPS4 pointed at the 3 validator peers connected cleanly but
couldn't close the 18K-block gap to the live tip because every
\`GetBlocks\` request for height < tip - 1000 came back empty.

## What changes

- New \`Blockchain::get_block_any(index)\` returns an owned Block,
  trying the in-memory sliding window first and falling back to MDBX
  via the stored \`block:{N}\` key scheme. Live validators always
  have full history on disk (block save is unconditional post-apply),
  so this fallback just serves what's already there.
- The \`GetBlocks\` handler now calls \`get_block_any\` — same 50-block
  cap and response shape, just no longer silently drops old blocks.

## Test plan

- [x] New regression test \`test_get_block_any_falls_back_to_mdbx_for_evicted_blocks\`:
  produces \`CHAIN_WINDOW_SIZE + 5\` blocks, persists each to MDBX,
  asserts \`get_block(1)\` returns None while \`get_block_any(1)\`
  returns \`Some(Block { index: 1, .. })\`. Passes on worktree.
- [x] \`cargo clippy -p sentrix-core -p sentrix-network --tests -- -D warnings\` clean.
- [ ] CI green on this PR (pending).
- [ ] Testnet bake ≥ 24h before mainnet rollout per release discipline
      — peer-serving hot path so a bad change would silently break
      fresh-node sync across the fleet.

## Non-consensus

State root and authority validation paths are untouched. This changes
only which blocks a peer-handler is willing to serve over the wire.