### PR TITLE
fix(bft,staking): count all precommit signers in liveness (closes #253)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1536,7 +1536,21 @@ async fn cmd_start(
 
                                                         let active =
                                                             bc.stake_registry.active_set.clone();
-                                                        let signers = vec![proposer.clone()];
+                                                        // #253: liveness-signers bug — the old
+                                                        // `signers = vec![proposer]` marked every
+                                                        // non-proposer as MISSED each block, so on
+                                                        // a 4-validator BFT chain each validator
+                                                        // signed only 25% of blocks vs the 30%
+                                                        // MIN_SIGNED_PER_WINDOW threshold, driving
+                                                        // deterministic cascade-jail every 14400
+                                                        // blocks (~80min). Correct model: every
+                                                        // precommit signer in the justification
+                                                        // signed the block, not just the proposer.
+                                                        let signers: Vec<String> = justification
+                                                            .precommits
+                                                            .iter()
+                                                            .map(|p| p.validator.clone())
+                                                            .collect();
                                                         bc.slashing.record_block_signatures(
                                                             &active, &signers, height,
                                                         );
@@ -1906,7 +1920,13 @@ async fn cmd_start(
                                                 bc.epoch_manager.record_block(reward);
 
                                                 let active = bc.stake_registry.active_set.clone();
-                                                let signers = vec![proposer.clone()];
+                                                // #253: see the sibling site above for rationale.
+                                                // Peer-finalize branch — same fix, same model.
+                                                let signers: Vec<String> = justification
+                                                    .precommits
+                                                    .iter()
+                                                    .map(|p| p.validator.clone())
+                                                    .collect();
                                                 bc.slashing.record_block_signatures(
                                                     &active, &signers, height,
                                                 );

--- a/crates/sentrix-staking/src/slashing.rs
+++ b/crates/sentrix-staking/src/slashing.rs
@@ -661,6 +661,88 @@ mod tests {
         assert_eq!(m2, 1);
     }
 
+    /// #253 regression: a 4-validator BFT chain where every block's
+    /// justification carries all four precommits should NOT trigger
+    /// downtime jail on any validator, even after a full LIVENESS_WINDOW.
+    ///
+    /// Before #253's fix, `main.rs` called `record_block_signatures`
+    /// with `signers = vec![proposer]`, so each non-proposer validator
+    /// was counted as MISSED every block. On a 4-validator chain, that
+    /// put each validator at 25% signed vs the 30% MIN_SIGNED_PER_WINDOW
+    /// threshold → deterministic cascade-jail every 14400 blocks
+    /// (~80min at 3 blocks/sec). This test pins the correct semantics:
+    /// every precommit signer in the justification counts as "signed".
+    #[test]
+    fn test_full_justification_no_cascade_jail() {
+        let mut engine = SlashingEngine::new();
+        let active = vec![
+            "0xval1".into(),
+            "0xval2".into(),
+            "0xval3".into(),
+            "0xval4".into(),
+        ];
+
+        // Simulate a full LIVENESS_WINDOW of blocks where every
+        // validator signs every block (healthy 4/4 justification).
+        for h in 0..LIVENESS_WINDOW {
+            engine.record_block_signatures(&active, &active, h);
+        }
+
+        for v in &active {
+            assert!(
+                !engine.liveness.is_downtime(v),
+                "#253: validator {} must not be downtime when all 4 precommits are recorded \
+                 every block — got downtime after LIVENESS_WINDOW of full participation",
+                v
+            );
+            let (signed, missed) = engine.liveness.get_stats(v);
+            assert_eq!(
+                signed, LIVENESS_WINDOW,
+                "#253: {} should show full signed_count, got signed={} missed={}",
+                v, signed, missed
+            );
+        }
+    }
+
+    /// #253 regression: the BROKEN pre-fix model (`signers = vec![proposer]`
+    /// where proposer rotates round-robin) deterministically cascade-jails
+    /// every validator. This test pins that the broken model WAS indeed
+    /// below threshold so the fix is load-bearing, not cosmetic.
+    #[test]
+    fn test_proposer_only_signers_triggers_cascade_jail() {
+        let mut engine = SlashingEngine::new();
+        let active: Vec<String> =
+            (0..4).map(|i| format!("0xval{}", i + 1)).collect();
+
+        // Simulate LIVENESS_WINDOW blocks with the BROKEN model:
+        // only the rotating proposer goes into `signers`.
+        for h in 0..LIVENESS_WINDOW {
+            let proposer_idx = (h as usize) % active.len();
+            let signers = vec![active[proposer_idx].clone()];
+            engine.record_block_signatures(&active, &signers, h);
+        }
+
+        // Each validator signed exactly 1/4 of blocks = 25% < 30% threshold.
+        for v in &active {
+            let (signed, _) = engine.liveness.get_stats(v);
+            let expected = LIVENESS_WINDOW / 4;
+            // Allow ±1 for integer division of LIVENESS_WINDOW / 4.
+            assert!(
+                signed.abs_diff(expected) <= 1,
+                "#253 broken-model pin: {} signed {} blocks; expected ≈{}",
+                v,
+                signed,
+                expected
+            );
+            assert!(
+                engine.liveness.is_downtime(v),
+                "#253 broken-model pin: {} must be flagged downtime under the old \
+                 signers=vec![proposer] scheme (25% signed < 30% threshold)",
+                v
+            );
+        }
+    }
+
     #[test]
     fn test_total_slashed_accumulates() {
         let mut reg = setup_registry();


### PR DESCRIPTION
Closes #253. Fixes the deterministic ~80min cascade-jail on Voyager BFT chains.

## Summary
`signers = vec![proposer]` at both FinalizeBlock sites in main.rs was marking 3 of every 4 validators as MISSED each block. At LIVENESS_WINDOW=14400 / MIN_SIGNED_PER_WINDOW=4320 (30%), round-robin 4-val chains signed 25% → all validators trip is_downtime() when window fills → cascade.

Fix: populate signers from justification.precommits.

## Test plan
- [x] `test_full_justification_no_cascade_jail` — passes. 4-val, all 4 precommits per block, full LIVENESS_WINDOW, no downtime flag on anyone.
- [x] `test_proposer_only_signers_triggers_cascade_jail` — passes. Pins the old broken model was below threshold.
- [x] `cargo test -p sentrix-staking --lib` — 81 pass.
- [x] `cargo build --release` clean.
- [ ] Post-merge: re-run v2.1.15 candidate on testnet (after remaining bisect completes) to verify ≥80min stability.

## Scope
Voyager BFT path only. Pioneer PoA unaffected (`record_block_signatures` not called on that path). Mainnet VPS1 is Pioneer, continues producing as-is.