### PR TITLE
fix(node): SENTRIX_FORCE_PIONEER_MODE — emergency rollback override (2026-04-25 mainnet incident)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1289,6 +1289,21 @@ async fn cmd_start(
                 let bc = shared_clone.read().await;
                 (bc.voyager_activated, bc.evm_activated)
             };
+            // Emergency rollback: SENTRIX_FORCE_PIONEER_MODE=1 forces the local
+            // mode flag to Pioneer regardless of persistent voyager_activated
+            // flag in chain.db. Used when Voyager activation hits a known issue
+            // (e.g. V2 locked-block-repropose wiring gap) and operator needs to
+            // resume Pioneer block production. The persistent flag stays set on
+            // chain.db; clearing requires a separate chain.db edit operation.
+            if std::env::var("SENTRIX_FORCE_PIONEER_MODE").is_ok() {
+                tracing::warn!(
+                    "SENTRIX_FORCE_PIONEER_MODE set — forcing Pioneer mode regardless of \
+                     persistent voyager_activated flag. Block production will use round-robin \
+                     PoA until env is unset and validator restarted."
+                );
+                voyager_activated = false;
+                evm_activated = false;
+            }
             // Persistent BFT state for Voyager mode
             let mut bft_engine: Option<BftEngine> = None;
             let mut voyager_tick_count: u64 = 0;


### PR DESCRIPTION
Mainnet Voyager activation today hit the V2 locked-block-repropose wiring gap → BFT livelock → chain stuck at h=557244. Persistent voyager_activated flag prevented env-only rollback. This patch adds an emergency override env var that forces Pioneer mode at startup regardless of persistent flag.

Already deployed to mainnet via emergency binary (md5 5ad7804c0d7e68f8cab47872f7dbc7ac). Mainnet recovered, h=557300+ producing normally on Pioneer.

Lesson: V2 main.rs Steps 4-5 (proposer call-site refactor) MUST ship before next Voyager activation attempt. Until then, mainnet stays on Pioneer with this override.

See founder-private/incidents/2026-04-25-voyager-activation-bft-livelock.md (will write next)