### PR TITLE
chore: release v2.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.13] — 2026-04-25 — Fix v2.1.12 testnet livelock (#247 partial)
+
+v2.1.12 bundled 10 PRs and was reproducibly livelocked on 4-validator BFT testnet bake — validators prevoted block, precommitted nil 12s later, rounds skipped forever. The v2.1.12 GitHub release is flagged `--prerelease` with operator warning.
+
+Bisected to PR #236's `on_proposal` check: the else-branch (reject when proposer is missing from `stake_registry.validators`) was too strict for real operational state where registry-vs-active_set drift happens. `weighted_proposer` already gated the proposer upstream, so the extra registry-miss reject was belt-and-suspenders that tripped itself.
+
+Fix preserves the original #236 intent (jailed/tombstoned validators cannot drive consensus) and drops the else-branch rejection. No other runtime logic changed.
+
+### Fixed
+
+- **bft: drop `stake_registry.get_validator()` miss-reject in `on_proposal`** (`crates/sentrix-bft/src/engine.rs`, #248). Bisected root cause of the v2.1.12 testnet livelock. With the else-branch removed, testnet immediately produced clean blocks at baseline rate for the first 82 blocks of bake before a separate cascade (PR #215 tight liveness thresholds interacting with PR #236 `update_active_set()` eviction) surfaced — documented in issue #247 for next-session follow-up. Regression test flipped: `test_unregistered_proposer_rejected_at_on_proposal` retired, replaced with `test_active_set_proposer_accepted_when_missing_from_registry_validators` pinning the new invariant. 71/71 BFT tests green.
+
 ## [2.1.12] — 2026-04-24 — Voyager-blocker sweep + BACKLOG #16 durable + REST/JSON-RPC parity
 
 Patch release bundling the 2026-04-24 late-night marathon: three Voyager blockers closed (V1 real precommit signatures, V3 jailing enforcement at consensus, V5 commission rate-limit), the C-03 trie-root rollback gap sealed, BACKLOG #16 gap formation eliminated at the durable fix point (atomic apply + MDBX persist with rollback), fresh-brain review follow-up aligning REST `/chain/finalized-height` semantics with JSON-RPC, plus observability + metrics surface work (supply + burn counters, silent P2P block-save alerting, TABLE_BLOOM visibility).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -4892,14 +4892,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4942,14 +4942,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "bincode",
  "blake3",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.12"
+version = "2.1.13"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Fix v2.1.12 testnet livelock (#247 partial). See CHANGELOG [2.1.13]. Fresh-brain review of #248 already landed; this is the release cut.