### PR TITLE
chore: release v2.1.15 — close #252 livelock + #253 cascade-jail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.15] — 2026-04-25 — Closes #252 livelock (revert #244 hot-path persist) + #253 liveness signers fix
+
+Third bisect pass on the v2.1.12 bundle found **PR #244** (BACKLOG #16 inline durable persist) as the residual trigger. Without #244, testnet runs at 4.47 blocks/sec sustained for 180s with zero skip-round / nil-majority warnings (955 blocks / 6 minutes clean). With all of #236-else / #237 / #244 reverted, the remaining bundle is safe to ship.
+
+Also closes the deterministic Voyager-chain cascade-jail from #253: `record_block_signatures` now receives the full list of precommit signers from `justification.precommits` instead of `vec![proposer]`, so non-proposer validators stop being counted as MISSED every block.
+
+### Fixed
+
+- **core(block_executor): remove inline `persist_block_durable` from commit hot path (#252)** (`crates/sentrix-core/src/block_executor.rs`). PR #244's inline persist did 3 MDBX puts + 1 `sync()` on every block under the blockchain write-lock. On a 4-validator Voyager testnet that pushed BFT rounds past the 12s precommit timeout under sustained load, producing the prevote→nil-precommit flip livelock pattern tracked in #252. The gap-formation risk it was guarding against (BACKLOG #16 / PR #226's 7,352 missing `block:N` keys) is already covered without hot-lock cost via #243 (loud save_block failure + Prometheus alert) and #225 (GetBlocks serves evicted blocks from MDBX for peer sync recovery). `persist_block_durable` stays on `Blockchain` as an opt-in tool for CLI / recovery flows.
+- **bft/staking: count ALL precommit signers in liveness, not just proposer (#253)** (`bin/sentrix/src/main.rs`, `crates/sentrix-staking/src/slashing.rs`). Both BFT FinalizeBlock call sites were passing `signers = vec![proposer]` to `record_block_signatures`, so on a 4-validator chain each validator was counted as SIGNED only 25% of blocks vs the 30% `MIN_SIGNED_PER_WINDOW` threshold — deterministic cascade-jail every 14400 blocks (~80 min at 3 blocks/sec). Fix extracts signers from `justification.precommits`. Two regression tests pin the semantics: `test_full_justification_no_cascade_jail` (healthy) + `test_proposer_only_signers_triggers_cascade_jail` (load-bearing proof the old model was broken).
+
+### Added (test infrastructure)
+
+- **4-validator in-memory BFT harness** (`crates/sentrix-bft/tests/four_validator_harness.rs`). 5 tests drive `BftEngine` through full Propose→Prevote→Precommit→Finalize cycles with a shared `StakeRegistry`, no libp2p. The missing infrastructure that would have caught #237 pre-merge. Happy path, three-consecutive-heights, round-advance, prevote + precommit dedup.
+
 ## [2.1.14] — 2026-04-25 — Revert PR #237 (V1 reopened) — close v2.1.12 livelock
 
 Second bisect pass over v2.1.12 exposed PR #237 (real precommit signatures) as the underlying cause of the prevote→nil-precommit flip livelock that v2.1.13's #236 trim did not fully close. Reverting #237's tuple extension and restoring the pre-V1 blanket `vec![]` placeholder emit loop allows 4-validator testnet to produce at baseline rate (2.69 blocks/sec sustained, 484 blocks over 180 seconds, zero skip-round warnings).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -4892,14 +4892,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4942,14 +4942,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "bincode",
  "blake3",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.14"
+version = "2.1.15"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -546,41 +546,34 @@ impl Blockchain {
 
         match self.apply_block_pass2(block) {
             Ok(()) => {
-                // BACKLOG #16 durable fix: persist the just-committed block
-                // to MDBX in the same scope that holds `snap`. If persist
-                // fails, we roll back in-memory state via the same
-                // mechanism as the Pass-2-Err branch below — chain state
-                // and disk stay in lock-step, so a crash + restart sees
-                // a consistent tip. No more "applied-in-memory-but-not-
-                // persisted" orphan windows that create the 7,352-block
-                // TABLE_META gap pattern surfaced by PR #226's sweep test.
+                // #252 / #244-revert: the earlier BACKLOG #16 "durable"
+                // fix called `persist_block_durable` here under the
+                // blockchain write-lock — three MDBX puts + one fsync
+                // on every single commit. On a 4-validator Voyager
+                // testnet that pushed BFT rounds past the 12s
+                // precommit timeout under sustained load, causing the
+                // prevote→nil-precommit flip livelock tracked in #252.
                 //
-                // `mdbx_storage` is None only in unit-test paths that
-                // don't bind storage. `persist_block_durable` returns Err
-                // in that case; production callers always bind storage
-                // via `init_storage_handle`. Treat the None case as a
-                // test harness and skip — no gap risk because there's no
-                // disk path at all.
-                if self.mdbx_storage.is_some()
-                    && let Some(just_committed) = self.chain.last().cloned()
-                    && let Err(e) = self.persist_block_durable(&just_committed)
-                {
-                    tracing::error!(
-                        "BACKLOG #16 durable fix triggered: persist failed for block {}: {}; rolling back in-memory state",
-                        just_committed.index,
-                        e
-                    );
-                    self.accounts = snap.accounts;
-                    self.contracts = snap.contracts;
-                    self.authority = snap.authority;
-                    self.mempool = snap.mempool;
-                    self.total_minted = snap.total_minted;
-                    self.chain.truncate(snap.chain_len);
-                    if let (Some(trie), Some(root)) = (self.state_trie.as_mut(), snap.trie_root) {
-                        trie.set_root(root);
-                    }
-                    return Err(e);
-                }
+                // The gap-formation risk it was guarding against
+                // (BACKLOG #16, PR #226 sweep found 7,352 missing
+                // `block:N` keys) is already covered without blocking
+                // the hot path:
+                //   - #243 turned the silent peer-block save_block
+                //     failure into `error!` + Prometheus counter +
+                //     alert rule, so gaps get caught at the moment
+                //     of formation.
+                //   - #225 taught `GetBlocks` to serve evicted blocks
+                //     from MDBX, so gaps that do form can be healed
+                //     via p2p sync instead of requiring an operator
+                //     rsync.
+                // Durability + observability + recovery without the
+                // hot-lock fsync cost.
+                //
+                // `persist_block_durable` remains on `Blockchain` as
+                // an opt-in tool — operator CLI ops, recovery
+                // scripts, and explicit admin flows can still call
+                // it when they genuinely need an immediate fsync.
+                // The validator loop does not.
                 Ok(())
             }
             Err(e) => {

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.14"
+version = "2.1.15"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Closes #252. Fixes #253.

Third bisect pass on the v2.1.12 bundle pinned **PR #244 inline durable persist** as the residual livelock trigger. Removed from the hot path. See CHANGELOG [2.1.15] for full context + upgrade path.

## Bake evidence
955 blocks in 6 minutes sustained at 4.47 blocks/sec on 4-validator Voyager testnet. Zero skip-round. Zero nil-majority. Zero CRITICAL. Zero state_root mismatches.

## What #252 was
v2.1.12 livelocked immediately at first uncommitted height after restart. v2.1.13 (#236 else trim) got 82 blocks. v2.1.14 (+ #237 revert) got 484 blocks. v2.1.15 (+ #244 hot-path revert + #253 liveness fix) ≥ 955 blocks sustained.

## What's still open
- #251 V1 re-implementation (real precommit signatures without livelock trigger) — Voyager blocker, needs clean re-impl of what #237 tried.

## Test plan
- [x] `cargo test -p sentrix-bft` — 76 pass (71 engine + 5 harness)
- [x] `cargo test -p sentrix-core` — 179 pass
- [x] `cargo test -p sentrix-staking` — 81 pass
- [x] 6-minute testnet bake at 4-validator chain, sustained production
- [ ] Post-merge: retire v2.1.12 / v2.1.13 / v2.1.14 prereleases; promote v2.1.15 to non-prerelease