### PR TITLE
chore: close 2 minor audit findings (log context + validate_chain consistency)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1752,7 +1752,12 @@ async fn cmd_start(
                                 }
                             }
                             Err(e) => {
-                                tracing::warn!("create_block failed: {}", e);
+                                tracing::warn!(
+                                    "create_block failed at height {} round {}: {}",
+                                    next_height,
+                                    bft.round(),
+                                    e
+                                );
                                 drop(bc);
                             }
                         }

--- a/crates/sentrix-rpc/src/routes/chain.rs
+++ b/crates/sentrix-rpc/src/routes/chain.rs
@@ -169,7 +169,7 @@ pub(super) async fn validate_chain(
     Json(serde_json::json!({
         "valid": valid,
         "height": height,
-        "total_blocks": bc.chain.len(),
+        "total_blocks": bc.height() + 1, // match cached path: true total from block index
         "cached": false,
     }))
 }


### PR DESCRIPTION
Closes audit findings #1 + #6 from minor-bug-hunt-2026-04-20.md. Pure log/return-shape cleanup, non-consensus.