### PR TITLE
chore: release v2.1.25 — emergency Pioneer override (post Voyager BFT livelock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.25] — 2026-04-25 — SENTRIX_FORCE_PIONEER_MODE emergency override (Voyager activation rollback)
+
+> **🚨 v2.1.25 hotfix released after the 2026-04-25 mainnet Voyager activation incident.** v2.1.24 was deployed cleanly to mainnet to close #268, then `VOYAGER_FORK_HEIGHT` was flipped to activate Voyager DPoS+BFT at h=557244. Activation succeeded (validators migrated, `voyager_activated=true` set persistently per PR #277), but BFT livelocked immediately due to V2 locked-block-repropose wiring gap (Steps 4-5 main.rs never shipped — see `audits/v2-locked-block-repropose-implementation-plan.md`). Rolled back to Pioneer via this hotfix's emergency override env. Mainnet stable on Pioneer with `SENTRIX_FORCE_PIONEER_MODE=1` set per validator. **Voyager activation re-attempt blocked on V2 Steps 4-5 implementation.**
+
+### Added (#290)
+
+- **`SENTRIX_FORCE_PIONEER_MODE` env var.** When set, the validator-loop's local `voyager_activated` and `evm_activated` booleans are forced to `false` at startup regardless of the persistent flags on `Blockchain` (PR #277). Used as emergency rollback path when Voyager BFT cannot finalise. The persistent flags stay set on chain.db; clearing them requires a separate operation. Once V2 main.rs wiring lands and BFT is verified live on testnet, the flag can be unset and the validator resumes Voyager mode based on its persistent state.
+
+### Default behaviour unchanged
+
+- Without `SENTRIX_FORCE_PIONEER_MODE`, the validator loads `voyager_activated` / `evm_activated` from chain.db as before. v2.1.25 is fully backward compatible with v2.1.24 chain.db.
+
+### Operational status post-incident
+
+- Mainnet at h=557415+, all 4 vals lockstep on emergency v2.1.25 binary in Pioneer mode
+- `SENTRIX_FORCE_PIONEER_MODE=1` set in each validator's env file
+- `VOYAGER_FORK_HEIGHT` reset to `u64::MAX` (redundant given FORCE_PIONEER, but defense-in-depth)
+- Voyager state on chain.db (stake_registry, epoch_manager, voyager_activated=true) intact but unused while Pioneer runs
+- Next Voyager activation attempt blocked on V2 main.rs Steps 4-5 implementation + testnet activation rehearsal
+
+Full incident analysis at `founder-private/incidents/2026-04-25-voyager-activation-bft-livelock.md`.
+
+---
+
 ## [2.1.24] — 2026-04-25 — Phase 1 mainnet legacy-compat (#268 closed via Path B)
 
 > **🟢 v2.1.24 UNFREEZES MAINNET DEPLOYMENT** with `SENTRIX_LEGACY_VALIDATION_HEIGHT` set per validator. The actual root cause of #268 was identified today: mainnet's chain.db carries historical state_root artifacts (BACKLOG #16 patches at h=32688/89, h=507499 anomaly, possibly more) from past repair operations. v2.1.16+ binaries enforce strict `#1e` validation that correctly rejects these. v2.1.15 has weaker validation that tolerates them. v2.1.24 adds env-gated tolerance: blocks below the cutoff are warn-only, blocks at/above are strictly validated. Operator-opt-in per validator. Default unset = strict (today's behaviour). Mainnet upgrade flow: set cutoff = current_tip + 1000, rolling restart with v2.1.24 binary.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "anyhow",
  "axum",
@@ -4893,14 +4893,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4943,14 +4943,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "bincode",
  "blake3",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "bincode",
  "sentrix-bft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.24"
+version = "2.1.25"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Hotfix bumping crates 2.1.24→2.1.25 + CHANGELOG. Includes #290 (SENTRIX_FORCE_PIONEER_MODE). Mainnet already running this binary as emergency deployment. See CHANGELOG + incidents/2026-04-25-voyager-activation-bft-livelock.md for full context.