### PR TITLE
feat(network): log request variant on libp2p OutboundFailure (#1d diag)

### DIFF
--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -375,6 +375,12 @@ async fn run_swarm(
     let mut pending_handshakes: HashMap<OutboundRequestId, PeerId> = HashMap::new();
     // Track outbound GetBlocks requests by ID so responses can be matched to the originating peer.
     let mut pending_syncs: HashMap<OutboundRequestId, PeerId> = HashMap::new();
+    // Bug #1d diagnostic: remember which `SentrixRequest` variant each
+    // in-flight outbound request was, so `OutboundFailure` can log the
+    // specific variant instead of the generic "outbound failure to X".
+    // Without this we cannot tell whether BFT proposals are the ones
+    // timing out or unrelated background traffic.
+    let mut pending_variants: HashMap<OutboundRequestId, &'static str> = HashMap::new();
 
     // Per-IP rate limiter for connection flood protection.
     let mut ip_limiter = IpRateLimiter::new();
@@ -401,8 +407,13 @@ async fn run_swarm(
                     }
                     Some(SwarmCommand::Broadcast(req)) => {
                         let peers: Vec<PeerId> = verified_peers.iter().cloned().collect();
+                        let variant = req.variant_name();
                         for peer_id in peers {
-                            swarm.behaviour_mut().rr.send_request(&peer_id, req.clone());
+                            let req_id = swarm
+                                .behaviour_mut()
+                                .rr
+                                .send_request(&peer_id, req.clone());
+                            pending_variants.insert(req_id, variant);
                         }
                     }
                     Some(SwarmCommand::GossipBlock(block)) => {
@@ -461,13 +472,14 @@ async fn run_swarm(
                         } else {
                             let our_height = blockchain.read().await.height();
                             if let Some(&peer_id) = verified_peers.iter().next() {
-                                let req_id = swarm.behaviour_mut().rr.send_request(
-                                    &peer_id,
-                                    SentrixRequest::GetBlocks {
-                                        from_height: our_height + 1,
-                                    },
-                                );
+                                let req = SentrixRequest::GetBlocks {
+                                    from_height: our_height + 1,
+                                };
+                                let variant = req.variant_name();
+                                let req_id =
+                                    swarm.behaviour_mut().rr.send_request(&peer_id, req);
                                 pending_syncs.insert(req_id, peer_id);
+                                pending_variants.insert(req_id, variant);
                                 tracing::info!(
                                     "libp2p trigger_sync: requested blocks from {} starting at {}",
                                     peer_id,
@@ -493,6 +505,7 @@ async fn run_swarm(
                     &mut verified_peers,
                     &mut pending_handshakes,
                     &mut pending_syncs,
+                    &mut pending_variants,
                     our_chain_id,
                     &mut ip_limiter,
                 )
@@ -507,11 +520,13 @@ async fn run_swarm(
                 }
                 let our_height = blockchain.read().await.height();
                 if let Some(&peer_id) = verified_peers.iter().next() {
-                    let req_id = swarm.behaviour_mut().rr.send_request(
-                        &peer_id,
-                        SentrixRequest::GetBlocks { from_height: our_height + 1 },
-                    );
+                    let req = SentrixRequest::GetBlocks {
+                        from_height: our_height + 1,
+                    };
+                    let variant = req.variant_name();
+                    let req_id = swarm.behaviour_mut().rr.send_request(&peer_id, req);
                     pending_syncs.insert(req_id, peer_id);
+                    pending_variants.insert(req_id, variant);
                 }
             }
 
@@ -536,6 +551,7 @@ async fn on_swarm_event(
     verified_peers: &mut HashSet<PeerId>,
     pending_handshakes: &mut HashMap<OutboundRequestId, PeerId>,
     pending_syncs: &mut HashMap<OutboundRequestId, PeerId>,
+    pending_variants: &mut HashMap<OutboundRequestId, &'static str>,
     our_chain_id: u64,
     ip_limiter: &mut IpRateLimiter,
 ) {
@@ -577,8 +593,10 @@ async fn on_swarm_event(
                 height,
                 chain_id: our_chain_id,
             };
+            let variant = req.variant_name();
             let req_id = swarm.behaviour_mut().rr.send_request(&peer_id, req);
             pending_handshakes.insert(req_id, peer_id);
+            pending_variants.insert(req_id, variant);
         }
 
         SwarmEvent::ConnectionClosed {
@@ -611,6 +629,7 @@ async fn on_swarm_event(
                 verified_peers,
                 pending_handshakes,
                 pending_syncs,
+                pending_variants,
                 our_chain_id,
             )
             .await;
@@ -736,6 +755,7 @@ async fn on_rr_event(
     verified_peers: &mut HashSet<PeerId>,
     pending_handshakes: &mut HashMap<OutboundRequestId, PeerId>,
     pending_syncs: &mut HashMap<OutboundRequestId, PeerId>,
+    pending_variants: &mut HashMap<OutboundRequestId, &'static str>,
     our_chain_id: u64,
 ) {
     use request_response::{Event as RrEvent, Message as RrMessage};
@@ -772,6 +792,11 @@ async fn on_rr_event(
                 },
             ..
         } => {
+            // Bug #1d diagnostic: release variant slot on successful response.
+            // Without this the map would grow unbounded across the process
+            // lifetime.
+            pending_variants.remove(&request_id);
+
             // Check if this response matches a pending GetBlocks sync request
             let followup = on_inbound_response(
                 peer,
@@ -787,11 +812,11 @@ async fn on_rr_event(
             .await;
             // If sync returned more blocks to fetch, send another GetBlocks
             if let Some((next_peer, from_height)) = followup {
-                let req_id = swarm
-                    .behaviour_mut()
-                    .rr
-                    .send_request(&next_peer, SentrixRequest::GetBlocks { from_height });
+                let req = SentrixRequest::GetBlocks { from_height };
+                let variant = req.variant_name();
+                let req_id = swarm.behaviour_mut().rr.send_request(&next_peer, req);
                 pending_syncs.insert(req_id, next_peer);
+                pending_variants.insert(req_id, variant);
             }
         }
 
@@ -803,10 +828,29 @@ async fn on_rr_event(
         } => {
             pending_handshakes.remove(&request_id);
             pending_syncs.remove(&request_id);
-            tracing::warn!("libp2p: outbound failure to {}: {}", peer, error);
+            // Bug #1d diagnostic: log the request variant that failed.
+            // "outbound failure to X: timeout" by itself is unactionable
+            // — we cannot tell if BFT proposals are timing out or unrelated
+            // background traffic (e.g. periodic GetBlocks for sync). Until
+            // the variant shows up in logs, investigation of the real
+            // latency hotspot is blind.
+            let variant = pending_variants
+                .remove(&request_id)
+                .unwrap_or("Unknown");
+            tracing::warn!(
+                "libp2p: outbound failure to {} ({}): {}",
+                peer,
+                variant,
+                error
+            );
         }
 
         RrEvent::InboundFailure { peer, error, .. } => {
+            // Inbound failures are on requests a PEER sent us that we
+            // failed to respond to — we never had pending_variants state
+            // for them (variant lives in the request the peer sent, which
+            // request_response drops on our side before surfacing this
+            // event). Peer-side logs have the variant on their end.
             tracing::warn!("libp2p: inbound failure from {}: {}", peer, error);
         }
 

--- a/crates/sentrix-wire/src/lib.rs
+++ b/crates/sentrix-wire/src/lib.rs
@@ -84,6 +84,29 @@ pub enum SentrixRequest {
     BftRoundStatus { status: RoundStatus },
 }
 
+impl SentrixRequest {
+    /// Static tag used in diagnostic logs and metrics labels. Needed by
+    /// bug #1d investigation — OutboundFailure logs today say "outbound
+    /// failure to {peer}: {err}" with no hint which request variant was
+    /// in flight, so we can't tell if BFT proposals are the ones timing
+    /// out or unrelated background traffic (e.g. periodic GetBlocks).
+    /// See `audits/bug-1d-proposer-request-response-design.md`.
+    pub fn variant_name(&self) -> &'static str {
+        match self {
+            SentrixRequest::Handshake { .. } => "Handshake",
+            SentrixRequest::NewBlock { .. } => "NewBlock",
+            SentrixRequest::NewTransaction { .. } => "NewTransaction",
+            SentrixRequest::GetBlocks { .. } => "GetBlocks",
+            SentrixRequest::GetHeight => "GetHeight",
+            SentrixRequest::Ping => "Ping",
+            SentrixRequest::BftProposal { .. } => "BftProposal",
+            SentrixRequest::BftPrevote { .. } => "BftPrevote",
+            SentrixRequest::BftPrecommit { .. } => "BftPrecommit",
+            SentrixRequest::BftRoundStatus { .. } => "BftRoundStatus",
+        }
+    }
+}
+
 /// Responses returned by a peer for the above requests.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SentrixResponse {


### PR DESCRIPTION
## Summary
- Diagnostic-only first step for bug #1d. Logs the `SentrixRequest` variant alongside every libp2p `OutboundFailure`, so testnet logs can finally tell us whether `BftProposal` is the one timing out or whether unrelated background traffic (periodic `GetBlocks`, `Handshake` retries) dominates the failure stream.
- Current log: `libp2p: outbound failure to X: timeout`. New log: `libp2p: outbound failure to X (BftProposal): timeout`.
- Zero behaviour change.

## Why this PR is tiny on purpose
The design doc (`audits/bug-1d-proposer-request-response-design.md`) was rewritten 2026-04-21 after the original premise ("migrate to request_response") turned out to be already implemented. The updated doc explicitly lists diagnostic logging as step 1 of the real investigation — the fix path (tighter RR timeout / fire-and-forget / channel prioritisation / lock audit) cannot be chosen without first knowing which request variant is the one actually timing out on the testnet stall.

## Changes
- `sentrix-wire::SentrixRequest::variant_name(&self) -> &'static str` — 10-variant tag
- `libp2p_node` swarm task: new `pending_variants` `HashMap<OutboundRequestId, &'static str>`, populated at all 5 outbound `send_request` sites:
  - `SwarmCommand::Broadcast` fan-out (BFT proposals/prevotes/precommits/round-status + block/tx push)
  - `SwarmCommand::TriggerSync` GetBlocks
  - Periodic 30s sync GetBlocks
  - `ConnectionEstablished` Handshake
  - Followup GetBlocks after partial sync response
- Map entries removed on both successful `Response` and `OutboundFailure` so memory stays bounded.
- `RrEvent::OutboundFailure` log upgraded with variant.
- `RrEvent::InboundFailure` left unchanged — inbound failures are on requests peers sent us, we never had pending state for them. Commented why.

## Next steps (NOT in this PR)
Per the investigation doc — each its own PR once testnet bake surfaces evidence:
1. Prometheus counter labelled by variant for outbound failures
2. Ack-latency span on inbound BFT-message handlers (`on_inbound_request`)
3. `NodeEvent` mpsc channel-depth gauge to test the "fast ACK + slow dispatch" hypothesis

## Test plan
- [x] `cargo build -p sentrix-node` — clean
- [x] `cargo test -p sentrix-network -p sentrix-wire --lib` — 6 green
- [x] `cargo clippy -p sentrix-network -p sentrix-wire --lib -- -D warnings` — clean
- [ ] CI green
- [ ] Testnet bake: after deploy, check `journalctl -u ... | grep 'outbound failure'` — expect variant names to appear; confirm whether `BftProposal` dominates the error stream