### PR TITLE
fix(rpc): align REST /chain/finalized-height fallback with JSON-RPC

### DIFF
--- a/crates/sentrix-rpc/src/routes/chain.rs
+++ b/crates/sentrix-rpc/src/routes/chain.rs
@@ -48,11 +48,16 @@ pub(super) async fn get_finalized_height(
     let next_height = latest.index.saturating_add(1);
     let bft_active = sentrix_core::blockchain::Blockchain::is_voyager_height(next_height);
 
+    // Fallback to latest when BFT is active but no justified block sits
+    // in the sliding window yet. Mirrors `sentrix_getFinalizedHeight`
+    // JSON-RPC semantics exactly — querying either endpoint must return
+    // the same value, otherwise light clients hitting REST see
+    // `finalized_height=0` on a chain JSON-RPC reports as finalized at tip.
     let (finalized_height, finalized_hash) = if !bft_active {
         (latest.index, latest.hash.clone())
     } else {
-        let mut h = 0u64;
-        let mut hash = String::new();
+        let mut h = latest.index;
+        let mut hash = latest.hash.clone();
         for b in bc.chain.iter().rev() {
             if b.justification.is_some() {
                 h = b.index;


### PR DESCRIPTION
## Summary

Fresh-brain review of PR #239 surfaced a client-visible semantic divergence: when BFT is active but no justified block sits in the sliding window, the REST handler returned `finalized_height=0` / `finalized_hash=""` while `sentrix_getFinalizedHeight` JSON-RPC returned `latest.index` / `latest.hash`. Clients hitting either endpoint on the same chain state saw different answers.

Sliding window rolls older blocks out of memory long before they drop off disk, so on a BFT chain (post PR #244 durable persistence) it is entirely normal for the in-memory window to hold zero justified blocks for stretches — straight after boot, after a long idle period, or on a node syncing from an older peer. The old REST behaviour falsely reported the chain at finality=0 in those windows.

Aligned to JSON-RPC: when the walk finds no justified block, fall back to latest index/hash. Same semantics, same payload.

## Test plan
- [x] `cargo build -p sentrix-rpc` (clean)
- [x] `cargo test -p sentrix-rpc --lib` (22 passed)
- [ ] Post-deploy: `curl $RPC/chain/finalized-height` and `curl -X POST $RPC/rpc -d sentrix_getFinalizedHeight` must return matching `finalized_height` on a testnet with BFT active