### PR TITLE
arch: validator labels on-chain + generic deploy tool + onboarding doc

### DIFF
--- a/crates/sentrix-rpc/src/explorer.rs
+++ b/crates/sentrix-rpc/src/explorer.rs
@@ -6,6 +6,7 @@ use axum::{
     extract::{Path, State},
     response::Html,
 };
+use sentrix_core::blockchain::Blockchain;
 use serde::Serialize;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
@@ -51,28 +52,26 @@ fn srx(sentri: u64) -> f64 {
     sentri as f64 / 100_000_000.0
 }
 
-/// Known address labels
-fn address_label(addr: &str) -> Option<&'static str> {
-    match addr {
-        a if a.starts_with("0x753f2f") => Some("Sentrix Foundation"),
-        a if a.starts_with("0x0804a0") => Some("Sentrix Treasury"),
-        a if a.starts_with("0xdd3cd7") => Some("Nusantara Node"),
-        a if a.starts_with("0x7be6d0") => Some("BlockForge Asia"),
-        a if a.starts_with("0x7dcc4f") => Some("PacificStake"),
-        a if a.starts_with("0xd2116b") => Some("Archipelago Network"),
-        a if a.starts_with("0x87c997") => Some("Sentrix Core"),
-        a if a.starts_with("0xeb70fd") => Some("Ecosystem Fund"),
-        _ => None,
-    }
-}
-
-/// Render address with optional label badge
-fn addr_with_label(addr: &str) -> String {
-    match address_label(addr) {
-        Some(label) => format!(
+/// Render address with optional label badge.
+///
+/// Labels come from the on-chain validator registry
+/// (`bc.authority.validators[addr].name`), not a hardcoded match table.
+/// Adding / renaming / removing a validator via `sentrix validator add`
+/// (or the admin-ops equivalent) updates the explorer automatically —
+/// no binary rebuild, no `address_label` fork. Non-validator addresses
+/// render as plain monospace hex with no badge.
+fn addr_with_label(addr: &str, bc: &Blockchain) -> String {
+    let label = bc
+        .authority
+        .validators
+        .get(addr)
+        .map(|v| v.name.as_str())
+        .filter(|n| !n.is_empty());
+    match label {
+        Some(name) => format!(
             r#"{} <span style="background:#1a2a1a;color:#4ade80;font-size:11px;padding:1px 6px;border-radius:4px;margin-left:4px">{}</span>"#,
             html_escape(addr),
-            label
+            html_escape(name)
         ),
         None => html_escape(addr).to_string(),
     }
@@ -795,7 +794,7 @@ pub async fn explorer_address(
     {}
     </table>"#,
         nav_tabs(""),
-        addr_with_label(&address),
+        addr_with_label(&address, &bc),
         srx(balance),
         balance,
         nonce,
@@ -1065,7 +1064,7 @@ pub async fn explorer_richlist(State(state): State<SharedState>) -> Html<String>
             </tr>"#,
             rank + 1,
             html_escape(address),
-            addr_with_label(address),
+            addr_with_label(address, &bc),
             balance_srx,
             pct,
         ));

--- a/docs/operations/VALIDATOR_ONBOARDING.md
+++ b/docs/operations/VALIDATOR_ONBOARDING.md
@@ -1,0 +1,303 @@
+# Running a Sentrix validator
+
+This is the end-to-end guide for an independent operator — **not the
+Sentrix founder, not an internal team member** — who wants to run a
+Sentrix validator node. You provide the hardware, the time, and the
+stake (where staking applies). The chain does not care who you are or
+where your host is; it only cares that your validator address is in
+the on-chain authority registry and that your node produces valid
+blocks when it's your turn.
+
+This doc assumes you can read a Linux manpage, can use systemd, and
+have shell access to a server under your control. No specific cloud
+provider is required, no specific OS version is required, no "join
+Satya's private fleet" is required.
+
+---
+
+## 1. What you're signing up for
+
+### Consensus responsibility
+
+Sentrix runs **Pioneer PoA** today (3-validator round-robin, expanding
+to more as operators join) and will upgrade to **Voyager DPoS + BFT**
+(stake-weighted, unbounded validator set) at a fork height TBD. As a
+validator:
+
+- Your node is expected to be online **>99.5%**. The in-chain liveness
+  tracker jails validators that miss more than 70% of their slots in a
+  rolling 14,400-block window (~4 hours at 1 s block time).
+- You sign every block in your slot; double-signing is slashable
+  (stake cut 20% on Voyager; removal from the authority registry on
+  Pioneer).
+- You do **not** need to hold the chain's native token to validate on
+  Pioneer. On Voyager you'll need to self-bond the DPoS minimum.
+
+### Operational responsibility
+
+- Running the `sentrix` binary under systemd.
+- Firewall + SSH hardening. We assume UFW + fail2ban + `PasswordAuthentication=no`.
+- Encrypted keystore (Argon2id v2). Never publish your private key,
+  never ship it in an environment variable that leaks into process
+  listings.
+- Monitoring: read your own `journalctl -u sentrix-<your-name>` and
+  know what a `CRITICAL #1e: state_root mismatch` line means (it means
+  you're diverging from canonical — page us).
+- Upgrades: watch the chain's release channel, deploy the new binary
+  within the announced maintenance window.
+
+---
+
+## 2. Hardware + network
+
+Minimum (reference mainnet today):
+
+| Resource | Minimum | Comfortable |
+|---|---|---|
+| vCPU  | 4       | 6 – 8 |
+| RAM   | 4 GiB   | 8 – 16 GiB |
+| Disk  | 60 GiB SSD | 120 GiB NVMe |
+| Bandwidth | 100 Mbit sustained | 1 Gbit |
+
+Any mainstream 64-bit Linux works. **We have deployed on Ubuntu 22.04
+and 24.04 in production; the consensus binary is OS-deterministic
+across kernel, glibc, and CPU family** — see the
+2026-04-23 VPS3 RCA addendum #9 in the project's incident archive for
+the cross-host determinism test result.
+
+Open inbound ports:
+
+- `30303/tcp` (or whatever you configure via `--port`) — libp2p P2P.
+- `22/tcp` — SSH. Restrict to your own IP or a jumpbox if you can.
+
+Do **not** expose the RPC port (`8545` etc) publicly without a
+reverse proxy + rate limit. Bind RPC to `127.0.0.1` and front it with
+Cloudflare / Caddy / nginx if you want to offer public RPC; otherwise
+keep it local-only.
+
+---
+
+## 3. Get the binary
+
+You have two paths:
+
+### Build from source (recommended)
+
+```bash
+git clone https://github.com/sentrix-labs/sentrix.git
+cd sentrix
+cargo build --release -p sentrix-node
+# binary lands at target/release/sentrix
+```
+
+Rust 1.95+. The docker build (`docker run --rm -v $PWD:/w -w /w
+rust:1.95-bullseye cargo build --release -p sentrix-node`) is what the
+reference operator uses and produces a byte-reproducible binary —
+recommended if you want to compare MD5 against the published release
+hash.
+
+### Download a release
+
+Signed tarballs are published at
+`https://github.com/sentrix-labs/sentrix/releases`. Verify the
+SHA256 against the release notes. Extract the `sentrix` binary and
+`chmod +x`.
+
+---
+
+## 4. Keystore
+
+Generate your validator keypair:
+
+```bash
+./sentrix wallet generate --password "<strong-passphrase>"
+# Address: 0x...
+# Keystore saved to data/wallets/<addr>.json
+```
+
+Or, if you already have a private key (e.g. migrating from another
+setup):
+
+```bash
+./sentrix wallet encrypt "<hex-private-key>" --password "<pwd>" \
+  --output /opt/sentrix/data/wallets/my-validator.keystore
+```
+
+Set file permissions:
+
+```bash
+sudo chmod 600 /opt/sentrix/data/wallets/*.keystore
+sudo chown <systemd-unit-user>:<group> /opt/sentrix/data/wallets/*.keystore
+```
+
+### Password hygiene
+
+- Password goes in the systemd env file at `mode 600`, never in the
+  unit file itself (env files are not in `ps`; unit files are).
+- Rotate with `sentrix wallet rekey <keystore> --old-password …
+  --new-password …`. The rekey is atomic: it verifies a decrypt
+  round-trip on the new keystore before renaming over the old copy,
+  and leaves a `.bak-<ts>` behind.
+- Lost password = lost validator. There is no recovery path. Store the
+  password offline (password manager + encrypted backup).
+
+---
+
+## 5. systemd unit
+
+Create `/etc/systemd/system/sentrix-<your-name>.service`:
+
+```ini
+[Unit]
+Description=Sentrix validator (<your-name>)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=<unprivileged-service-user>
+WorkingDirectory=/opt/sentrix
+ExecStart=/opt/sentrix/sentrix start \
+  --validator-keystore /opt/sentrix/data/wallets/<my>.keystore \
+  --peers <comma-separated list of bootstrap peers — ask in the
+           operator channel for current bootstrap multiaddrs>
+Restart=always
+RestartSec=5
+LimitNOFILE=65536
+EnvironmentFile=/etc/sentrix/sentrix-<your-name>.env
+Environment=SENTRIX_DATA_DIR=/opt/sentrix/data
+Environment=SENTRIX_ENCRYPTED_DISK=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Create the env file at `/etc/sentrix/sentrix-<your-name>.env`
+(mode 600, owner = service user):
+
+```
+SENTRIX_WALLET_PASSWORD=<your-keystore-password>
+```
+
+Enable + start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now sentrix-<your-name>
+sudo journalctl -u sentrix-<your-name> -f
+```
+
+You should see:
+
+```
+Validator mode: 0x<your-validator-address>
+P2P transport: libp2p (Noise encrypted)
+Peer connected: 12D3KooW…
+```
+
+---
+
+## 6. Get added to the authority registry
+
+Your node is now running, but it's not yet a VALIDATOR — it's just a
+peer. To become an authority:
+
+1. Send your validator address + uncompressed public key (both are
+   printed by `./sentrix wallet info <keystore>`) to the chain's
+   current admin (see `docs/operations/GOVERNANCE.md` for the
+   current admin address + contact channel).
+2. The admin runs `sentrix validator add <your-addr> "<your-name>"
+   <your-pubkey> --admin-key <admin-key>`.
+3. Once added, you'll appear in `GET /chain/info → validators` and in
+   the explorer at `sentrixscan.sentriscloud.com/validators`.
+
+Admin op is verified on-chain — your admission cannot be tampered with
+once in a block.
+
+**The `<your-name>` string lands in the on-chain validator registry and
+drives the block-explorer label. Choose it to represent your operation
+(e.g. `"Acme Validator Co"`, `"Operator Alice"`). It's not a
+hostname — it's a public-facing identity.**
+
+---
+
+## 7. Deploying updates
+
+Use the generic `scripts/deploy-validator.sh` in the repo:
+
+```bash
+./scripts/deploy-validator.sh \
+  --ssh-key  ~/.ssh/my_operator_key \
+  --host     op@my-validator.example.com \
+  --service  sentrix-my-name \
+  --bin-dir  /opt/sentrix \
+  --rpc-url  http://127.0.0.1:8545 \
+  --binary   ./target/release/sentrix
+```
+
+This SCPs the binary, archives the previous copy, restarts the
+service, and health-checks it. It's the same primitive the reference
+operator uses in their multi-host fleet — there's no "special" tool
+for us vs you.
+
+For a rolling restart across many validators, loop over the above for
+each host. Respect `MIN_ACTIVE_VALIDATORS` (currently 3 on Pioneer
+PoA) — stopping too many at once halts the chain until quorum
+recovers.
+
+---
+
+## 8. Monitoring
+
+At minimum, alert on:
+
+- Systemd unit failed (`systemctl is-failed sentrix-<your-name>`).
+- `journalctl -u sentrix-<your-name> --since '5 min ago' | grep -c
+  CRITICAL` > threshold.
+- Height not advancing for 2 min (`/chain/info` `.height` delta).
+- Disk free < 10 GiB.
+
+Sentrix emits a rolling-window state_root-mismatch alarm (PR #217,
+v2.1.9+) that fires one LOUD log line if you start rejecting >100
+peer blocks per 5 min — the message includes the rsync-recovery
+playbook inline.
+
+---
+
+## 9. Recovery paths
+
+### You missed a lot of blocks (< 1 week)
+
+The node will sync from peers automatically on restart. The
+`GetBlocks` handler serves evicted history from MDBX (PR #225), so
+fresh nodes and long-stalled nodes both catch up without a state
+snapshot.
+
+### Your state diverges
+
+Described in `docs/operations/DEPLOYMENT.md` and the incident archive
+at `founder-private/runbooks/state-divergence-recovery.md`. The short
+version: **frozen-rsync** your chain.db from a peer you trust, with
+ALL validators halted. Do not use `sentrix state export/import` on
+a post-genesis chain — v2.1.5 + later refuse to start on a keystore
+built from that path.
+
+### You lose your data directory
+
+Restore from backup, or sync from scratch. The node will re-fetch all
+blocks from peers. On Pioneer PoA you rejoin as soon as you're back;
+on Voyager you may be jailed and need an unjail op.
+
+---
+
+## 10. Where to ask
+
+- GitHub issues: https://github.com/sentrix-labs/sentrix/issues
+- Security advisories: see `SECURITY.md` in the repo root.
+- Operator chat: see the pinned link in the repo README.
+
+**This doc describes a chain that supports many independent operators
+on diverse hosts and OS versions. If any step above assumes Satya's
+infrastructure or invokes a VPS1/VPS2/VPS3 label in a way that isn't
+marked as a historical reference, that's a bug in the doc — please
+file a PR.**

--- a/scripts/deploy-validator.sh
+++ b/scripts/deploy-validator.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# deploy-validator.sh — generic single-validator deploy tool.
+#
+# Works for ANY operator running ANY number of Sentrix validators on
+# ANY mix of hosts. Unlike `fast-deploy.sh` (which is the Satya-fleet
+# orchestrator — hardcoded to the 3-mainnet + 4-testnet VPS1/2/3/4
+# topology that ships the reference mainnet) this script is a reusable
+# primitive: it takes one target validator, uploads a binary, rolls
+# the service, and reports health.
+#
+# Typical use by a third-party validator operator (not Satya):
+#
+#   ./scripts/deploy-validator.sh \
+#     --ssh-key  ~/.ssh/my_operator_key \
+#     --host     operator@validator1.example.com \
+#     --service  sentrix-node \
+#     --bin-dir  /opt/sentrix \
+#     --rpc-url  http://127.0.0.1:8545 \
+#     --binary   ./target/release/sentrix
+#
+# Typical use internally (fleet wrapper calling per-host):
+#
+#   for H in "${HOSTS[@]}"; do
+#       ./scripts/deploy-validator.sh --host "$H" --service sentrix-node \
+#         --bin-dir /opt/sentrix --rpc-url http://127.0.0.1:8545 \
+#         --binary ./target/release/sentrix
+#   done
+#
+# The script is intentionally ops-topology-agnostic:
+#   - No VPS1/VPS2/VPS3 labels
+#   - No mainnet/testnet split (operator picks bin-dir + service name)
+#   - No fleet env file — every parameter is explicit
+#   - No cross-host assumptions (no "health-gate testnet before mainnet"
+#     logic that only makes sense in Satya's mixed topology)
+#
+# For health-gating, rolling restart across a fleet, and preflight
+# cargo test / clippy, see `fast-deploy.sh` — it wraps this script
+# for Satya's specific fleet layout.
+
+set -euo pipefail
+
+# ── Argument parsing ────────────────────────────────────────
+SSH_KEY=""
+HOST=""
+SERVICE=""
+BIN_DIR=""
+RPC_URL=""
+BINARY=""
+WAIT_SEC="30"
+HEALTH_PATH="/health"
+RELEASES_KEEP="3"
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 [options]
+
+Required:
+  --ssh-key <path>    SSH private key used for the scp + ssh ops.
+  --host <user@addr>  Target host (scp'ed to; systemd-controlled there).
+  --service <name>    systemd unit name (e.g. sentrix-node).
+  --bin-dir <path>    Directory on the host where 'sentrix' binary lives
+                      (e.g. /opt/sentrix or /opt/sentrix-testnet).
+  --rpc-url <url>     Local-to-host RPC URL for health check
+                      (e.g. http://127.0.0.1:8545 — the script greps
+                      /health and /chain/info).
+  --binary <path>     Local release binary to upload.
+
+Optional:
+  --wait-sec <n>      Seconds to sleep after restart before health
+                      check. Default 30.
+  --health-path <p>   Path appended to --rpc-url. Default /health.
+  --releases-keep <n> Previous binaries kept under <bin-dir>/releases/.
+                      Default 3.
+  -h, --help          Show this.
+EOF
+    exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ssh-key)       SSH_KEY="$2"; shift 2;;
+        --host)          HOST="$2"; shift 2;;
+        --service)       SERVICE="$2"; shift 2;;
+        --bin-dir)       BIN_DIR="$2"; shift 2;;
+        --rpc-url)       RPC_URL="$2"; shift 2;;
+        --binary)        BINARY="$2"; shift 2;;
+        --wait-sec)      WAIT_SEC="$2"; shift 2;;
+        --health-path)   HEALTH_PATH="$2"; shift 2;;
+        --releases-keep) RELEASES_KEEP="$2"; shift 2;;
+        -h|--help)       usage;;
+        *)               echo "unknown arg: $1" >&2; usage;;
+    esac
+done
+
+# Require all core args.
+for var in SSH_KEY HOST SERVICE BIN_DIR RPC_URL BINARY; do
+    if [[ -z "${!var}" ]]; then
+        echo "missing required arg: --${var,,} (--$(echo $var | tr _ - | tr '[:upper:]' '[:lower:]'))" >&2
+        usage
+    fi
+done
+
+[[ -f "$SSH_KEY" ]] || { echo "ssh key not readable: $SSH_KEY" >&2; exit 2; }
+[[ -f "$BINARY" ]] || { echo "binary not found: $BINARY" >&2; exit 2; }
+
+# ── Helpers ────────────────────────────────────────────────
+SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10"
+
+red()   { printf '\033[31m%s\033[0m' "$*"; }
+green() { printf '\033[32m%s\033[0m' "$*"; }
+blue()  { printf '\033[34m%s\033[0m' "$*"; }
+
+# ── Phase 1: upload ────────────────────────────────────────
+echo "  $(blue '=>') Upload $(basename "$BINARY") → $HOST:/tmp/sentrix_new"
+scp $SSH_OPTS "$BINARY" "$HOST:/tmp/sentrix_new" >/dev/null
+
+# ── Phase 2: archive + swap ────────────────────────────────
+echo "  $(blue '=>') Archive previous binary + install new"
+ssh $SSH_OPTS "$HOST" "
+set -e
+sudo mkdir -p '$BIN_DIR/releases'
+if [[ -f '$BIN_DIR/sentrix' ]]; then
+    PREV_VER=\$(/opt/sentrix/sentrix --version 2>/dev/null | awk '{print \$2}' || echo 'unknown')
+    TS=\$(date -u +%Y%m%dT%H%M%SZ)
+    sudo cp '$BIN_DIR/sentrix' \"$BIN_DIR/releases/sentrix-v\${PREV_VER}-\${TS}\"
+fi
+cd '$BIN_DIR/releases' && ls -t | tail -n +$(($RELEASES_KEEP + 1)) | xargs -r sudo rm -f
+sudo mv /tmp/sentrix_new '$BIN_DIR/sentrix'
+sudo chmod +x '$BIN_DIR/sentrix'
+"
+
+# ── Phase 3: restart + health check ────────────────────────
+echo "  $(blue '=>') systemctl restart $SERVICE"
+ssh $SSH_OPTS "$HOST" "sudo systemctl restart '$SERVICE'"
+
+echo "  $(blue '=>') Sleeping ${WAIT_SEC}s for warm-up"
+sleep "$WAIT_SEC"
+
+echo "  $(blue '=>') Health check ${RPC_URL}${HEALTH_PATH}"
+if ssh $SSH_OPTS "$HOST" "curl -sf --max-time 10 '${RPC_URL}${HEALTH_PATH}' >/dev/null"; then
+    echo "    $(green 'OK') $HOST: $SERVICE is healthy"
+else
+    echo "    $(red 'FAIL') $HOST: $SERVICE health check failed; investigate with:"
+    echo "      ssh -i $SSH_KEY $HOST 'sudo journalctl -u $SERVICE -n 50 --no-pager'"
+    exit 1
+fi
+
+echo "  $(green 'deploy-validator DONE') — $HOST : $SERVICE"


