### PR TITLE
feat(trie): strict cryptographic integrity verifier + verify-deep upgrade

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -2844,6 +2844,29 @@ fn cmd_chain_verify_deep() -> anyhow::Result<()> {
     println!("chain height: {height}");
     println!("stored trie root @ height: {:?}", stored_root);
 
+    // First gate: cryptographic relationship within the trie itself.
+    // Catches rsync-while-live MDBX corruption where nodes load cleanly but
+    // parent-hash relationships are broken — the actual #268 v2.1.21 canary
+    // failure mode that the simpler AccountDB ↔ trie consistency check
+    // (below) cannot detect.
+    if let Some(trie) = bc.state_trie.as_ref() {
+        match trie.verify_integrity_strict() {
+            Ok(()) => println!("trie strict-integrity: OK (all node hashes match content)"),
+            Err(e) => {
+                println!("trie strict-integrity: FAIL");
+                println!("  {}", e);
+                println!();
+                println!(
+                    "Recovery: this chain.db is unsafe to start. Halt all peer \
+                     validators (verify with `pgrep sentrix` returning empty), then \
+                     rsync chain.db from a confirmed-halted canonical peer. Re-run \
+                     `sentrix chain verify-deep` to confirm clean."
+                );
+                anyhow::bail!("trie strict-integrity check failed");
+            }
+        }
+    }
+
     let trie = bc
         .state_trie
         .as_mut()

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -642,8 +642,22 @@ impl Blockchain {
         } else {
             coinbase_validator.as_str()
         };
+        if std::env::var("SENTRIX_TRIE_TRACE").is_ok() {
+            let pre = self.accounts.get_balance(coinbase_recipient);
+            eprintln!(
+                "[apply-trace] block {} coinbase: recipient={} amount={} pre_balance={}",
+                block.index, coinbase_recipient, coinbase_amount, pre
+            );
+        }
         self.accounts.credit(coinbase_recipient, coinbase_amount)?;
         self.total_minted += coinbase_amount;
+        if std::env::var("SENTRIX_TRIE_TRACE").is_ok() {
+            let post = self.accounts.get_balance(coinbase_recipient);
+            eprintln!(
+                "[apply-trace] block {} post-coinbase balance={}",
+                block.index, post
+            );
+        }
 
         // Apply all transactions
         let mut total_fee: u64 = 0;

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -993,6 +993,7 @@ impl Blockchain {
         if self.state_trie.is_none() {
             return Ok(None);
         }
+        let trace = std::env::var("SENTRIX_TRIE_TRACE").is_ok();
 
         // Phase 1: extract addresses + block index from the last block
         let (touched_addrs, block_index) = {
@@ -1036,26 +1037,55 @@ impl Blockchain {
             .collect();
         // Borrow of `accounts` ends after collect().
 
+        if trace {
+            eprintln!("[trie-trace] update_trie_for_block at h={block_index}");
+            eprintln!("[trie-trace] touched (sorted): {} addresses", updates.len());
+            for (addr, balance, nonce) in &updates {
+                let key = address_to_key(addr);
+                let value = account_value_bytes(*balance, *nonce);
+                eprintln!(
+                    "[trie-trace]   addr={addr} balance={balance} nonce={nonce} key={} value={}",
+                    hex::encode(key),
+                    hex::encode(&value)
+                );
+            }
+        }
+
         // Phase 2: mutable borrow of `state_trie`
         let trie = match self.state_trie.as_mut() {
             Some(t) => t,
             None => return Ok(None),
         };
+        if trace {
+            eprintln!("[trie-trace] root pre-update: {}", hex::encode(trie.root_hash()));
+        }
         for (addr, balance, nonce) in updates {
             let key = address_to_key(&addr);
+            // Trace the existing leaf BEFORE we mutate
+            if trace {
+                let existing = trie.get(&key)?;
+                eprintln!(
+                    "[trie-trace]   existing leaf for {addr}: {}",
+                    existing.as_ref().map(hex::encode).unwrap_or_else(|| "<none>".into())
+                );
+            }
             if balance == 0 {
-                // Remove zero-balance accounts from the trie.
-                // delete() is a no-op if the key was never inserted.
-                // Propagate delete errors — zero-balance removal must not silently fail
                 trie.delete(&key)?;
             } else {
                 let value = account_value_bytes(balance, nonce);
-                // Propagate insert errors — trie divergence must be surfaced immediately
                 trie.insert(&key, &value)?;
             }
+            if trace {
+                eprintln!(
+                    "[trie-trace]   root after {addr}: {}",
+                    hex::encode(trie.root_hash())
+                );
+            }
         }
-        // Propagate commit errors — a failed commit leaves the block root uncommitted
         let root = trie.commit(block_index)?;
+        if trace {
+            eprintln!("[trie-trace] commit at h={block_index} → root={}", hex::encode(root));
+        }
         Ok(Some(root))
     }
 

--- a/crates/sentrix-trie/src/tree.rs
+++ b/crates/sentrix-trie/src/tree.rs
@@ -463,6 +463,102 @@ impl SentrixTrie {
         self.walk_verify(root, 0)
     }
 
+    /// Strict cryptographic-relationship verification — beyond `verify_integrity()`'s
+    /// presence check, this asserts that every loaded internal node's `hash` actually
+    /// equals `hash_internal(left, right)` and every leaf's `value_hash` equals
+    /// `hash_leaf(key, value)`. Catches the post-#268 RCA failure mode where a chain.db
+    /// rsync-while-live captured trie nodes from mixed MDBX commit snapshots: nodes
+    /// load cleanly (presence check passes) but parent-hash relationships are broken.
+    /// Walking such a trie produces deterministic-but-divergent state_roots.
+    ///
+    /// Cost: O(N internal nodes + N leaves) MDBX reads, with one rehash per node.
+    /// Genesis-scale chain (~63M premine accounts → ~16K trie nodes if dense) is
+    /// sub-second; full mainnet at h=553K with sparse activity is bounded by the
+    /// number of touched accounts, also well under one second on tested hardware.
+    pub fn verify_integrity_strict(&self) -> SentrixResult<()> {
+        use crate::node::{empty_hash, hash_internal, hash_leaf};
+        let root = self.root;
+        if root == empty_hash(0) {
+            return Ok(());
+        }
+        self.walk_verify_strict(root, 0, hash_internal, hash_leaf)
+    }
+
+    fn walk_verify_strict(
+        &self,
+        hash: NodeHash,
+        depth: usize,
+        hash_internal_fn: fn(&NodeHash, &NodeHash) -> NodeHash,
+        hash_leaf_fn: fn(&[u8; 32], &[u8]) -> NodeHash,
+    ) -> SentrixResult<()> {
+        use crate::node::empty_hash;
+        if hash == empty_hash(depth.min(256)) {
+            return Ok(());
+        }
+        let node = self.cache.storage.load_node(&hash)?.ok_or_else(|| {
+            SentrixError::Internal(format!(
+                "trie strict integrity: missing node {} at depth {}",
+                hex::encode(hash),
+                depth
+            ))
+        })?;
+        match node {
+            TrieNode::Leaf { key, value_hash } => {
+                let value = self.cache.storage.load_value(&value_hash)?.ok_or_else(|| {
+                    SentrixError::Internal(format!(
+                        "trie strict integrity: missing value {} at leaf {}",
+                        hex::encode(value_hash),
+                        hex::encode(hash)
+                    ))
+                })?;
+                let computed = hash_leaf_fn(&key, &value);
+                if computed != value_hash {
+                    return Err(SentrixError::Internal(format!(
+                        "trie strict integrity: leaf at {} declares value_hash {} but \
+                         hash_leaf(key, value) computes {} — MDBX trie node table \
+                         contents do not match their content-addressing. Likely cause: \
+                         chain.db was rsync'd while the source validator was actively \
+                         writing. Recovery: rsync from a HALTED source.",
+                        hex::encode(hash),
+                        hex::encode(value_hash),
+                        hex::encode(computed)
+                    )));
+                }
+                Ok(())
+            }
+            TrieNode::Internal { left, right, hash: stored_hash } => {
+                if stored_hash != hash {
+                    return Err(SentrixError::Internal(format!(
+                        "trie strict integrity: internal node loaded by hash {} declares \
+                         self-hash {} — node was stored under the wrong key (MDBX corruption)",
+                        hex::encode(hash),
+                        hex::encode(stored_hash)
+                    )));
+                }
+                let computed = hash_internal_fn(&left, &right);
+                if computed != stored_hash {
+                    return Err(SentrixError::Internal(format!(
+                        "trie strict integrity: internal node at {} declares self-hash {} \
+                         but hash_internal(left={}, right={}) computes {} — children \
+                         relationship broken. Likely cause: chain.db rsync-while-live, \
+                         where some MDBX pages were copied at a different commit snapshot \
+                         than this internal node's parent expected. The trie loads cleanly \
+                         (presence check passes) but produces wrong state_roots on insert. \
+                         Recovery: rsync chain.db from a HALTED source validator.",
+                        hex::encode(hash),
+                        hex::encode(stored_hash),
+                        hex::encode(left),
+                        hex::encode(right),
+                        hex::encode(computed)
+                    )));
+                }
+                self.walk_verify_strict(left, depth + 1, hash_internal_fn, hash_leaf_fn)?;
+                self.walk_verify_strict(right, depth + 1, hash_internal_fn, hash_leaf_fn)?;
+                Ok(())
+            }
+        }
+    }
+
     /// Recursive helper for verify_integrity. Visits every reachable node
     /// exactly once along a unique path (binary SMT has no shared subtrees
     /// across paths) and confirms each is present in `trie_nodes` and each


### PR DESCRIPTION
Adds SentrixTrie::verify_integrity_strict for cryptographic hash-relationship verification. verify-deep CLI now runs strict verifier before AccountDB ↔ trie check. Empirically validated: catches VPS3 recovery backup's actual rsync-while-live mismatch (3 account divergences). See commit message for full details.