### PR TITLE
chore: release v2.1.19 — V4 Step 3 treasury-escrow + ClaimRewards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.19] — 2026-04-25 — V4 Step 3 — treasury-escrow + ClaimRewards dispatch (gated fork)
+
+Closes the V4 design. `PROTOCOL_TREASURY` address reserved, coinbase routing gated on `VOYAGER_REWARD_V2_HEIGHT` env var, `StakingOp::ClaimRewards` dispatch wired in `block_executor`. Supply invariant restored: post-fork, every SRX block reward lands in treasury, drains only via a claim tx that decrements the per-delegator / per-validator accumulator.
+
+### Added
+
+- **primitives: `PROTOCOL_TREASURY` address** (`crates/sentrix-primitives/src/transaction.rs`). `0x0000000000000000000000000000000000000002`. No private key → no one can sign as treasury; treasury state only moves via consensus-level dispatch in `block_executor`.
+- **core: `VOYAGER_REWARD_V2_HEIGHT` env-var fork gate** (`crates/sentrix-core/src/blockchain.rs`). Default `u64::MAX` = disabled (mainnet-safe pre-fork behaviour preserved). `Blockchain::is_reward_v2_height(h)` + `is_reward_v2_active()` helpers. Coordinated operator rollout required for activation (consensus change).
+- **core: coinbase routing gate** (`crates/sentrix-core/src/block_executor.rs:apply_block_pass2`). Post-fork: coinbase credits `PROTOCOL_TREASURY` instead of the proposer. Pre-fork path unchanged.
+- **core: accumulator reset at fork activation** — on the single transition block (`is_reward_v2_height(block.index) && !is_reward_v2_height(block.index - 1)`), all pre-existing `pending_rewards` + `delegator_rewards` are zeroed. Pre-fork accumulator values represented rewards ALREADY credited via coinbase → proposer balance; without the reset, claim would double-mint. Resets keep supply invariant load-bearing from block 0 of the post-fork era.
+- **core: `StakingOp::ClaimRewards` dispatch** (`block_executor.rs:apply_block_pass2`). Decodes `StakingOp` from `tx.data`, on `ClaimRewards`: drains `take_delegator_rewards(sender)` + `std::mem::take(validator.pending_rewards)` (if sender is a validator), transfers `PROTOCOL_TREASURY → sender` for the sum. Gated on `is_reward_v2_height(block.index)` so pre-fork chains ignore it. Other `StakingOp` variants (Delegate/Undelegate/Redelegate/Unjail/SubmitEvidence) silently no-op pending a follow-up staking-via-tx dispatch PR.
+
+### Tests
+
+- `test_v4_reward_v2_fork_height_default_disabled` pins the mainnet-safe default (`u64::MAX`) in `block_executor::tests`.
+- Existing 179 sentrix-core + 88 sentrix-staking + 76 sentrix-bft + 5 harness tests all pass.
+
+### Testnet bake
+
+v2.1.19 binary `ecb18d63a4e0a5da` on 4-validator Voyager testnet with `VOYAGER_REWARD_V2_HEIGHT=188836`. Post-fork treasury accrued **70 SRX per 70 blocks = 1 SRX/block** exactly — supply invariant holds at the coinbase-routing level. Chain sustained 2.33 blocks/sec, zero skip-round / nil-majority / CRITICAL errors.
+
+Accumulator-reset activation not exercised on this testnet (chain had already crossed the old fork before the reset-logic binary deployed). Next-session task: spin up a clean testnet (wipe `data/val*/chain.db`) + verify reset fires at the fork transition block. Until then, reset is compile-tested + logic-reviewed.
+
+### Still open for Voyager mainnet activation
+
+- **Staking-via-tx dispatch for other `StakingOp` variants** (Delegate/Undelegate/Redelegate/Unjail/SubmitEvidence) — current release wires only ClaimRewards. Users can't submit Delegate transactions yet. Separate follow-up PR.
+- **Operator coordination**: set `VOYAGER_FORK_HEIGHT` + `VOYAGER_REWARD_V2_HEIGHT` env vars on all 4 mainnet validators at the same target height + coordinated restart.
+
+### No mainnet impact today
+
+Both `VOYAGER_FORK_HEIGHT` and `VOYAGER_REWARD_V2_HEIGHT` default `u64::MAX`. Mainnet runs Pioneer PoA unchanged.
+
 ## [2.1.18] — 2026-04-25 — V4 reward distribution v2 Step 2 (multi-signer pro-rata payout)
 
 Step 2 of V4 per `audits/reward-distribution-fix-design.md`. `distribute_reward` now accepts a signers list and pays every precommit signer in the justification pro-rata by stake, splitting each signer's share into commission + self-stake + per-delegator accumulator. Step 1 (delegator_rewards field) shipped in PR #262; Step 3 (claim CLI + blockchain::apply wire) deferred.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "anyhow",
  "axum",
@@ -4893,14 +4893,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4943,14 +4943,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "bincode",
  "blake3",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -607,8 +607,45 @@ impl Blockchain {
             (coinbase.amount, block.validator.clone())
         };
 
