### PR TITLE
feat(wallet): sentrix wallet rekey — atomic keystore password rotation

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -182,6 +182,23 @@ enum WalletCommands {
         #[arg(long)]
         password: Option<String>,
     },
+    /// Rotate a keystore's password without ever exposing the private
+    /// key to disk or logs. Atomic: writes the new keystore to a
+    /// sibling tempfile and renames into place only after a verify
+    /// round-trip succeeds; leaves a timestamped `.bak-<TS>` so a
+    /// failed rotation is always recoverable.
+    Rekey {
+        keystore_file: String,
+        /// Old password (prefer `SENTRIX_WALLET_OLD_PASSWORD` env var
+        /// or the interactive prompt — passing on the CLI leaves the
+        /// password in shell history).
+        #[arg(long)]
+        old_password: Option<String>,
+        /// New password (prefer `SENTRIX_WALLET_NEW_PASSWORD` env var
+        /// or the interactive prompt).
+        #[arg(long)]
+        new_password: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -432,6 +449,11 @@ async fn main() -> anyhow::Result<()> {
                 keystore_file,
                 password,
             } => cmd_wallet_decrypt(&keystore_file, password)?,
+            WalletCommands::Rekey {
+                keystore_file,
+                old_password,
+                new_password,
+            } => cmd_wallet_rekey(&keystore_file, old_password, new_password)?,
         },
 
         Commands::Validator { action } => match action {
@@ -738,6 +760,133 @@ fn cmd_wallet_decrypt(keystore_file: &str, password: Option<String>) -> anyhow::
     // Private key printed to stdout ONLY — never logged, never in API
     println!("  Private key: {}", wallet.secret_key_hex());
     Ok(())
+}
+
+/// Rotate a keystore's password without exposing the private key to
+/// disk or logs. Atomic: decrypt → re-encrypt → verify round-trip →
+/// backup old file → rename new file over old.
+///
+/// The private key lives only inside the in-memory `Wallet` struct,
+/// which zeroises its secret on drop (`Zeroizing<[u8;32]>`). No
+/// stdout/stderr output reveals the key. Only the ADDRESS is printed
+/// for operator confirmation.
+fn cmd_wallet_rekey(
+    keystore_file: &str,
+    old_password: Option<String>,
+    new_password: Option<String>,
+) -> anyhow::Result<()> {
+    use std::path::Path;
+
+    // Resolve old password via CLI / SENTRIX_WALLET_OLD_PASSWORD env /
+    // prompt. Prompt happens if both unset.
+    let old_pwd = resolve_password_named(
+        old_password,
+        "SENTRIX_WALLET_OLD_PASSWORD",
+        "Enter OLD wallet password",
+    )?;
+    // New password: same resolution path + confirm-twice on prompt.
+    let new_pwd = resolve_password_named(
+        new_password,
+        "SENTRIX_WALLET_NEW_PASSWORD",
+        "Enter NEW wallet password",
+    )?;
+    if old_pwd == new_pwd {
+        anyhow::bail!("new password is identical to old — rotation would be a no-op");
+    }
+
+    // Step 1 — decrypt old keystore (this also validates old_pwd).
+    let old_keystore = Keystore::load(keystore_file)?;
+    let wallet = old_keystore
+        .decrypt(&old_pwd)
+        .map_err(|e| anyhow::anyhow!("old password rejected: {}", e))?;
+    let address = wallet.address.clone();
+
+    // Step 2 — re-encrypt with new_pwd (fresh salt, nonce, mac).
+    let new_keystore = Keystore::encrypt(&wallet, &new_pwd)?;
+
+    // Step 3 — verify round-trip BEFORE touching the original file.
+    // If any implementation bug produces an un-decryptable keystore,
+    // we catch it here instead of after overwriting the operator's
+    // only copy.
+    let verify = new_keystore
+        .decrypt(&new_pwd)
+        .map_err(|e| anyhow::anyhow!("new keystore failed self-decrypt — aborting: {}", e))?;
+    if verify.address != address {
+        anyhow::bail!(
+            "address mismatch after rekey self-verify (got {}, expected {}); aborting",
+            verify.address,
+            address
+        );
+    }
+
+    // Step 4 — atomic replace via sibling tempfile + rename.
+    let path = Path::new(keystore_file);
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("keystore_file has no parent directory"))?;
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let tmp_path = parent.join(format!(".rekey-tmp-{}", ts));
+    new_keystore.save(tmp_path.to_str().ok_or_else(|| {
+        anyhow::anyhow!("tempfile path contains non-UTF-8 bytes — refusing to save")
+    })?)?;
+
+    // Timestamped backup of the old file. Operator can `rm` after a
+    // stable period (suggested 48 h).
+    let bak_path = parent.join(format!(
+        "{}.bak-{}",
+        path.file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("keystore"),
+        ts
+    ));
+    std::fs::rename(path, &bak_path)?;
+    std::fs::rename(&tmp_path, path)?;
+
+    // Drop the in-memory plaintext as early as possible. `Wallet`
+    // already zeroises its secret on drop, but explicit drop pins
+    // the timing.
+    drop(old_pwd);
+    drop(new_pwd);
+    drop(wallet);
+    drop(verify);
+
+    println!("Keystore rekeyed:");
+    println!("  Address:   {}", address);
+    println!("  File:      {}", keystore_file);
+    println!("  Old copy:  {}", bak_path.display());
+    println!();
+    println!("Next steps (operator):");
+    println!("  1. Update SENTRIX_WALLET_PASSWORD in the env file to the new password.");
+    println!("  2. Restart the validator service (e.g. `systemctl restart sentrix-node`).");
+    println!("  3. Confirm 'Validator mode: {}' appears in journalctl.", address);
+    println!("  4. After the node runs stable for 48h, delete {}.", bak_path.display());
+    Ok(())
+}
+
+/// Like `resolve_password` but with a named env var + custom prompt.
+/// Lets `rekey` distinguish OLD vs NEW password sources cleanly.
+fn resolve_password_named(
+    cli_password: Option<String>,
+    env_var: &str,
+    prompt: &str,
+) -> anyhow::Result<String> {
+    if let Some(pw) = cli_password {
+        return Ok(pw);
+    }
+    if let Ok(pw) = std::env::var(env_var) {
+        return Ok(pw);
+    }
+    eprint!("{}: ", prompt);
+    let mut pw = String::new();
+    std::io::stdin().read_line(&mut pw)?;
+    let pw = pw.trim().to_string();
+    if pw.is_empty() {
+        anyhow::bail!("Password cannot be empty");
+    }
+    Ok(pw)
 }
 
 /// Resolve password from CLI arg, SENTRIX_WALLET_PASSWORD env var, or terminal prompt.


