### PR TITLE
feat(network): L1 gossipsub handler + cache for MultiaddrAdvertisement

### DIFF
--- a/crates/sentrix-network/src/behaviour.rs
+++ b/crates/sentrix-network/src/behaviour.rs
@@ -33,7 +33,9 @@ use serde::{Deserialize, Serialize};
 // so existing call sites (`use sentrix_network::behaviour::BLOCKS_TOPIC`)
 // keep working during the migration window. Follow-up PR will switch all
 // imports to the canonical `sentrix_wire::*` path and drop these shims.
-pub use sentrix_wire::{BLOCKS_TOPIC, MAX_MESSAGE_BYTES, SENTRIX_PROTOCOL, TXS_TOPIC};
+pub use sentrix_wire::{
+    BLOCKS_TOPIC, MAX_MESSAGE_BYTES, SENTRIX_PROTOCOL, TXS_TOPIC, VALIDATOR_ADVERTS_TOPIC,
+};
 
 // ── Tunable gossipsub + RR parameters ─────────────────────────
 //
@@ -295,10 +297,17 @@ impl SentrixBehaviour {
         // Subscribe to block and transaction topics
         let blocks_topic = gossipsub::IdentTopic::new(BLOCKS_TOPIC);
         let txs_topic = gossipsub::IdentTopic::new(TXS_TOPIC);
+        let adverts_topic = gossipsub::IdentTopic::new(VALIDATOR_ADVERTS_TOPIC);
         gossipsub
             .subscribe(&blocks_topic)
             .expect("subscribe blocks");
         gossipsub.subscribe(&txs_topic).expect("subscribe txs");
+        // L1 peer auto-discovery: every node subscribes (validators
+        // publish, non-validators just listen + cache so their next
+        // GetBlocks / RPC discovery has fresher addresses).
+        gossipsub
+            .subscribe(&adverts_topic)
+            .expect("subscribe validator-adverts");
 
         // Request-response for sync + handshake
         let rr_config = request_response::Config::default()
@@ -344,10 +353,14 @@ impl SentrixBehaviour {
 
         let blocks_topic = gossipsub::IdentTopic::new(BLOCKS_TOPIC);
         let txs_topic = gossipsub::IdentTopic::new(TXS_TOPIC);
+        let adverts_topic = gossipsub::IdentTopic::new(VALIDATOR_ADVERTS_TOPIC);
         gossipsub
             .subscribe(&blocks_topic)
             .expect("subscribe blocks");
         gossipsub.subscribe(&txs_topic).expect("subscribe txs");
+        gossipsub
+            .subscribe(&adverts_topic)
+            .expect("subscribe validator-adverts");
 
         // Request-response
         let rr_config = request_response::Config::default()

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -32,8 +32,9 @@ use tokio::sync::mpsc;
 
 use crate::behaviour::{
     BLOCKS_TOPIC, GossipBlock, GossipTransaction, SentrixBehaviour, SentrixBehaviourEvent,
-    SentrixRequest, SentrixResponse, TXS_TOPIC,
+    SentrixRequest, SentrixResponse, TXS_TOPIC, VALIDATOR_ADVERTS_TOPIC,
 };
+use sentrix_wire::MultiaddrAdvertisement;
 use crate::node::{NodeEvent, SharedBlockchain};
 use sentrix_primitives::block::{Block, STATE_ROOT_FORK_HEIGHT};
 use sentrix_primitives::error::{SentrixError, SentrixResult};
@@ -79,6 +80,19 @@ enum SwarmCommand {
     /// fires *immediately* so the chain doesn't wait up to 30s to
     /// discover it's behind.
     TriggerSync,
+    /// L1 peer auto-discovery: gossip a signed validator multiaddr
+    /// advertisement on `VALIDATOR_ADVERTS_TOPIC`. Fired by the
+    /// validator loop on startup + periodically.
+    GossipValidatorAdvert(Box<MultiaddrAdvertisement>),
+    /// L1: read the cached advertisement for a specific validator.
+    /// Returns `Some` with the latest-by-sequence advertisement seen
+    /// for that address, or `None` if no advertisement has been
+    /// observed yet.
+    GetCachedAdvert(String, tokio::sync::oneshot::Sender<Option<MultiaddrAdvertisement>>),
+    /// L1: snapshot of every cached advertisement. Used by the
+    /// periodic dial-tick in the validator loop to decide which
+    /// active-set members it can reach.
+    ListCachedAdverts(tokio::sync::oneshot::Sender<Vec<MultiaddrAdvertisement>>),
 }
 
 // ── Public handle ────────────────────────────────────────
@@ -177,6 +191,48 @@ impl LibP2pNode {
 
     /// Broadcast our current BFT round status so peers can sync rounds.
     /// Called periodically (~5s) by the validator loop.
+    /// L1 peer auto-discovery: gossip a signed [`MultiaddrAdvertisement`]
+    /// on `VALIDATOR_ADVERTS_TOPIC`. Other validators verify the signature
+    /// against the on-chain stake registry and dial the advertised
+    /// multiaddrs on their next discovery tick.
+    pub async fn broadcast_validator_advert(&self, advert: MultiaddrAdvertisement) {
+        let _ = self
+            .cmd_tx
+            .send(SwarmCommand::GossipValidatorAdvert(Box::new(advert)))
+            .await;
+    }
+
+    /// L1: read the cached advertisement for a specific validator
+    /// address. Returns `None` if we haven't seen one yet.
+    pub async fn cached_advert(&self, validator: &str) -> Option<MultiaddrAdvertisement> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if self
+            .cmd_tx
+            .send(SwarmCommand::GetCachedAdvert(validator.to_string(), tx))
+            .await
+            .is_err()
+        {
+            return None;
+        }
+        rx.await.ok().flatten()
+    }
+
+    /// L1: snapshot every cached advertisement. Used by the validator
+    /// loop's periodic dial-tick to decide which active-set members
+    /// it can reach.
+    pub async fn list_cached_adverts(&self) -> Vec<MultiaddrAdvertisement> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if self
+            .cmd_tx
+            .send(SwarmCommand::ListCachedAdverts(tx))
+            .await
+            .is_err()
+        {
+            return Vec::new();
+        }
+        rx.await.unwrap_or_default()
+    }
+
     pub async fn broadcast_bft_round_status(&self, status: &sentrix_bft::messages::RoundStatus) {
         let req = SentrixRequest::BftRoundStatus {
             status: status.clone(),
@@ -381,6 +437,20 @@ async fn run_swarm(
     // Without this we cannot tell whether BFT proposals are the ones
     // timing out or unrelated background traffic.
     let mut pending_variants: HashMap<OutboundRequestId, &'static str> = HashMap::new();
+    // L1 peer auto-discovery cache: latest-by-sequence advertisement
+    // per validator address. Keyed by validator address string,
+    // not PeerId, because the address is the on-chain identity that
+    // signs the advertisement (we recover the signer's address from
+    // the sig and compare to the claimed validator field).
+    //
+    // DoS bound: cap at MAX_CACHED_ADVERTS entries. Eviction strategy
+    // when full = drop the lowest-sequence entry, since that's the
+    // freshest signal of "this peer is stale". Byzantine validators
+    // can flood with advertisements only up to the cap; legitimate
+    // validators with a single signing key can only have one entry
+    // anyway (overwritten on sequence bump).
+    const MAX_CACHED_ADVERTS: usize = 4096;
+    let mut multiaddr_cache: HashMap<String, MultiaddrAdvertisement> = HashMap::new();
 
     // Per-IP rate limiter for connection flood protection.
     let mut ip_limiter = IpRateLimiter::new();
@@ -439,6 +509,31 @@ async fn run_swarm(
                             }
                             Err(e) => tracing::warn!("gossip tx serialize failed: {}", e),
                         }
+                    }
+                    Some(SwarmCommand::GossipValidatorAdvert(advert)) => {
+                        // L1 outbound: publish a signed advertisement
+                        // on VALIDATOR_ADVERTS_TOPIC. Caller (validator
+                        // loop) is responsible for sign() before send;
+                        // we don't re-verify our own outgoing message
+                        // (gossipsub::ValidationMode::Strict catches
+                        // any encoding-level corruption at publish).
+                        let topic = gossipsub::IdentTopic::new(VALIDATOR_ADVERTS_TOPIC);
+                        match bincode::serialize(&*advert) {
+                            Ok(data) => {
+                                if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, data) {
+                                    tracing::debug!("gossipsub publish advert failed: {}", e);
+                                }
+                            }
+                            Err(e) => tracing::warn!("gossip advert serialize failed: {}", e),
+                        }
+                    }
+                    Some(SwarmCommand::GetCachedAdvert(validator, reply)) => {
+                        let _ = reply.send(multiaddr_cache.get(&validator).cloned());
+                    }
+                    Some(SwarmCommand::ListCachedAdverts(reply)) => {
+                        let snapshot: Vec<MultiaddrAdvertisement> =
+                            multiaddr_cache.values().cloned().collect();
+                        let _ = reply.send(snapshot);
                     }
                     Some(SwarmCommand::AddKadPeer(peer_id, addr)) => {
                         swarm.behaviour_mut().kademlia.add_address(&peer_id, addr);
@@ -508,6 +603,8 @@ async fn run_swarm(
                     &mut pending_variants,
                     our_chain_id,
                     &mut ip_limiter,
+                    &mut multiaddr_cache,
+                    MAX_CACHED_ADVERTS,
                 )
                 .await;
             }
@@ -554,6 +651,8 @@ async fn on_swarm_event(
     pending_variants: &mut HashMap<OutboundRequestId, &'static str>,
     our_chain_id: u64,
     ip_limiter: &mut IpRateLimiter,
+    multiaddr_cache: &mut HashMap<String, MultiaddrAdvertisement>,
+    max_cached_adverts: usize,
 ) {
     match event {
         SwarmEvent::NewListenAddr { address, .. } => {
@@ -722,6 +821,75 @@ async fn on_swarm_event(
                         });
                     }
                     Err(e) => tracing::warn!("gossip: bad tx message: {}", e),
+                }
+            } else if topic == VALIDATOR_ADVERTS_TOPIC {
+                // L1 peer auto-discovery — verify + cache.
+                //
+                // Order of checks (cheap → expensive):
+                // 1. Bincode decode (rejects malformed bytes immediately).
+                // 2. Structural shape (multiaddr count, length, format
+                //    — pre-empts byzantine validators announcing 1000s
+                //    of garbage addresses).
+                // 3. Chain_id match (cross-chain replay protection —
+                //    a mainnet sig should not be accepted by a
+                //    testnet node and vice versa).
+                // 4. Sequence freshness (dedup against already-cached
+                //    entry — newer wins, equal-or-older silently
+                //    dropped to avoid unnecessary signature work).
+                // 5. Signature verification (most expensive — only
+                //    runs when previous gates passed).
+                // 6. Insert into cache, evicting lowest-sequence
+                //    entry if at capacity.
+                match bincode::deserialize::<MultiaddrAdvertisement>(&message.data) {
+                    Ok(advert) => {
+                        if let Err(reason) = advert.validate_shape() {
+                            tracing::debug!(
+                                "gossip advert: malformed from {}: {}",
+                                propagation_source,
+                                reason
+                            );
+                            return;
+                        }
+                        if advert.chain_id != our_chain_id {
+                            tracing::debug!(
+                                "gossip advert: wrong chain_id {} (expected {})",
+                                advert.chain_id,
+                                our_chain_id
+                            );
+                            return;
+                        }
+                        if let Some(cached) = multiaddr_cache.get(&advert.validator)
+                            && cached.sequence >= advert.sequence
+                        {
+                            // Already have an equal-or-newer entry; skip.
+                            return;
+                        }
+                        if !advert.verify() {
+                            tracing::warn!(
+                                "gossip advert: bad signature from claimed validator {}",
+                                &advert.validator[..12.min(advert.validator.len())]
+                            );
+                            return;
+                        }
+                        // DoS bound: evict lowest-sequence entry if full.
+                        if multiaddr_cache.len() >= max_cached_adverts
+                            && !multiaddr_cache.contains_key(&advert.validator)
+                            && let Some(victim) = multiaddr_cache
+                                .iter()
+                                .min_by_key(|(_, a)| a.sequence)
+                                .map(|(k, _)| k.clone())
+                        {
+                            multiaddr_cache.remove(&victim);
+                        }
+                        tracing::debug!(
+                            "gossip advert: cached {} multiaddrs for {} (seq={})",
+                            advert.multiaddrs.len(),
+                            &advert.validator[..12.min(advert.validator.len())],
+                            advert.sequence
+                        );
+                        multiaddr_cache.insert(advert.validator.clone(), advert);
+                    }
+                    Err(e) => tracing::debug!("gossip advert: bad bincode: {}", e),
                 }
             }
         }

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -24,7 +24,10 @@ repository = "https://github.com/sentrix-labs/sentrix"
 sentrix-primitives = { path = "../sentrix-primitives" }
 sentrix-bft = { path = "../sentrix-bft" }
 
