### PR TITLE
fix(rpc): historical block queries use get_block_any (BACKLOG #15)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -2404,8 +2404,8 @@ fn cmd_chain_block(index: u64) -> anyhow::Result<()> {
     let bc = storage
         .load_blockchain()?
         .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-    match bc.get_block(index) {
-        Some(block) => println!("{}", serde_json::to_string_pretty(block)?),
+    match bc.get_block_any(index) {
+        Some(block) => println!("{}", serde_json::to_string_pretty(&block)?),
         None => println!("Block {} not found", index),
     }
     Ok(())

--- a/crates/sentrix-rpc/src/explorer.rs
+++ b/crates/sentrix-rpc/src/explorer.rs
@@ -300,7 +300,7 @@ pub async fn explorer_home(State(state): State<SharedState>) -> Html<String> {
     let mut sample_newest_ts: u64 = 0;
 
     for i in 0..=height {
-        if let Some(block) = bc.get_block(i) {
+        if let Some(block) = bc.get_block_any(i) {
             let non_cb = block
                 .transactions
                 .iter()
@@ -337,7 +337,7 @@ pub async fn explorer_home(State(state): State<SharedState>) -> Html<String> {
     let mut blocks_html = String::new();
     let start = height.saturating_sub(19);
     for i in (start..=height).rev() {
-        if let Some(block) = bc.get_block(i) {
+        if let Some(block) = bc.get_block_any(i) {
             blocks_html.push_str(&format!(
                 r#"<tr>
                 <td><a href="/explorer/block/{}">{}</a></td>
@@ -450,7 +450,7 @@ pub async fn stats_daily(State(state): State<SharedState>) -> Json<Vec<DailyStat
     // UTC clock (previously used WIB / UTC+7 which off-by-one'd the chart
     // around 17:00 UTC).
     let today_day = bc
-        .get_block(height)
+        .get_block_any(height)
         .map(|b| b.timestamp / 86400)
         .unwrap_or(0);
 
@@ -459,7 +459,7 @@ pub async fn stats_daily(State(state): State<SharedState>) -> Json<Vec<DailyStat
     if today_day > 0 {
         let earliest = today_day.saturating_sub(13);
         for i in 0..=height {
-            if let Some(block) = bc.get_block(i) {
+            if let Some(block) = bc.get_block_any(i) {
                 let day = block.timestamp / 86400;
                 if day >= earliest && day <= today_day {
                     let e = map.entry(day).or_insert((0, 0));
@@ -519,7 +519,7 @@ pub async fn explorer_blocks(State(state): State<SharedState>) -> Html<String> {
     let mut rows = String::new();
     let start = height.saturating_sub(49);
     for i in (start..=height).rev() {
-        if let Some(block) = bc.get_block(i) {
+        if let Some(block) = bc.get_block_any(i) {
             rows.push_str(&format!(
                 r#"<tr>
                 <td><a href="/explorer/block/{}">{}</a></td>
@@ -566,7 +566,7 @@ pub async fn explorer_transactions(State(state): State<SharedState>) -> Html<Str
     let mut regular_rows = String::new();
 
     for i in (scan_start..=height).rev() {
-        if let Some(block) = bc.get_block(i) {
+        if let Some(block) = bc.get_block_any(i) {
             for tx in &block.transactions {
                 let is_cb = tx.is_coinbase();
                 let data_str = &tx.data;
@@ -676,7 +676,7 @@ pub async fn explorer_block(
     Path(index): Path<u64>,
 ) -> Html<String> {
     let bc = state.read().await;
-    match bc.get_block(index) {
+    match bc.get_block_any(index) {
         Some(block) => {
             let mut txs_html = String::new();
             for tx in &block.transactions {

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -84,7 +84,10 @@ async fn eth_get_block_by_number(params: &Value, state: &SharedState) -> Dispatc
             }
         }
     };
-    match bc.get_block(index) {
+    // BACKLOG #15: get_block_any so historical blocks outside the
+    // in-memory sliding window are served from MDBX, not silently
+    // returned as null.
+    match bc.get_block_any(index) {
         Some(block) => Ok(json!({
             "number": to_hex(block.index),
             "hash": format!("0x{}", block.hash),
@@ -203,7 +206,8 @@ async fn eth_get_block_receipts(params: &Value, state: &SharedState) -> Dispatch
                 Ok(h) => h,
                 Err(e) => return Err((-32602, e.into())),
             };
-            bc.get_block(height).cloned()
+            // BACKLOG #15: MDBX fallback for historical queries.
+            bc.get_block_any(height)
         }
     } else if let Some(obj) = params[0].as_object() {
         if let Some(h) = obj.get("blockHash").and_then(|v| v.as_str()) {
@@ -215,7 +219,7 @@ async fn eth_get_block_receipts(params: &Value, state: &SharedState) -> Dispatch
                 Ok(h) => h,
                 Err(e) => return Err((-32602, e.into())),
             };
-            bc.get_block(height).cloned()
+            bc.get_block_any(height)
         } else {
             return Err((-32602, "expected blockHash or blockNumber".into()));
         }

--- a/crates/sentrix-rpc/src/routes/chain.rs
+++ b/crates/sentrix-rpc/src/routes/chain.rs
@@ -75,7 +75,7 @@ pub(super) async fn get_block(
     Path(index): Path<u64>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let bc = state.read().await;
-    match bc.get_block(index) {
+    match bc.get_block_any(index) {
         Some(block) => serde_json::to_value(block)
             .map(Json)
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR),


### PR DESCRIPTION
## Why

Followup to PR #225 (BACKLOG #14). That PR added
\`Blockchain::get_block_any\` with MDBX fallback and wired it into the
\`GetBlocks\` sync handler, but left every other caller on
\`bc.get_block(i)\` which still returns None for blocks outside
\`CHAIN_WINDOW_SIZE\`. User-facing RPC / CLI callers hit that silently:
any query for a block older than ~1000 from tip returns null/404.

## What changes

Swap every user-facing historical-block callsite to \`get_block_any\`.
Ten callsites across four files:

| File | Lines | Function |
|---|---|---|
| \`crates/sentrix-rpc/src/jsonrpc/eth.rs\` | 87 / 206 / 218 | \`eth_getBlockByNumber\` (three parameter shapes) |
| \`crates/sentrix-rpc/src/explorer.rs\` | 303 / 340 / 453 / 462 / 522 / 569 / 679 | block-explorer endpoints (recent blocks, stats, single-block fetch) |
| \`crates/sentrix-rpc/src/routes/chain.rs\` | 78 | \`/chain/block/<h>\` REST endpoint |
| \`bin/sentrix/src/main.rs\` | 2407 | \`sentrix chain block <N>\` CLI |

Blocks previously served from the in-memory sliding window still are —
\`get_block_any\` tries the window first, only falling back to MDBX on
a miss. No behavioural change for recent-block queries; historical
queries now succeed where they previously returned null/404.

## Test plan

- [x] \`cargo check --workspace --tests\` clean.
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean.
- [x] Full workspace test suite green (179-test \`sentrix-core\` suite
      including the PR #225 regression, plus all downstream crates).
      Zero failures across the workspace.
- [ ] CI green on this PR (pending).
- [ ] Hit \`sentrixscan.sentriscloud.com\` against a block deeper than
      1000 from tip post-deploy to confirm user-facing fix.

## Non-consensus

Same category as PR #225 — read-only transparency improvement. State
root, authority, and block-apply paths are all untouched.

## Residual

Will still return None when a block is missing from MDBX itself
(BACKLOG #16 / PR #226's 7,352-block mainnet-wide gap finding). Those
holes are a separate investigation; this PR fixes the subset of
queries that currently fail despite the block being on disk.