### PR TITLE
fix(bft): clear locked_block on PoLC mismatch + M-15 integration tests

### DIFF
--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -468,16 +468,17 @@ impl BftEngine {
         //     in the current round, `on_prevote_weighted` updates
         //     `locked_hash` to the new value — the implicit PoLC.
         //
-        // Known gap (tracked as M-15 follow-up):
+        // M-15 status:
         //
-        //   1. We do not re-propose the locked block when WE become
-        //      proposer of a new round while locked — Tendermint says
-        //      we must. Current behaviour: build a fresh block, which
-        //      peers prevote-nil on because they observe a lock
-        //      conflict, and the round times out. Ultimately not
-        //      unsafe (eventually someone else proposes the locked
-        //      value or the lock shifts via fresh PoLC) but reduces
-        //      liveness.
+        //   1. Locked-block re-propose IS implemented (PR #258 engine
+        //      cache + PR #259 main.rs wiring). When a validator is
+        //      locked on hash H and rotates into proposer slot at a
+        //      later round, `build_or_reuse_proposal` in main.rs
+        //      consults `locked_proposal_bytes()` and re-broadcasts
+        //      cached B(H) instead of building a fresh block. The
+        //      "prevote nil on lock conflict" guard below remains
+        //      load-bearing — it's how locked validators reject a
+        //      fresh-proposal attempt from a peer that lost its cache.
         //
         //   2. We do not persist per-round prevote history, so an
         //      explicit PoLC object carrying the 2/3 signatures is
@@ -491,10 +492,19 @@ impl BftEngine {
         //      (collector keys on validator address + stake from
         //      StakeRegistry — no self-inflation path).
         //
-        // The guard below implements the "prevote nil on lock
-        // conflict" part correctly; a proper fix for (1) above
-        // belongs in block_producer.rs (cache the proposed block and
-        // re-use when locked).
+        //   3. Open liveness gap: a validator whose libp2p dropped
+        //      the round-N Propose message will lock via peer
+        //      prevotes but never stash the bytes, so
+        //      `locked_proposal_bytes()` returns None for them. If
+        //      that validator becomes round-(N+1) proposer they fall
+        //      through to `create_block_voyager` and build a
+        //      fresh-hash block, which peers reject by lock — round
+        //      times out via skip-round. Pinned by
+        //      `tests/m15_repropose.rs::test_m15_locked_without_bytes_returns_none_from_accessor`.
+        //      Fix candidate: when locked + no cached bytes + we are
+        //      proposer, gossip a `RoundStatus` "I need bytes for H"
+        //      and prevote nil rather than proposing fresh. Belongs
+        //      in main.rs / network layer, not the engine.
         self.state.proposed_hash = Some(block_hash.to_string());
         self.state.phase = BftPhase::Prevote;
         self.phase_start = Instant::now();
@@ -1329,6 +1339,62 @@ mod tests {
     fn test_v2_locked_proposal_bytes_none_when_unlocked() {
         let (engine, _reg) = setup();
         assert!(engine.locked_proposal_bytes().is_none());
+    }
+
+    /// V2 PoLC happy path: lock on A in round 0, PoLC to B in round 1
+    /// with matching staging → `locked_block` is REPLACED with bytes_B,
+    /// not preserved as bytes_A. This is the symmetric case to
+    /// `test_v2_polc_clears_locked_block_when_staging_mismatch` —
+    /// together they pin the rule "locked_block always tracks the
+    /// currently-locked hash, never an earlier one."
+    #[test]
+    fn test_v2_polc_replaces_locked_block_when_staging_matches() {
+        let (mut engine, _reg) = setup();
+        let total = engine.state.total_active_stake;
+        let per_val = total / 21;
+        let threshold = supermajority_threshold(total);
+        let needed = ((threshold / per_val) + 1) as usize;
+
+        // Round 0: lock on hash_A with bytes_A.
+        engine.state.phase = BftPhase::Prevote;
+        engine.stash_proposal_bytes("hash_A", b"bytes_A".to_vec());
+        for i in 0..needed {
+            let pv = Prevote {
+                height: 100,
+                round: 0,
+                block_hash: Some("hash_A".into()),
+                validator: format!("0xval{:03}", i),
+                signature: vec![],
+            };
+            let _ = engine.on_prevote_weighted(&pv, per_val);
+        }
+        assert_eq!(
+            engine.locked_proposal_bytes(),
+            Some(("hash_A".into(), b"bytes_A".to_vec()))
+        );
+
+        // Round 1: PoLC to hash_B, staging matches.
+        engine.advance_round();
+        engine.state.phase = BftPhase::Prevote;
+        engine.stash_proposal_bytes("hash_B", b"bytes_B".to_vec());
+        for i in 0..needed {
+            let pv = Prevote {
+                height: 100,
+                round: 1,
+                block_hash: Some("hash_B".into()),
+                validator: format!("0xval{:03}", i),
+                signature: vec![],
+            };
+            let _ = engine.on_prevote_weighted(&pv, per_val);
+        }
+
+        // PoLC fired: lock + cache both moved to hash_B.
+        assert_eq!(engine.state.locked_hash.as_deref(), Some("hash_B"));
+        assert_eq!(
+            engine.locked_proposal_bytes(),
+            Some(("hash_B".into(), b"bytes_B".to_vec())),
+            "PoLC with matching staging must replace locked_block with new bytes"
+        );
     }
 
     /// V2 PoLC regression: when a 2/3+ supermajority forms on a hash

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -583,6 +583,18 @@ impl BftEngine {
             self.phase_start = Instant::now();
 
             if let Some(ref h) = hash {
+                // Invariant for `locked_proposal_bytes`: when
+                // `locked_block` is Some, its bytes MUST hash to
+                // `locked_hash`. PoLC moves the lock to a new hash —
+                // any cached bytes from the previous lock are now
+                // stale and must be cleared before the new hash is
+                // pinned. Without this, a PoLC where staging mismatches
+                // the new winner returns Some((new_hash, old_bytes))
+                // from `locked_proposal_bytes`, which would corrupt
+                // the re-propose path.
+                if self.state.locked_hash.as_deref() != Some(h.as_str()) {
+                    self.state.locked_block = None;
+                }
                 self.state.locked_hash = Some(h.clone());
                 self.state.locked_round = Some(self.state.round);
                 // V2 M-15 Step 3: promote staging → locked if its hash
@@ -1317,6 +1329,81 @@ mod tests {
     fn test_v2_locked_proposal_bytes_none_when_unlocked() {
         let (engine, _reg) = setup();
         assert!(engine.locked_proposal_bytes().is_none());
+    }
+
+    /// V2 PoLC regression: when a 2/3+ supermajority forms on a hash
+    /// DIFFERENT from the currently-locked hash (proof-of-lock-change),
+    /// `locked_block` must be replaced with the new winner's bytes —
+    /// or cleared if the new winner's bytes weren't staged.
+    ///
+    /// This test pins the failure mode where staging.hash != quorum.hash
+    /// AND we were already locked on a third (or first) hash: the old
+    /// `locked_block` must NOT survive into a state where `locked_hash`
+    /// has moved on. If it does, `locked_proposal_bytes()` returns
+    /// stale bytes whose hash doesn't match the lock — corrupting the
+    /// re-propose path.
+    #[test]
+    fn test_v2_polc_clears_locked_block_when_staging_mismatch() {
+        let (mut engine, _reg) = setup();
+        let total = engine.state.total_active_stake;
+        let per_val = total / 21;
+        let threshold = supermajority_threshold(total);
+        let needed = ((threshold / per_val) + 1) as usize;
+
+        // Round 0: lock on hash_A with bytes_A.
+        engine.state.phase = BftPhase::Prevote;
+        engine.stash_proposal_bytes("hash_A", b"bytes_A".to_vec());
+        for i in 0..needed {
+            let pv = Prevote {
+                height: 100,
+                round: 0,
+                block_hash: Some("hash_A".into()),
+                validator: format!("0xval{:03}", i),
+                signature: vec![],
+            };
+            let _ = engine.on_prevote_weighted(&pv, per_val);
+        }
+        assert_eq!(engine.state.locked_hash.as_deref(), Some("hash_A"));
+        assert_eq!(
+            engine.state.locked_block.as_deref(),
+            Some(&b"bytes_A"[..])
+        );
+
+        // Round 1: simulate the validator stashing bytes for hash_C
+        // (decoy — the wrong hash) but the network forming PoLC quorum
+        // on hash_B. Could happen if our peers proposed B but our local
+        // gossip delivered C first into the staging slot.
+        engine.advance_round();
+        engine.state.phase = BftPhase::Prevote;
+        engine.stash_proposal_bytes("hash_C", b"bytes_C".to_vec());
+        for i in 0..needed {
+            let pv = Prevote {
+                height: 100,
+                round: 1,
+                block_hash: Some("hash_B".into()),
+                validator: format!("0xval{:03}", i),
+                signature: vec![],
+            };
+            let _ = engine.on_prevote_weighted(&pv, per_val);
+        }
+
+        // PoLC fired: lock has moved to hash_B.
+        assert_eq!(engine.state.locked_hash.as_deref(), Some("hash_B"));
+        // Staging was for hash_C, didn't match — bytes can't be promoted.
+        // locked_block must NOT keep the round-0 bytes_A: they hash to A,
+        // but the lock now claims B. Either clear locked_block (None)
+        // or the bug surfaces via locked_proposal_bytes returning a
+        // hash/bytes mismatch — which corrupts re-propose.
+        assert!(
+            engine.state.locked_block.is_none(),
+            "PoLC to a non-staged hash must clear locked_block, not retain stale bytes from \
+             a previous lock — got {:?}",
+            engine.state.locked_block.as_ref().map(|b| String::from_utf8_lossy(b).into_owned())
+        );
+        assert!(
+            engine.locked_proposal_bytes().is_none(),
+            "locked_proposal_bytes must be None when we cannot honour the lock with cached bytes"
+        );
     }
 
     /// V2 regression: staging for a different hash than the quorum winner

--- a/crates/sentrix-bft/tests/m15_repropose.rs
+++ b/crates/sentrix-bft/tests/m15_repropose.rs
@@ -1,0 +1,432 @@
+// m15_repropose.rs
+//
+// V2 M-15 locked-block re-propose: integration tests that simulate
+// today's 2026-04-25 mainnet livelock pattern.
+//
+// Scenario being pinned: round R forms a 2/3+ prevote supermajority
+// on hash H but precommits don't reach supermajority (network drop,
+// timing, signature path bug). Round R+1 advances. The new round's
+// proposer is locked on H. With M-15 wired correctly, that proposer
+// re-broadcasts the cached block bytes for H — peers prevote H (lock
+// matches), precommit succeeds, chain finalizes block H at round R+1.
+//
+// Without M-15 wiring, the proposer builds a fresh block H' instead.
+// Peers (locked on H) prevote nil because H' != H. Nil-supermajority
+// → SkipRound → next round repeats. Livelock.
+//
+// This file tests the engine in isolation. If the integration tests
+// pass on `main`, the engine's lock-cache lifecycle is sound and a
+// production livelock root-causes elsewhere (validator-loop wiring,
+// libp2p, signature handling, BFT signer-set composition post-DPoS
+// migration — all out of scope for this harness).
+//
+// Reference: founder-private/audits/v2-locked-block-repropose-implementation-plan.md §9
+
+use sentrix_bft::{BftAction, BftEngine, BftPhase, Precommit, Prevote};
+use sentrix_staking::StakeRegistry;
+use sentrix_staking::staking::MIN_SELF_STAKE;
+
+/// 4-validator stake registry, equal stakes, all active.
+fn setup_four_val_registry() -> (StakeRegistry, Vec<String>, u64, u64) {
+    let mut reg = StakeRegistry::new();
+    let addresses: Vec<String> = (1..=4).map(|i| format!("0xval{:03}", i)).collect();
+    for addr in &addresses {
+        reg.register_validator(addr, MIN_SELF_STAKE, 1000, 0).unwrap();
+    }
+    reg.update_active_set();
+
+    let total_stake: u64 = reg
+        .active_set
+        .iter()
+        .filter_map(|a| reg.get_validator(a))
+        .map(|v| v.total_stake())
+        .sum();
+
+    let per_val = total_stake / addresses.len() as u64;
+    (reg, addresses, per_val, total_stake)
+}
+
+fn setup_four_engines(addresses: &[String], total_stake: u64, height: u64) -> Vec<BftEngine> {
+    addresses
+        .iter()
+        .map(|addr| BftEngine::new(height, addr.clone(), total_stake))
+        .collect()
+}
+
+fn mk_prevote(height: u64, round: u32, block_hash: Option<String>, validator: &str) -> Prevote {
+    Prevote {
+        height,
+        round,
+        block_hash,
+        validator: validator.to_string(),
+        signature: vec![],
+    }
+}
+
+/// Drive each engine through round 0 up to (but not past) precommit
+/// supermajority: stash bytes, deliver proposal, fan 4 prevotes.
+/// On return every engine has `locked_hash = Some(block_hash)`,
+/// `locked_block = Some(block_bytes)`, phase = Precommit, but no
+/// FinalizeBlock has been emitted (caller controls precommit fan-in).
+fn drive_round_to_lock(
+    engines: &mut [BftEngine],
+    reg: &StakeRegistry,
+    addresses: &[String],
+    height: u64,
+    round: u32,
+    block_hash: &str,
+    block_bytes: &[u8],
+    per_val: u64,
+) {
+    let proposer = reg
+        .weighted_proposer(height, round)
+        .expect("active set has 4 validators");
+    let proposer_idx = addresses.iter().position(|a| a == &proposer).unwrap();
+
+    // Every engine stashes the proposal's bytes (validator loop does this
+    // at on_proposal entry + at the proposer's build_or_reuse_proposal exit).
+    for engine in engines.iter_mut() {
+        engine.stash_proposal_bytes(block_hash, block_bytes.to_vec());
+    }
+
+    // Drive the proposal into each engine: own for proposer, peer for others.
+    for (i, engine) in engines.iter_mut().enumerate() {
+        let action = if i == proposer_idx {
+            engine.on_own_proposal(block_hash)
+        } else {
+            engine.on_proposal(block_hash, &proposer, reg)
+        };
+        assert!(
+            matches!(action, BftAction::BroadcastPrevote(_)),
+            "engine {} ({}): expected BroadcastPrevote, got {:?}",
+            i,
+            addresses[i],
+            action
+        );
+    }
+
+    // Fan 4 prevotes for `block_hash` into every engine. Supermajority
+    // forms → each engine flips Prevote → Precommit AND promotes
+    // staging → locked_block.
+    for sender in addresses {
+        let pv = mk_prevote(height, round, Some(block_hash.to_string()), sender);
+        for engine in engines.iter_mut() {
+            let _ = engine.on_prevote_weighted(&pv, per_val);
+        }
+    }
+
+    // Post-condition: every engine is locked on `block_hash` with bytes
+    // promoted into locked_block, and phase has advanced to Precommit.
+    for (i, engine) in engines.iter().enumerate() {
+        assert_eq!(
+            engine.locked_proposal_bytes(),
+            Some((block_hash.to_string(), block_bytes.to_vec())),
+            "engine {} ({}): expected locked cache after prevote supermajority",
+            i,
+            addresses[i]
+        );
+        assert_eq!(
+            engine.phase(),
+            BftPhase::Precommit,
+            "engine {} should be in Precommit phase after prevote supermajority",
+            i
+        );
+    }
+}
+
+/// Test 1 — happy path: locked validators preserve cached bytes
+/// across a round advance. After round 0 fails to precommit, every
+/// engine's `locked_proposal_bytes()` still returns the cached B(H)
+/// in round 1. This is the engine-side precondition that makes
+/// re-propose possible.
+#[test]
+fn test_m15_locked_validator_reproposes_cached_block() {
+    let (reg, addresses, per_val, total_stake) = setup_four_val_registry();
+    let height: u64 = 100;
+    let mut engines = setup_four_engines(&addresses, total_stake, height);
+
+    let block_hash = "hash_R0_winner".to_string();
+    let block_bytes = b"opaque-block-bytes-for-R0-winner".to_vec();
+
+    // Round 0: drive to lock (precommits NOT delivered).
+    drive_round_to_lock(
+        &mut engines,
+        &reg,
+        &addresses,
+        height,
+        0,
+        &block_hash,
+        &block_bytes,
+        per_val,
+    );
+
+    // Simulate every validator timing out and advancing to round 1.
+    // Real validator loop calls advance_round on TimeoutAdvanceRound;
+    // the harness mimics that path.
+    for engine in engines.iter_mut() {
+        engine.advance_round();
+    }
+
+    // Post-advance: lock state must persist across the round boundary.
+    // This is the M-15 contract: advance_round preserves locked_hash +
+    // locked_block, only staging is reset.
+    for (i, engine) in engines.iter().enumerate() {
+        assert_eq!(
+            engine.round(),
+            1,
+            "engine {} did not advance to round 1",
+            i
+        );
+        assert_eq!(
+            engine.phase(),
+            BftPhase::Propose,
+            "engine {} should be in Propose phase at round 1 start",
+            i
+        );
+
+        let cached = engine.locked_proposal_bytes();
+        assert!(
+            cached.is_some(),
+            "engine {} ({}) lost cached block across advance_round — \
+             this is the M-15 invariant break",
+            i,
+            addresses[i]
+        );
+        let (cached_hash, cached_bytes) = cached.unwrap();
+        assert_eq!(
+            cached_hash, block_hash,
+            "engine {} cached_hash drift after advance_round",
+            i
+        );
+        assert_eq!(
+            cached_bytes, block_bytes,
+            "engine {} cached_bytes drift after advance_round",
+            i
+        );
+    }
+
+    // The validator loop's `build_or_reuse_proposal` would consult
+    // `locked_proposal_bytes()` here and re-broadcast the cached
+    // block. The engine's contract is satisfied — re-propose can fire.
+}
+
+/// Test 2 — unstick path: from the locked-state at round 1, the new
+/// round's proposer re-broadcasts cached bytes. Peers (also locked
+/// on H) accept the proposal, prevote H, precommit H, finalize H.
+/// Chain unsticks at round 1 instead of looping forever.
+#[test]
+fn test_m15_unlock_after_repropose_quorum() {
+    let (reg, addresses, per_val, total_stake) = setup_four_val_registry();
+    let height: u64 = 100;
+    let mut engines = setup_four_engines(&addresses, total_stake, height);
+
+    let block_hash = "hash_R0_winner".to_string();
+    let block_bytes = b"opaque-block-bytes-for-R0-winner".to_vec();
+
+    // Round 0: form lock, precommits dropped.
+    drive_round_to_lock(
+        &mut engines,
+        &reg,
+        &addresses,
+        height,
+        0,
+        &block_hash,
+        &block_bytes,
+        per_val,
+    );
+
+    // Round advance — every engine to round 1, locks preserved.
+    for engine in engines.iter_mut() {
+        engine.advance_round();
+    }
+
+    // Round 1: re-propose. Identify the new proposer; pull cached
+    // bytes from its engine; replay them to all 4 engines as if the
+    // proposer had broadcast them.
+    let r1_proposer = reg.weighted_proposer(height, 1).unwrap();
+    let r1_proposer_idx = addresses.iter().position(|a| a == &r1_proposer).unwrap();
+
+    let cached = engines[r1_proposer_idx]
+        .locked_proposal_bytes()
+        .expect("R1 proposer must have cached bytes from R0 lock");
+    let (re_hash, re_bytes) = cached;
+    assert_eq!(re_hash, block_hash, "R1 proposer cache must match R0 lock");
+    assert_eq!(re_bytes, block_bytes, "R1 proposer cache bytes must match R0");
+
+    // Validator loop pattern: every receiving engine stashes bytes
+    // BEFORE on_proposal — the engine's `BftMessage::Propose` handler
+    // does this in main.rs at line ~1936.
+    for engine in engines.iter_mut() {
+        engine.stash_proposal_bytes(&re_hash, re_bytes.clone());
+    }
+
+    // Drive the re-proposed block into each engine.
+    for (i, engine) in engines.iter_mut().enumerate() {
+        let action = if i == r1_proposer_idx {
+            engine.on_own_proposal(&re_hash)
+        } else {
+            engine.on_proposal(&re_hash, &r1_proposer, &reg)
+        };
+        // Locked on this exact hash → prevote should be Some(re_hash),
+        // not None (nil). If a peer prevoted nil here it means the
+        // lock-match check in accept_proposal mis-fired.
+        match action {
+            BftAction::BroadcastPrevote(pv) => {
+                assert_eq!(
+                    pv.block_hash.as_deref(),
+                    Some(re_hash.as_str()),
+                    "engine {} ({}): locked on {}, should prevote {} not {:?}",
+                    i,
+                    addresses[i],
+                    block_hash,
+                    re_hash,
+                    pv.block_hash
+                );
+            }
+            other => panic!(
+                "engine {} ({}): expected BroadcastPrevote, got {:?}",
+                i, addresses[i], other
+            ),
+        }
+    }
+
+    // Fan 4 prevotes for re_hash into every engine — supermajority
+    // forms, every engine emits BroadcastPrecommit.
+    let mut precommits_seen: Vec<Precommit> = Vec::new();
+    for sender in &addresses {
+        let pv = mk_prevote(height, 1, Some(re_hash.clone()), sender);
+        for engine in engines.iter_mut() {
+            if let BftAction::BroadcastPrecommit(pc) = engine.on_prevote_weighted(&pv, per_val) {
+                precommits_seen.push(pc);
+            }
+        }
+    }
+    assert!(
+        precommits_seen.len() >= 4,
+        "expected ≥4 BroadcastPrecommit emissions at round 1; got {}",
+        precommits_seen.len()
+    );
+    for pc in &precommits_seen[..4] {
+        assert_eq!(
+            pc.block_hash.as_deref(),
+            Some(re_hash.as_str()),
+            "round-1 precommit must target re-proposed hash, not nil"
+        );
+    }
+
+    // Fan 4 precommits for re_hash → supermajority → every engine
+    // emits FinalizeBlock. The chain unsticks at round 1.
+    let mut finalized = vec![false; engines.len()];
+    for pc in &precommits_seen[..4] {
+        for (i, engine) in engines.iter_mut().enumerate() {
+            if let BftAction::FinalizeBlock {
+                block_hash: bh,
+                round,
+                ..
+            } = engine.on_precommit_weighted(pc, per_val)
+            {
+                assert_eq!(bh, re_hash, "engine {} finalized wrong hash", i);
+                assert_eq!(round, 1, "engine {} finalized at wrong round", i);
+                finalized[i] = true;
+            }
+        }
+    }
+
+    for (i, f) in finalized.iter().enumerate() {
+        assert!(
+            *f,
+            "engine {} ({}) did not finalize at round 1 — re-propose path is broken",
+            i, addresses[i]
+        );
+    }
+}
+
+/// Test 3 — pin the livelock failure mode where a validator locks on
+/// hash H without having stashed the bytes (e.g. their libp2p never
+/// delivered the Propose message in round 0, but they still observed
+/// peer prevotes and locked).
+///
+/// In this case `locked_hash = Some(H)` but `locked_block = None` →
+/// `locked_proposal_bytes()` returns None. If THAT validator is
+/// elected proposer of round 1, the validator loop's
+/// `build_or_reuse_proposal` falls through to `create_block_voyager`
+/// → builds a fresh B'(H') → peers prevote nil (locked on H ≠ H') →
+/// SkipRound → loops.
+///
+/// This test asserts the engine state matches the bug pattern, which
+/// makes the production fix obvious: a locked-but-byteless validator
+/// should NOT propose in the first place. They should send a nil
+/// prevote and let a peer-with-bytes drive the round.
+#[test]
+fn test_m15_locked_without_bytes_returns_none_from_accessor() {
+    let (reg, addresses, per_val, total_stake) = setup_four_val_registry();
+    let height: u64 = 100;
+    let mut engines = setup_four_engines(&addresses, total_stake, height);
+
+    let block_hash = "hash_R0_winner".to_string();
+    let block_bytes = b"opaque-block-bytes".to_vec();
+    let proposer = reg.weighted_proposer(height, 0).unwrap();
+    let proposer_idx = addresses.iter().position(|a| a == &proposer).unwrap();
+
+    // Pick a non-proposer validator to be the "byteless" victim. It
+    // never stashes bytes — simulates libp2p drop of the Proposal
+    // message before stash_proposal_bytes was called.
+    let byteless_idx = (proposer_idx + 1) % engines.len();
+
+    // Three of four engines stash bytes (proposer + the two
+    // non-byteless peers).
+    for (i, engine) in engines.iter_mut().enumerate() {
+        if i != byteless_idx {
+            engine.stash_proposal_bytes(&block_hash, block_bytes.clone());
+        }
+    }
+
+    // Drive proposal into each engine. The byteless victim still
+    // processes on_proposal (they got the message just AFTER stash
+    // was missed — or got it via post-vote gossip), so they prevote.
+    // The lock will form via prevote tally regardless.
+    for (i, engine) in engines.iter_mut().enumerate() {
+        let action = if i == proposer_idx {
+            engine.on_own_proposal(&block_hash)
+        } else {
+            engine.on_proposal(&block_hash, &proposer, &reg)
+        };
+        assert!(
+            matches!(action, BftAction::BroadcastPrevote(_)),
+            "engine {} expected BroadcastPrevote, got {:?}",
+            i,
+            action
+        );
+    }
+
+    // Fan 4 prevotes → all 4 engines lock on hash. The byteless one
+    // promotes nothing into locked_block because its staging is empty.
+    for sender in &addresses {
+        let pv = mk_prevote(height, 0, Some(block_hash.clone()), sender);
+        for engine in engines.iter_mut() {
+            let _ = engine.on_prevote_weighted(&pv, per_val);
+        }
+    }
+
+    // Verify the bug pattern: byteless engine has locked_hash but no
+    // locked_block.
+    let byteless = &engines[byteless_idx];
+    assert!(
+        byteless.locked_proposal_bytes().is_none(),
+        "byteless engine should have no cached bytes — got {:?}",
+        byteless.locked_proposal_bytes().map(|(h, _)| h)
+    );
+
+    // Post advance_round, the byteless engine still has no bytes.
+    // If that engine is the round-1 proposer in production, the
+    // helper falls through to create_block_voyager and builds a
+    // wrong-hash block — peers prevote nil, livelock starts.
+    for engine in engines.iter_mut() {
+        engine.advance_round();
+    }
+    let byteless = &engines[byteless_idx];
+    assert!(
+        byteless.locked_proposal_bytes().is_none(),
+        "byteless engine still has no cached bytes after advance_round"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds 3 integration tests in `crates/sentrix-bft/tests/m15_repropose.rs` covering the M-15 locked-block re-propose lifecycle: round-0 lock survives advance_round, round-1 re-propose unsticks the chain, and the byteless-victim edge case.
- Adds 2 new PoLC unit tests (`test_v2_polc_clears_locked_block_when_staging_mismatch` + `test_v2_polc_replaces_locked_block_when_staging_matches`) that pin the rule "locked_block tracks the currently-locked hash, never an earlier one."
- Fixes a real PoLC bug found while writing the harness: when supermajority moved the lock from hash A to hash B without staging hash B's bytes, `locked_block` was retaining stale `bytes_A`, so `locked_proposal_bytes()` returned a `(B, bytes_A)` tuple. Re-propose would then broadcast bytes whose hash didn't match the lock, breaking the very liveness path M-15 is meant to fix.
- Refreshes the now-stale `accept_proposal` doc comment (it still claimed M-15 follow-up was unimplemented).

## Context — relationship to #292

Today's same-day post-livelock writeup blamed the 2026-04-25 h=557244 mainnet failure on \"main.rs Steps 4-5 wiring not shipped.\" That diagnosis is wrong: \`git log -S build_or_reuse_proposal\` shows the wiring landed in PR #259 (v2.1.16, commit \`af6953f\`) before the activation attempt. All 7 proposer call sites already invoke the helper; the \`BftMessage::Propose\` handler already stashes bytes before \`on_proposal\`.

The 3 integration tests in this PR pass on v2.1.24 main, which means the engine cache lifecycle is sound in isolation. The PoLC bug fixed here is real but **probably not** today's livelock root cause — today's pattern was prevotes forming on the same hash across rounds, not PoLC across different hashes. The actual root cause is still unpinned. Three plausible hypotheses are documented in the impl plan (byteless-victim libp2p drop, DPoS-migration race, mixed lock state across the fleet).

This PR therefore does NOT close #292. It re-scopes #292 to \"pin and fix the actual livelock root cause\" and ships the integration harness + a real-but-distinct bug fix found during the harness-writing.

## Test plan

- [x] `cargo test -p sentrix-bft` — 78 lib + 5 four_validator_harness + 3 m15_repropose = 86 green
- [x] `cargo test --workspace` — full workspace green
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] PoLC mismatch test FAILS on \`v2.1.24\` main pre-fix and PASSES with the fix — bisectable regression
- [ ] Fresh-brain review of this diff in a separate session before merge
- [ ] Operator pulls journalctl from VPS1+2+3+5 at h=557244 to discriminate the three livelock hypotheses
- [ ] Docker-testnet rehearsal of the pinned scenario before any mainnet Voyager re-attempt

## Risk

Branch from \`v2.1.24\` (last full-function binary), not \`v2.1.25\` (emergency rollback). No behavioural change to existing-passing tests. Engine-internal change only — no wire-format, no on-chain semantics, no migration.

Refs #292.