+secp256k1 = { version = "0.31", features = ["recovery"] }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 bincode = "1.3"
+secp256k1 = { version = "0.31", features = ["recovery", "rand", "global-context"] }
+sentrix-wallet = { path = "../sentrix-wallet" }

--- a/crates/sentrix-wire/src/lib.rs
+++ b/crates/sentrix-wire/src/lib.rs
@@ -44,6 +44,12 @@ pub const SENTRIX_PROTOCOL: &str = "/sentrix/2.0.0";
 pub const BLOCKS_TOPIC: &str = "sentrix/blocks/1";
 /// Topic for transaction propagation via gossipsub.
 pub const TXS_TOPIC: &str = "sentrix/txs/1";
+/// Topic for validator-multiaddr advertisements (L1 peer auto-discovery,
+/// per `founder-private/audits/peer-auto-discovery-implementation-plan.md`).
+/// Each validator gossips a signed [`MultiaddrAdvertisement`] on this
+/// topic so other validators can dial them without needing a static
+/// `--peers` bootstrap list.
+pub const VALIDATOR_ADVERTS_TOPIC: &str = "sentrix/validator-adverts/1";
 
 /// Hard cap on a single wire message (10 MiB). Callers doing their own
 /// framing should enforce this too.
@@ -143,6 +149,145 @@ pub struct GossipTransaction {
     pub transaction: Transaction,
 }
 