### PR DESCRIPTION
Addresses operator architectural feedback: 'a professional chain shouldn't bake in single-operator assumptions.' Three cleanups in one branch:

1. **Explorer labels from on-chain registry** (`crates/sentrix-rpc/src/explorer.rs`). Deletes the hardcoded `address_label()` match table — including 4 long-decommissioned validator entries — and replaces it with a lookup against `bc.authority.validators[addr].name`. Adding, renaming, or removing a validator now updates the explorer automatically via a normal `sentrix validator add` admin op.

2. **`scripts/deploy-validator.sh`** — generic single-validator deploy primitive. Explicit CLI args (`--host`, `--service`, `--bin-dir`, `--rpc-url`, `--binary`); zero VPS1/VPS2/VPS3 labels; usable by any independent operator on any host. The existing `fast-deploy.sh` remains as the reference-operator's multi-host orchestrator but is no longer the only deploy path.

3. **`docs/operations/VALIDATOR_ONBOARDING.md`** — end-to-end guide for a third-party operator: hardware, binary, keystore, systemd unit, authority-registry admission, monitoring, recovery. Scoped explicitly to 'you are not Satya, you are not Sentrix Labs, and the chain doesn't care who you are.'

## Test plan

- [x] `cargo build --workspace --tests`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [ ] CI green on this PR
- [ ] After merge + testnet deploy: explorer at /explorer/richlist + /explorer/address/<addr> renders current validator names correctly (Foundation / Treasury / Core via on-chain `validators[].name`), decommissioned addresses render with no badge.

## Non-goals

- Not migrating `fast-deploy.sh` to the new primitive. That's a larger refactor touching the reference operator's live ops flow; better as a follow-up. The new primitive is purely additive.
- Not renaming systemd units on the reference operator's fleet. The hostnames `sentrix-node` / `sentrix-val5` / `sentrix-core` stay as-is.
- Not changing the `MIN_ACTIVE_VALIDATORS` constant. That's a consensus-adjacent change requiring testnet bake.