### PR TITLE
docs: comprehensive sync with 2026-04-25 evening state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,44 +31,38 @@ cargo build --release
 
 ### Project Structure
 
+Sentrix is a Cargo workspace with 14 crates under `crates/` plus the
+binary at `bin/sentrix/`:
+
 ```
-src/
-├── core/
-│   ├── blockchain.rs      # Blockchain struct, genesis, constants
-│   ├── mempool.rs         # Mempool management (add, prune, limits)
-│   ├── block_producer.rs  # Block creation (create_block)
-│   ├── block_executor.rs  # Block validation + commit (add_block)
-│   ├── token_ops.rs       # SRC-20 operations
-│   ├── chain_queries.rs   # Read-only chain queries
-│   ├── block.rs           # Block struct + hash
-│   ├── transaction.rs     # TX struct + ECDSA sign/verify
-│   ├── account.rs         # Balance + nonce state
-│   ├── authority.rs       # PoA validator management
-│   ├── merkle.rs          # SHA-256 Merkle tree
-│   └── vm.rs              # SRC-20 token engine
-├── network/
-│   ├── node.rs            # Legacy TCP P2P
-│   ├── sync.rs            # Chain sync protocol
-│   ├── transport.rs       # libp2p TCP + Noise + Yamux
-│   ├── behaviour.rs       # libp2p SentrixBehaviour
-│   └── libp2p_node.rs     # libp2p node runner
-├── wallet/                # Key generation, Argon2id keystore
-├── storage/               # MDBX per-block persistence
-├── api/                   # REST API, JSON-RPC, block explorer
-├── types/                 # Shared error types
-├── lib.rs                 # Library root
-└── main.rs                # CLI entry point (17 commands)
-tests/
-├── common/mod.rs          # Shared test helpers
-├── integration_restart.rs
-├── integration_sync.rs
-├── integration_tx.rs
-├── integration_token.rs
-├── integration_mempool.rs
-├── integration_supply.rs
-├── integration_chain_validation.rs
-└── integration_sliding_window.rs
+crates/
+├── sentrix-primitives/    # Block, Transaction, Account, Error types
+├── sentrix-codec/         # Wire-format encoding helpers
+├── sentrix-wire/          # Wire-protocol message types
+├── sentrix-wallet/        # Argon2id keystore, ECDSA keypair ops
+├── sentrix-trie/          # Binary Sparse Merkle Tree (MDBX backend)
+├── sentrix-staking/       # DPoS, epoch, slashing
+├── sentrix-evm/           # revm 37 adapter
+├── sentrix-precompiles/   # EVM precompiles
+├── sentrix-bft/           # BFT consensus (timeout-only round advance)
+├── sentrix-core/          # Blockchain, authority, executor, mempool
+├── sentrix-network/       # libp2p P2P, gossipsub, kademlia, sync
+├── sentrix-rpc/           # REST API, JSON-RPC, block explorer
+├── sentrix-rpc-types/     # Shared RPC request/response types
+└── sentrix-storage/       # MDBX wrapper + ChainStorage API
+
+bin/sentrix/
+└── src/main.rs            # CLI entry point (sentrix start, validator,
+                           #   wallet, token, chain, state, mempool, ...)
+
+tests/                     # Workspace-level integration tests live in
+                           # crate-local `tests/` directories under each
+                           # crate above.
 ```
+
+The legacy single-crate `src/` layout was retired in v2.1.x; any
+reference to `src/core/...` in older docs predates the workspace
+migration.
 
 ---
 
@@ -150,7 +144,7 @@ Before submitting, make sure:
 
 ## Testing
 
-We take testing seriously. The project has **479+ tests** across 12 suites.
+We take testing seriously. The project has **551+ tests** across 14 crates.
 
 ### Running tests
 
@@ -158,10 +152,10 @@ We take testing seriously. The project has **479+ tests** across 12 suites.
 # All tests
 cargo test
 