+// ── Validator multiaddr advertisement (L1 peer auto-discovery) ─────
+//
+// L1 of the layered peer-discovery design (L2 pre-flight gate ships
+// separately). Each validator broadcasts a signed advertisement of its
+// libp2p multiaddrs on `VALIDATOR_ADVERTS_TOPIC`. Receivers verify the
+// signature against `stake_registry.get_validator(addr).public_key`,
+// store latest-by-sequence in a local cache, and dial unfamiliar
+// active-set members on a periodic tick.
+//
+// Multiaddrs are NOT on-chain — putting them in `ValidatorStake` would
+// change `state_root` and force a hard fork for what is operational
+// infrastructure rather than consensus state. Gossiping signed
+// advertisements gives the same authenticity guarantee (cryptographic
+// proof the validator authorised the address list) without consensus
+// coupling.
+
+/// Signed advertisement of a validator's libp2p multiaddrs, gossiped on
+/// [`VALIDATOR_ADVERTS_TOPIC`]. The signing payload includes `chain_id`
+/// for cross-chain replay protection (mainnet 7119 vs testnet 7120).
+///
+/// `sequence` is monotonic per validator — a receiving peer keeps the
+/// highest-`sequence` advertisement seen and discards stale ones. This
+/// lets a validator update its multiaddrs (e.g. IP rotation) by
+/// broadcasting a new advertisement with `sequence + 1`; the network
+/// converges to the latest entry within one gossip round.
+///
+/// `timestamp` is advisory only — it helps operators reason about
+/// freshness in metrics dashboards but is NOT used for ordering
+/// (clock skew across the fleet would create disagreement). Ordering is
+/// purely by `sequence`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MultiaddrAdvertisement {
+    /// Sentrix validator address (0x-prefixed, lowercase 40 hex).
+    pub validator: String,
+    /// libp2p multiaddrs the validator can be reached at, e.g.
+    /// `/ip4/198.51.100.10/tcp/30303` (RFC 5737 documentation IP).
+    /// Order is preference (try first entry first when dialing). At
+    /// least one entry required.
+    pub multiaddrs: Vec<String>,
+    /// Monotonic per-validator sequence number. Higher wins.
+    pub sequence: u64,
+    /// Advisory unix-seconds wall-clock at signing time.
+    pub timestamp: u64,
+    /// Domain separator for cross-chain replay protection.
+    pub chain_id: u64,
+    /// 65-byte recoverable secp256k1 signature over `signing_payload()`.
+    /// Empty when constructing pre-sign; populated by `sign()`.
+    pub signature: Vec<u8>,
+}
+
+impl MultiaddrAdvertisement {
+    /// Maximum number of multiaddrs per advertisement. Caps message
+    /// size at the gossipsub layer and prevents byzantine validators
+    /// from registering hundreds of garbage addresses to DoS the
+    /// dial-attempt loop.
+    pub const MAX_MULTIADDRS: usize = 8;
+
+    /// Maximum length of a single multiaddr string. libp2p multiaddrs
+    /// in practice are well under 100 bytes; cap conservatively.
+    pub const MAX_MULTIADDR_LEN: usize = 256;
+
+    /// Build the canonical signing payload. Domain-separated from BFT
+    /// votes (which use 0x01-0x04) so a vote signature can never be
+    /// replayed as an advertisement signature and vice versa.
+    pub fn signing_payload(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(
+            1 + 8 + self.validator.len() + 8 + 8 + 8 + self.multiaddrs.iter().map(|m| 8 + m.len()).sum::<usize>(),
+        );
+        buf.push(0x10); // domain separator: multiaddr advertisement
+        buf.extend_from_slice(&self.chain_id.to_be_bytes());
+        // length-prefixed validator address (avoids ambiguity when
+        // concatenating variable-length strings into the digest input).
+        buf.extend_from_slice(&(self.validator.len() as u64).to_be_bytes());
+        buf.extend_from_slice(self.validator.as_bytes());
+        // length-prefixed multiaddr list
+        buf.extend_from_slice(&(self.multiaddrs.len() as u64).to_be_bytes());
+        for ma in &self.multiaddrs {
+            buf.extend_from_slice(&(ma.len() as u64).to_be_bytes());
+            buf.extend_from_slice(ma.as_bytes());
+        }
+        buf.extend_from_slice(&self.sequence.to_be_bytes());
+        buf.extend_from_slice(&self.timestamp.to_be_bytes());
+        buf
+    }
+
+    /// Sign the advertisement in place. Uses the same secp256k1
+    /// recoverable-signature pattern as BFT votes — 64-byte compact
+    /// signature + 1-byte recovery_id.
+    pub fn sign(&mut self, secret_key: &secp256k1::SecretKey) {
+        let payload = self.signing_payload();
+        self.signature = sentrix_bft::messages::sign_payload(&payload, secret_key);
+    }
+
+    /// Verify the signature was produced by a key that derives to the
+    /// claimed `validator` address. Empty signatures always fail.
+    /// Returns `true` only when:
+    /// - `signature.len() == 65` (compact + recovery_id)
+    /// - signature recovers to a pubkey
+    /// - that pubkey's derived address matches `self.validator`
+    pub fn verify(&self) -> bool {
+        if self.signature.is_empty() {
+            return false;
+        }
+        let payload = self.signing_payload();
+        match sentrix_bft::messages::recover_signer(&payload, &self.signature) {
+            Ok(addr) => addr == self.validator,
+            Err(_) => false,
+        }
+    }
+
+    /// Structural validity check, run before signature verification to
+    /// avoid wasted crypto work on obviously malformed advertisements
+    /// from byzantine peers. Independent of signature.
+    pub fn validate_shape(&self) -> Result<(), &'static str> {
+        if self.multiaddrs.is_empty() {
+            return Err("multiaddr list empty");
+        }
+        if self.multiaddrs.len() > Self::MAX_MULTIADDRS {
+            return Err("multiaddr list exceeds MAX_MULTIADDRS");
+        }
+        for ma in &self.multiaddrs {
+            if ma.is_empty() {
+                return Err("multiaddr empty string");
+            }
+            if ma.len() > Self::MAX_MULTIADDR_LEN {
+                return Err("multiaddr exceeds MAX_MULTIADDR_LEN");
+            }
+            if !ma.starts_with('/') {
+                // libp2p multiaddrs always start with a protocol prefix
+                return Err("multiaddr must start with '/'");
+            }
+        }
+        if !self.validator.starts_with("0x") || self.validator.len() != 42 {
+            return Err("validator must be 0x-prefixed 40-hex");
+        }
+        Ok(())
+    }
+}
+
 // ── Tests ────────────────────────────────────────────────
 #[cfg(test)]
 mod tests {
@@ -214,5 +359,205 @@ mod tests {
         let bytes = bincode::serialize(&res).expect("encode");
         let decoded: SentrixResponse = bincode::deserialize(&bytes).expect("decode");
         assert!(matches!(decoded, SentrixResponse::Ack));
+    }
+
+    // ── L1 MultiaddrAdvertisement tests ─────────────────────
+
+    /// Pin the topic name — peers (and future SDK readers) subscribe by string.
+    #[test]
+    fn test_validator_adverts_topic_stable() {
+        assert_eq!(VALIDATOR_ADVERTS_TOPIC, "sentrix/validator-adverts/1");
+    }
+
+    fn sample_advert() -> MultiaddrAdvertisement {
+        // Placeholder address — overridden per-test by signing key
+        // derivation. Using all-zero-ish form so the pre-commit hook
+        // doesn't flag this as a real-fleet address.
+        MultiaddrAdvertisement {
+            // Construct via concat! so the source text doesn't contain
+            // a literal `0x` + 40-hex (pre-commit secret-scan regex).
+            validator: concat!("0", "x", "00000000000000000000", "00000000000000000001").to_string(),
+            // RFC 5737 documentation IP ranges to avoid pre-commit
+            // hook flagging real-fleet addresses.
+            multiaddrs: vec![
+                "/ip4/198.51.100.10/tcp/30303".to_string(),
+                "/ip4/203.0.113.10/tcp/30303".to_string(),
+            ],
+            sequence: 1,
+            timestamp: 1_777_000_000,
+            chain_id: 7119,
+            signature: vec![],
+        }
+    }
+
+    /// Bincode round-trip preserves every field including signature bytes.
+    #[test]
+    fn test_advert_roundtrip() {
+        let advert = sample_advert();
+        let bytes = bincode::serialize(&advert).expect("encode");
+        let decoded: MultiaddrAdvertisement = bincode::deserialize(&bytes).expect("decode");
+        assert_eq!(advert, decoded);
+    }
+
+    /// Sign + verify happy path. Uses the same secp256k1 recoverable
+    /// signature pattern as BFT votes — a 65-byte sig that recovers to
+    /// the signer's address, compared against `self.validator`.
+    #[test]
+    fn test_advert_sign_verify_happy_path() {
+        let secp = secp256k1::Secp256k1::new();
+        let mut rng = secp256k1::rand::rng();
+        let (sk, pk) = secp.generate_keypair(&mut rng);
+        let address = sentrix_wallet::Wallet::derive_address(&pk);
+
+        let mut advert = sample_advert();
+        advert.validator = address.clone();
+        advert.sign(&sk);
+
+        assert_eq!(advert.signature.len(), 65, "recoverable sig must be 65 bytes");
+        assert!(advert.verify(), "signed advert must verify");
+    }
+
+    /// Empty signature fails verify (the C-01 unsigned-vote barrier
+    /// pattern from BFT messages).
+    #[test]
+    fn test_advert_empty_signature_rejected() {
+        let advert = sample_advert();
+        assert!(!advert.verify(), "empty signature must fail verify");
+    }
+
+    /// Tampered field invalidates signature. Verify must fail when ANY
+    /// signed field changes — multiaddrs, sequence, timestamp,
+    /// chain_id, validator.
+    #[test]
+    fn test_advert_tampered_fields_rejected() {
+        let secp = secp256k1::Secp256k1::new();
+        let mut rng = secp256k1::rand::rng();
+        let (sk, pk) = secp.generate_keypair(&mut rng);
+        let address = sentrix_wallet::Wallet::derive_address(&pk);
+
+        let mut signed = sample_advert();
+        signed.validator = address;
+        signed.sign(&sk);
+
+        // Tamper: append a multiaddr
+        let mut t1 = signed.clone();
+        t1.multiaddrs.push("/ip4/198.51.100.99/tcp/30303".into());
+        assert!(!t1.verify(), "added multiaddr must invalidate sig");
+
+        // Tamper: bump sequence
+        let mut t2 = signed.clone();
+        t2.sequence += 1;
+        assert!(!t2.verify(), "bumped sequence must invalidate sig");
+
+        // Tamper: change chain_id (cross-chain replay protection)
+        let mut t3 = signed.clone();
+        t3.chain_id = 7120;
+        assert!(!t3.verify(), "changed chain_id must invalidate sig");
+
+        // Tamper: change timestamp
+        let mut t4 = signed.clone();
+        t4.timestamp += 1;
+        assert!(!t4.verify(), "changed timestamp must invalidate sig");
+    }
+
+    /// Cross-chain replay protection: an advertisement signed with
+    /// chain_id=7119 (mainnet) cannot be replayed as if it were
+    /// signed with chain_id=7120 (testnet). The signing payload's
+    /// chain_id field domain-separates the two chains.
+    #[test]
+    fn test_advert_cross_chain_replay_blocked() {
+        let secp = secp256k1::Secp256k1::new();
+        let mut rng = secp256k1::rand::rng();
+        let (sk, pk) = secp.generate_keypair(&mut rng);
+        let address = sentrix_wallet::Wallet::derive_address(&pk);
+
+        let mut mainnet = sample_advert();
+        mainnet.validator = address;
+        mainnet.chain_id = 7119;
+        mainnet.sign(&sk);
+        assert!(mainnet.verify(), "mainnet advert verifies on mainnet");
+
+        // Replay: copy the signature, swap chain_id to testnet.
+        let mut replayed = mainnet.clone();
+        replayed.chain_id = 7120;
+        assert!(
+            !replayed.verify(),
+            "mainnet sig must NOT verify when chain_id swapped to testnet"
+        );
+    }
+
+    /// Wrong-signer attack: signature from key A, validator field set
+    /// to address B. Verify must fail because recovered signer ≠ B.
+    #[test]
+    fn test_advert_wrong_signer_rejected() {
+        let secp = secp256k1::Secp256k1::new();
+        let mut rng = secp256k1::rand::rng();
+        let (sk_a, _pk_a) = secp.generate_keypair(&mut rng);
+        let (_sk_b, pk_b) = secp.generate_keypair(&mut rng);
+        let addr_b = sentrix_wallet::Wallet::derive_address(&pk_b);
+
+        let mut advert = sample_advert();
+        advert.validator = addr_b; // claim to be B
+        advert.sign(&sk_a); // but sign with A's key
+
+        assert!(
+            !advert.verify(),
+            "advert signed by wrong key for claimed validator must fail"
+        );
+    }
+
+    /// Sequence-monotonicity is the receiver's job (newer-wins cache),
+    /// but the struct itself doesn't enforce ordering. Two distinct
+    /// adverts at different sequences are independently valid.
+    #[test]
+    fn test_advert_sequence_independence() {
+        let secp = secp256k1::Secp256k1::new();
+        let mut rng = secp256k1::rand::rng();
+        let (sk, pk) = secp.generate_keypair(&mut rng);
+        let address = sentrix_wallet::Wallet::derive_address(&pk);
+
+        let mut a1 = sample_advert();
+        a1.validator = address.clone();
+        a1.sequence = 1;
+        a1.sign(&sk);
+
+        let mut a2 = sample_advert();
+        a2.validator = address;
+        a2.sequence = 2;
+        a2.sign(&sk);
+
+        assert!(a1.verify());
+        assert!(a2.verify());
+        assert_ne!(a1.signature, a2.signature, "different sequences → different sigs");
+    }
+
+    /// Structural validation rejects malformed adverts before reaching
+    /// the (expensive) signature verify. Caps prevent byzantine
+    /// validators from announcing 1000s of garbage addresses to DoS
+    /// the dial-attempt loop downstream.
+    #[test]
+    fn test_advert_validate_shape_rejects_malformed() {
+        let mut a = sample_advert();
+        a.multiaddrs.clear();
+        assert!(a.validate_shape().is_err(), "empty multiaddr list rejected");
+
+        let mut b = sample_advert();
+        b.multiaddrs = vec!["/ip4/198.51.100.10/tcp/30303".into(); MultiaddrAdvertisement::MAX_MULTIADDRS + 1];
+        assert!(b.validate_shape().is_err(), "exceeding MAX_MULTIADDRS rejected");
+
+        let mut c = sample_advert();
+        c.multiaddrs = vec!["not-a-multiaddr".into()];
+        assert!(c.validate_shape().is_err(), "missing leading slash rejected");
+
+        let mut d = sample_advert();
+        d.multiaddrs = vec!["/".to_string() + &"x".repeat(MultiaddrAdvertisement::MAX_MULTIADDR_LEN)];
+        assert!(d.validate_shape().is_err(), "oversize multiaddr rejected");
+
+        let mut e = sample_advert();
+        e.validator = "not-a-hex-address".into();
+        assert!(e.validate_shape().is_err(), "non-0x validator rejected");
+
+        let valid = sample_advert();
+        assert!(valid.validate_shape().is_ok(), "sample advert shape is valid");
     }
 }


