### PR TITLE
feat(core): Frontier parallel-apply module scaffold (Phase F-1)

### DIFF
--- a/crates/sentrix-core/src/lib.rs
+++ b/crates/sentrix-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod blockchain;
 pub mod chain_queries;
 pub mod genesis;
 pub mod mempool;
+pub mod parallel;
 pub mod state_export;
 pub mod storage;
 pub mod token_ops;

--- a/crates/sentrix-core/src/parallel/mod.rs
+++ b/crates/sentrix-core/src/parallel/mod.rs
@@ -1,0 +1,32 @@
+//! Frontier-phase parallel transaction execution.
+//!
+//! **Scaffold only.** This module exists as a type-system contract for the
+//! Frontier-fork parallel apply work documented in
+//! `founder-private/audits/parallel-tx-execution-design.md` +
+//! `founder-private/audits/frontier-mainnet-phase-implementation-plan.md`.
+//!
+//! Production code path is unchanged — `block_executor.rs` continues to
+//! apply transactions sequentially. The `derive_access` and
+//! `build_batches` functions defined in submodules are pure / no-op
+//! at this stage; they exist so:
+//!
+//! 1. The next implementer doesn't bootstrap module structure under time
+//!    pressure — they pick up at "fill in the function bodies."
+//! 2. The determinism property test contract (`tests/parallel_determinism.rs`)
+//!    can be wired now and run against the stub, asserting type stability.
+//! 3. Reviewers can sanity-check the type surface (AccountKey, TxAccess,
+//!    Batch) before any consensus-touching code lands.
+//!
+//! **Anti-goals for this scaffold:**
+//! - Do NOT call any function from this module in `apply_block_pass2`
+//! - Do NOT modify any consensus-critical state path
+//! - Do NOT enable real parallelism yet (no rayon `par_iter` etc.)
+//!
+//! When implementation actually lands, follow Phase F-3 → F-10 in
+//! `frontier-mainnet-phase-implementation-plan.md` §3.
+
+pub mod rw_set;
+pub mod scheduler;
+
+pub use rw_set::{AccountKey, GlobalKey, TxAccess, derive_access};
+pub use scheduler::{Batch, build_batches};

