### PR TITLE
core(authority): MIN_ACTIVE_VALIDATORS 3 → 1 (v2.1.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.11] — 2026-04-23 — MIN_ACTIVE_VALIDATORS: 3 → 1 (bootstrap-friendly)
+
+Patch release. Unlocks a legitimate ops pattern that the previous hard floor blocked: running the chain with as few as one validator during bootstrap, disaster-recovery, or a deliberate centralisation window.
+
+### Changed
+
+- **core(authority): MIN_ACTIVE_VALIDATORS 3 → 1** (`crates/sentrix-core/src/authority.rs`). The guard now only stops the admin from deactivating or removing the *last* validator — anything above that is fine. The old floor of 3 baked a specific topology into the protocol and wouldn't let the operator scale back under it even when consensus was fine with any count ≥ 1. Round-robin math (`height % active.len()`) already handled any validator count, so this is a CLI-only guard change — consensus, block validation, and gossip paths are untouched.
+- Four test expectations refreshed to the new floor: `test_h03_toggle_cannot_deactivate_last_validator`, `test_v501_remove_enforces_min_active_validators`, `test_v501_toggle_enforces_min_active_validators`, `test_h03_toggle_allows_deactivate_with_others`. All now assert the MIN=1 boundary.
+
+### Operator note
+
+`sentrix validator toggle` / `remove` must be run on every validator's chain DB to keep the `is_active` flag consistent cluster-wide — admin ops are local-node-state, not transactions. Centralising to one validator means zero fault tolerance (the single host is a hard single point of failure); treat it as a temporary state, not a destination.
+
 ## [2.1.10] — 2026-04-23 — Network tuning + sentrix-wire split
 
 Patch release bundling three network-layer improvements. Zero consensus impact — all changes are network/observability config or pure refactors.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "anyhow",
  "axum",
@@ -4892,14 +4892,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4942,14 +4942,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "bincode",
  "blake3",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5003,12 +5003,13 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3 0.11.0",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/authority.rs
+++ b/crates/sentrix-core/src/authority.rs
@@ -6,7 +6,16 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Minimum active validators for collusion resistance (PoA N/2+1 design)
-pub const MIN_ACTIVE_VALIDATORS: usize = 3;
+/// Minimum active validators the authority manager will keep alive.
+///
+/// Kept at 1 so the network can be operated with as few as one
+/// validator during bootstrap, disaster-recovery, or deliberate
+/// centralisation windows. The guard exists only to prevent the
+/// admin from deactivating / removing the *last* validator, which
+/// would leave the round-robin scheduler with nothing to pick and
+/// halt the chain permanently. Scaling back up is a matter of
+/// running `validator add` — the protocol handles any count ≥ 1.
+pub const MIN_ACTIVE_VALIDATORS: usize = 1;
 // Admin log size is bounded to prevent unbounded memory growth
 pub const MAX_ADMIN_LOG_SIZE: usize = 10_000;
 
@@ -580,7 +589,7 @@ mod tests {
         assert!(result.is_err());
         let err_str = result.unwrap_err().to_string();
         assert!(
-            err_str.contains("at least 3"),
+            err_str.contains("at least 1"),
             "Expected min validator error, got: {}",
             err_str
         );
@@ -721,30 +730,35 @@ mod tests {
 
     #[test]
     fn test_v501_remove_enforces_min_active_validators() {
-        let mut mgr = setup(); // exactly 3 validators = MIN_ACTIVE_VALIDATORS
-        let addr = mgr.active_validators()[0].address.clone();
-        // Removing one would leave 2 < MIN_ACTIVE_VALIDATORS
+        // Single-validator setup — removing the only one would leave 0,
+        // below MIN_ACTIVE_VALIDATORS and would halt the round-robin.
+        let mut mgr = AuthorityManager::new("admin".to_string());
+        let (addr, pk) = gen_validator_keypair();
+        mgr.add_validator("admin", addr.clone(), "V1".to_string(), pk)
+            .unwrap();
         let result = mgr.remove_validator("admin", &addr);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("at least 3"),
-            "Expected min 3 error, got: {}",
+            err.contains("at least 1"),
+            "Expected min 1 error, got: {}",
             err
         );
     }
 
     #[test]
     fn test_v501_toggle_enforces_min_active_validators() {
-        let mut mgr = setup(); // exactly 3 validators = MIN_ACTIVE_VALIDATORS
-        let addr = mgr.active_validators()[0].address.clone();
-        // Deactivating one would leave 2 < MIN_ACTIVE_VALIDATORS
+        // Same as above but via toggle_validator.
+        let mut mgr = AuthorityManager::new("admin".to_string());
+        let (addr, pk) = gen_validator_keypair();
+        mgr.add_validator("admin", addr.clone(), "V1".to_string(), pk)
+            .unwrap();
         let result = mgr.toggle_validator("admin", &addr);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("at least 3"),
-            "Expected min 3 error, got: {}",
+            err.contains("at least 1"),
+            "Expected min 1 error, got: {}",
             err
         );
     }
