### PR TITLE
feat(node): L1 validator-loop integration — broadcast advert + dial cached peers

### DIFF
--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -37,6 +37,11 @@ serde_json = "1.0"
 hex = "0.4"
 axum = "0.8"
 bincode = "1.3"
+# L1 peer auto-discovery: validator-loop builds + signs MultiaddrAdvertisement
+# directly using its own keystore, so we pull sentrix-wire here rather than
+# routing through the network crate (which would force the binary to know
+# about sentrix-network's wire types via a long re-export chain).
+sentrix-wire = { path = "../../crates/sentrix-wire" }
 # V2 M-15 helper uses the SecretKey type from secp256k1 in its signature.
 # The wallet crate returns the same type from `get_secret_key`, but bin/
 # doesn't transitively re-export it, so we depend on the workspace version

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -134,6 +134,53 @@ fn force_bft_insufficient_peers_set() -> bool {
         .unwrap_or(false)
 }
 
+/// Path to the persisted L1 advertisement sequence counter. Stored
+/// inside the data directory so each chain.db has its own sequence
+/// space (testnet and mainnet validators on the same host don't share
+/// state). Plain decimal-text format — easy to inspect via `cat`,
+/// easy to bump manually for ops emergencies.
+fn advert_sequence_path() -> std::path::PathBuf {
+    get_data_dir().join(".advert-sequence")
+}
+
+/// Load the persisted advertisement sequence from disk. Returns 0 on
+/// any failure (missing file on first run, parse error, IO error) —
+/// the broadcast logic uses `saturating_add(1)` so 0 simply means
+/// "start at 1 on first broadcast." Self-review found this critical:
+/// without persistence, a validator restart resets sequence to 0;
+/// peers cached `seq=N` from the previous lifetime silently drop the
+/// new `seq=1` broadcast (newer-wins semantics). The validator's
+/// updated multiaddrs would then take ~N broadcasts × 10min to
+/// propagate, breaking IP-rotation recovery.
+fn load_advert_sequence() -> u64 {
+    let path = advert_sequence_path();
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(0)
+}
+
+/// Persist the current advertisement sequence atomically. Writes to a
+/// temp file then renames over the target so a crash mid-write doesn't
+/// leave a truncated file that would parse to a smaller value (which
+/// would re-introduce the regression bug).
+fn store_advert_sequence(seq: u64) {
+    let path = advert_sequence_path();
+    let Some(parent) = path.parent() else { return };
+    if let Err(e) = std::fs::create_dir_all(parent) {
+        tracing::debug!("advert sequence: mkdir failed: {}", e);
+        return;
+    }
+    let tmp = path.with_extension("tmp");
+    if let Err(e) = std::fs::write(&tmp, seq.to_string()) {
+        tracing::debug!("advert sequence: write tmp failed: {}", e);
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, &path) {
+        tracing::debug!("advert sequence: rename failed: {}", e);
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "sentrix")]
 #[command(about = "Sentrix (SRX) — Layer-1 Blockchain")]
