### PR TITLE
chore: release v2.1.21 — observability + startup perf (no consensus change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.21] — 2026-04-24 — Observability + startup perf (no consensus change)
+
+Maintenance patch collecting three bite-sized improvements merged over the 2026-04-24 session. No consensus, wire, or storage format change; `VOYAGER_*_HEIGHT` env vars remain the sole activation gates for Voyager behaviour.
+
+### Added (#269)
+
+- **`Blockchain::reset_reward_accumulators_for_fork_activation` extracted helper** with a unit test pinning the V4 Step 3 accumulator-reset invariant: both `pending_rewards` and `delegator_rewards` zeroed, validator entries themselves preserved. Closes the v2.1.19 CHANGELOG follow-up flag at the unit level. `apply_block_pass2` call site + gate predicate unchanged.
+
+### Added (#271 — bug #1d diagnostic pass 1)
+
+- **`SentrixRequest::variant_name() -> &'static str`** tag for all 10 request variants.
+- **`pending_variants: HashMap<OutboundRequestId, &'static str>`** tracked at all 5 outbound `send_request` sites in the libp2p swarm task, released on both successful `Response` and `OutboundFailure`.
+- **`RrEvent::OutboundFailure` log now includes the variant**: `libp2p: outbound failure to {peer} ({variant}): {error}`. Lets the next testnet bake finally distinguish BFT-proposal timeouts from background-traffic noise. Pure observability — call paths, timeouts, retry logic all untouched.
+
+### Added + fixed (#273 — issue #268 diagnostic)
+
+- **`Blockchain::backfill_txid_index` fast path**: on a warm chain (latest block's last tx already indexed), skip the whole-chain scan. Previously every startup did `height + 1` redundant MDBX reads with zero writes — on a 500K-block chain that's a silent several-minute CPU phase between MDBX open and the validator loop's first log, matching the "process alive, journal empty" shape operators saw on the first Voyager activation attempt.
+- **Cold-path progress log every 50K blocks scanned** so operators see activity rather than a silent freeze during first-ever backfill on a large chain.
+- **`load_blockchain` startup banner** emitted after the window is populated, reporting `height {n} ({window_len} blocks in window)`. Gives a clean marker between MDBX open and the first validator-loop tick.
+
+### Diagnostic findings from this session
+
+Local repro of #268 against a clean 1 GB mainnet `chain.db` snapshot rsynced from VPS1 (via 28 s halt window):
+
+- v2.1.20 release binary + no fork envs → clean startup, height 506078 loaded, 4 validators detected, idle.
+- v2.1.20 release binary + fork envs (`VOYAGER_FORK_HEIGHT=502000` / `VOYAGER_REWARD_V2_HEIGHT=502100`, both below current) → same clean startup.
+
+Conclusion: the v2.1.20 binary itself is not the regression source. #268 remains OPEN and the most likely remaining cause is 4-validator peer-gossip interaction on shared mainnet state — not reproducible in a single-process test harness. Mainnet activation runbook stays flagged BLOCKED.
+
+### Mainnet / testnet impact
+
+No runtime behaviour change on Pioneer chains. `VOYAGER_*_HEIGHT` env vars default `u64::MAX`; without explicit opt-in this release runs identically to v2.1.20 on a pre-fork chain.
+
 ## [2.1.20] — 2026-04-25 — Full StakingOp dispatch (Delegate / Undelegate / Redelegate / Unjail / RegisterValidator / SubmitEvidence)
 
 v2.1.19 wired only ClaimRewards. This release closes the last code-side Voyager launch blocker by wiring every remaining `StakingOp` variant into the `block_executor` dispatch, all escrowed through `PROTOCOL_TREASURY` so the supply invariant holds across the full delegate → reward → unbond cycle.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "anyhow",
  "axum",
@@ -4893,14 +4893,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4943,14 +4943,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "bincode",
  "blake3",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.20"
+version = "2.1.21"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/storage.rs
+++ b/crates/sentrix-core/src/storage.rs
@@ -53,7 +53,6 @@ impl Storage {
                 return Ok(None);
             }
         };
-        tracing::info!("Blockchain state loaded: height {}", bc.height());
 
         // Load only the sliding window (last CHAIN_WINDOW_SIZE blocks) into RAM.
         let height = self
@@ -96,6 +95,11 @@ impl Storage {
             }
         }
         bc.chain = blocks;
+        tracing::info!(
+            "Blockchain state loaded: height {} ({} blocks in window)",
+            bc.height(),
+            bc.chain.len()
+        );
 
         // M-05: validate the in-memory chain window on load so a
         // corrupted DB is surfaced instead of silently serving stale

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.20"
+version = "2.1.21"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary
Maintenance patch — no consensus, wire, or storage format change. Runs identically to v2.1.20 on a pre-fork chain without `VOYAGER_*_HEIGHT` env vars set.

Bundles three already-merged PRs + one misplaced-log fix:
- #269 V4 accumulator-reset helper + unit test
- #271 libp2p `OutboundFailure` variant logging (#1d diag)
- #273 `backfill_txid_index` fast-path + progress logs (#268 diag)
- **Log fix**: `Blockchain state loaded: height N` now emits AFTER the sliding-window load so reported height matches chain/info (previously always showed 0 due to serde(skip) on `bc.chain`).

## Diagnostic findings from this session

Rsynced a clean 1 GB mainnet `chain.db` snapshot from VPS1 (28 s halt window). Tested v2.1.20 release binary locally:
- No fork envs → clean startup, height 506078, 4 validators, idle
- Fork envs set below current (`VOYAGER_FORK_HEIGHT=502000` / `VOYAGER_REWARD_V2_HEIGHT=502100`) → same

Rules out binary-on-chain.db as the #268 hang trigger in a single-process test harness. Bug remains OPEN and most likely cause is 4-validator peer-gossip interaction, not reproducible here. Mainnet Voyager activation runbook stays flagged BLOCKED.

## Test plan
- [x] `cargo build --release -p sentrix-node` — clean
- [x] `cargo test --workspace --lib` — all green (~600 tests across the workspace)
- [x] v2.1.21 release binary loads clean 1 GB mainnet chain.db snapshot, reports correct height 506078, runs idle without errors
- [ ] CI green

## Deploy plan (post-merge, staged)
1. VPS5 Beacon first (lowest-stake canary) — observe 5 min clean production
2. If clean: VPS3 Core, VPS2 Treasury, VPS1 Foundation in sequence
3. Rollback to v2.1.20 binary via `/opt/*/releases/` on any regression
4. Do NOT set Voyager fork envs — #268 blocker still open