### PR DESCRIPTION
Motivated by the 2026-04-23 session accidentally leaking the live `sentrix-node` keystore password into a Claude conversation. The operator needed a rotation path that doesn't route secrets through chat, and the previous flow (decrypt to stdout, pipe into encrypt) either exposed the private key on stdout or required careful shell composition to avoid it.

New subcommand: `sentrix wallet rekey <keystore_file>`.

### Flow

1. Decrypt with old password (validates old_pwd).
2. Re-encrypt with new password (fresh salt / nonce / MAC).
3. Self-decrypt verify — if this fails we haven't touched the original file yet, so a buggy encrypt path can never orphan the operator's only copy.
4. Atomic replace via sibling `.rekey-tmp-<ts>` → rename original to `<file>.bak-<ts>` → rename new file into place.
5. Drop + zeroise the in-memory plaintext. Private key never hits stdout, never logged, never in any output.

### Password resolution (in priority order)

- `--old-password` / `--new-password` CLI flags (discouraged — leaves the password in shell history).
- `SENTRIX_WALLET_OLD_PASSWORD` / `SENTRIX_WALLET_NEW_PASSWORD` env vars.
- Interactive prompt.

Rejects old == new as a no-op before any file mutation.

### Test plan

- [x] `cargo build -p sentrix-node`
- [x] `cargo clippy -p sentrix-node -- -D warnings`
- [x] E2E on a temp keystore: encrypt→OLD info→rekey OLD to NEW→NEW info→old=new rejection. Backup file retained. Address preserved across rotation.
- [ ] CI green on this PR.

### Operator next steps (post-merge)

Deploy the new binary to the validator host where rotation is needed, then:

```bash
sudo systemctl stop sentrix-node
SENTRIX_WALLET_OLD_PASSWORD='<old>' SENTRIX_WALLET_NEW_PASSWORD='<new>' \
  sudo -E /opt/sentrix/sentrix wallet rekey \
  /opt/sentrix/data/wallets/sentrix-node.keystore
# Update /etc/sentrix/sentrix-node.env with the new SENTRIX_WALLET_PASSWORD.
sudo systemctl start sentrix-node
sudo journalctl -u sentrix-node -n 20 | grep -i 'validator mode'
# After 48h stable, `rm` the `.bak-<ts>` file.
```

(Or use an interactive prompt if you don't want the env form.)