### PR TITLE
chore: release v2.1.22 — Phase 1 prep + #268 repro harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.22] — 2026-04-25 — Phase 1 prep: voyager activation idempotency + #268 repro harness
+
+> **🚨 v2.1.21 + v2.1.22 DEPLOYMENT FROZEN** — issue #268 disk-roundtrip trie divergence remains unresolved. v2.1.22 ships a fast unit-test reproducer + the Phase 1 idempotency hard-gate identified during the pre-implementation scan, but does NOT close #268. Mainnet stays on v2.1.15 until #268 is fixed and a v2.1.23 ships clean against the new repro harness.
+
+### Added (#276)
+
+- **`crates/sentrix-core/tests/fork_determinism.rs`** — 4-test harness for state-root determinism. 3 active in-memory parity tests (self-produced ↔ peer-applied path convergence on short coinbase chains, 200-block coinbase chains, and tx-bearing chains) become permanent regression guards. The 4th test (`#[ignore]`'d) reproduces the actual #268-class disk-roundtrip divergence at unit-test scale: producer commits a trie root, freshly loaded `Blockchain` reading the same MDBX gets a different root for the same height. Reference in-memory peer-replay matches the producer, isolating the bug to the disk roundtrip path. Currently smells like bug #3 class — committed root garbage-collected by a subsequent insert that PR #184's `is_committed_root()` doesn't fully cover. Fast feedback loop (~3s) replaces the docker canary cycle for the next #268 bisect attempt.
+
+### Fixed (#277 — Phase 1 prep, hard-gate)
+
+- **Persistent `voyager_activated` + `evm_activated` flags on `Blockchain`** (`#[serde(default)]` for chain.db forward-compat). The validator-loop activation guard at `bin/sentrix/src/main.rs` was previously a local boolean that reset on every restart — past a Voyager fork height, that meant `activate_voyager` re-fired on every boot, re-registering validators (warning-spammed but consensus-safe today) and re-running `update_active_set` + `epoch_manager.initialize` redundantly. The Phase 1 pre-implementation scan flagged this as a non-negotiable pre-fork fix because any future non-deterministic mutation in the activation path would propagate into state_root divergence.
+- Each `activate_*` early-returns if the flag is already set; the validator loop reads the flags on entry to seed its local fast-path booleans, skipping the read-then-write-lock sequence after the first tick post-restart.
+- Behaviour on existing chains: testnet docker (post-Voyager-fork) experiences a one-time idempotent re-run on first restart with v2.1.22 (chain.db deserialises with `voyager_activated = false`), then sets the flag and skips cleanly on subsequent restarts. Mainnet (`VOYAGER_FORK_HEIGHT = u64::MAX`) sees no behavioural change — `activate_voyager` has never fired on prod.
+
+### Designed against
+
+- `founder-private/architecture/FORK_SEQUENCE_PREIMPL_SCAN_2026-04-24.md` — Q1 (#268 hypothesis re-rank), Q2 point 1 (Phase 1 hard-gate). The scan ranks PR #273's `txid_index` as a top suspect for #268 but rules it out via the commit-message disclaimer; the actual top hypothesis is `init_trie` backfill firing on reload because committed root nodes are GC'd by subsequent inserts. The ignored test in this release validates that hypothesis at unit-test scale.
+
+---
+
 ## [2.1.21] — 2026-04-24 — Observability + startup perf (no consensus change)
 
 > **🚨 DEPLOYMENT FROZEN** — 2026-04-24 Beacon canary (VPS5) triggered immediate `CRITICAL #1e: state_root mismatch` against v2.1.15 peers even with fork envs unset. Rolled back to v2.1.15; divergence persisted through 3 rsync recovery attempts. Root cause remains unresolved — see GitHub issue #268. Do NOT deploy v2.1.21 to any mainnet VPS until the issue closes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "anyhow",
  "axum",
@@ -4893,14 +4893,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4943,14 +4943,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "bincode",
  "blake3",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.21"
+version = "2.1.22"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Bumps all crate versions 2.1.21 → 2.1.22 + CHANGELOG entry covering the two PRs that landed this session:

- #276 — fork-determinism harness (3 active CI guards + 1 ignored #268 reproducer at unit-test scale)
- #277 — persistent voyager_activated + evm_activated flags (Phase 1 hard-gate)

**v2.1.22 deployment stays frozen on mainnet** — same #268 issue blocks v2.1.21+ shipping. v2.1.22 ships the fast-iteration repro harness for the next bisect attempt and lands the Phase 1 prep fix while the risk surface is small.

## Test plan

- [x] `cargo build -p sentrix-node` — clean
- [x] `cargo test -p sentrix-core --tests` — 181 lib + 4 fork_determinism (3 pass + 1 ignored) + voyager integration green
- [x] CHANGELOG entry follows Keep a Changelog format
- [x] All 17 Cargo.toml files bumped + lockfile regenerated