### PR TITLE
chore: release v2.1.14 — revert #237 (closes v2.1.12 livelock #247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.14] — 2026-04-25 — Revert PR #237 (V1 reopened) — close v2.1.12 livelock
+
+Second bisect pass over v2.1.12 exposed PR #237 (real precommit signatures) as the underlying cause of the prevote→nil-precommit flip livelock that v2.1.13's #236 trim did not fully close. Reverting #237's tuple extension and restoring the pre-V1 blanket `vec![]` placeholder emit loop allows 4-validator testnet to produce at baseline rate (2.69 blocks/sec sustained, 484 blocks over 180 seconds, zero skip-round warnings).
+
+V1 (empty justification signatures, Voyager blocker) is REOPENED by this revert. Voyager activation is gated on V1 plus the remaining P0 blockers. A follow-up PR must re-implement real-sig emission without triggering the precommit flip — the obvious suspects are (a) tuple widening on `BftRoundState.precommits` interacting with dedup timing under libp2p message fan-in, or (b) the finalize-emit filter on `vote_hash == block_hash` excluding precommits that should still count. Next-session work.
+
+Everything else in v2.1.12's bundle stays shipped: #215 V6 liveness retune, #235 V5 commission rate-limit, #238 C-03 trie-root rollback, #239 REST finalized-height, #240 audit log context, #241 TABLE_BLOOM visibility, #242 supply + burn metrics, #243 peer-save fail alerting, #244 BACKLOG #16 durable persist, #245 REST/JSON-RPC parity. And v2.1.13's #236 trim stays (jailed/tombstoned check preserved, miss-from-registry rejection dropped).
+
+### Reverted
+
+- **bft: revert PR #237's real precommit signatures** (`crates/sentrix-bft/src/engine.rs`). `BftRoundState.precommits` tuple restored to `(Option<String>, u64)`. Finalize emit loop restored to blanket `add_precommit(val, vec![], w)` over all precommits. `test_finalize_emits_real_precommit_signatures` marked `#[ignore]` pending V1 re-implementation. V3 jail-check (#236) and V5 commission (#235) unaffected.
+
 ## [2.1.13] — 2026-04-25 — Fix v2.1.12 testnet livelock (#247 partial)
 
 v2.1.12 bundled 10 PRs and was reproducibly livelocked on 4-validator BFT testnet bake — validators prevoted block, precommitted nil 12s later, rounds skipped forever. The v2.1.12 GitHub release is flagged `--prerelease` with operator warning.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "anyhow",
  "axum",
@@ -4892,14 +4892,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4942,14 +4942,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "bincode",
  "blake3",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -60,14 +60,10 @@ pub struct BftRoundState {
     pub proposed_hash: Option<String>,
     /// Prevotes collected: validator → (block_hash option, stake_weight)
     pub prevotes: HashMap<String, (Option<String>, u64)>,
-    /// Precommits collected: validator → (block_hash option, signature bytes, stake_weight).
-    /// Signature is the ECDSA bytes from the peer's `Precommit` message
-    /// — kept alongside the vote so that when a 2/3+ supermajority lands
-    /// we can emit a `BlockJustification` with REAL signatures, not
-    /// `vec![]` placeholders. Closes V1 Voyager-blocker (empty
-    /// justification signatures — silent-reorg surface when Voyager
-    /// activates).
-    pub precommits: HashMap<String, (Option<String>, Vec<u8>, u64)>,
+    /// Precommits collected: validator → (block_hash option, stake_weight).
+    /// BISECT #247: PR #237's signature-bytes extension REVERTED here to
+    /// test hypothesis it caused the v2.1.12 precommit-flip livelock.
+    pub precommits: HashMap<String, (Option<String>, u64)>,
     /// Our own vote cast this round (prevent double-voting)
     pub our_prevote_cast: bool,
     pub our_precommit_cast: bool,
@@ -590,11 +586,7 @@ impl BftEngine {
 
         self.state.precommits.insert(
             precommit.validator.clone(),
-            (
-                precommit.block_hash.clone(),
-                precommit.signature.clone(),
-                stake,
-            ),
+            (precommit.block_hash.clone(), stake),
         );
         self.collector
             .add_precommit(precommit.block_hash.clone(), stake);
@@ -611,17 +603,11 @@ impl BftEngine {
                         self.state.round,
                         block_hash.clone(),
                     );
-                    // V1: emit REAL signatures. Only include precommits
-                    // that voted for the finalized hash — nil precommits
-                    // and precommits for other hashes don't belong in
-                    // this block's justification. The aggregated stake
-                    // across included entries is what a verifier will
-                    // weigh against `total_active_stake` to reconstruct
-                    // the 2/3+ supermajority.
-                    for (val, (vote_hash, sig, w)) in &self.state.precommits {
-                        if vote_hash.as_deref() == Some(block_hash.as_str()) {
-                            justification.add_precommit(val.clone(), sig.clone(), *w);
-                        }
+                    // BISECT #247: PR #237 filtered+added real sigs here;
+                    // reverted to pre-V1 blanket vec![] placeholder to test
+                    // whether the tuple-widening caused the livelock.
+                    for (val, (_, w)) in &self.state.precommits {
+                        justification.add_precommit(val.clone(), vec![], *w);
                     }
 
                     self.state.phase = BftPhase::Finalize;
@@ -1684,6 +1670,7 @@ mod tests {
     /// hash are NOT included in the finalized block's justification
     /// (only the winning hash's backers should be counted).
     #[test]
+    #[ignore = "BISECT #247: #237 temporarily reverted while diagnosing livelock"]
     fn test_finalize_emits_real_precommit_signatures() {
         let (mut engine, _) = setup();
         let total = engine.state.total_active_stake;

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary
Second bisect pass found PR #237 was the underlying cause of the v2.1.12 testnet livelock that v2.1.13's #236 trim didn't fully close. Reverting #237 restores working 4-validator testnet.

## Bake evidence (post-force-unjail)
484 blocks in 180s = 2.69 blocks/sec sustained. Zero skip-round warnings. Zero CRITICAL.

## V1 reopened
Empty justification signatures (Voyager blocker) is now OPEN again. Must be re-implemented without the livelock trigger. Tracked in follow-up work.

## Test plan
- [x] cargo test -p sentrix-bft --lib: 70 pass, 1 ignored (the V1-specific test pending re-impl)
- [x] Testnet bake 180s sustained
- [ ] Close #247 once v2.1.14 ships