@@ -854,24 +868,31 @@ mod tests {
 
     #[test]
     fn test_h03_toggle_allows_deactivate_with_others() {
-        // 4 validators so toggling one leaves 3 ≥ MIN_ACTIVE_VALIDATORS
+        // 4 validators — can deactivate down to exactly 1 (the MIN),
+        // trying to deactivate the last one fails.
         let mut mgr = setup_4();
-        let addr1 = mgr.active_validators()[0].address.clone();
-        let addr2 = mgr.active_validators()[1].address.clone();
+        let mut remaining: Vec<String> = mgr
+            .active_validators()
+            .iter()
+            .map(|v| v.address.clone())
+            .collect();
         assert_eq!(mgr.active_count(), 4);
 
-        // Deactivating one leaves 3 — should succeed
-        let result = mgr.toggle_validator("admin", &addr1);
-        assert!(result.is_ok());
-        assert_eq!(mgr.active_count(), 3);
+        // Deactivate three of the four — each should succeed.
+        for _ in 0..3 {
+            let addr = remaining.remove(0);
+            mgr.toggle_validator("admin", &addr).unwrap();
+        }
+        assert_eq!(mgr.active_count(), 1);
 
-        // Deactivating another would leave 2 < 3 — should fail
-        let result = mgr.toggle_validator("admin", &addr2);
+        // Last one left — deactivating would drop below MIN_ACTIVE_VALIDATORS=1.
+        let last = remaining.remove(0);
+        let result = mgr.toggle_validator("admin", &last);
         assert!(result.is_err());
         let err_str = result.unwrap_err().to_string();
         assert!(
-            err_str.contains("at least 3"),
-            "Expected min 3 error, got: {}",
+            err_str.contains("at least 1"),
+            "Expected min 1 error, got: {}",
             err_str
         );
     }

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

- Lower `MIN_ACTIVE_VALIDATORS` from 3 to 1 in `crates/sentrix-core/src/authority.rs`
- Refresh 4 boundary tests to assert the new MIN=1 floor
- Bump to v2.1.11 + CHANGELOG entry

## Why

The old floor of 3 baked a specific topology into the protocol and wouldn't let the operator scale back under it even when consensus was fine with any count ≥ 1. Round-robin math (`height % active.len()`) already handled any validator count — the guard was redundant for consensus and restrictive for ops.

Unlocks: run with 1 validator during bootstrap, disaster-recovery, or deliberate centralisation window. Scale back up via `validator add` — nothing in the protocol assumes 3.

The guard still exists, just at 1: admin can't remove / deactivate the *last* validator (that would halt the round-robin permanently).

## Scope

- CLI-only guard change. Consensus, block validation, gossip paths untouched.
- `sentrix validator toggle` / `remove` are already local-node-state operations (not transactions), so running them requires touching every validator's chain DB — this PR doesn't change that.

## Operator note

Centralising to 1 validator = zero fault tolerance. Treat as a temporary state, not a destination.

## Test plan

- [x] `cargo test -p sentrix-core authority` — 33/33 pass locally
- [ ] CI green