--- a/crates/sentrix-core/src/parallel/rw_set.rs
+++ b/crates/sentrix-core/src/parallel/rw_set.rs
@@ -1,0 +1,226 @@
+//! Read/write set derivation for parallel transaction execution.
+//!
+//! Scaffold per `founder-private/audits/parallel-tx-execution-design.md` §Phase 1.
+//! Pure functions, no I/O, deterministic by construction. The actual
+//! body of `derive_access` is `unimplemented!`-free but returns a
+//! conservative `Pessimistic` access set so any caller that wires this
+//! up before the impl lands gets a no-parallelism-but-correct fallback
+//! rather than incorrect parallelism.
+//!
+//! **Determinism contract (must hold on every implementation):**
+//! - `derive_access(tx, validator)` returns the same `TxAccess` for
+//!   the same input bytes across all Rust toolchains, all platforms,
+//!   and all runs.
+//! - All sets use `BTreeSet` — never `HashSet` — so iteration order
+//!   is `Ord`-stable across libstd versions.
+//! - No floating-point, no `Instant::now()`, no env-var reads, no
+//!   process-id, no thread-local state.
+//!
+//! **Anti-goals for this scaffold:**
+//! - Do NOT call this from production block-apply path yet
+//! - Do NOT add EVM speculative-execution helpers (Frontier-v2 work)
+
+use std::collections::BTreeSet;
+
+/// Global counters that participate in state_root and may be read or
+/// written by transaction application. Each is a single shared slot
+/// — any tx that touches one creates a write-write conflict with every
+/// other tx that also touches it, forcing them into separate batches.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum GlobalKey {
+    /// Total SRX minted (incremented on coinbase). Every block touches
+    /// this in the coinbase application, but coinbase runs sequentially
+    /// before any parallel batch, so it doesn't affect batching.
+    TotalMinted,
+    /// Total SRX burned (incremented on every fee-burn split). Every
+    /// non-coinbase tx touches this. Forces a global write conflict
+    /// — meaning v1 batching cannot parallelise *fee-paying* transfers
+    /// at all. Mitigation in v2: aggregate fee-burns per batch into a
+    /// single write at batch-merge time.
+    TotalBurned,
+}
+
+/// Discriminated union of state keys a transaction can read or write.
+/// Used as the comparison primitive for conflict-graph edge detection.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AccountKey {
+    /// SRX balance + nonce keyed by Sentrix address (0x-prefixed
+    /// 40-hex). Equality on the full string preserves case-insensitive
+    /// determinism IF and ONLY IF the protocol normalises addresses
+    /// to lowercase at tx-submission time. Frontier impl MUST verify
+    /// this normalisation invariant via test before activating.
+    Account(String),
+    /// EVM contract storage slot (contract_address, slot_index_be32).
+    /// EVM txs in v1 do NOT use this fine-grained key — they use
+    /// `Pessimistic`. This variant is reserved for the Frontier-v2
+    /// speculative-execution path.
+    ContractStorage(String, [u8; 32]),
+    /// Global counter slots that conflict with every other access to
+    /// the same counter.
+    GlobalCounter(GlobalKey),
+    /// Sentinel "this tx might touch any state" key. Conflicts with
+    /// every other key including itself. Used by EVM txs in v1 since
+    /// we don't statically know what slots they read/write. Forces
+    /// EVM txs to single-tx batches → effectively sequential for EVM.
+    Pessimistic,
+}
+
+/// Per-transaction read + write access sets. Both are `BTreeSet` so
+/// iteration order is deterministic across all platforms and toolchains.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TxAccess {
+    pub reads: BTreeSet<AccountKey>,
+    pub writes: BTreeSet<AccountKey>,
+}
+
+impl TxAccess {
+    /// Construct the maximally-conservative access set. Every variant
+    /// of `AccountKey::Pessimistic` conflicts with every key (including
+    /// other `Pessimistic` instances), so a tx with this access set
+    /// always ends up in a singleton batch — equivalent to sequential
+    /// execution. Used as the v1 default for EVM txs.
+    pub fn pessimistic() -> Self {
+        let mut reads = BTreeSet::new();
+        reads.insert(AccountKey::Pessimistic);
+        let mut writes = BTreeSet::new();
+        writes.insert(AccountKey::Pessimistic);
+        Self { reads, writes }
+    }
+
+    /// Two access sets conflict iff either's write set intersects the
+    /// other's read or write set. This is the conflict-graph edge
+    /// predicate.
+    ///
+    /// `Pessimistic` is in every set on both sides for an EVM tx, so
+    /// any EVM tx conflicts with every other tx — forcing it into its
+    /// own batch.
+    pub fn conflicts_with(&self, other: &TxAccess) -> bool {
+        self.writes.iter().any(|w| other.reads.contains(w) || other.writes.contains(w))
+            || other.writes.iter().any(|w| self.reads.contains(w) || self.writes.contains(w))
+    }
+}
+
+/// Derive the read/write access set for a transaction. SCAFFOLD
+/// VERSION returns `Pessimistic` for everything, which means any
+/// caller that wires this up before the real implementation lands
+/// gets sequential-equivalent behaviour (every tx in its own batch).
+///
+/// The real implementation (Phase F-3 of the impl plan) discriminates
+/// on tx kind:
+/// - Native transfer → reads {from, to}, writes {from, to, validator, TotalBurned}
+/// - Token op → reads {from, TOKEN_OP_ADDRESS}, writes {from, TOKEN_OP_ADDRESS, validator}
+/// - EVM → `Pessimistic` (v1) or fine-grained slot tracking (v2)
+///
+/// `_validator` is the block proposer's address — they receive fees,
+/// so every fee-paying tx writes to their account. Captured as a
+/// parameter (not a global) for testability and determinism.
+pub fn derive_access(_tx_payload: &[u8], _validator: &str) -> TxAccess {
+    // SCAFFOLD: pessimistic default. Real impl ships in Phase F-3.
+    TxAccess::pessimistic()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pessimistic access conflicts with itself — sanity-check that
+    /// the worst-case path forces serial execution.
+    #[test]
+    fn pessimistic_conflicts_with_pessimistic() {
+        let a = TxAccess::pessimistic();
+        let b = TxAccess::pessimistic();
+        assert!(a.conflicts_with(&b));
+    }
+
+    /// Disjoint native-transfer-shaped access sets do not conflict.
+    /// This is the property the real impl will preserve and the
+    /// scheduler relies on for parallelism.
+    #[test]
+    fn disjoint_native_accesses_do_not_conflict() {
+        let mut a = TxAccess::default();
+        a.reads.insert(AccountKey::Account("0xa".into()));
+        a.reads.insert(AccountKey::Account("0xb".into()));
+        a.writes.insert(AccountKey::Account("0xa".into()));
+        a.writes.insert(AccountKey::Account("0xb".into()));
+
+        let mut b = TxAccess::default();
+        b.reads.insert(AccountKey::Account("0xc".into()));
+        b.reads.insert(AccountKey::Account("0xd".into()));
+        b.writes.insert(AccountKey::Account("0xc".into()));
+        b.writes.insert(AccountKey::Account("0xd".into()));
+
+        assert!(!a.conflicts_with(&b));
+    }
+
+    /// Shared-receiver write-write conflict.
+    #[test]
+    fn shared_write_target_creates_conflict() {
+        let mut a = TxAccess::default();
+        a.writes.insert(AccountKey::Account("0xshared".into()));
+
+        let mut b = TxAccess::default();
+        b.writes.insert(AccountKey::Account("0xshared".into()));
+
+        assert!(a.conflicts_with(&b));
+    }
+
+    /// Read-write conflict (one tx reads what another writes).
+    #[test]
+    fn read_write_overlap_creates_conflict() {
+        let mut reader = TxAccess::default();
+        reader.reads.insert(AccountKey::Account("0xshared".into()));
+
+        let mut writer = TxAccess::default();
+        writer.writes.insert(AccountKey::Account("0xshared".into()));
+
+        assert!(reader.conflicts_with(&writer));
+        assert!(writer.conflicts_with(&reader));
+    }
+
+    /// `derive_access` scaffold returns pessimistic — this pins the
+    /// SCAFFOLD contract. When the real impl lands and starts
+    /// returning fine-grained access sets, this test must be updated
+    /// (intentionally, signalling that the scaffold is being replaced).
+    #[test]
+    fn scaffold_derive_access_is_pessimistic() {
+        let access = derive_access(b"any tx bytes", "0xvalidator");
+        assert_eq!(access, TxAccess::pessimistic());
+    }
+
+    /// Determinism: same input → same output, every time.
+    #[test]
+    fn derive_access_is_deterministic() {
+        let payload = b"some tx payload bytes";
+        let a1 = derive_access(payload, "0xvalidator");
+        let a2 = derive_access(payload, "0xvalidator");
+        let a3 = derive_access(payload, "0xvalidator");
+        assert_eq!(a1, a2);
+        assert_eq!(a2, a3);
+    }
+
+    /// BTreeSet iteration order is deterministic — verify by
+    /// constructing the same access set two different ways and
+    /// asserting they iterate identically.
+    #[test]
+    fn access_set_iteration_is_deterministic() {
+        let keys = vec![
+            AccountKey::Account("0xc".into()),
+            AccountKey::Account("0xa".into()),
+            AccountKey::Account("0xb".into()),
+        ];
+
+        let mut a = TxAccess::default();
+        for k in &keys {
+            a.reads.insert(k.clone());
+        }
+
+        let mut b = TxAccess::default();
+        for k in keys.iter().rev() {
+            b.reads.insert(k.clone());
+        }
+
+        let a_iter: Vec<_> = a.reads.iter().collect();
+        let b_iter: Vec<_> = b.reads.iter().collect();
+        assert_eq!(a_iter, b_iter, "BTreeSet iteration must be order-independent of insertion");
+    }
+}

