### PR TITLE
chore: release v2.1.24 — Phase 1 legacy-compat (#268 Path B close)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.24] — 2026-04-25 — Phase 1 mainnet legacy-compat (#268 closed via Path B)
+
+> **🟢 v2.1.24 UNFREEZES MAINNET DEPLOYMENT** with `SENTRIX_LEGACY_VALIDATION_HEIGHT` set per validator. The actual root cause of #268 was identified today: mainnet's chain.db carries historical state_root artifacts (BACKLOG #16 patches at h=32688/89, h=507499 anomaly, possibly more) from past repair operations. v2.1.16+ binaries enforce strict `#1e` validation that correctly rejects these. v2.1.15 has weaker validation that tolerates them. v2.1.24 adds env-gated tolerance: blocks below the cutoff are warn-only, blocks at/above are strictly validated. Operator-opt-in per validator. Default unset = strict (today's behaviour). Mainnet upgrade flow: set cutoff = current_tip + 1000, rolling restart with v2.1.24 binary.
+
+### Added (#288)
+
+- **`SENTRIX_LEGACY_VALIDATION_HEIGHT` env var.** When set on a validator, the strict `CRITICAL #1e: state_root mismatch` check in `apply_block_pass2` is downgraded to warn-only for blocks with `index < cutoff`. The block's stamped state_root is retained (so block hash chain stays intact), the `divergence_tracker` still records the mismatch (visible in metrics, just doesn't fire the rate-alarm), and apply continues normally. Above the cutoff, strict reject behaviour is unchanged.
+- **Test harness `test_legacy_validation_height_branches`** in `crates/sentrix-core/tests/fork_determinism.rs` documents the three behavioural branches (env unset = strict; env set & block.index < cutoff = tolerate; env set & block.index ≥ cutoff = strict). Marked `#[ignore]` because reproducing strict #1e in unit tests requires blocks past `STATE_ROOT_FORK_HEIGHT` (100,000); operator-driven manual verification via `apply_canonical_block_to_forensic` against the VPS5 forensic backup is the integration-level test (verified empirically: env=600000 → tolerate, env=100000 → strict, env unset → strict).
+
+### Closed by Path B vs the alternative
+
+The other path considered was a chain.db rebuild via genesis-replay — produce a clean canonical chain.db with v2.1.23-correct state_roots, halt all 4 mainnet validators, replace chain.db, restart on v2.1.24, then activate Voyager. The chain.db rebuild path was rejected because it changes block hashes for affected heights → all subsequent blocks' `previous_hash` chain breaks → effectively a chain reorganisation/restart from the first patched height, breaking external services that cache block hashes (block explorer, RPC clients). Multi-day operation. Path B preserves block hashes and unblocks Phase 1 within days.
+
+Full design + trade-off analysis at `founder-private/architecture/PHASE_1_LEGACY_COMPAT_DESIGN.md`. RCA evidence trail at `founder-private/incidents/2026-04-25-268-root-cause-pinned.md`.
+
+### Operational rollout this release enables
+
+1. Choose `legacy_height = mainnet_tip + 1000` at deploy moment.
+2. Update each validator's env file in lockstep (md5sum parity check), rolling restart with v2.1.24 binary (~30s halt per validator, mainnet round-robin tolerates).
+3. Verify chain producing post-deploy with all 4 vals.
+4. Voyager activation env flips (`VOYAGER_FORK_HEIGHT`, `VOYAGER_REWARD_V2_HEIGHT`) at heights ABOVE the legacy cutoff so post-cutoff blocks are fully strictly validated.
+
+---
+
 ## [2.1.23] — 2026-04-25 — init_trie empty-hash false-positive fix (partial #268 close)
 
 > **🚨 v2.1.21–v2.1.23 DEPLOYMENT FROZEN ON MAINNET** — v2.1.23 closes ONE disk-roundtrip divergence class identified by yesterday's repro harness, but mainnet's specific v2.1.21 canary symptom (non-empty roots, immediate mismatch against v2.1.15 peers) is **not** explained by this fix. Mainnet stays on v2.1.15 until further #268 investigation lands. v2.1.23 deployed to testnet docker for soak.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "anyhow",
  "axum",
@@ -4893,14 +4893,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4943,14 +4943,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "bincode",
  "blake3",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.23"
+version = "2.1.24"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/tests/rca_vps3_env_repro.rs
+++ b/crates/sentrix-core/tests/rca_vps3_env_repro.rs
@@ -98,6 +98,22 @@ fn read_committed_trie_root() {
             let r = bc.trie_root_at(h).map(hex::encode).unwrap_or_else(|| "<none>".to_string());
             println!("  h={} root={}", h, r);
         }
+        // If TEST_BLOCK_AT is set, dump that specific block's header instead of tip's.
+        if let Ok(h_str) = std::env::var("TEST_BLOCK_AT") {
+            let h: u64 = h_str.parse().expect("TEST_BLOCK_AT must be integer");
+            match bc.get_block_any(h) {
+                Some(block) => {
+                    println!("BLOCK_AT_HEIGHT={}", h);
+                    println!("  hash={}", block.hash);
+                    println!("  prev_hash={}", block.previous_hash);
+                    println!("  state_root={:?}", block.state_root.map(hex::encode));
+                    println!("  validator={}", block.validator);
+                    println!("  tx_count={}", block.transactions.len());
+                }
+                None => println!("BLOCK_AT_HEIGHT={}  not found", h),
+            }
+            return;
+        }
         if let Some(trie) = bc.state_trie.as_ref() {
             print!("TRIE_INTEGRITY=");
             match trie.verify_integrity() {

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.23"
+version = "2.1.24"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Bumps all crates 2.1.23 → 2.1.24 + CHANGELOG. Includes #288 (SENTRIX_LEGACY_VALIDATION_HEIGHT). Unfreezes mainnet deployment with operator-set cutoff. See CHANGELOG.md for full operational rollout sequence.