### PR TITLE
chore: release v2.1.23 — init_trie empty-hash fix (partial #268 close)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.23] — 2026-04-25 — init_trie empty-hash false-positive fix (partial #268 close)
+
+> **🚨 v2.1.21–v2.1.23 DEPLOYMENT FROZEN ON MAINNET** — v2.1.23 closes ONE disk-roundtrip divergence class identified by yesterday's repro harness, but mainnet's specific v2.1.21 canary symptom (non-empty roots, immediate mismatch against v2.1.15 peers) is **not** explained by this fix. Mainnet stays on v2.1.15 until further #268 investigation lands. v2.1.23 deployed to testnet docker for soak.
+
+### Fixed (#279 — partial #268 close)
+
+- **`Blockchain::init_trie` `node_exists` false-positive on `empty_hash(0)`**. The empty-trie sentinel is never materialised in `TABLE_TRIE_NODES` because the binary SMT short-circuits empty subtrees, so `node_exists(empty_hash(0))` always returns false. The init_trie node-missing check at `blockchain.rs:847` mistook that for "node missing from storage" and triggered a spurious backfill from AccountDB on chains where every committed root equalled the empty hash (coinbase-only test, genuinely-quiet recovery windows). Three things compounded:
+  1. Backfill rebuilt a non-empty root from genesis premine.
+  2. `trie.commit(height)` wrote that backfilled root to MDBX BEFORE the divergence safeguard fired.
+  3. The safeguard correctly returned `Err`, but `Storage::load_blockchain` swallows that Err below `STATE_ROOT_FORK_HEIGHT` (warn-only) — silent permanent corruption of the chain.db.
+- Fix short-circuits `node_exists` for `empty_hash(0)`. The empty subtree is trivially valid without any storage entry, so it's safe to treat as "node exists" and skip backfill. Trigger conditions for the bug are narrow (chains with empty trie state) so mainnet at h=553K is not affected — but the destructive-backfill path is closed for any future operator scenario that hits this regime.
+- Drops `#[ignore]` on `test_mdbx_roundtrip_then_peer_block` in `crates/sentrix-core/tests/fork_determinism.rs` — now a permanent CI regression guard.
+
+### Honest framing
+
+This release closes **one** disk-roundtrip divergence class. Mainnet's specific `#268` symptom (v2.1.21 canary on VPS5 with non-empty rsync'd chain.db, immediate `#1e` mismatch against v2.1.15 peers) is **not** explained by this fix and remains under investigation. v2.1.23 ships the protection where it applies + locks the regression test.
+
+### Follow-up tracked
+
+- **Destructive-backfill-before-safeguard**: even with this fix, any future `needs_backfill = true` path writes the recomputed root to MDBX BEFORE the safeguard runs. If safeguard fires, on-disk state is left inconsistent. Hardening: compute backfill root in a scratch space, compare, persist only on agreement.
+- **`Storage::load_blockchain` swallows init_trie Err below 100K**: warn-only path was justified for P2P-recoverable failures, but the interaction with the destructive backfill means a silently-warned init_trie Err can leave corrupted state. Worth revisiting.
+
+---
+
 ## [2.1.22] — 2026-04-25 — Phase 1 prep: voyager activation idempotency + #268 repro harness
 
 > **🚨 v2.1.21 + v2.1.22 DEPLOYMENT FROZEN** — issue #268 disk-roundtrip trie divergence remains unresolved. v2.1.22 ships a fast unit-test reproducer + the Phase 1 idempotency hard-gate identified during the pre-implementation scan, but does NOT close #268. Mainnet stays on v2.1.15 until #268 is fixed and a v2.1.23 ships clean against the new repro harness.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "anyhow",
  "axum",
@@ -4893,14 +4893,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4943,14 +4943,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "bincode",
  "blake3",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.22"
+version = "2.1.23"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.22"
+version = "2.1.23"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Bumps all crate versions 2.1.22 → 2.1.23 + CHANGELOG entry covering #279.

v2.1.23 closes one #268 disk-roundtrip divergence class (init_trie node_exists false-positive on empty_hash sentinel) and locks the previously-ignored regression test as a permanent guard. Mainnet's specific v2.1.21 canary symptom is NOT explained by this fix — mainnet stays on v2.1.15.

## Test plan
- [x] cargo build clean
- [x] cargo test -p sentrix-core --tests — 181 lib + 4 fork_determinism (no ignored) green
- [x] CHANGELOG entry honest about partial close