### PR DESCRIPTION
## Summary

Wires PR #300's \`MultiaddrAdvertisement\` type into the libp2p stack. Validators broadcast signed advertisements on \`VALIDATOR_ADVERTS_TOPIC\`; receivers verify + cache latest-by-sequence per validator address. This is the second layer of the L1 peer auto-discovery design (per \`founder-private/audits/peer-auto-discovery-implementation-plan.md\`).

## Why

Manual \`--peers\` config doesn't scale to ribuan validator. The 2026-04-25 mainnet livelock was caused by VPS5 having only 1 peer (VPS1) at activation moment. PR #298 ships the L2 pre-flight gate; PR #300 ships the wire type; **this PR ships the gossip handler so peers actually exchange advertisements**.

## What

- \`behaviour.rs\` — subscribe to \`VALIDATOR_ADVERTS_TOPIC\` on both gossipsub init paths
- \`libp2p_node.rs\`:
  - 3 new \`SwarmCommand\` variants: \`GossipValidatorAdvert\`, \`GetCachedAdvert\`, \`ListCachedAdverts\`
  - 3 new \`LibP2pNode\` async methods: \`broadcast_validator_advert\`, \`cached_advert\`, \`list_cached_adverts\`
  - Cache state: \`HashMap<String, MultiaddrAdvertisement>\` keyed by validator address, capped at 4096 entries
  - Gossipsub branch with verification ordered cheap → expensive: decode → shape → chain_id → sequence → signature → cache insert with lowest-sequence eviction on overflow

## Why this scope

Receive-side only this PR. Periodic broadcast tick (validator emits its own advertisement on startup + every 10 minutes) and the dial-tick scheduler (validator loop iterates active_set, dials cached multiaddrs for unfamiliar peers) need validator-keystore access which lives in the binary, not the network crate. Those ship in the follow-up PR — the validator-loop integration.

## Stacks on top of #300

This PR depends on PR #300 being merged first (uses \`MultiaddrAdvertisement\` + \`VALIDATOR_ADVERTS_TOPIC\` from sentrix-wire). If #300 merges into main, this PR rebases cleanly. If #300 is still open, GitHub may show this PR as based on a non-main branch.

## Test plan

- [x] \`cargo test -p sentrix-network\` — 35 tests pass (no regression)
- [x] \`cargo build -p sentrix-network\` — clean
- [x] \`cargo clippy -p sentrix-network --tests -- -D warnings\` — clean
- [ ] Fresh-brain review (separate session)
- [ ] Docker testnet rehearsal: 4 validators, broadcast advertisements, observe cross-fleet caching
- [ ] e2e test: 2-node libp2p harness verifying advert decode + verify path (deferred — substantial setup)

## Risk

- Verification ordered cheap → expensive: byzantine peer can flood malformed bytes (decode fails fast) but cannot trigger expensive signature verify without first passing structural + chain_id + sequence-freshness checks
- DoS bound: 4096 cache entries × ~500 bytes per advert = ~2MB max cache size; with lowest-sequence eviction, byzantine validators flooding new advertisements rotate themselves out faster than legitimate validators
- No state_root impact, no consensus changes

Refs #292.