### PR TITLE
fix(core): persistent voyager_activated + evm_activated flags — Phase 1 hard-gate

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1272,8 +1272,16 @@ async fn cmd_start(
                 }
             }
 
-            let mut voyager_activated = false;
-            let mut evm_activated = false;
+            // Sync local fast-path booleans from persistent on-chain flags so
+            // a validator restarting post-fork skips the activation re-entry
+            // entirely (no warn-spam, no redundant update_active_set call).
+            // The Blockchain methods themselves are also idempotent via the
+            // same flags — local boolean here just avoids taking the write
+            // lock on every loop tick once the chain has crossed the fork.
+            let (mut voyager_activated, mut evm_activated) = {
+                let bc = shared_clone.read().await;
+                (bc.voyager_activated, bc.evm_activated)
+            };
             // Persistent BFT state for Voyager mode
             let mut bft_engine: Option<BftEngine> = None;
             let mut voyager_tick_count: u64 = 0;

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -192,6 +192,27 @@ pub struct Blockchain {
     /// but is clean now shouldn't keep alarming).
     #[serde(skip, default)]
     pub(crate) divergence_tracker: DivergenceTracker,
+
+    /// Persistent one-shot guard for `activate_voyager`. Set to `true`
+    /// inside `activate_voyager` after the migration commits successfully;
+    /// any subsequent call to `activate_voyager` (e.g. on validator
+    /// restart, when the local `voyager_activated` boolean in the
+    /// validator loop has reset) is a no-op. Without this guard the
+    /// loop re-registers the same 4 mainnet validators on every boot
+    /// post-fork, which double-runs `update_active_set` /
+    /// `epoch_manager.initialize` deterministically (so consensus stays
+    /// safe today) but trips noisy "validator already registered" warns
+    /// and is fragile against any future non-deterministic mutation in
+    /// that path. Phase 1 hard-gate per
+    /// `founder-private/architecture/FORK_SEQUENCE_PREIMPL_SCAN_2026-04-24.md`.
+    #[serde(default)]
+    pub voyager_activated: bool,
+
+    /// Persistent one-shot guard for `activate_evm`. Same rationale as
+    /// `voyager_activated`: prevents redundant `migrate_to_evm` runs at
+    /// every restart post-fork.
+    #[serde(default)]
+    pub evm_activated: bool,
 }
 
 /// Rate-threshold detector for "this validator has diverged from peers".
@@ -323,6 +344,8 @@ impl Blockchain {
             slashing: sentrix_staking::slashing::SlashingEngine::new(),
             source_for_current_add: crate::block_executor::BlockSource::SelfProduced,
             divergence_tracker: DivergenceTracker::default(),
+            voyager_activated: false,
+            evm_activated: false,
         };
         bc.initialize_genesis(genesis);
         bc
@@ -593,9 +616,15 @@ impl Blockchain {
     /// Initialize EVM state at fork activation.
     /// Called once when chain reaches VOYAGER_EVM_HEIGHT.
     /// Migrates all account code_hash fields and initializes gas tracking.
+    /// Idempotent — guarded by the persistent `evm_activated` flag.
     pub fn activate_evm(&mut self) {
+        if self.evm_activated {
+            tracing::debug!("activate_evm: already activated, skipping");
+            return;
+        }
         tracing::info!("Activating EVM at height {}", self.height());
         let migrated = self.accounts.migrate_to_evm();
+        self.evm_activated = true;
         tracing::info!(
             "EVM activated: {} accounts migrated, gas metering enabled",
             migrated
@@ -604,9 +633,17 @@ impl Blockchain {
 
     /// Initialize Voyager state at fork activation.
     /// Called once when chain reaches VOYAGER_DPOS_HEIGHT.
-    /// Migrates existing 7 Pioneer validators to DPoS with equal stake.
+    /// Migrates existing Pioneer validators to DPoS with equal stake.
+    /// Idempotent — guarded by the persistent `voyager_activated` flag so
+    /// validator restarts post-fork don't re-register validators or
+    /// re-snapshot the epoch.
     pub fn activate_voyager(&mut self) -> SentrixResult<()> {
         use sentrix_staking::MIN_SELF_STAKE;
+
+        if self.voyager_activated {
+            tracing::debug!("activate_voyager: already activated, skipping");
+            return Ok(());
+        }
 
         // Migrate Pioneer validators → DPoS validators
         let validators: Vec<String> = self
@@ -630,6 +667,8 @@ impl Blockchain {
         self.stake_registry.update_active_set();
         self.epoch_manager
             .initialize(&self.stake_registry, self.height());
+
+        self.voyager_activated = true;
 
         tracing::info!(
             "Voyager DPoS activated at height {}. {} validators migrated.",


### PR DESCRIPTION
## Summary

The validator-loop activation guard at `bin/sentrix/src/main.rs:1275` lived as a local boolean that reset on every restart. Past Voyager fork height that meant `activate_voyager` re-fired on every boot — re-registering mainnet validators (warning-spammed but consensus-safe today, fragile against any future non-deterministic mutation in the activation path) and re-running `update_active_set` + `epoch_manager.initialize` redundantly. Same shape on `activate_evm`.

This PR persists the activation flags on `Blockchain` (JSON-serialized, `#[serde(default)]` for chain.db forward-compat). Each `activate_*` early-returns if the flag is already set. The validator loop reads the flags on entry to seed its local fast-path booleans, so a restarted post-fork validator skips the read-then-write-lock sequence after the first tick.

Phase 1 mainnet activation (per `founder-private/architecture/FORK_SEQUENCE_PREIMPL_SCAN_2026-04-24.md`) treated this as a non-negotiable pre-fork fix. Landing now while risk surface is small (no chain has crossed Voyager fork on prod).

## Test plan

- [x] `cargo test -p sentrix-core --lib` — 181/181 green
- [x] `cargo test --test integration_voyager` — 10/10 green
- [x] `cargo test -p sentrix-core --tests` — full suite green
- [x] `cargo build -p sentrix-node` — clean

## Compat notes

- New fields are `#[serde(default)]` bool — old chain.db deserializes with `false` → first restart post-deploy re-fires activation idempotently (register_validator errs on duplicates, swallowed; update_active_set + epoch_manager.initialize are deterministic), then sets the flag. Subsequent restarts skip cleanly.
- Mainnet currently `VOYAGER_FORK_HEIGHT=u64::MAX`, so activate_voyager has never fired on prod — zero behavioural change there.
- Testnet docker stack has crossed fork: first restart will exhibit the one-time idempotent re-run, identical observable behaviour to today.