-        // Apply coinbase reward
-        self.accounts.credit(&coinbase_validator, coinbase_amount)?;
+        // Apply coinbase reward.
+        //
+        // V4 Step 3 / reward-v2 hard-fork: at/after VOYAGER_REWARD_V2_HEIGHT,
+        // mint goes to PROTOCOL_TREASURY instead of directly to the proposer.
+        // distribute_reward then updates in-registry accumulators
+        // (pending_rewards + delegator_rewards) which are claims against
+        // the treasury; ClaimRewards dispatch below transfers treasury →
+        // claimer's balance on claim.
+        //
+        // Pre-fork behaviour is preserved exactly: proposer's balance gets
+        // the full block_reward at commit time, same as v2.1.x today.
+        //
+        // Accumulator reset at fork activation: on the FIRST post-fork
+        // block, zero out every pre-existing pending_rewards +
+        // delegator_rewards entry. Pre-fork accumulator values represented
+        // rewards that were ALREADY credited via coinbase → proposer
+        // balance, so they are not real claims against the new treasury.
+        // Reset keeps the supply invariant
+        //   `accounts[TREASURY] == sum(pending_rewards) + sum(delegator_rewards)`
+        // load-bearing from block 0 of the post-fork era onward.
+        if Self::is_reward_v2_height(block.index)
+            && !Self::is_reward_v2_height(block.index.saturating_sub(1))
+        {
+            for v in self.stake_registry.validators.values_mut() {
+                v.pending_rewards = 0;
+            }
+            self.stake_registry.delegator_rewards.clear();
+            tracing::info!(
+                "V4 reward-v2 fork activated at height {} — pre-fork pending_rewards + delegator_rewards cleared (supply invariant reset)",
+                block.index
+            );
+        }
+
+        let coinbase_recipient = if Self::is_reward_v2_height(block.index) {
+            sentrix_primitives::transaction::PROTOCOL_TREASURY
+        } else {
+            coinbase_validator.as_str()
+        };
+        self.accounts.credit(coinbase_recipient, coinbase_amount)?;
         self.total_minted += coinbase_amount;
 
         // Apply all transactions
@@ -681,6 +718,52 @@ impl Blockchain {
                             amount,
                         )?;
                     }
+                }
+            }
+
+            // V4 Step 3: StakingOp dispatch. Only ClaimRewards wired in
+            // this patch — other variants (Delegate, Undelegate,
+            // Redelegate, Unjail, SubmitEvidence) are defined in
+            // primitives but unwired here; a separate staking-via-tx
+            // dispatch PR will handle those.
+            //
+            // Gated on `is_reward_v2_height(block.index)` — pre-fork
+            // chains ignore the op entirely (same as today's pre-V4
+            // behaviour where StakingOp has no runtime effect).
+            if Self::is_reward_v2_height(block.index)
+                && let Some(staking_op) = sentrix_primitives::transaction::StakingOp::decode(&tx.data)
+            {
+                use sentrix_primitives::transaction::StakingOp;
+                match staking_op {
+                    StakingOp::ClaimRewards => {
+                        let claimer = tx.from_address.clone();
+                        let delegator_amount = self.stake_registry.take_delegator_rewards(&claimer);
+                        let validator_amount = self
+                            .stake_registry
+                            .validators
+                            .get_mut(&claimer)
+                            .map(|v| std::mem::take(&mut v.pending_rewards))
+                            .unwrap_or(0);
+                        let total_claim = delegator_amount.saturating_add(validator_amount);
+                        if total_claim > 0 {
+                            // Transfer treasury → claimer (zero fee on the
+                            // claim itself; sender's own fee was already
+                            // paid via the outer tx.fee at `transfer` above).
+                            self.accounts.transfer(
+                                sentrix_primitives::transaction::PROTOCOL_TREASURY,
+                                &claimer,
+                                total_claim,
+                                0,
+                            )?;
+                        }
+                    }
+                    // Unwired variants — accepted at tx-decode time but
+                    // silently no-op at apply time. Prevents accidental
+                    // state mutations while the dispatch framework lands
+                    // in follow-up PRs. Caller's fee still burns (via the
+                    // outer `transfer` above) so this isn't a free-tx
+                    // surface.
+                    _ => {}
                 }
             }
 