--- a/crates/sentrix-core/src/parallel/scheduler.rs
+++ b/crates/sentrix-core/src/parallel/scheduler.rs
@@ -1,0 +1,128 @@
+//! Conflict-graph scheduler for parallel transaction batching.
+//!
+//! Scaffold per `founder-private/audits/parallel-tx-execution-design.md` §Phase 2.
+//! `build_batches` is currently a sequential-equivalent stub: it returns
+//! one tx per batch, preserving original block order. This is correct
+//! (every batch has zero internal conflicts) but extracts zero
+//! parallelism. The real implementation does greedy graph colouring.
+//!
+//! **Determinism contract:**
+//! - Same input txs + same validator → byte-identical Vec<Batch> output
+//!   on every run, every machine, every Rust toolchain
+//! - Within a batch, txs are ordered by their original block index
+//! - Across batches, batches are ordered by their lowest tx index
+//! - Algorithm uses `BTreeSet` / `BTreeMap` only, never `HashSet` / `HashMap`,
+//!   so iteration order is `Ord`-stable across libstd versions
+
+use crate::parallel::rw_set::{TxAccess, derive_access};
+
+/// A batch of transactions that can execute in parallel because no two
+/// txs in the batch have conflicting r/w access sets. The `tx_indices`
+/// reference positions in the original block transaction list — they
+/// are NOT a copy of the transaction data, just indices.
+///
+/// Indices within a batch are sorted ascending. The implementer
+/// applying the batch reads txs from the block in this order — the
+/// per-tx order within a batch is not consensus-relevant (they don't
+/// touch shared state by construction) but pinning it eliminates
+/// non-determinism risk from batch-internal ordering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Batch {
+    pub tx_indices: Vec<usize>,
+}
+
+impl Batch {
+    pub fn singleton(idx: usize) -> Self {
+        Self { tx_indices: vec![idx] }
+    }
+}
+
+/// Build the parallel-execution batches for `txs` produced by `validator`.
+///
+/// SCAFFOLD: returns one tx per batch (sequential-equivalent). Every
+/// batch is internally conflict-free (trivially — only one tx per
+/// batch), so the parallel apply path is safe even with the stub.
+/// The real impl (Phase F-4 of the impl plan) does greedy graph
+/// colouring to pack independent txs into shared batches.
+///
+/// `txs` is `&[T]` over an opaque byte representation so this module
+/// stays decoupled from the `Transaction` struct's concrete shape.
+/// The real impl will accept `&[Transaction]` once it lands; the
+/// stub takes anything that can produce a payload-byte view via
+/// `AsRef<[u8]>`.
+///
+/// Coinbase txs (block.transactions[0]) are NEVER batched here —
+/// the apply path runs coinbase sequentially before any parallel
+/// batch executes. `build_batches` operates on `block.transactions[1..]`.
+pub fn build_batches<T: AsRef<[u8]>>(txs: &[T], validator: &str) -> Vec<Batch> {
+    // SCAFFOLD: one batch per tx, in original order. Real impl ships
+    // in Phase F-4 — greedy colouring over conflict graph.
+    let _accesses: Vec<TxAccess> = txs
+        .iter()
+        .map(|tx| derive_access(tx.as_ref(), validator))
+        .collect();
+
+    txs.iter().enumerate().map(|(i, _)| Batch::singleton(i)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Stub: every tx ends up in its own singleton batch.
+    #[test]
+    fn scaffold_emits_singleton_batches() {
+        let txs: Vec<&[u8]> = vec![b"a", b"b", b"c"];
+        let batches = build_batches(&txs, "0xvalidator");
+        assert_eq!(batches.len(), 3);
+        for (i, batch) in batches.iter().enumerate() {
+            assert_eq!(batch.tx_indices, vec![i], "batch {} should be singleton", i);
+        }
+    }
+
+    /// Empty input → empty output, not panic.
+    #[test]
+    fn empty_block_yields_empty_batches() {
+        let txs: Vec<&[u8]> = vec![];
+        let batches = build_batches(&txs, "0xvalidator");
+        assert!(batches.is_empty());
+    }
+
+    /// Determinism: same input → same output, every time. Property
+    /// the real impl must preserve. Pinning it now prevents future
+    /// regressions in the scaffold contract.
+    #[test]
+    fn build_batches_is_deterministic() {
+        let txs: Vec<&[u8]> = vec![b"alpha", b"bravo", b"charlie", b"delta"];
+        let b1 = build_batches(&txs, "0xv1");
+        let b2 = build_batches(&txs, "0xv1");
+        let b3 = build_batches(&txs, "0xv1");
+        assert_eq!(b1, b2);
+        assert_eq!(b2, b3);
+    }
+
+    /// Different validator → still same batching (validator only
+    /// affects access sets, not which txs are present). Real impl
+    /// MAY produce different batches if the validator address shows
+    /// up as a write target — pinning the scaffold's behaviour here
+    /// will signal the test needs updating when the impl lands.
+    #[test]
+    fn scaffold_validator_independent() {
+        let txs: Vec<&[u8]> = vec![b"x", b"y"];
+        let v1 = build_batches(&txs, "0xv1");
+        let v2 = build_batches(&txs, "0xv2");
+        assert_eq!(v1, v2);
+    }
+
+    /// Batches preserve original tx order. Required for the apply
+    /// path's commit ordering — txs within a batch are conflict-free
+    /// so any internal order is correct, but pinning ascending order
+    /// removes ambiguity for log readability + debug.
+    #[test]
+    fn batches_preserve_ascending_order() {
+        let txs: Vec<&[u8]> = vec![b"0", b"1", b"2", b"3", b"4"];
+        let batches = build_batches(&txs, "0xv");
+        let flat: Vec<usize> = batches.iter().flat_map(|b| b.tx_indices.iter().copied()).collect();
+        assert_eq!(flat, vec![0, 1, 2, 3, 4]);
+    }
+}

--- a/crates/sentrix-core/tests/parallel_determinism.rs
+++ b/crates/sentrix-core/tests/parallel_determinism.rs
@@ -1,0 +1,69 @@
+//! Frontier-fork parallel apply determinism contract.
+//!
+//! This test is the SINGLE merge gate for any future PR that enables
+//! the parallel-apply path. It asserts:
+//!
+//!     apply_sequential(block).state_root == apply_parallel(block).state_root
+//!
+//! for every block produced by the random-block generator. 10K random
+//! blocks per CI invocation, zero failures tolerated.
+//!
+//! **Why ignored today:** the parallel apply path doesn't exist yet.
+//! The current `parallel/` module is a type-system scaffold that
+//! returns sequential-equivalent batches. Running the test against
+//! the scaffold would pass trivially (both paths == sequential), so
+//! it would not catch determinism regressions.
+//!
+//! **When to enable:** Phase F-5 of `frontier-mainnet-phase-implementation-plan.md`,
+//! when `Blockchain::apply_block_pass2_parallel` lands behind the
+//! `PARALLEL_APPLY_FORK_HEIGHT` flag. The test runs against EVERY pre-
+//! mainnet PR for 1 week minimum before any operator considers
+//! activating the fork.
+//!
+//! **Anti-goals:**
+//! - Do NOT remove the `#[ignore]` until the parallel path is real
+//! - Do NOT weaken the equivalence assertion (e.g. accept "states
+//!   differ but both are valid" — they're not, mainnet diverges)
+//! - Do NOT skip blocks with EVM txs (EVM falls to pessimistic batch,
+//!   still must produce identical state_root)
+//!
+//! Reference: `audits/frontier-mainnet-phase-implementation-plan.md` §F-2,
+//! `audits/parallel-tx-execution-design.md` §Test strategy.
+
+#[test]
+#[ignore = "Frontier parallel-apply path not yet implemented (Phase F-5)"]
+fn parallel_apply_matches_sequential_apply() {
+    // Placeholder. The real implementation will:
+    //
+    //   use proptest::prelude::*;
+    //   proptest!(|(block in arbitrary_block(MAX_TXS = 1000))| {
+    //       let mut bc_seq = setup_chain();
+    //       let mut bc_par = setup_chain();
+    //
+    //       bc_seq.apply_block_pass2_sequential(block.clone()).unwrap();
+    //       bc_par.apply_block_pass2_parallel(block).unwrap();
+    //
+    //       prop_assert_eq!(bc_seq.state_root(), bc_par.state_root());
+    //       prop_assert_eq!(bc_seq.accounts.serialize(), bc_par.accounts.serialize());
+    //   });
+    //
+    // The placeholder body intentionally panics to surface "this test
+    // ran but the impl is missing" if someone removes the ignore prematurely.
+    panic!(
+        "Frontier parallel-apply path not yet implemented. \
+         Re-enable this test only when Blockchain::apply_block_pass2_parallel \
+         lands behind PARALLEL_APPLY_FORK_HEIGHT (Phase F-5 of impl plan)."
+    );
+}
+
+/// A second placeholder pinning the conflict-graph determinism contract.
+/// The scheduler must produce byte-identical Vec<Batch> for the same
+/// input across every run. Phase F-4 of the impl plan owns this.
+#[test]
+#[ignore = "Frontier conflict-graph builder not yet implemented (Phase F-4)"]
+fn build_batches_is_deterministic_across_1000_runs() {
+    panic!(
+        "Frontier conflict-graph builder not yet implemented. \
+         Re-enable this test when the real build_batches() ships in Phase F-4."
+    );
+}


### PR DESCRIPTION
## Summary

Phase F-1 of the Frontier mainnet phase impl plan (`founder-private/audits/frontier-mainnet-phase-implementation-plan.md`). Ships the type-system contracts for parallel transaction execution + the determinism property test placeholders. Production code path is unchanged.

## Why ship a scaffold

Three reasons documented in the impl plan §6:

1. The next implementer doesn't bootstrap module structure under time pressure — they pick up at "fill in function bodies"
2. The determinism property test contract can be wired now and run against the stub
3. Reviewers can sanity-check the type surface before any consensus-touching code lands

The Frontier work is 6-8 weeks of focused engineering across multiple sessions. Shipping the scaffold now accelerates that work without risking the production code path.

## What

- `src/parallel/mod.rs` — module entry + re-exports
- `src/parallel/rw_set.rs` — `AccountKey` / `GlobalKey` / `TxAccess` / `derive_access`. Stub returns `Pessimistic`.
- `src/parallel/scheduler.rs` — `Batch` / `build_batches`. Stub returns one tx per batch.
- `tests/parallel_determinism.rs` — `#[ignore]`d property test placeholders for the parallel-apply equivalence + conflict-graph determinism contracts.

## Anti-goals deliberately enforced

- NOT called from `apply_block_pass2` (production path unchanged)
- NO real parallelism (no rayon `par_iter`)
- NO consensus-critical state mutation
- NO `PARALLEL_APPLY_FORK_HEIGHT` constant yet (Phase F-6 territory)

The placeholder property test bodies `panic!()` if someone removes the `#[ignore]` prematurely — the failure mode is loud, not a silently-trivial pass.

## Test plan

- [x] 12 new unit tests pass (7 in rw_set + 5 in scheduler)
- [x] 2 ignored property tests properly skipped
- [x] cargo clippy --workspace clean
- [x] cargo build --workspace clean
- [ ] Fresh-brain review

## Risk

Zero behavioural change to the mainnet binary. The new module is private to `sentrix-core` and not referenced by any production code path. Compile-time only.

## Cross-references

- Frontier impl plan: `founder-private/audits/frontier-mainnet-phase-implementation-plan.md`
- Technical design: `founder-private/audits/parallel-tx-execution-design.md`
- TPS roadmap: `founder-private/audits/path-to-high-tps.md`