### PR TITLE
fix(core): saturating_add for total_minted on coinbase credit

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -660,7 +660,14 @@ impl Blockchain {
             );
         }
         self.accounts.credit(coinbase_recipient, coinbase_amount)?;
-        self.total_minted += coinbase_amount;
+        // saturating_add hardens against overflow on inflated-reward testnets
+        // and future tunables. Production reward * MAX_HEIGHT is ~210M SRX
+        // (= 21e15 sentri = ~0.11% of u64::MAX) so overflow is unreachable
+        // at mainnet parameters, but the saturating form costs nothing and
+        // matches the rest of this module (see line 780 reward summation).
+        // If saturation ever fires, the next supply check will reject the
+        // block via the MAX_SUPPLY invariant guard rather than silently wrap.
+        self.total_minted = self.total_minted.saturating_add(coinbase_amount);
         if std::env::var("SENTRIX_TRIE_TRACE").is_ok() {
             let post = self.accounts.get_balance(coinbase_recipient);
             eprintln!(


### PR DESCRIPTION
## Summary

Replace unchecked \`total_minted += coinbase_amount\` at \`block_executor.rs:663\` with \`saturating_add\` to harden against u64 overflow.

## Why

Production reward × MAX_HEIGHT puts mainnet ~3 orders of magnitude below u64::MAX, so overflow is unreachable today. But inflated-reward testnets and future block-reward tunables make the defensive form prudent. Catastrophic failure mode (silent wrap → supply divergence across the fleet) shifts to controlled block rejection via the existing MAX_SUPPLY invariant guard.

Matches the existing \`saturating_add\` pattern at line 780 (reward summation) and the \`checked_add\` pattern in the fee accumulator immediately below.

## Test plan

- [x] \`cargo build -p sentrix-core\` green
- [x] \`cargo test -p sentrix-core\` — all 181 existing tests pass (no behavioural change at production parameters)
- [ ] Fresh-brain review

## Risk

Single-line change, pure hardening, no semantic difference at production reward levels. No fork-gating needed because the saturated value (u64::MAX) would still trip MAX_SUPPLY rejection rather than being accepted.

Part of the bug-fix sweep documented in \`founder-private/audits/peer-auto-discovery-implementation-plan.md\` §4 (P1-6).