### PR TITLE
test(rca): MDBX block-gap sweep test + mainnet-wide 7K gap finding

### DIFF
--- a/crates/sentrix-core/tests/rca_vps3_env_repro.rs
+++ b/crates/sentrix-core/tests/rca_vps3_env_repro.rs
@@ -108,6 +108,94 @@ fn load_block_by_height(
     storage.load_block(height).ok().flatten()
 }
 
+/// Walk every height from 1 to `tip` and count the ones whose
+/// `TABLE_META` key `block:{N}` is missing from MDBX. Surfaces silent
+/// write-failure gaps — discovered during the VPS3 env-repro run at
+/// h=32,690 (RCA addendum #4). Prints the first 200 missing heights,
+/// the last 200, total counts, and cluster shape (longest contiguous
+/// run of missing) so the operator can tell at a glance whether gaps
+/// are isolated (one per restart?) or systemic (every N blocks?).
+///
+/// Use `TEST_SWEEP_STRIDE` to downsample if the full 1..=height walk
+/// is too slow — e.g. `TEST_SWEEP_STRIDE=100` checks every 100th
+/// height first for a shape estimate before a full pass.
+#[test]
+#[ignore = "requires real chain.db — run manually; full 388K walk is a few minutes"]
+fn sweep_mdbx_block_gaps() {
+    let path = std::env::var("TEST_CHAIN_DB")
+        .expect("set TEST_CHAIN_DB=/path/to/chain.db");
+    let stride: u64 = std::env::var("TEST_SWEEP_STRIDE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+    let storage = Storage::open(&path).expect("chain.db open failed");
+    let tip = storage
+        .load_blockchain()
+        .expect("load_blockchain failed")
+        .expect("chain.db has no persisted state")
+        .height();
+
+    println!("CHAIN_DB={}", path);
+    println!("TIP={}", tip);
+    println!("STRIDE={}", stride);
+
+    let mut missing: Vec<u64> = Vec::new();
+    let mut found: u64 = 0;
+    let mut h = 1u64;
+    while h <= tip {
+        if load_block_by_height(&storage, h).is_none() {
+            missing.push(h);
+        } else {
+            found += 1;
+        }
+        h = h.saturating_add(stride);
+    }
+
+    println!("FOUND={} MISSING={}", found, missing.len());
+
+    // Cluster shape: longest contiguous run of missing heights.
+    let mut longest_run_start = 0u64;
+    let mut longest_run_len = 0u64;
+    let mut cur_start = 0u64;
+    let mut cur_len = 0u64;
+    for pair in missing.windows(2) {
+        if pair[1] == pair[0] + stride {
+            if cur_len == 0 {
+                cur_start = pair[0];
+                cur_len = 1;
+            }
+            cur_len += 1;
+            if cur_len > longest_run_len {
+                longest_run_len = cur_len;
+                longest_run_start = cur_start;
+            }
+        } else {
+            cur_len = 0;
+        }
+    }
+    println!(
+        "LONGEST_RUN start={} len={}",
+        longest_run_start, longest_run_len
+    );
+
+    // Print first 200 + last 200 missing heights (or all if fewer).
+    let head_n = missing.len().min(200);
+    for m in &missing[..head_n] {
+        println!("MISSING h={}", m);
+    }
+    if missing.len() > 400 {
+        println!("... ({} more) ...", missing.len() - 400);
+        let tail_start = missing.len() - 200;
+        for m in &missing[tail_start..] {
+            println!("MISSING h={}", m);
+        }
+    } else if missing.len() > head_n {
+        for m in &missing[head_n..] {
+            println!("MISSING h={}", m);
+        }
+    }
+}
+
 /// Replay a range of blocks from a chain.db snapshot and diff the
 /// recomputed state_root against the value stamped on each block.
 ///


### PR DESCRIPTION
## Why

While running the VPS3 env-repro replay from PR #224 in release mode,
the warmup panicked at h=32,690 with \`source chain.db missing block\`.
\`Storage::load_block\` — which reads \`TABLE_META\` key \`block:32690\`
directly from MDBX — returned None.

This PR adds a third test to the same harness to walk the full height
range and surface every gap, plus the longest contiguous run (so the
operator can tell isolated faults from systemic ones at a glance).

## Findings

Ran the sweep against three independent chain.db snapshots — an
**identical** gap pattern on all three:

| Snapshot | Tip | Found | Missing | Longest run |
|---|---|---|---|---|
| VPS3 forensic (\`chain.db.bak-rca-20260423T065915Z\`) | 388,397 | 381,045 | **7,352** | 5,042 blocks from h=139,703 |
| VPS2 forensic (\`chain.db.bak-v218fork-20260423T050300Z\`) | 378,003 | 370,651 | **7,352** | 5,042 blocks from h=139,703 |
| VPS1 live (copy taken 2026-04-23 ~18:50 WIB) | 401,515 | 394,163 | **7,352** | 5,042 blocks from h=139,703 |

Identical footprint across all three validators = common source, not a
per-host MDBX write failure.

## Root cause — unknown

Initial PR description attributed this to the peer-sync path at
\`libp2p_node.rs:1193\` missing \`save_block\`. Revisiting in detail:
that path DOES emit \`NodeEvent::NewBlock\` which IS handled at
\`bin/sentrix/src/main.rs:2131\` with an explicit
\`storage_for_p2p.save_block(&block)\`. Same for the gossip path at
\`:680\` and the direct-message path at \`:932\`. So the path is wired.

Plausible causes that remain to investigate:

1. **\`save_block\` errors swallowed silently.** Line 2132 logs
   \`tracing::warn!\` but doesn't retry or surface. If MDBX writes
   failed for a contiguous window (disk full, transaction contention,
   crash-in-progress), 5K consecutive saves lost would produce exactly
   the gap shape observed.
2. **\`save_height\` race across concurrent spawned tasks.** Gossip /
   direct-message / batch-sync all spawn separate tasks that each call
   \`save_block\` which \`save_height(block.index)\` as its last step.
   Interleaving could overwrite height with an earlier index, but
   that's orthogonal to block:N keys being absent. Still worth a look.
3. **Historic code path.** The gap window (h=139,703..144,745) predates
   the v2.1.5 safeguards. The state_import/export flow may have
   populated the chain without per-block writes at that time.

**All three merit a dedicated investigation** beyond this PR's scope.
The test landed here is the tool that enables that investigation.

## Implications

- **Not the VPS3 RCA root cause.** VPS1 canonical has identical gaps
  yet is the source-of-truth chain. Separate, older ecosystem bug.
- **PR #225's MDBX fallback still works for the ~381K blocks that DO
  exist in MDBX**, just not for the 7K that don't. Partial mitigation.

## What ships

One test added to \`crates/sentrix-core/tests/rca_vps3_env_repro.rs\`:
\`sweep_mdbx_block_gaps\`. \`#[ignore]\`'d, manual-run, 6s for a full
388K walk in release mode. Prints head-200 + tail-200 of missing
heights plus the longest contiguous run. Optional \`TEST_SWEEP_STRIDE\`
env var for downsampled spot-checks.

## Test plan

- [x] \`cargo clippy --release -p sentrix-core --tests -- -D warnings\` clean.
- [x] Smoke run on VPS1 live + VPS2 forensic + VPS3 forensic reproduces
      the documented pattern.
- [x] CI green on this PR.

## Non-goals

This PR only documents + detects. The underlying gap fix is a separate
investigation — test lands first so the investigation has a tool.