### PR TITLE
feat(rpc,metrics): supply + burn counters at /metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - **rpc(rest): `GET /chain/finalized-height`** — REST alias for the existing `sentrix_getFinalizedHeight` JSON-RPC method. Closes the A5 audit finding. Returns `finalized_height` / `finalized_hash` / `latest_height` / `blocks_behind_finality` / `consensus`. On Pioneer PoA every committed block is final — endpoint returns the tip. On Voyager BFT walks back from the tip for the newest block with `justification.is_some()`. Lets light clients + dashboards + Prometheus exporters learn finality lag without speaking JSON-RPC.
+- **rpc(metrics): supply + burn counters exposed at `/metrics`** — three new Prometheus gauges/counters: `sentrix_total_minted_sentri` (counter, all SRX ever minted), `sentrix_total_burned_sentri` (counter, all SRX burned from fee split + explicit burns), `sentrix_circulating_supply_sentri` (gauge = minted − burned). Unlocks supply-curve and burn-rate charts in Grafana + lets Prometheus alert on supply-invariant violations (e.g. `sentrix_total_minted_sentri > MAX_SUPPLY_sentri` should NEVER fire on a healthy chain). Raw sentri integers (not SRX floats) so rates/deltas stay exact across 1 SRX = 100M sentri scale.
 
 ## [2.1.11] — 2026-04-23 — MIN_ACTIVE_VALIDATORS: 3 → 1 (bootstrap-friendly)
 

--- a/crates/sentrix-rpc/src/routes/ops.rs
+++ b/crates/sentrix-rpc/src/routes/ops.rs
@@ -132,6 +132,11 @@ pub(super) async fn metrics(State(state): State<SharedState>) -> axum::response:
     let mempool = bc.mempool_size();
     let chain_id = bc.chain_id;
     let deployed_tokens = bc.list_tokens().len();
+    let total_minted_sentri = bc.total_minted;
+    let total_burned_sentri = bc.accounts.total_burned;
+    // Circulating = minted − burned. Cheap to compute here so Prometheus/Grafana
+    // can chart it directly without users learning the burn semantics.
+    let circulating_sentri = total_minted_sentri.saturating_sub(total_burned_sentri);
 
     // Compute avg block time from last 10 blocks in the window.
     let mut block_times: Vec<u64> = Vec::new();
@@ -191,7 +196,16 @@ pub(super) async fn metrics(State(state): State<SharedState>) -> axum::response:
          sentrix_uptime_seconds {uptime}\n\
          # HELP sentrix_chain_id Chain identifier.\n\
          # TYPE sentrix_chain_id gauge\n\
-         sentrix_chain_id {chain_id}\n"
+         sentrix_chain_id {chain_id}\n\
+         # HELP sentrix_total_minted_sentri Total SRX ever minted by the chain (coinbase rewards + genesis premine). 1 SRX = 100_000_000 sentri.\n\
+         # TYPE sentrix_total_minted_sentri counter\n\
+         sentrix_total_minted_sentri {total_minted_sentri}\n\
+         # HELP sentrix_total_burned_sentri Total SRX burned (50% of each tx fee + explicit burns). Monotonically increasing counter.\n\
+         # TYPE sentrix_total_burned_sentri counter\n\
+         sentrix_total_burned_sentri {total_burned_sentri}\n\
+         # HELP sentrix_circulating_supply_sentri Currently circulating SRX = total_minted − total_burned.\n\
+         # TYPE sentrix_circulating_supply_sentri gauge\n\
+         sentrix_circulating_supply_sentri {circulating_sentri}\n"
     );
 
     axum::response::Response::builder()


### PR DESCRIPTION
3 new Prometheus metrics: sentrix_total_minted_sentri, sentrix_total_burned_sentri, sentrix_circulating_supply_sentri. Read-only, integer sentri units. Unlocks supply/burn Grafana charts + supply-invariant alerts.