### PR TITLE
chore: release v2.1.17 — V1 real precommit signatures (closes #251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.17] — 2026-04-25 — V1 real precommit signatures (Voyager #251 closed)
+
+Re-applies PR #237's precommit-tuple widening + finalize-emit filter on top of v2.1.16's V2 M-15. The prior bisect wrongly pinned V1 as the v2.1.12 livelock cause — the real trigger was PR #244's hot-path fsync (closed v2.1.15), and the secondary livelock that v2.1.14 exposed was the V2 locked-block-re-propose scenario (closed v2.1.16). With both of those gone, V1 is now a pure emission-path improvement with no runtime consequences for consensus timing.
+
+Closes issue #251 and the last of four originally-flagged Voyager BFT blockers from the 2026-04-20 audit (V1, V2, V3, V5 — all now shipped).
+
+### Fixed
+
+- **bft: emit REAL precommit signatures in BlockJustification (#251)** (`crates/sentrix-bft/src/engine.rs`). `BftRoundState.precommits` tuple widened from `(Option<String>, u64)` to `(Option<String>, Vec<u8>, u64)` so the ECDSA sig bytes from each peer's Precommit message are stored alongside the vote + stake. At finalize, the emit loop filters to precommits that voted for the winning hash and attaches their real signatures to the emitted `BlockJustification`. Nil precommits and precommits for other hashes are correctly excluded. The previous `vec![]` placeholder was unforgeable-but-unverifiable — a silent-reorg surface at Voyager activation. `test_finalize_emits_real_precommit_signatures` un-`#[ignore]`'d.
+
+### Testnet bake evidence
+
+4-validator Voyager docker stack on v2.1.17 binary `7181d37e56b00316`: **1318 blocks / 10 min sustained at 2.2 blocks/sec**, zero skip-round / nil-majority / CRITICAL warnings, zero state_root mismatches. V2 M-15 re-propose events fired where appropriate (2 events in first 5min window) — chain recovers from partial-quorum situations without stalling.
+
+### Voyager blocker ledger (all shipped)
+
+| # | Blocker | Release |
+|---|---|---|
+| V1 | Real precommit signatures | **v2.1.17** (this) |
+| V2 | Locked-block re-propose | v2.1.16 |
+| V3 | Jailing enforcement at consensus | v2.1.13 |
+| V5 | Commission rate-limit | v2.1.12 |
+| V6 | Liveness thresholds retune | v2.1.12 (#215) |
+
+### Remaining before Voyager activation
+
+- **V4 reward distribution v2** (delegator reverse-lookup + claim flow) — 2-3 week scope, design at `audits/reward-distribution-fix-design.md`.
+- Operator coordination: `VOYAGER_FORK_HEIGHT` env var set on all 4 mainnet validators + coordinated restart window.
+
 ## [2.1.16] — 2026-04-25 — V2 M-15 locked-block re-propose shipped (Voyager liveness)
 
 Closes the second of four Voyager mainnet blockers from the 2026-04-20 audit. V2 M-15 was the "locked-block re-propose" liveness gap — when an earlier round reached 2/3+ prevote quorum but failed precommit, locked validators would prevote nil on later rounds' fresh-built blocks (safety invariant), leaving the chain stuck until the lock expired. With V2, a locked validator elected proposer in a later round re-broadcasts the CACHED block bytes from the round it locked on. Chain unsticks at tempo.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -4893,14 +4893,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4943,14 +4943,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "bincode",
  "blake3",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -60,10 +60,17 @@ pub struct BftRoundState {
     pub proposed_hash: Option<String>,
     /// Prevotes collected: validator → (block_hash option, stake_weight)
     pub prevotes: HashMap<String, (Option<String>, u64)>,
-    /// Precommits collected: validator → (block_hash option, stake_weight).
-    /// BISECT #247: PR #237's signature-bytes extension REVERTED here to
-    /// test hypothesis it caused the v2.1.12 precommit-flip livelock.
-    pub precommits: HashMap<String, (Option<String>, u64)>,
+    /// Precommits collected: validator → (block_hash option, signature bytes, stake_weight).
+    /// V1 (re-applied 2026-04-25 on v2.1.16 base): signature bytes kept
+    /// alongside vote so `BlockJustification` emits REAL signatures at
+    /// finalize, not `vec![]` placeholders. Closes V1 Voyager blocker.
+    ///
+    /// Prior v2.1.14 revert was the wrong diagnosis — the real v2.1.12
+    /// livelock trigger was PR #244's hot-path fsync (closed v2.1.15).
+    /// With V2 M-15 locked-block re-propose now shipped in v2.1.16 too,
+    /// the locked-validator-prevote-nil scenario self-unsticks via
+    /// re-propose instead of livelocking.
+    pub precommits: HashMap<String, (Option<String>, Vec<u8>, u64)>,
     /// Our own vote cast this round (prevent double-voting)
     pub our_prevote_cast: bool,
     pub our_precommit_cast: bool,
@@ -625,7 +632,11 @@ impl BftEngine {
 
         self.state.precommits.insert(
             precommit.validator.clone(),
-            (precommit.block_hash.clone(), stake),
+            (
+                precommit.block_hash.clone(),
+                precommit.signature.clone(),
+                stake,
+            ),
         );
         self.collector
             .add_precommit(precommit.block_hash.clone(), stake);
@@ -642,11 +653,19 @@ impl BftEngine {
                         self.state.round,
                         block_hash.clone(),
                     );
-                    // BISECT #247: PR #237 filtered+added real sigs here;
-                    // reverted to pre-V1 blanket vec![] placeholder to test
-                    // whether the tuple-widening caused the livelock.
-                    for (val, (_, w)) in &self.state.precommits {
-                        justification.add_precommit(val.clone(), vec![], *w);
+                    // V1 (re-applied 2026-04-25 on v2.1.16 base): emit REAL
+                    // signatures. Filter to precommits that voted for the
+                    // finalized hash — nil precommits and precommits for
+                    // other hashes don't belong in this block's justification.
+                    // With V2 locked-block re-propose now shipped in v2.1.16,
+                    // the locked-validator-prevote-nil scenario self-unsticks
+                    // via re-propose instead of livelocking, so this emission
+                    // path no longer has the timing vulnerability that
+                    // surfaced in the v2.1.12 bake.
+                    for (val, (vote_hash, sig, w)) in &self.state.precommits {
+                        if vote_hash.as_deref() == Some(block_hash.as_str()) {
+                            justification.add_precommit(val.clone(), sig.clone(), *w);
+                        }
                     }
 
                     self.state.phase = BftPhase::Finalize;
@@ -1879,7 +1898,7 @@ mod tests {
     /// hash are NOT included in the finalized block's justification
     /// (only the winning hash's backers should be counted).
     #[test]
-    #[ignore = "BISECT #247: #237 temporarily reverted while diagnosing livelock"]
+    
     fn test_finalize_emits_real_precommit_signatures() {
         let (mut engine, _) = setup();
         let total = engine.state.total_active_stake;

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.16"
+version = "2.1.17"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
V1 re-applied on v2.1.16 base. Closes the last Voyager BFT blocker from the 2026-04-20 audit. Bake: 1318 blocks / 10 min / 2.2 blocks/sec sustained on 4-validator Voyager testnet. Mainnet no-op (Pioneer path).