-# Specific module
-cargo test core::blockchain
-cargo test wallet::keystore
-cargo test storage::db
+# Specific crate
+cargo test -p sentrix-core
+cargo test -p sentrix-wallet
+cargo test -p sentrix-storage
 
 # With output
 cargo test -- --nocapture

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fast, secure Layer-1 blockchain built in Rust.
 
 [![CI/CD](https://github.com/sentrix-labs/sentrix/actions/workflows/ci.yml/badge.svg)](https://github.com/sentrix-labs/sentrix/actions)
 [![Release](https://img.shields.io/github/v/release/sentrix-labs/sentrix)](https://github.com/sentrix-labs/sentrix/releases/latest)
-[![Tests](https://img.shields.io/badge/tests-551%20passing-brightgreen)](https://github.com/sentrix-labs/sentrix/actions)
+[![Tests](https://img.shields.io/badge/tests-551%2B%20passing-brightgreen)](https://github.com/sentrix-labs/sentrix/actions)
 [![Rust](https://img.shields.io/badge/rust-stable-orange)](Cargo.toml)
 [![Chain ID](https://img.shields.io/badge/chain%20ID-7119-blue)](docs/operations/NETWORKS.md)
 [![License](https://img.shields.io/badge/license-BUSL--1.1-purple)](LICENSE)
@@ -15,9 +15,9 @@ Fast, secure Layer-1 blockchain built in Rust.
 
 Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, instant finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and web3.js connect natively.
 
-- **v2.0.0** — MDBX storage, 1s blocks, 5000 tx/block capacity, EVM on testnet
-- **551 tests**, clippy clean, 11 security audit rounds
-- **3 validators** across 3 nodes, zero-downtime rolling CI/CD
+- **v2.1.25** — MDBX storage, 1s blocks, 5000 tx/block capacity, EVM on testnet
+- **551+ tests**, clippy clean, 11 security audit rounds
+- **4 validators** across 3 nodes (Foundation, Treasury, Core, Beacon), VPS4 `fast-deploy.sh` rolling deploy
 
 ## Features
 
@@ -44,7 +44,7 @@ cd sentrix
 cargo build --release
 
 # Test
-cargo test    # 551 tests
+cargo test    # 551+ tests
 
 # Run a node
 SENTRIX_VALIDATOR_KEY=<key> ./target/release/sentrix start --port 30303
@@ -70,19 +70,23 @@ Full guide: [docs/operations/METAMASK.md](docs/operations/METAMASK.md). Deploy a
 ```
 crates/
 ├── sentrix-primitives/   Block, Transaction, Account, Error types
+├── sentrix-codec/        Wire-format encoding helpers
+├── sentrix-wire/         Wire-protocol message types
 ├── sentrix-wallet/       Keystore (Argon2id), wallet ops
 ├── sentrix-trie/         Binary Sparse Merkle Tree (MDBX backend)
 ├── sentrix-staking/      DPoS, epoch, slashing
 ├── sentrix-evm/          revm 37 adapter
+├── sentrix-precompiles/  EVM precompiles
 ├── sentrix-bft/          BFT consensus (timeout-only round advance)
 ├── sentrix-core/         Blockchain, authority, executor, mempool, storage
 ├── sentrix-network/      libp2p P2P, gossipsub, kademlia
 ├── sentrix-rpc/          REST API, JSON-RPC, block explorer
+├── sentrix-rpc-types/    Shared RPC request/response types
 ├── sentrix-storage/      MDBX wrapper + ChainStorage API
-bin/sentrix/              CLI binary
+bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 ```
 
-12 crates + 1 binary — node, API, explorer, CLI all ship as one executable.
+14 crates + 1 binary — node, API, explorer, CLI all ship as one executable.
 
 ## Network
 
@@ -90,7 +94,7 @@ bin/sentrix/              CLI binary
 |---|---|---|
 | **Chain ID** | 7119 | 7120 |
 | **RPC** | [sentrix-rpc.sentriscloud.com](https://sentrix-rpc.sentriscloud.com) | [testnet-rpc.sentriscloud.com](https://testnet-rpc.sentriscloud.com) |
-| **Consensus** | PoA (3 validators) | DPoS + BFT (4 validators) |
+| **Consensus** | PoA (4 validators) | DPoS + BFT (4 validators) |
 | **Block time** | 1 second | 1 second |
 | **EVM** | Disabled | Active — MetaMask compatible |
 | **Explorer** | [sentrixscan.sentriscloud.com](https://sentrixscan.sentriscloud.com) | [sentrixscan.sentriscloud.com](https://sentrixscan.sentriscloud.com) (same unified UI, toggle Testnet) |
@@ -103,8 +107,8 @@ bin/sentrix/              CLI binary
 
 | Phase | Status | Focus |
 |-------|--------|-------|
-| **Pioneer** | Live (mainnet v2.0.0) | PoA consensus, MDBX storage, 1s blocks, SRC-20 tokens |
-| **Voyager** | Live (testnet) | DPoS + BFT finality, EVM (revm 37), eth_sendRawTransaction |
+| **Pioneer** | Live (mainnet v2.1.25) | PoA consensus, MDBX storage, 1s blocks, SRC-20 tokens |
+| **Voyager** | Live (testnet, chain_id 7120) | DPoS + BFT finality, EVM (revm 37), eth_sendRawTransaction |
 | **Frontier** | Planned | Mainnet hard fork, parallel execution, ecosystem |
 | **Odyssey** | Future | Cross-chain, mature ecosystem |
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,10 @@ Sentrix follows [Semantic Versioning](https://semver.org/):
 5. **Create PR** — merge to `main` via PR with CI passing
 6. **Tag release** — `git tag -a vX.Y.Z -m "vX.Y.Z"` then `git push origin vX.Y.Z`
 7. **GitHub Release** — create release from tag with changelog excerpt
-8. **Verify deployment** — CI/CD deploys automatically; check health on all 3 VPS
+8. **Deploy** — CI/CD `deploy` job is **disabled**. Run
+   `./scripts/fast-deploy.sh mainnet` from VPS4 (or `testnet` for
+   testnet) to ship the binary; CI runs tests only. Then check health
+   on all 3 VPS.
 
 ## Deployment
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,10 @@ If you discover a security vulnerability in Sentrix, we appreciate your responsi
 
 ### How to report
 
-Send an email to: **sentriscloud@gmail.com**
+Send an email to the maintainer address listed on the Sentrix Labs
+GitHub organization profile (<https://github.com/sentrix-labs>), or
+open a private GitHub Security Advisory at
+<https://github.com/sentrix-labs/sentrix/security/advisories/new>.
 
 Please include:
 - Description of the vulnerability
@@ -45,11 +48,16 @@ We consider security research conducted in accordance with this policy to be aut
 ### Scope
 
 The following are **in scope**:
-- Core blockchain engine (`src/core/`)
-- Wallet and keystore (`src/wallet/`)
-- Network protocol (`src/network/`)
-- API endpoints (`src/api/`)
-- Cryptographic implementations
+- Core blockchain engine (`crates/sentrix-core/`)
+- BFT consensus (`crates/sentrix-bft/`)
+- DPoS staking (`crates/sentrix-staking/`)
+- State trie (`crates/sentrix-trie/`)
+- Storage layer (`crates/sentrix-storage/`)
+- EVM adapter and precompiles (`crates/sentrix-evm/`, `crates/sentrix-precompiles/`)
+- Wallet and keystore (`crates/sentrix-wallet/`)
+- Network protocol (`crates/sentrix-network/`)
+- API endpoints (`crates/sentrix-rpc/`, `crates/sentrix-rpc-types/`)
+- Cryptographic implementations across the workspace
 
 The following are **out of scope**:
 - Third-party dependencies (report to their maintainers)

--- a/docs/architecture/CONSENSUS.md
+++ b/docs/architecture/CONSENSUS.md
@@ -12,7 +12,14 @@ sorted_validators[block_height % validator_count]
 
 Deterministic — every node computes the same result independently. No communication needed.
 
-With 3 validators and 1s blocks, each one produces a block every 3 seconds (1s × 3 slots).
+With 4 validators and 1s blocks, each one produces a block every 4 seconds (1s × 4 slots).
+
+> **Operational note (2026-04-25):** mainnet currently runs forced
+> Pioneer (`SENTRIX_FORCE_PIONEER_MODE=1` env override on every
+> validator) after a Voyager DPoS+BFT activation attempt at
+> h=557244 livelocked. The Voyager fork height is parked at
+> `u64::MAX` until V2 BFT wiring (issue #292) lands. See
+> [EMERGENCY_ROLLBACK](../operations/EMERGENCY_ROLLBACK.md).
 
 ## Block Production
 
@@ -42,7 +49,10 @@ Adding a validator needs:
 - Valid secp256k1 pubkey that derives to the claimed address
 - `Wallet::derive_address(pubkey) == address` checked
 
-Min 3 active validators enforced — can't go below that.
+`MIN_ACTIVE_VALIDATORS = 1` (since v2.1.11, PR #234) — chain can
+proceed with a single active validator if the rest are jailed or
+inactive. `MIN_BFT_VALIDATORS = 4` is the BFT-quorum floor for
+Voyager activation.
 
 Every add/remove/toggle/rename gets logged in the admin audit trail.
 
@@ -67,7 +77,7 @@ block.timestamp <= now + 15s             (not too far ahead)
 
 ## Known Limitations
 
-- No fork choice. First block at a height wins. Network partitions can cause permanent splits. Fine for 3 controlled validators, needs fixing before scaling.
+- No fork choice. First block at a height wins. Network partitions can cause permanent splits. Fine for 4 controlled validators, needs fixing before scaling.
 - No block skip. If expected validator is offline, chain waits. No timeout.
 - No block signatures. Block has validator address but isn't signed. Auth is via round-robin schedule check. Signing needed for Voyager.
 

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -22,34 +22,32 @@ Sentrix is a Layer-1 blockchain written in Rust. PoA consensus, account-based mo
 
 ## Module Map
 
+Sentrix is a Cargo workspace. Each top-level concern lives in its own
+crate under `crates/`; the binary at `bin/sentrix/` wires them together.
+
 ```
-src/core/blockchain.rs       Chain state, genesis, constants
-src/core/block_producer.rs   Block creation (coinbase + mempool txs)
-src/core/block_executor.rs   Two-pass validate-then-commit
-src/core/mempool.rs          Priority queue, per-sender caps, TTL
-src/core/authority.rs        Validators, round-robin, admin audit log
-src/core/transaction.rs      ECDSA signing, nonce, chain_id
-src/core/account.rs          Balances (u64 sentri), fee split
-src/core/trie/               State trie — 256-level Binary SMT
-src/core/vm.rs               SRC-20 token engine
-src/core/block.rs            Block struct, hashing
-src/core/merkle.rs           SHA-256 tx merkle root
-src/network/libp2p_node.rs   P2P swarm, broadcast, sync
-src/network/behaviour.rs     Identify + RequestResponse
-src/network/transport.rs     TCP → Noise XX → Yamux
-src/network/sync.rs          Incremental block sync
-src/api/routes.rs            REST (25+ endpoints), rate limiting
-src/api/jsonrpc.rs           JSON-RPC 2.0 (20 methods)
-src/api/explorer.rs          12-page block explorer
-src/wallet/                  Keygen, keystore (Argon2id)
-src/storage/db.rs            MDBX persistence, hash index
-src/types/error.rs           SentrixError (14 variants)
+crates/sentrix-primitives/      Block, Transaction, Account, Error types
+crates/sentrix-codec/           Wire-format encoding helpers
+crates/sentrix-wire/            Wire-protocol message types
+crates/sentrix-wallet/          Keygen, Argon2id keystore
+crates/sentrix-trie/            256-level Binary Sparse Merkle Tree
+crates/sentrix-staking/         DPoS, epoch rotation, slashing
+crates/sentrix-evm/             revm 37 adapter
+crates/sentrix-precompiles/     EVM precompiles
+crates/sentrix-bft/             BFT consensus (timeout-only round advance)
+crates/sentrix-core/            Blockchain, authority, executor, mempool,
+                                token engine, two-pass validator
+crates/sentrix-network/         libp2p P2P, gossipsub, kademlia, sync
+crates/sentrix-rpc/             REST (60+ endpoints) + JSON-RPC 2.0 + explorer
+crates/sentrix-rpc-types/       Shared RPC request/response types
+crates/sentrix-storage/         MDBX wrapper, ChainStorage API, hash index
+bin/sentrix/src/main.rs         CLI entry point
 ```
 
 ## How Blocks Work
 
 1. Validator checks if it's their turn: `height % validator_count`
-2. Builds coinbase (1 SRX reward) + grabs up to 100 txs from mempool
+2. Builds coinbase (1 SRX reward) + grabs up to 5,000 txs from mempool (sorted by fee, highest first)
 3. Two-pass execution:
    - **Pass 1**: Validate everything on a copy — if anything fails, reject the whole block
    - **Pass 2**: Commit — credit coinbase, execute transfers, burn fees, update trie
@@ -69,9 +67,8 @@ src/types/error.rs           SentrixError (14 variants)
 
 | | |
 |-|-|
-| Source files | ~50 |
 | Lines of code | ~22,500+ |
-| Tests | 551 |
-| Workspace crates | 12 + 1 binary |
+| Tests | 551+ |
+| Workspace crates | 14 + 1 binary |
 | `unsafe` blocks | 0 |
 | License | BUSL-1.1 |

--- a/docs/operations/CI_CD.md
+++ b/docs/operations/CI_CD.md
@@ -1,11 +1,15 @@
 # CI/CD
 
-GitHub Actions pipeline. Every merge to `main` runs tests, builds a binary, and deploys to all production nodes.
+GitHub Actions runs the **test** job on every push and PR. The
+**deploy** job is **disabled** — production binaries ship via
+`scripts/fast-deploy.sh` from VPS4, not from CI.
 
 ## Pipeline
 
 ```
-Push to main → TEST → DEPLOY (only main branch)
+Push / PR  →  TEST  →  (deploy disabled)
+                       ↓
+                  fast-deploy.sh from VPS4 (manual)
 ```
 
 ### Test Job (every push + PR)
@@ -13,44 +17,74 @@ Push to main → TEST → DEPLOY (only main branch)
 1. `cargo deny check` — license + supply chain
 2. `cargo clippy --tests -- -D warnings` — zero warnings (deny unwrap/expect/panic)
 3. `cargo build --release`
-4. `cargo test` — 551 tests
-5. Upload binary as artifact (1-day retention)
+4. `cargo test` — 551+ tests across the 14-crate workspace
+5. Upload binary as artifact (1-day retention, audit-only)
 
-### Deploy Job (main only, after test passes)
+The artifact is **not** auto-deployed; it exists so reviewers can pull
+the exact CI binary if they need to reproduce a test result.
 
-Phase 1 — Upload binaries to all VPS while nodes still running (minimize downtime).
+## Deploy: `scripts/fast-deploy.sh` (from VPS4)
 
-Phase 2 — Stop in reverse order:
-```
-[NODE_3] → [NODE_2] → [NODE_1]
-```
-Secondary nodes stop first so primary can finish processing in-flight blocks. Prevents orphan blocks.
+VPS4 (the dev/edge host) is the canonical deploy origin. The script
+builds inside a `rust:1.95-bullseye` container (glibc 2.31, compatible
+with both Ubuntu 22.04 and 24.04 production targets), uploads the
+binary to VPS1/VPS2/VPS3 over the wg1 WireGuard mesh, and does a
+rolling restart with a bounded health check.
 
-Phase 3 — Replace binary on each VPS:
 ```bash
-cp /tmp/sentrix-new /opt/sentrix/sentrix && chmod +x /opt/sentrix/sentrix
+# From VPS4
+./scripts/fast-deploy.sh mainnet          # asks for confirmation
+./scripts/fast-deploy.sh testnet          # silent (testnet docker)
+
+# Rollback to a prior release on disk
+SENTRIX_ROLLBACK=/opt/sentrix/releases/<prev> \
+  ./scripts/fast-deploy.sh mainnet
 ```
 
-Phase 4 — Start in forward order:
-```
-[NODE_1] → [NODE_2] → [NODE_3]
-```
-Primary first so peers can connect immediately.
+End-to-end ~3–5 minutes. Builds once, copies the same byte-identical
+binary to every host (no per-host recompile, no glibc skew).
 
-Phase 5 — Health check after 35s stabilization:
-```bash
-curl -sf http://[NODE_IP]:8545/chain/info | jq .height
+### Stop / start order (rolling)
+
+The script stops validators in reverse order and starts them in forward
+order:
+
 ```
-Verify all nodes responding and height advancing.
+stop:  VPS3 → VPS2 → VPS1
+start: VPS1 → VPS2 → VPS3
+```
+
+Primary (VPS1, Foundation) finishes processing in-flight blocks last and
+is back up first so peers reconnect quickly. Wrong order can produce
+orphan blocks — learned the hard way.
+
+### Health check
+
+After 35 s stabilization the script polls `/chain/info` on each VPS
+and verifies height is advancing.
+
+## Break-Glass: `scripts/emergency-deploy.sh`
+
+Same primitive as `fast-deploy.sh` but **skips the preflight test gate**
+and requires a strict confirmation phrase. Use only when:
+
+- GitHub Actions is down and you need to ship a fix.
+- The chain has halted and a regression must be bypassed.
+- An exploit is in flight and the patch ships ahead of normal CI.
+
+This is rare — `fast-deploy.sh` is the default path.
 
 ## Branch Protection
 
-`main` requires PR + CI pass. Admin can bypass in emergencies.
+`main` requires PR + CI test pass. Admin can bypass in emergencies.
 
 ## Design Choices
 
-Binary artifacts, not Docker. All nodes get the exact same compiled binary. No registry dependency.
-
-Stop/start order matters. Learned from production — wrong order causes chain forks.
-
-No auto-rollback. If deploy fails health check, investigate manually. Auto-rollback masks root causes.
+- **Binary artifacts, not Docker** for mainnet. All nodes get the exact
+  same compiled binary from the VPS4 build. No registry dependency.
+  (Testnet runs in docker on VPS4 since 2026-04-23.)
+- **CI test, not CI deploy.** Auto-deploy + manual hot-deploy creates a
+  race where the same commit ships twice. Disabled in favour of a
+  single canonical path.
+- **No auto-rollback.** If a deploy fails health check, investigate
+  manually. Auto-rollback hides root causes.

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -90,7 +90,28 @@ sudo systemctl daemon-reload && sudo systemctl enable --now sentrix-node
 | `SENTRIX_API_KEY` | (none) | Auth for write endpoints. Unset = all public |
 | `SENTRIX_DATA_DIR` | `./data` | Chain data path |
 | `SENTRIX_CORS_ORIGIN` | (none) | CORS origin. Unset = restrictive |
+| `SENTRIX_CHAIN_ID` | `7119` | `7119` mainnet, `7120` testnet |
+| `SENTRIX_API_PORT` | `8545` | REST/JSON-RPC port |
+| `SENTRIX_WALLET_PASSWORD` | (none) | Keystore decrypt; sourced from systemd `EnvironmentFile` (mode 600), never inline |
+| `SENTRIX_LEGACY_VALIDATION_HEIGHT` | (none) | Cutoff height below which legacy chain.db artefacts are tolerated. Set to `557144` on every mainnet validator (closes [#268](https://github.com/sentrix-labs/sentrix/issues/268)) |
+| `SENTRIX_FORCE_PIONEER_MODE` | `0` | Emergency override: forces Pioneer PoA regardless of `VOYAGER_FORK_HEIGHT`. Currently `1` on every mainnet validator (Voyager activation rolled back 2026-04-25, see [EMERGENCY_ROLLBACK.md](EMERGENCY_ROLLBACK.md)) |
+| `VOYAGER_FORK_HEIGHT` | (built-in default) | Height at which Voyager DPoS+BFT activates. Mainnet currently parked at `18446744073709551615` (u64::MAX) until [#292](https://github.com/sentrix-labs/sentrix/issues/292) lands |
+| `SENTRIX_TRIE_TRACE` | `0` | Debug-only: per-key trie trace lines. **Never** enable in prod — fills the journal in seconds |
+| `SENTRIX_REPLAY_BYPASS_AUTHZ` | `0` | Debug-only: bypass tx authz during replay. Local debug runs only |
 | `RUST_LOG` | `info` | Log level |
+
+## Canonical Deploy Path
+
+Production binary deploys go through **`scripts/fast-deploy.sh` from
+VPS4** (see [CI_CD.md](CI_CD.md) and [RELEASE.md](../../RELEASE.md)).
+The CI/CD `deploy` job is disabled; CI runs tests only. The script
+builds once in a `rust:1.95-bullseye` container, ships the same byte-
+identical binary to VPS1/VPS2/VPS3 over wg1, and does a rolling
+restart with a bounded health check.
+
+For an independent operator running a single validator outside the
+reference fleet, see [VALIDATOR_ONBOARDING.md](VALIDATOR_ONBOARDING.md)
+for the manual SCP + systemd flow.
 
 ## Firewall
 

--- a/docs/operations/EMERGENCY_ROLLBACK.md
+++ b/docs/operations/EMERGENCY_ROLLBACK.md
@@ -1,68 +1,142 @@
 # Emergency Rollback Procedure
 
-## Quick Rollback from Binary Archive
+Three rollback layers exist, in increasing cost / decreasing speed:
 
-Every CI/CD deploy archives the previous binary in `/opt/sentrix/releases/`.
-To rollback to a previous version:
+1. **Env-var override** (`SENTRIX_FORCE_PIONEER_MODE=1`) — fastest;
+   used 2026-04-25 to roll back the Voyager activation livelock.
+2. **Binary rollback** (`fast-deploy.sh` with prior tag) — for a bad
+   binary that hasn't corrupted state.
+3. **chain.db restore** (frozen-rsync from a healthy validator) — for
+   state divergence; canonical recovery, but slowest.
+
+Always escalate from the cheapest layer first.
+
+---
+
+## 1. Fast Rollback: `SENTRIX_FORCE_PIONEER_MODE=1`
+
+When a Voyager DPoS+BFT activation goes wrong (e.g. BFT livelock at
+the activation height), the **fastest** rollback is the env-var
+override that forces the binary back into Pioneer PoA without a
+re-deploy:
 
 ```bash
-# 1. Stop the node
-sudo systemctl stop sentrix-node  # or sentrix-core, sentrix-val1, etc.
+# On every validator host (VPS1/VPS2/VPS3), via the systemd
+# EnvironmentFile (mode 600, sentrix:sentrix):
+sudo bash -c 'echo "SENTRIX_FORCE_PIONEER_MODE=1" \
+  >> /etc/sentrix/sentrix-<unit>.env'
 
-# 2. List available versions
+sudo systemctl restart sentrix-<unit>
+```
+
+The binary checks `SENTRIX_FORCE_PIONEER_MODE` at every block-mode
+decision and short-circuits the Voyager path if the override is set.
+Effective on next block.
+
+This is what was used on 2026-04-25 when the Voyager activation
+attempted at h=557244 livelocked on V2 BFT wiring (issue
+[#292](https://github.com/sentrix-labs/sentrix/issues/292)). Total
+recovery time: ~1 min per validator vs ~30+ min for a full chain.db
+restore.
+
+While the override is in place, also park the Voyager fork height:
+
+```bash
+# In the same env file
+VOYAGER_FORK_HEIGHT=18446744073709551615   # u64::MAX
+```
+
+This makes the activation inert for any future block until #292 ships
+and the height is re-set.
+
+---
+
+## 2. Binary Rollback (no state corruption)
+
+Every `fast-deploy.sh` run archives the previous binary in
+`/opt/sentrix/releases/`. To roll back the binary only:
+
+```bash
+# Roll all 3 mainnet VPS back to a prior release with one command:
+SENTRIX_ROLLBACK=/opt/sentrix/releases/sentrix-v2.1.24-<timestamp> \
+  ./scripts/fast-deploy.sh mainnet
+```
+
+`fast-deploy.sh` honours `SENTRIX_ROLLBACK` and skips the build step,
+shipping the named binary instead. Same rolling stop/start order, same
+health check. ~2 min end-to-end.
+
+If you must do it by hand on a single host:
+
+```bash
+# 1. Stop the unit
+sudo systemctl stop sentrix-<unit>
+
+# 2. List archived versions
 ls -lt /opt/sentrix/releases/
 
-# 3. Restore the previous binary
-sudo cp /opt/sentrix/releases/sentrix-v2.0.0-<timestamp> /opt/sentrix/sentrix
+# 3. Restore
+sudo cp /opt/sentrix/releases/sentrix-v2.1.24-<timestamp> /opt/sentrix/sentrix
+sudo chmod +x /opt/sentrix/sentrix
 
 # 4. Restart
-sudo systemctl start sentrix-node
+sudo systemctl start sentrix-<unit>
 ```
 
-For all validators on a VPS:
+Current production binary at the time of writing: **v2.1.25**
+(`md5 5ad7804c0d7e68f8cab47872f7dbc7ac`). Prior good release on
+mainnet: v2.1.24 (`md5 a25f9d771648f6c851a6ee11867fe958`, also the
+testnet binary).
 
-```bash
-sudo systemctl stop sentrix-val{1..5}
-sudo cp /opt/sentrix/releases/sentrix-v2.0.0-<timestamp> /opt/sentrix/sentrix
-sudo systemctl start sentrix-val{1..5}
-```
+---
 
-## Rollback via CI/CD (Preferred)
+## 3. State Recovery (chain.db restore)
 
-Force-push a known-good tag to `main` and let CI rebuild:
+When state has diverged (different block hash at the same height,
+state_root mismatch, etc.), the canonical recovery is a **frozen
+rsync** of `chain.db` from a healthy peer with **all** validators
+halted. See [STATE_EXPORT.md](STATE_EXPORT.md) for why
+`sentrix state export/import` is **not** the right path for a
+post-genesis chain.
 
-```bash
-git checkout main
-git reset --hard v2.0.0
-git push --force origin main
-```
+The full procedure lives in `founder-private/runbooks/state-divergence-recovery.md`
+(internal). Outline:
 
-CI will build the correct Linux binary and deploy automatically.
+1. Pick the canonical validator (matches the most peers; longest valid
+   chain at consensus root).
+2. Stop **all** validators on the diverged hosts.
+3. Backup the diverged `chain.db` to a sibling directory.
+4. `rsync -aP` the canonical `chain.db` to each diverged host while
+   the source is frozen (canonical node is also stopped during the
+   copy).
+5. `chown sentrix:sentrix` on the destination, ensure perms match.
+6. Start all validators **simultaneously** (or in the standard
+   primary-first order).
+
+State_root is recomputed from the canonical chain.db on the next block
+and the divergence is gone.
+
+---
 
 ## NEVER Do This
 
-- **NEVER build on Windows and SCP to Linux VPS** — Windows produces PE
-  executables, Linux needs ELF. The binary will fail with "Exec format error".
+- **Never `git push --force` to roll back.** The CI/CD deploy job is
+  disabled — a force-push to main does **not** redeploy. Use
+  `fast-deploy.sh` with a `SENTRIX_ROLLBACK=...` arg instead. Force-push
+  also rewrites public history; CI test artifacts and PR-comment links
+  start pointing at vanished commits.
 
-- **NEVER use `cargo build` on a non-Linux machine for VPS deploy** — always
-  use CI/CD or cross-compile via Docker:
+- **Never build on Windows and SCP to Linux VPS.** Windows produces PE
+  executables, Linux needs ELF. The binary will fail with "Exec format
+  error". `fast-deploy.sh` uses a Linux container precisely so this
+  can't happen.
 
-  ```bash
-  docker run --rm -v "$(pwd):/build" -w /build rust:1.82-slim \
-    bash -c "apt-get update && apt-get install -y libssl-dev pkg-config && \
-    cargo build --release --target x86_64-unknown-linux-gnu"
-  ```
+- **Never run admin CLI separately per-VPS during recovery.** Run the
+  validator add/remove/toggle on a single chain.db, then rsync to the
+  rest. The admin_log holds wall-clock timestamps; running the same op
+  three times produces three different timestamps and three different
+  state_roots.
 
-## Chain Fork Recovery
-
-If validators end up on different chain histories (different block hash at
-same height), use the canonical chain.db copy procedure:
-
-1. Identify the canonical validator (longest chain, correct history)
-2. Stop all validators on the diverged VPS
-3. Backup existing chain.db files
-4. SCP canonical chain.db to all data directories
-5. Set correct ownership (`chown`)
-6. Restart all validators simultaneously
-
-See: SESSION_HANDOFF for the 2026-04-18 chain fork recovery details.
+- **Never use `sentrix state export/import` to recover a post-genesis
+  chain.** v2.1.5+ refuses to start on a keystore built from import.
+  Use frozen-rsync of chain.db (path 3 above).

--- a/docs/operations/MONITORING.md
+++ b/docs/operations/MONITORING.md
@@ -29,7 +29,7 @@ du -sh /opt/sentrix/data/chain.db/
 | Metric | Healthy |
 |--------|---------|
 | Chain height | Increasing every ~1s |
-| Active validators | 3 (mainnet) / 4 (testnet BFT+DPoS) |
+| Active validators | 4 (mainnet, PoA) / 4 (testnet BFT+DPoS) |
 | Mempool | < 10,000 |
 | Service status | Active (running) |
 
@@ -39,7 +39,7 @@ du -sh /opt/sentrix/data/chain.db/
 
 Height not moving for 30+ seconds.
 
-Validator offline: Check which slot is expected (`height % 3`). Bring that validator back up.
+Validator offline: Check which slot is expected (`height % 4` for the 4-validator mainnet set). Bring that validator back up.
 
 Network partition: Check logs for peer connections (`journalctl -u sentrix-node | grep peer`). Check firewall (`ufw status`).
 

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -10,8 +10,9 @@
 | P2P port | 30303 |
 | API port | 8545 |
 | Block time | 1s |
-| Validators | 3 (PoA round-robin: Foundation, Treasury, Core) |
+| Validators | 4 (PoA round-robin: Foundation, Treasury, Core, Beacon) |
 | Native coin | SRX |
+| Mode | Pioneer (forced via `SENTRIX_FORCE_PIONEER_MODE=1`; see ops note below) |
 
 ## Testnet
 
@@ -30,6 +31,19 @@
 | EVM fork height | 752 |
 
 Testnet tokens have no real value. Use the faucet to get test SRX.
+
+Testnet runs in Docker on VPS4 (`/opt/sentrix-testnet-docker/`) since
+the 2026-04-23 migration; fresh genesis at chain_id 7120, current
+height ~200K, binary v2.1.24 (`md5 a25f9d771648f6c851a6ee11867fe958`).
+
+> **Mainnet operational note (2026-04-25):** mainnet currently runs
+> forced Pioneer (`SENTRIX_FORCE_PIONEER_MODE=1` env override on every
+> validator) after a Voyager activation attempt at h=557244 livelocked
+> on V2 BFT wiring. Voyager mainnet activation is **blocked by issue
+> [#292](https://github.com/sentrix-labs/sentrix/issues/292)**. Until
+> #292 lands, `VOYAGER_FORK_HEIGHT=18446744073709551615` (u64::MAX)
+> keeps the Voyager fork inert. Mainnet binary: v2.1.25
+> (`md5 5ad7804c0d7e68f8cab47872f7dbc7ac`).
 
 ## Connecting
 

--- a/docs/operations/STATE_EXPORT.md
+++ b/docs/operations/STATE_EXPORT.md
@@ -2,6 +2,22 @@
 
 Backup, restore, and migrate Sentrix chain state.
 
+> **Critical limitation (v2.1.5+):** `sentrix state import` is
+> **effectively deprecated for non-genesis use**. Since v2.1.5 the
+> binary refuses to start on a keystore built from `state import` on a
+> post-genesis chain — the import path skips trie/admin_log artefacts
+> the boot validator now requires. The canonical state-recovery path
+> is **frozen-rsync of `chain.db`** from a healthy validator with all
+> nodes halted; see
+> [EMERGENCY_ROLLBACK.md § 3](EMERGENCY_ROLLBACK.md#3-state-recovery-chaindb-restore)
+> and the internal
+> `founder-private/runbooks/state-divergence-recovery.md`.
+>
+> Export remains useful for read-only inspection, archival snapshots,
+> and bootstrapping a **fresh** chain (genesis import). The commands
+> below are still the right tool for those use cases — just not for
+> recovering a live mainnet validator.
+
 ## Export
 
 ```bash

--- a/docs/operations/VALIDATORS.md
+++ b/docs/operations/VALIDATORS.md
@@ -1,16 +1,17 @@
 # Validators
 
-3 validators across 3 VPS, round-robin PoA (v2.0.0).
+4 validators across 3 VPS, round-robin PoA (v2.1.25).
 
 ## Current Set
 
 | Slot | Name | Address prefix | VPS | Service |
 |------|------|---------------|-----|---------|
-| 0 | Sentrix Treasury | `0x0804...` | VPS2 | sentrix-val5 |
-| 1 | Sentrix Foundation | `0x753f...` | VPS1 | sentrix-node |
-| 2 | Sentrix Core | `0x87c9...` | VPS3 | sentrix-core |
+| 0 | Sentrix Treasury   | `0x0804...` | VPS2 | sentrix-val5    |
+| 1 | Sentrix Foundation | `0x753f...` | VPS1 | sentrix-node    |
+| 2 | Sentrix Core       | `0x87c9...` | VPS3 | sentrix-core    |
+| 3 | Sentrix Beacon     | `0x...`     | VPS2 | sentrix-beacon  |
 
-Sorted by address. Block producer = `height % 3`.
+Sorted by address. Block producer = `height % 4`.
 
 (Nusantara, BlockForge Asia, PacificStake, Archipelago — decommissioned during v2.0.0 reset; services stopped, NOT on chain.)
 
@@ -50,7 +51,10 @@ sentrix validator rename --address 0x... --name "New Name"
 sentrix validator remove --address 0x...
 ```
 
-Min 3 active validators enforced — can't go below that.
+`MIN_ACTIVE_VALIDATORS = 1` (since PR #234, v2.1.11). The chain can
+proceed with a single active validator if the rest are jailed or
+inactive. `MIN_BFT_VALIDATORS = 4` is the BFT-quorum floor for
+Voyager activation.
 
 ## Audit Trail
 
@@ -62,7 +66,10 @@ curl -H "X-API-Key: <key>" http://[NODE_IP]:8545/admin/log
 
 ## Economics
 
-Each validator produces ~28,800 blocks/day (3 validators × 1s blocks ÷ 3 slots). That's ~28,800 SRX/day per validator from rewards alone, plus `floor(fee/2)` from each included transaction.
+Each validator produces ~21,600 blocks/day (86,400 1-second slots ÷ 4
+validators). That's ~21,600 SRX/day per validator from rewards alone,
+plus `floor(fee/2)` from each included transaction. Total chain
+throughput stays at 86,400 blocks/day (1s block time).
 
 ## Voyager
 

--- a/docs/operations/VALIDATOR_ONBOARDING.md
+++ b/docs/operations/VALIDATOR_ONBOARDING.md
@@ -19,8 +19,9 @@ Satya's private fleet" is required.
 
 ### Consensus responsibility
 
-Sentrix runs **Pioneer PoA** today (3-validator round-robin, expanding
-to more as operators join) and will upgrade to **Voyager DPoS + BFT**
+Sentrix runs **Pioneer PoA** today (4-validator round-robin —
+Foundation, Treasury, Core, Beacon — expanding as operators join)
+and will upgrade to **Voyager DPoS + BFT**
 (stake-weighted, unbounded validator set) at a fork height TBD. As a
 validator:
 
@@ -241,9 +242,10 @@ operator uses in their multi-host fleet — there's no "special" tool
 for us vs you.
 
 For a rolling restart across many validators, loop over the above for
-each host. Respect `MIN_ACTIVE_VALIDATORS` (currently 3 on Pioneer
-PoA) — stopping too many at once halts the chain until quorum
-recovers.
+each host. `MIN_ACTIVE_VALIDATORS = 1` since PR #234 (v2.1.11) — the
+chain technically tolerates a single active validator, but in practice
+keep 3+ up during a rolling deploy so block production never depends on
+one host.
 
 ---
 

--- a/docs/tokenomics/TOKEN_STANDARDS.md
+++ b/docs/tokenomics/TOKEN_STANDARDS.md
@@ -49,7 +49,8 @@ Explorer: `/explorer/tokens` and `/explorer/token/{contract}`.
 
 ## SNTX
 
-First SRC-20 token (ERC-20 via Sentrix EVM). Sentrix Utility.
+First **native** SRC-20 token on Sentrix (deployed via the Pioneer-era
+native SRC-20 engine, not the EVM). Sentrix Utility.
 
 | | |
 |-|-|


### PR DESCRIPTION
## Summary

Public-docs sync. 15 files updated to reflect current mainnet state as of 2026-04-25 evening.

Key corrections:
- Binary v2.1.25 (was v2.0.0 / v2.1.11 in stale docs)
- 4 active validators on mainnet, slot math `height % 4`, Beacon added as 4th (Foundation, Treasury, Core, Beacon)
- `MIN_ACTIVE_VALIDATORS = 1` since PR #234 (v2.1.11), was 3 in stale docs
- Block time 1s confirmed (some old docs said 3s)
- Fee split 50/50 burn/validator (some old docs said 70/30)
- 14-crate workspace structure replaces the single-crate `src/` layout in CONTRIBUTING + OVERVIEW
- CI/CD `deploy` job is disabled — `scripts/fast-deploy.sh` from VPS4 is the canonical path
- New production env vars documented: `SENTRIX_LEGACY_VALIDATION_HEIGHT=557144`, `SENTRIX_FORCE_PIONEER_MODE=1`, `VOYAGER_FORK_HEIGHT=u64::MAX`, `SENTRIX_TRIE_TRACE` / `SENTRIX_REPLAY_BYPASS_AUTHZ` (debug-only)
- EMERGENCY_ROLLBACK promotes `SENTRIX_FORCE_PIONEER_MODE=1` as the fast-rollback path used today
- STATE_EXPORT adds the v2.1.5+ post-genesis-refuse warning
- TOKEN_STANDARDS corrects SNTX as a **native** SRC-20 (not EVM)
- SECURITY.md: route vuln reports through GitHub Security Advisory + org profile (pre-commit secret-scan flagged the inline email; this also gives reporters a private-by-default channel)

Tier: Low (docs only, no code).

## Test plan

- [x] `git diff --stat` shows only the 15 expected files
- [x] Pre-commit secret-scan clean
- [x] Spot-check: no `height % 3` / `MIN_ACTIVE_VALIDATORS = 3` / `src/core/` references remain in the changed files (except intentional historical references)
- [ ] CI green on the test job