### PR TITLE
chore: release v2.1.16 — V2 M-15 locked-block re-propose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.16] — 2026-04-25 — V2 M-15 locked-block re-propose shipped (Voyager liveness)
+
+Closes the second of four Voyager mainnet blockers from the 2026-04-20 audit. V2 M-15 was the "locked-block re-propose" liveness gap — when an earlier round reached 2/3+ prevote quorum but failed precommit, locked validators would prevote nil on later rounds' fresh-built blocks (safety invariant), leaving the chain stuck until the lock expired. With V2, a locked validator elected proposer in a later round re-broadcasts the CACHED block bytes from the round it locked on. Chain unsticks at tempo.
+
+### Added
+
+- **bft: V2 M-15 locked-block re-propose, end-to-end** (`crates/sentrix-bft/src/engine.rs` + `bin/sentrix/src/main.rs`). Four-step rollout across PRs #257, #258, and this release:
+  - Step 1 (#257): `BftRoundState.locked_block` + `staging_block` fields with `#[serde(default)]` backward-compat + lifecycle hooks (`new`, `advance_round`, `advance_height`).
+  - Step 2 (#258): `stash_proposal_bytes(hash, bytes)` method — validator loop stashes before routing proposal hash into on_proposal.
+  - Step 3 (#258): prevote-supermajority branch promotes `staging_block` → `locked_block` when the staged hash matches. Wrong-hash staging discarded (byzantine protection).
+  - Step 4+5 (this release): main.rs `build_or_reuse_proposal` helper replaces 7 proposer call-sites — checks `locked_proposal_bytes()` first, re-broadcasts cached block if locked, else calls `create_block_voyager`. Peer-proposal path at `BftMessage::Propose` also stashes bytes via `stash_proposal_bytes`.
+- 5 new BFT engine regression tests pin: promotion on supermajority, advance_round preserves locked clears staging, new_height clears both, unlocked returns None, wrong-hash staging discarded.
+
+Evidence: 4-validator testnet deploy produces 1.6-1.8 blocks/sec sustained over 8+ minutes with 7 V2 re-propose events observed in logs (`V2 M-15: re-proposing locked block <hash>... at height N round K`). Chain recovers from skip-round conditions that previously would have livelocked — same class as the symptom tracked in issue #252.
+
+### Impact on Voyager mainnet launch
+
+- **Closed:** V2 M-15 (this release)
+- **Closed:** V3 jailing enforcement (#236 trim in v2.1.13)
+- **Closed:** V5 commission rate-limit (#235 in v2.1.12)
+- **Still open:** V1 real precommit signatures (#251) + V4 reward distribution v2 (design exists)
+
+Mainnet today is Pioneer PoA (VOYAGER_FORK_HEIGHT=u64::MAX env var). V2 wiring only exercises on the Voyager BFT path, so this release is a no-op at runtime on the current mainnet chain. It's loaded for the future Voyager activation moment.
+
 ## [2.1.15] — 2026-04-25 — Closes #252 livelock (revert #244 hot-path persist) + #253 liveness signers fix
 
 Third bisect pass on the v2.1.12 bundle found **PR #244** (BACKLOG #16 inline durable persist) as the residual trigger. Without #244, testnet runs at 4.47 blocks/sec sustained for 180s with zero skip-round / nil-majority warnings (955 blocks / 6 minutes clean). With all of #236-else / #237 / #244 reverted, the remaining bundle is safe to ship.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "anyhow",
  "axum",
@@ -4882,6 +4882,7 @@ dependencies = [
  "clap",
  "hex",
  "libp2p",
+ "secp256k1 0.31.1",
  "sentrix",
  "serde_json",
  "tokio",
@@ -4892,14 +4893,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4913,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4942,14 +4943,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4959,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4974,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "bincode",
  "blake3",
@@ -4990,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5009,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.15"
+version = "2.1.16"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"
@@ -37,6 +37,12 @@ serde_json = "1.0"
 hex = "0.4"
 axum = "0.8"
 bincode = "1.3"
+# V2 M-15 helper uses the SecretKey type from secp256k1 in its signature.
+# The wallet crate returns the same type from `get_secret_key`, but bin/
+# doesn't transitively re-export it, so we depend on the workspace version
+# directly. Pinned to match sentrix-wallet / sentrix-bft to avoid two
+# incompatible copies.
+secp256k1 = { version = "0.31", features = ["rand", "recovery", "serde"] }
 # Wraps the env-var validator key so the source `String`'s heap allocation
 # is wiped after we derive the `Wallet` (C-06 hardening).
 zeroize = "1.7"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1206,6 +1206,72 @@ async fn cmd_start(
             use sentrix::core::bft_messages::{BftMessage, Proposal};
             use sentrix::core::block::Block;
 
+            // V2 M-15 Step 4+5 helper: produce a signed Proposal for the
+            // current (height, round). If the engine is locked and has a
+            // cached block (populated via Step 3 promotion), re-broadcast
+            // the cached bytes — this is what breaks the locked-nil-prevote
+            // livelock pattern when a locked validator rotates into the
+            // proposer slot at a later round. Otherwise fall through to the
+            // existing `create_block_voyager` path.
+            //
+            // Design: audits/v2-locked-block-repropose-implementation-plan.md
+            fn build_or_reuse_proposal(
+                bft: &BftEngine,
+                bc: &mut Blockchain,
+                wallet_address: &str,
+                validator_sk: &secp256k1::SecretKey,
+                height: u64,
+            ) -> Option<(Block, Proposal)> {
+                if let Some((cached_hash, cached_bytes)) = bft.locked_proposal_bytes() {
+                    match bincode::deserialize::<Block>(&cached_bytes) {
+                        Ok(block) => {
+                            tracing::info!(
+                                "V2 M-15: re-proposing locked block {:.16}... at height {} round {}",
+                                cached_hash,
+                                height,
+                                bft.round()
+                            );
+                            let mut proposal = Proposal {
+                                height,
+                                round: bft.round(),
+                                block_hash: cached_hash,
+                                block_data: cached_bytes,
+                                proposer: wallet_address.to_string(),
+                                signature: vec![],
+                            };
+                            proposal.sign(validator_sk);
+                            return Some((block, proposal));
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "V2 re-propose: cached bytes failed to deserialize: {} — falling back to create_block_voyager",
+                                e
+                            );
+                        }
+                    }
+                }
+                match bc.create_block_voyager(wallet_address) {
+                    Ok(block) => {
+                        let block_hash = block.hash.clone();
+                        let block_data = bincode::serialize(&block).unwrap_or_default();
+                        let mut proposal = Proposal {
+                            height,
+                            round: bft.round(),
+                            block_hash,
+                            block_data,
+                            proposer: wallet_address.to_string(),
+                            signature: vec![],
+                        };
+                        proposal.sign(validator_sk);
+                        Some((block, proposal))
+                    }
+                    Err(e) => {
+                        tracing::warn!("create_block_voyager failed: {}", e);
+                        None
+                    }
+                }
+            }
+
             let mut voyager_activated = false;
             let mut evm_activated = false;
             // Persistent BFT state for Voyager mode
@@ -1432,21 +1498,22 @@ async fn cmd_start(
                     drop(bc);
 
                     if we_are_proposer {
-                        // We're the proposer — create block (Voyager: skip Pioneer authority)
+                        // We're the proposer — create block (Voyager: skip Pioneer authority).
+                        // V2 M-15 Step 4+5: helper checks locked_proposal_bytes first
+                        // and re-broadcasts the cached block if we're locked, which is
+                        // what unsticks the chain when an earlier round's prevote
+                        // supermajority didn't precommit.
                         let mut bc = shared_clone.write().await;
-                        match bc.create_block_voyager(&wallet.address) {
-                            Ok(block) => {
+                        match build_or_reuse_proposal(
+                            &bft,
+                            &mut bc,
+                            &wallet.address,
+                            &validator_secret_key,
+                            next_height,
+                        ) {
+                            Some((block, proposal)) => {
                                 let block_hash = block.hash.clone();
-                                let block_data = bincode::serialize(&block).unwrap_or_default();
-                                let mut proposal = Proposal {
-                                    height: next_height,
-                                    round: bft.round(),
-                                    block_hash: block_hash.clone(),
-                                    block_data,
-                                    proposer: wallet.address.clone(),
-                                    signature: vec![],
-                                };
-                                proposal.sign(&validator_secret_key);
+                                let block_data = proposal.block_data.clone();
                                 proposed_block = Some(block);
                                 drop(bc);
 
@@ -1458,6 +1525,10 @@ async fn cmd_start(
                                 proposal_broadcast_at = Some(std::time::Instant::now());
                                 proposal_rebroadcast_count = 0;
 
+                                // V2 M-15: stash bytes so if prevote-supermajority
+                                // forms on this hash, they get promoted into
+                                // locked_block for a future round's re-propose.
+                                bft.stash_proposal_bytes(&block_hash, block_data);
                                 // Self-vote: on_own_proposal triggers prevote
                                 let initial_action = bft.on_own_proposal(&block_hash);
 
@@ -1676,21 +1747,17 @@ async fn cmd_start(
                                             drop(bc_r);
                                             if we_propose {
                                                 let mut bc = shared_clone.write().await;
-                                                if let Ok(block) =
-                                                    bc.create_block_voyager(&wallet.address)
+                                                if let Some((block, proposal)) =
+                                                    build_or_reuse_proposal(
+                                                        &bft,
+                                                        &mut bc,
+                                                        &wallet.address,
+                                                        &validator_secret_key,
+                                                        bft.height(),
+                                                    )
                                                 {
                                                     let block_hash = block.hash.clone();
-                                                    let block_data = bincode::serialize(&block)
-                                                        .unwrap_or_default();
-                                                    let mut proposal = Proposal {
-                                                        height: bft.height(),
-                                                        round: bft.round(),
-                                                        block_hash: block_hash.clone(),
-                                                        block_data,
-                                                        proposer: wallet.address.clone(),
-                                                        signature: vec![],
-                                                    };
-                                                    proposal.sign(&validator_secret_key);
+                                                    let block_data = proposal.block_data.clone();
                                                     drop(bc);
                                                     lp2p_clone
                                                         .broadcast_bft_proposal(&proposal)
@@ -1699,6 +1766,10 @@ async fn cmd_start(
                                                         Some(std::time::Instant::now());
                                                     proposal_rebroadcast_count = 0;
                                                     proposed_block = Some(block);
+                                                    bft.stash_proposal_bytes(
+                                                        &block_hash,
+                                                        block_data,
+                                                    );
                                                     let _ = bft.on_own_proposal(&block_hash);
                                                     tracing::info!(
                                                         "BFT: proposed block after timeout \
@@ -1724,21 +1795,17 @@ async fn cmd_start(
                                             drop(bc_r);
                                             if we_propose {
                                                 let mut bc = shared_clone.write().await;
-                                                if let Ok(block) =
-                                                    bc.create_block_voyager(&wallet.address)
+                                                if let Some((block, proposal)) =
+                                                    build_or_reuse_proposal(
+                                                        &bft,
+                                                        &mut bc,
+                                                        &wallet.address,
+                                                        &validator_secret_key,
+                                                        bft.height(),
+                                                    )
                                                 {
                                                     let block_hash = block.hash.clone();
-                                                    let block_data = bincode::serialize(&block)
-                                                        .unwrap_or_default();
-                                                    let mut proposal = Proposal {
-                                                        height: bft.height(),
-                                                        round: bft.round(),
-                                                        block_hash: block_hash.clone(),
-                                                        block_data,
-                                                        proposer: wallet.address.clone(),
-                                                        signature: vec![],
-                                                    };
-                                                    proposal.sign(&validator_secret_key);
+                                                    let block_data = proposal.block_data.clone();
                                                     drop(bc);
                                                     lp2p_clone
                                                         .broadcast_bft_proposal(&proposal)
@@ -1747,6 +1814,10 @@ async fn cmd_start(
                                                         Some(std::time::Instant::now());
                                                     proposal_rebroadcast_count = 0;
                                                     proposed_block = Some(block);
+                                                    bft.stash_proposal_bytes(
+                                                        &block_hash,
+                                                        block_data,
+                                                    );
                                                     let _ = bft.on_own_proposal(&block_hash);
                                                     tracing::info!(
                                                         "BFT: proposed block after skip-round \
@@ -1765,13 +1836,10 @@ async fn cmd_start(
                                     }
                                 }
                             }
-                            Err(e) => {
-                                tracing::warn!(
-                                    "create_block failed at height {} round {}: {}",
-                                    next_height,
-                                    bft.round(),
-                                    e
-                                );
+                            None => {
+                                // build_or_reuse_proposal already tracing::warn!'d
+                                // the specific failure reason (deserialize of
+                                // cached bytes or create_block_voyager Err).
                                 drop(bc);
                             }
                         }
@@ -1803,6 +1871,17 @@ async fn cmd_start(
                                     bincode::deserialize::<Block>(&proposal.block_data)
                                 {
                                     proposed_block = Some(block);
+                                    // V2 M-15 Step 4: stash the block bytes so
+                                    // if prevote-supermajority forms on this
+                                    // proposal's hash (Step 3 in engine.rs),
+                                    // they get promoted into locked_block and
+                                    // remain available for re-propose when we
+                                    // become proposer in a later round at this
+                                    // height.
+                                    bft.stash_proposal_bytes(
+                                        &proposal.block_hash,
+                                        proposal.block_data.clone(),
+                                    );
                                     let bc = shared_clone.read().await;
                                     let a = bft.on_proposal(
                                         &proposal.block_hash,
@@ -2043,25 +2122,21 @@ async fn cmd_start(
                                     drop(bc_r);
                                     if we_propose {
                                         let mut bc = shared_clone.write().await;
-                                        if let Ok(block) = bc.create_block_voyager(&wallet.address)
-                                        {
+                                        if let Some((block, proposal)) = build_or_reuse_proposal(
+                                            &bft,
+                                            &mut bc,
+                                            &wallet.address,
+                                            &validator_secret_key,
+                                            bft.height(),
+                                        ) {
                                             let block_hash = block.hash.clone();
-                                            let block_data =
-                                                bincode::serialize(&block).unwrap_or_default();
-                                            let mut proposal = Proposal {
-                                                height: bft.height(),
-                                                round: bft.round(),
-                                                block_hash: block_hash.clone(),
-                                                block_data,
-                                                proposer: wallet.address.clone(),
-                                                signature: vec![],
-                                            };
-                                            proposal.sign(&validator_secret_key);
+                                            let block_data = proposal.block_data.clone();
                                             drop(bc);
                                             lp2p_clone.broadcast_bft_proposal(&proposal).await;
                                             proposal_broadcast_at = Some(std::time::Instant::now());
                                             proposal_rebroadcast_count = 0;
                                             proposed_block = Some(block);
+                                            bft.stash_proposal_bytes(&block_hash, block_data);
                                             let _ = bft.on_own_proposal(&block_hash);
                                             tracing::info!(
                                                 "BFT: proposed block for new round {}",
@@ -2085,25 +2160,21 @@ async fn cmd_start(
                                     drop(bc_r);
                                     if we_propose {
                                         let mut bc = shared_clone.write().await;
-                                        if let Ok(block) = bc.create_block_voyager(&wallet.address)
-                                        {
+                                        if let Some((block, proposal)) = build_or_reuse_proposal(
+                                            &bft,
+                                            &mut bc,
+                                            &wallet.address,
+                                            &validator_secret_key,
+                                            bft.height(),
+                                        ) {
                                             let block_hash = block.hash.clone();
-                                            let block_data =
-                                                bincode::serialize(&block).unwrap_or_default();
-                                            let mut proposal = Proposal {
-                                                height: bft.height(),
-                                                round: bft.round(),
-                                                block_hash: block_hash.clone(),
-                                                block_data,
-                                                proposer: wallet.address.clone(),
-                                                signature: vec![],
-                                            };
-                                            proposal.sign(&validator_secret_key);
+                                            let block_data = proposal.block_data.clone();
                                             drop(bc);
                                             lp2p_clone.broadcast_bft_proposal(&proposal).await;
                                             proposal_broadcast_at = Some(std::time::Instant::now());
                                             proposal_rebroadcast_count = 0;
                                             proposed_block = Some(block);
+                                            bft.stash_proposal_bytes(&block_hash, block_data);
                                             let _ = bft.on_own_proposal(&block_hash);
                                             tracing::info!(
                                                 "BFT: proposed block after skip-round at round {}",
@@ -2221,25 +2292,21 @@ async fn cmd_start(
                                     drop(bc_r);
                                     if we_propose {
                                         let mut bc = shared_clone.write().await;
-                                        if let Ok(block) = bc.create_block_voyager(&wallet.address)
-                                        {
+                                        if let Some((block, proposal)) = build_or_reuse_proposal(
+                                            &bft,
+                                            &mut bc,
+                                            &wallet.address,
+                                            &validator_secret_key,
+                                            bft.height(),
+                                        ) {
                                             let block_hash = block.hash.clone();
-                                            let block_data =
-                                                bincode::serialize(&block).unwrap_or_default();
-                                            let mut proposal = Proposal {
-                                                height: bft.height(),
-                                                round: bft.round(),
-                                                block_hash: block_hash.clone(),
-                                                block_data,
-                                                proposer: wallet.address.clone(),
-                                                signature: vec![],
-                                            };
-                                            proposal.sign(&validator_secret_key);
+                                            let block_data = proposal.block_data.clone();
                                             drop(bc);
                                             lp2p_clone.broadcast_bft_proposal(&proposal).await;
                                             proposal_broadcast_at = Some(std::time::Instant::now());
                                             proposal_rebroadcast_count = 0;
                                             proposed_block = Some(block);
+                                            bft.stash_proposal_bytes(&block_hash, block_data);
                                             let _ = bft.on_own_proposal(&block_hash);
                                             tracing::info!(
                                                 "BFT: proposed block after timeout at round {}",
@@ -2265,25 +2332,21 @@ async fn cmd_start(
                                     drop(bc_r);
                                     if we_propose {
                                         let mut bc = shared_clone.write().await;
-                                        if let Ok(block) = bc.create_block_voyager(&wallet.address)
-                                        {
+                                        if let Some((block, proposal)) = build_or_reuse_proposal(
+                                            &bft,
+                                            &mut bc,
+                                            &wallet.address,
+                                            &validator_secret_key,
+                                            bft.height(),
+                                        ) {
                                             let block_hash = block.hash.clone();
-                                            let block_data =
-                                                bincode::serialize(&block).unwrap_or_default();
-                                            let mut proposal = Proposal {
-                                                height: bft.height(),
-                                                round: bft.round(),
-                                                block_hash: block_hash.clone(),
-                                                block_data,
-                                                proposer: wallet.address.clone(),
-                                                signature: vec![],
-                                            };
-                                            proposal.sign(&validator_secret_key);
+                                            let block_data = proposal.block_data.clone();
                                             drop(bc);
                                             lp2p_clone.broadcast_bft_proposal(&proposal).await;
                                             proposal_broadcast_at = Some(std::time::Instant::now());
                                             proposal_rebroadcast_count = 0;
                                             proposed_block = Some(block);
+                                            bft.stash_proposal_bytes(&block_hash, block_data);
                                             let _ = bft.on_own_proposal(&block_hash);
                                             tracing::info!(
                                                 "BFT: proposed block after skip-round at \

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.15"
+version = "2.1.16"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Closes V2 M-15 (locked-block re-propose), second of four Voyager mainnet blockers. See CHANGELOG [2.1.16]. Testnet bake clean (1.6-1.8 blocks/sec, 7 re-propose events observed, no livelocks). Runtime no-op on current Pioneer mainnet.