### PR TITLE
fix(clippy): collapse nested if + drop needless borrow (closes GH Actions reds)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -2168,7 +2168,7 @@ async fn cmd_start(
                                     if we_propose {
                                         let mut bc = shared_clone.write().await;
                                         if let Some((block, proposal)) = build_or_reuse_proposal(
-                                            &bft,
+                                            bft,
                                             &mut bc,
                                             &wallet.address,
                                             &validator_secret_key,
@@ -2206,7 +2206,7 @@ async fn cmd_start(
                                     if we_propose {
                                         let mut bc = shared_clone.write().await;
                                         if let Some((block, proposal)) = build_or_reuse_proposal(
-                                            &bft,
+                                            bft,
                                             &mut bc,
                                             &wallet.address,
                                             &validator_secret_key,
@@ -2338,7 +2338,7 @@ async fn cmd_start(
                                     if we_propose {
                                         let mut bc = shared_clone.write().await;
                                         if let Some((block, proposal)) = build_or_reuse_proposal(
-                                            &bft,
+                                            bft,
                                             &mut bc,
                                             &wallet.address,
                                             &validator_secret_key,
@@ -2378,7 +2378,7 @@ async fn cmd_start(
                                     if we_propose {
                                         let mut bc = shared_clone.write().await;
                                         if let Some((block, proposal)) = build_or_reuse_proposal(
-                                            &bft,
+                                            bft,
                                             &mut bc,
                                             &wallet.address,
                                             &validator_secret_key,

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -591,12 +591,12 @@ impl BftEngine {
                 // the cache populated here; callers that didn't stash
                 // leave `locked_block` None and fall back to
                 // build-new-block behaviour in the validator loop.
-                if let Some((staged_hash, staged_bytes)) = self.state.staging_block.take() {
-                    if &staged_hash == h {
-                        self.state.locked_block = Some(staged_bytes);
-                    }
-                    // Staging for a different hash is discarded —
-                    // proposer rotated or we saw PoLC on an alternate.
+                // Staging for a different hash is discarded (take() leaves
+                // None regardless); promote only if hashes match.
+                if let Some((staged_hash, staged_bytes)) = self.state.staging_block.take()
+                    && &staged_hash == h
+                {
+                    self.state.locked_block = Some(staged_bytes);
                 }
             }
 


### PR DESCRIPTION
Two clippy errors from v2.1.18-v2.1.20 runs. Workspace clippy + 349 tests all pass locally.