### PR TITLE
fix(evm): bulk pre-load all contract bytecodes in from_account_db

### DIFF
--- a/crates/sentrix-evm/src/database.rs
+++ b/crates/sentrix-evm/src/database.rs
@@ -87,6 +87,33 @@ impl SentrixEvmDb {
                 db.accounts.insert(addr, info);
             }
         }
+        // Pre-load every contract's bytecode into `db.code`. block_executor
+        // already pre-loads the direct CALL target's code at the per-tx
+        // entry point, but a contract that DELEGATECALLs / CALLs / STATIC
+        // CALLs another contract triggers `code_by_hash` for the SECOND
+        // contract's hash — which would fail with "code hash X not found"
+        // because only the entry-point target was loaded. Bulk-loading
+        // every contract's bytecode here fixes cross-contract calls.
+        //
+        // Cost: O(N_contracts × bytecode_size) memory per EVM tx. At
+        // realistic chain sizes (thousands of contracts × ~10KB each)
+        // this is bounded; if a chain grows large enough that bulk-load
+        // becomes a problem, the right fix is a lazy `code_by_hash`
+        // callback that fetches from the live AccountDB on demand —
+        // schema below already supports that pattern.
+        for (addr_str, account) in &account_db.accounts {
+            if account.code_hash == EMPTY_CODE_HASH {
+                continue; // EOA, no bytecode
+            }
+            let code_hash_hex = hex::encode(account.code_hash);
+            if let Some(bytecode) = account_db.get_contract_code(&code_hash_hex) {
+                let _ = addr_str; // address not needed for the code map
+                db.code.insert(
+                    B256::from(account.code_hash),
+                    Bytecode::new_raw(alloy_primitives::Bytes::from(bytecode.clone())),
+                );
+            }
+        }
         db
     }
 


### PR DESCRIPTION
## Summary

P0 fix from the impl plan bug-fix sweep. Bulk-load every contract's bytecode in \`SentrixEvmDb::from_account_db\` so cross-contract calls don't fail with \"code hash X not found\".

## Why

\`block_executor.rs:1214-1223\` pre-loads only the direct \`CALL\` target. Any sub-call (DELEGATECALL / CALL / STATICCALL) to a SECOND contract triggers revm's \`code_by_hash\` for that contract's hash, which isn't in the pre-loaded map. revm errors out, the EVM tx fails silently, downstream contract logic breaks.

This affects any contract that calls another contract — common pattern (DEX router → pair, OpenZeppelin proxies → impl, etc).

## What

Single-method change in \`database.rs\`: extend \`from_account_db\` to iterate every account, skip EOAs, and bulk-insert all contract bytecodes into \`db.code\`.

## Cost

O(N_contracts × bytecode_size) memory per EVM tx. At realistic chain sizes (thousands × ~10KB) bounded. If chains grow large enough that bulk-load is a problem, the right fix is a lazy callback in \`code_by_hash\` — defer to that PR.

## Test plan

- [x] cargo build clean
- [x] 36 sentrix-evm tests pass
- [x] clippy clean
- [ ] Fresh-brain review
- [ ] Testnet: deploy a contract that calls another contract (e.g. ERC-20 router pattern), verify the call succeeds end-to-end

Refs #292.