@@ -1114,6 +1197,35 @@ mod tests {
         bc.authority
             .add_validator_unchecked("v1".to_string(), "V1".to_string(), "pk1".to_string());
         bc
+    }
+
+    /// V4 Step 3 regression: default reward-v2 fork height must be
+    /// u64::MAX so a node without `VOYAGER_REWARD_V2_HEIGHT` env var
+    /// never activates the treasury-escrow path. This pins the
+    /// mainnet-safe default and prevents a silent consensus drift if
+    /// someone inadvertently flips the default.
+    #[test]
+    fn test_v4_reward_v2_fork_height_default_disabled() {
+        // Ensure env var is not set for this test — if other tests
+        // set it we'd need serial_test, but currently no test does.
+        // Defensive: read the actual function and assert the
+        // mainnet-safe default.
+        unsafe {
+            std::env::remove_var("VOYAGER_REWARD_V2_HEIGHT");
+        }
+        assert_eq!(
+            crate::blockchain::get_reward_v2_fork_height(),
+            u64::MAX,
+            "default must keep mainnet on pre-V4 behaviour until operator opts in"
+        );
+        assert!(
+            !Blockchain::is_reward_v2_height(0),
+            "height 0 must be pre-fork with default env"
+        );
+        assert!(
+            !Blockchain::is_reward_v2_height(1_000_000_000),
+            "even huge heights must be pre-fork with default env"
+        );
     }
 
     // Pass 1 rejection must not mutate state

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -38,6 +38,16 @@ const VOYAGER_DPOS_HEIGHT_DEFAULT: u64 = u64::MAX;
 /// u64::MAX = disabled. Override via VOYAGER_EVM_HEIGHT env var.
 const VOYAGER_EVM_HEIGHT_DEFAULT: u64 = u64::MAX;
 
+/// V4 Step 3 / reward-v2 hard-fork height — coinbase routes to
+/// `PROTOCOL_TREASURY` at/after this height, ClaimRewards dispatch
+/// becomes valid. u64::MAX = disabled (Pioneer + v2.1.x accumulator-only
+/// behaviour). Override via `VOYAGER_REWARD_V2_HEIGHT` env var.
+///
+/// This is a CONSENSUS CHANGE. Every validator on the same chain must
+/// set the same value; mismatch produces a fork. Coordinated operator
+/// rollout required.
+const VOYAGER_REWARD_V2_HEIGHT_DEFAULT: u64 = u64::MAX;
+
 /// Read Voyager fork height from env, default u64::MAX (mainnet safe).
 /// Testnet sets VOYAGER_FORK_HEIGHT=<height> in systemd service.
 pub fn get_voyager_fork_height() -> u64 {
@@ -54,6 +64,17 @@ pub fn get_evm_fork_height() -> u64 {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(VOYAGER_EVM_HEIGHT_DEFAULT)
+}
+
+/// V4 Step 3: read reward-v2 hard-fork height from env, default
+/// u64::MAX (disabled — keeps current accumulator-only behaviour).
+/// Post-fork: coinbase → `PROTOCOL_TREASURY`, ClaimRewards dispatch
+/// becomes consensus-valid.
+pub fn get_reward_v2_fork_height() -> u64 {
+    std::env::var("VOYAGER_REWARD_V2_HEIGHT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(VOYAGER_REWARD_V2_HEIGHT_DEFAULT)
 }
 
 /// Read chain_id from SENTRIX_CHAIN_ID env var, fallback to 7119.
@@ -506,6 +527,18 @@ impl Blockchain {
     /// Is the current chain past the Voyager fork?
     pub fn is_voyager_active(&self) -> bool {
         Self::is_voyager_height(self.height())
+    }
+
+    /// V4 Step 3: is the given height at or after the reward-v2 fork?
+    /// Post-fork: coinbase routes to PROTOCOL_TREASURY, ClaimRewards
+    /// dispatch is consensus-valid.
+    pub fn is_reward_v2_height(height: u64) -> bool {
+        let fork = get_reward_v2_fork_height();
+        fork != u64::MAX && height >= fork
+    }
+
+    pub fn is_reward_v2_active(&self) -> bool {
+        Self::is_reward_v2_height(self.height())
     }
 
     /// Is the given height at or after the EVM fork?

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-primitives/src/transaction.rs
+++ b/crates/sentrix-primitives/src/transaction.rs
@@ -10,6 +10,23 @@ pub const MIN_TX_FEE: u64 = 10_000; // 0.0001 SRX in sentri
 pub const COINBASE_ADDRESS: &str = "COINBASE";
 pub const TOKEN_OP_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
 
+/// V4 Step 3 reward-v2 escrow address. After `VOYAGER_REWARD_V2_HEIGHT`
+/// activates, coinbase credits go here instead of directly to the
+/// proposer's balance. `distribute_reward` updates in-registry
+/// accumulators (`pending_rewards`, `delegator_rewards`) which are
+/// receivables against this treasury. `StakingOp::ClaimRewards` drains
+/// the claimer's accumulator by transferring `PROTOCOL_TREASURY →
+/// claimer`.
+///
+/// No private key exists for this address — `tx.from_address ==
+/// PROTOCOL_TREASURY` is rejected at signature-verify time (nothing
+/// can sign as treasury). Treasury is drained only via the consensus-
+/// level claim dispatch in `block_executor::apply_block_pass2`.
+///
+/// Supply invariant post-fork:
+///   accounts[PROTOCOL_TREASURY] == sum(pending_rewards) + sum(delegator_rewards)
+pub const PROTOCOL_TREASURY: &str = "0x0000000000000000000000000000000000000002";
+
 // ── Token operation types (encoded in Transaction.data field) ──
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.18"
+version = "2.1.19"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
See CHANGELOG [2.1.19]. Testnet treasury-accrual verified 1 SRX/block. Accumulator reset logic needs clean-testnet activation test (next session).