### PR TITLE
fix(core): init_trie node_exists false-positive on empty_hash sentinel — partial #268 close

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -844,7 +844,24 @@ impl Blockchain {
                     // is, something has gone seriously wrong (manual data corruption,
                     // storage bug, regression).  Log at ERROR so ops are alerted; the
                     // backfill below may produce a state root that differs from peers.
-                    let node_missing = !trie.node_exists(&root_hash)?;
+                    //
+                    // ISSUE #268 FALSE-POSITIVE GUARD: empty_hash(0) is the sentinel
+                    // for an empty trie level — it's NEVER materialised in trie_nodes
+                    // because empty subtrees are short-circuited. So node_exists()
+                    // always returns false for it. On a chain where no block has
+                    // mutated any account (coinbase-only blocks against an empty
+                    // initial state, or genuinely-quiet recovery windows), every
+                    // committed root equals empty_hash(0) and the old check fired a
+                    // spurious backfill. The backfill from AccountDB then computed
+                    // a non-empty root (because AccountDB has the genesis premine
+                    // entries), persisted it to MDBX BEFORE the safeguard ran, and
+                    // even if the safeguard returned Err the chain.db was already
+                    // corrupted. Below STATE_ROOT_FORK_HEIGHT, Storage::load_blockchain
+                    // swallows that Err — so the corruption became permanent.
+                    // Treat the empty sentinel as "node exists" since the empty
+                    // subtree is trivially correct without storage.
+                    let node_missing = root_hash != sentrix_trie::node::empty_hash(0)
+                        && !trie.node_exists(&root_hash)?;
                     if node_missing {
                         tracing::error!(
                             "trie: CRITICAL — root {} for height {} is recorded in trie_roots \

--- a/crates/sentrix-core/tests/fork_determinism.rs
+++ b/crates/sentrix-core/tests/fork_determinism.rs
@@ -187,25 +187,23 @@ fn test_signed_tx_blocks_self_vs_peer_determinism() {
 /// from disk computes a different state-root than the producer that wrote
 /// it, that's the #268 class.
 ///
-/// **Currently fails on main.** When this test was written (2026-04-25),
-/// the producer's trie root at h=30 differs from `reloaded.trie_root_at(30)`
-/// even though both back into the same MDBX. The reference instance
-/// (replays the same blocks via peer-apply, never touches disk) matches the
-/// producer — so the divergence is purely on the disk-roundtrip path.
-/// Most likely culprit: `init_trie`'s backfill branch fires on the reload
-/// because `node_exists(&committed_root)` returns false for a root the
-/// producer just committed, and then the backfill recomputation produces
-/// a different root than the incremental path stamped (bug #3 class —
-/// supposed-to-be-fixed in PR #184 via `is_committed_root` guard).
+/// **History**: when first written (2026-04-25, this PR's predecessor) the
+/// test reproduced a real disk-roundtrip divergence — producer at h=30 had
+/// trie root `cfd6581…`, freshly loaded chain reading the same MDBX got
+/// `6310b98…`. Diagnosis traced it to `init_trie`'s `node_exists`
+/// false-positive on `empty_hash(0)`: the empty-trie sentinel is never
+/// materialised in `trie_nodes`, so any chain whose every committed root
+/// equalled the empty hash (coinbase-only test, genuinely-quiet recovery
+/// window) tripped a spurious backfill. The backfill rebuilt a non-empty
+/// root from AccountDB premine, persisted it to MDBX BEFORE the safeguard
+/// could fire, and even when the safeguard returned Err, `Storage::load_blockchain`
+/// swallowed it below STATE_ROOT_FORK_HEIGHT — leaving permanent corruption.
 ///
-/// Until #268 is closed, this test is `#[ignore]`'d so CI stays green.
-/// Run manually with:
-///   `cargo test -p sentrix-core --test fork_determinism \
-///     test_mdbx_roundtrip_then_peer_block -- --ignored --nocapture`
-/// Once #268 fixes the roundtrip divergence, drop the `#[ignore]` and the
-/// test becomes the permanent regression guard.
+/// Fixed by short-circuiting `node_exists` for `empty_hash(0)` in
+/// `Blockchain::init_trie`. This test now passes and locks that guard in
+/// place: any future change that re-introduces the false-positive will
+/// turn this test red.
 #[test]
-#[ignore = "currently reproduces #268 disk-roundtrip divergence — enable once that issue closes"]
 fn test_mdbx_roundtrip_then_peer_block() {
     let dir = TempDir::new().expect("tempdir");
     let storage = sentrix_core::storage::Storage::open(dir.path().to_str().unwrap())


### PR DESCRIPTION
## Summary

Closes one #268 disk-roundtrip divergence class identified by the (previously-ignored) `test_mdbx_roundtrip_then_peer_block` in `crates/sentrix-core/tests/fork_determinism.rs`.

### Root cause

`empty_hash(0)` is the sentinel for an empty trie level. The binary SMT short-circuits empty subtrees → the empty hash is never materialised in `TABLE_TRIE_NODES`. So `TrieStorage::node_exists(empty_hash(0))` always returns `false`.

`Blockchain::init_trie` at `blockchain.rs:847` treated that as "node missing from storage" → triggered a spurious backfill from AccountDB. Three things compounded:

1. Backfill rebuilt a non-empty root from genesis premine (Founder, Ecosystem Fund, Reserve, etc.).
2. `trie.commit(height)` wrote the non-empty backfilled root to MDBX **before** the divergence safeguard fired.
3. The safeguard at `blockchain.rs:925` correctly identified the divergence and returned `Err`, **but** `Storage::load_blockchain` at `storage.rs:136-150` swallows that Err below `STATE_ROOT_FORK_HEIGHT` (just `tracing::warn!`, then continues). Permanent silent corruption.

### Trigger conditions

A chain whose every committed trie root equals `empty_hash(0)`:

- Coinbase-only blocks against a state where the validator address has no account record (the failing test scenario).
- Genuinely-quiet recovery windows where a sequence of blocks doesn't touch any account.
- First-time trie init on a chain that predates `SentrixTrie` and where AccountDB happens to be empty.

Mainnet at h=553K is **not** in this regime — its committed roots are non-empty (validator coinbase credits its own account every block). So this specific bug isn't the smoking gun for the v2.1.21 mainnet canary failure.

### Honest scope

This closes **one disk-roundtrip divergence class** plus the **destructive-backfill-before-safeguard** path. Mainnet's specific `#268` symptom on v2.1.21 (canary boots from rsync'd chain.db with non-empty roots, immediately mismatches v2.1.15 peers) is **not** explained by this fix — that mainnet investigation continues. v2.1.22+ deployment to mainnet stays frozen.

What this PR DOES change:
- Fixes any future test or recovery path that operates on a chain with empty trie state.
- Closes the silent-permanent-corruption gap below `STATE_ROOT_FORK_HEIGHT` for this specific class.
- Locks the previously-ignored regression test as a permanent CI guard.

### Test plan

- [x] `cargo test -p sentrix-core --test fork_determinism` — 4/4 active pass (was 3 active + 1 ignored before fix)
- [x] `cargo test -p sentrix-core --lib` — 181/181 green
- [x] `cargo test -p sentrix-core --tests` — full suite green
- [x] `cargo build -p sentrix-node` — clean

### Follow-up

- **Issue C (destructive backfill before safeguard)** — backfill writes to MDBX before the divergence check. Even with this fix in place, any future code that triggers `needs_backfill` will silently corrupt MDBX if the backfill produces a different root from the stored one. Worth a separate hardening PR: compute the backfill root WITHOUT committing, compare to stored, only persist on agreement.
- **Issue B (`Storage::load_blockchain` Err swallow below 100K)** — the warn-only path is justified per its comment (mainnet recovery via P2P sync), but the destructive-backfill interaction means an `init_trie` Err can leave inconsistent on-disk state that the warn-only path doesn't recognise. Worth revisiting the trade-off.