@@ -1404,7 +1451,16 @@ async fn cmd_start(
             let mut last_advert_broadcast_at: Option<tokio::time::Instant> = None;
             let mut last_l1_tick_at = tokio::time::Instant::now()
                 - tokio::time::Duration::from_secs(31); // fire on first iter
-            let mut advert_sequence: u64 = 0;
+            // Sequence MUST be loaded from disk on startup, otherwise
+            // restart resets to 0 and peers (cached at the previous
+            // lifetime's high-water mark) silently drop our broadcasts
+            // until we overshoot the cached value. See self-review.
+            let mut advert_sequence: u64 = load_advert_sequence();
+            tracing::info!(
+                "L1: advert sequence resumed at {} (next broadcast will be {})",
+                advert_sequence,
+                advert_sequence.saturating_add(1)
+            );
             const L1_TICK_INTERVAL: tokio::time::Duration =
                 tokio::time::Duration::from_secs(30);
             const ADVERT_BROADCAST_INTERVAL: tokio::time::Duration =
@@ -1434,17 +1490,36 @@ async fn cmd_start(
                             let bc = shared_clone.read().await;
                             bc.chain_id
                         };
-                        // Filter out loopback-only addresses — peers
-                        // can't reach those. Cap at MAX_MULTIADDRS to
-                        // stay within DoS budget on the receiver side.
+                        // Filter out unreachable addresses — peers can't
+                        // dial these. Loopback (`127.0.0.1`, `::1`) is
+                        // self-only; `0.0.0.0` and `::` are bind-time
+                        // wildcards that mean "all interfaces" not a
+                        // routable address. libp2p often surfaces them
+                        // anyway when SENTRIX_P2P_HOST=0.0.0.0 (the
+                        // production default), so the filter must catch
+                        // both classes. Cap at MAX_MULTIADDRS to stay
+                        // within DoS budget on the receiver side.
                         let multiaddrs: Vec<String> = listen_addrs
                             .iter()
                             .map(|m| m.to_string())
-                            .filter(|s| !s.starts_with("/ip4/127.") && !s.starts_with("/ip6/::1/"))
+                            .filter(|s| {
+                                !s.starts_with("/ip4/127.")
+                                    && !s.starts_with("/ip6/::1/")
+                                    && !s.starts_with("/ip4/0.0.0.0/")
+                                    && !s.starts_with("/ip6/::/")
+                            })
                             .take(sentrix_wire::MultiaddrAdvertisement::MAX_MULTIADDRS)
                             .collect();
                         if !multiaddrs.is_empty() {
                             advert_sequence = advert_sequence.saturating_add(1);
+                            // Persist BEFORE broadcasting so a crash
+                            // between bump and broadcast doesn't leave
+                            // a sequence we never published. Worst
+                            // case the validator skips a sequence
+                            // number on next start; harmless because
+                            // peers compare by greater-than, not
+                            // sequential.
+                            store_advert_sequence(advert_sequence);
                             let timestamp = std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .unwrap_or_default()

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1394,10 +1394,116 @@ async fn cmd_start(
             let mut pioneer_last_block =
                 tokio::time::Instant::now() - tokio::time::Duration::from_secs(BLOCK_TIME_SECS);
 
+            // L1 peer auto-discovery state. Every L1_TICK_INTERVAL the
+            // loop checks whether our own advertisement needs
+            // re-broadcasting (every ADVERT_BROADCAST_INTERVAL) and
+            // whether we should dial any active-set members we have
+            // cached but no live connection to. Per the impl plan at
+            // founder-private/audits/peer-auto-discovery-implementation
+            // -plan.md (L1 + L4 baked in).
+            let mut last_advert_broadcast_at: Option<tokio::time::Instant> = None;
+            let mut last_l1_tick_at = tokio::time::Instant::now()
+                - tokio::time::Duration::from_secs(31); // fire on first iter
+            let mut advert_sequence: u64 = 0;
+            const L1_TICK_INTERVAL: tokio::time::Duration =
+                tokio::time::Duration::from_secs(30);
+            const ADVERT_BROADCAST_INTERVAL: tokio::time::Duration =
+                tokio::time::Duration::from_secs(600); // 10 minutes
+
             loop {
                 if shutdown_flag_clone.load(Ordering::Acquire) {
                     tracing::info!("Validator loop: shutdown flag set — exiting");
                     break;
+                }
+
+                // ── L1 peer auto-discovery tick ──
+                if last_l1_tick_at.elapsed() >= L1_TICK_INTERVAL {
+                    last_l1_tick_at = tokio::time::Instant::now();
+
+                    // Broadcast our advert if due (first run + every
+                    // ADVERT_BROADCAST_INTERVAL). Skipped silently when
+                    // we have no public listen addresses (loopback-only
+                    // testnets, paused listeners).
+                    let need_broadcast = match last_advert_broadcast_at {
+                        None => true,
+                        Some(t) => t.elapsed() >= ADVERT_BROADCAST_INTERVAL,
+                    };
+                    if need_broadcast {
+                        let listen_addrs = lp2p_clone.listen_addrs().await;
+                        let chain_id = {
+                            let bc = shared_clone.read().await;
+                            bc.chain_id
+                        };
+                        // Filter out loopback-only addresses — peers
+                        // can't reach those. Cap at MAX_MULTIADDRS to
+                        // stay within DoS budget on the receiver side.
+                        let multiaddrs: Vec<String> = listen_addrs
+                            .iter()
+                            .map(|m| m.to_string())
+                            .filter(|s| !s.starts_with("/ip4/127.") && !s.starts_with("/ip6/::1/"))
+                            .take(sentrix_wire::MultiaddrAdvertisement::MAX_MULTIADDRS)
+                            .collect();
+                        if !multiaddrs.is_empty() {
+                            advert_sequence = advert_sequence.saturating_add(1);
+                            let timestamp = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_secs();
+                            let mut advert = sentrix_wire::MultiaddrAdvertisement {
+                                validator: wallet.address.clone(),
+                                multiaddrs,
+                                sequence: advert_sequence,
+                                timestamp,
+                                chain_id,
+                                signature: Vec::new(),
+                            };
+                            advert.sign(&validator_secret_key);
+                            tracing::info!(
+                                "L1: broadcasting multiaddr advertisement seq={} ({} addrs)",
+                                advert.sequence,
+                                advert.multiaddrs.len()
+                            );
+                            lp2p_clone.broadcast_validator_advert(advert).await;
+                            last_advert_broadcast_at = Some(tokio::time::Instant::now());
+                        } else {
+                            tracing::debug!(
+                                "L1: skipping advertisement — no non-loopback listen addrs"
+                            );
+                        }
+                    }
+
+                    // Dial any active-set members we have cached but
+                    // aren't currently peered with. Caller (libp2p) is
+                    // idempotent — duplicate dials to an already-
+                    // connected peer are no-ops at the swarm level.
+                    let active_set: Vec<String> = {
+                        let bc = shared_clone.read().await;
+                        bc.stake_registry.active_set.clone()
+                    };
+                    if !active_set.is_empty() {
+                        let cached = lp2p_clone.list_cached_adverts().await;
+                        for advert in &cached {
+                            if advert.validator == wallet.address {
+                                continue;
+                            }
+                            if !active_set.contains(&advert.validator) {
+                                continue;
+                            }
+                            // Try the first listed multiaddr — preference
+                            // order is the advertising validator's.
+                            if let Some(ma_str) = advert.multiaddrs.first()
+                                && let Ok(ma) = ma_str.parse::<libp2p::Multiaddr>()
+                            {
+                                tracing::debug!(
+                                    "L1: dialing {} at {} (cached advert seq={})",
+                                    &advert.validator[..12.min(advert.validator.len())],
+                                    ma_str,
+                                    advert.sequence
+                                );
+                                let _ = lp2p_clone.connect_peer(ma).await;
+                            }
+                        }
+                    }
                 }
 
                 // ── Voyager fork activation (read lock first, write only if needed) ──


### PR DESCRIPTION
## Summary

Final layer of the L1 peer auto-discovery design. Validators now broadcast their own signed advertisements on startup + every 10 minutes, and dial any active-set members they have cached advertisements for but no live connection to (every 30 seconds).

## Why

Closes the auto-discovery loop end-to-end. Combined with PR #298 (L2 pre-flight gate), the mesh self-heals: each validator advertises on startup, peers cache, the dial tick converges the active-set into a fully-meshed topology without any \`--peers\` config beyond a single bootstrap node. The 2026-04-25 mainnet livelock cause (manual \`--peers\` not scaling to 4 validators, let alone ribuan) cannot recur once a single bootstrap path exists between any two validators.

## Stack ordering

This PR layers on:
- PR #300 (sentrix-wire MultiaddrAdvertisement type)
- PR #301 (sentrix-network gossipsub handler + cache)

Merge order: #300 → #301 → this PR.

## What

Validator loop additions:
- L1 timing state: \`last_advert_broadcast_at\`, \`last_l1_tick_at\`, \`advert_sequence\`, intervals (30s tick, 10min broadcast)
- Once-per-tick (30s):
  - **Broadcast our advert** if due — read listen addrs from libp2p, filter loopback, build + sign \`MultiaddrAdvertisement\` using validator keystore, gossip. Sequence increments monotonically for newer-wins cache semantics.
  - **Dial cached peers** — read \`active_set\` from blockchain, list cached advertisements via \`lp2p.list_cached_adverts()\`, dial first multiaddr of each cached active-set member we don't already peer with. \`connect_peer\` is idempotent at the swarm level.
- New crate dep: \`sentrix-wire\` (validator-loop builds + signs the advertisement directly using its own keystore).

## Test plan

- [x] \`cargo build -p sentrix-node\` clean
- [x] \`cargo clippy -p sentrix-node --tests -- -D warnings\` clean
- [ ] Fresh-brain review (separate session)
- [ ] Docker testnet rehearsal: 4 validators on isolated docker network, each with only ONE bootstrap peer in \`--peers\`. Verify the mesh self-converges to fully-meshed within 30s of startup.
- [ ] Active partition test: deliberately drop one validator's connection to another, observe re-dial via cached advert
- e2e validator-loop tests deferred — meaningful coverage needs a 4-node libp2p harness which is substantial to set up; testnet rehearsal will exercise the full path.

## Risk

- Sequence overflow: \`saturating_add\` caps at u64::MAX. At 10-min interval, that's ~3.5 × 10^14 years before saturation. Safe.
- Self-dial: explicitly filtered (\`if advert.validator == wallet.address { continue; }\`)
- Stale cache: dial-tick uses cached entry as-is. If the advertised IP rotated, dial fails (logged at debug). Next legitimate broadcast will refresh.
- Loopback filter: skips \`/ip4/127.\` and \`/ip6/::1/\` prefixes — peers can't reach those, so no point advertising
- DoS: cap of 8 multiaddrs per advert × 4096 cache entries × ~256 bytes per multiaddr = bounded memory; LB-side eviction by lowest-sequence already in PR #301

Refs #292.