### PR TITLE
docs(cli): clarify --peers is bootstrap seed, NOT the validator set

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -116,7 +116,22 @@ enum Commands {
         /// P2P port
         #[arg(long, default_value_t = DEFAULT_PORT)]
         port: u16,
-        /// Bootstrap peers (comma-separated host:port)
+        /// Bootstrap peers (comma-separated host:port).
+        ///
+        /// This is a SEED list for the first-time connect; it is NOT the
+        /// validator set and does NOT need to be kept in sync with it.
+        /// After any one of these peers is reachable, Kademlia DHT
+        /// auto-discovers every other peer on the mesh (periodic 60 s
+        /// random walk + Identify-driven routing-table updates). Adding
+        /// a new validator therefore only requires (a) the new node
+        /// boots with `--peers` pointing at ONE existing operator's
+        /// public endpoint, and (b) the admin runs
+        /// `sentrix validator add`. No existing validator needs a
+        /// systemd-unit edit, a restart, or a `--peers` update.
+        ///
+        /// Recommended: point at 1–3 stable reference bootnodes rather
+        /// than every known validator, so the list doesn't churn when
+        /// the operator community grows.
         #[arg(long, default_value = "")]
         peers: String,
         /// Optional path to a genesis TOML. When absent, the binary uses the


### PR DESCRIPTION
Follow-up to PR #232 architectural cleanup. The `--peers` CLI arg's doc comment was a single line ('Bootstrap peers') that could be misread as 'every validator maintains a list of every other validator' — which would scale badly and is not actually how the chain works.

In reality the list is only a first-time dial seed. libp2p Kademlia runs a 60 s random-walk bootstrap + Identify-driven routing-table updates (`crates/sentrix-network/src/libp2p_node.rs:384, 518, 624`), so ongoing peer discovery is automatic after any one bootstrap peer is reachable.

Adding a new validator therefore does NOT require any existing validator to edit `--peers` or restart. The flow is:

1. New operator's node boots with `--peers` pointing at one existing public endpoint.
2. Admin runs `sentrix validator add <addr> "<name>" <pubkey> --admin-key …`.
3. Kademlia propagates the new node into every existing validator's routing table within ~1 minute.

Pure doc-comment change in `bin/sentrix/src/main.rs`; no runtime behaviour change. The clap `--help` text now matches the actual semantics.

## Test plan
- [x] `cargo build -p sentrix-node`
- [x] `cargo clippy -p sentrix-node -- -D warnings`
- [ ] CI green