### PR TITLE
fix(rpc): consensus mode uses runtime flag, not chain_id heuristic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -4894,14 +4894,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4944,14 +4944,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "bincode",
  "blake3",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.27"
+version = "2.1.28"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "anyhow",
  "axum",
@@ -4894,14 +4894,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4944,14 +4944,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "bincode",
  "blake3",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.26"
+version = "2.1.27"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "anyhow",
  "axum",
@@ -4894,14 +4894,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4944,14 +4944,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "bincode",
  "blake3",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1581,6 +1581,50 @@ async fn cmd_start(
                     }
                 }
 
+                // ── L2 cold-start gate (2026-04-25 second-incident fix) ──
+                //
+                // The original L2 gate (post-this-block) only fires on
+                // ACTIVATION TRANSITION, when voyager_activated is loaded
+                // as false. On cold-start with chain.db's persistent
+                // voyager_activated=true (e.g. after a previous activation),
+                // validators enter BFT IMMEDIATELY — before the L1 mesh
+                // has had time to converge. BFT proposal/precommit
+                // messages travel via libp2p request_response (1-to-1),
+                // not gossipsub, so they only reach peers connected at
+                // the exact moment of broadcast. Activation #2 on
+                // 2026-04-25 split-brained at h=578006 because not all
+                // 4 validators had a fully-formed mesh at the moment
+                // VPS1 broadcast its precommit.
+                //
+                // This second gate fires at EVERY loop iteration when
+                // BFT mode is active. If peer count is insufficient,
+                // sleep 5s and retry — by then L1 self-discovery has
+                // had a chance to converge the mesh. Once mesh is
+                // healthy the gate passes and BFT proceeds normally.
+                //
+                // Steady-state cost: one read-lock + one async peer_count
+                // query per iteration = negligible (microseconds).
+                if voyager_activated {
+                    let active_set_len = {
+                        let bc = shared_clone.read().await;
+                        bc.stake_registry.active_set.len()
+                    };
+                    let peer_count = lp2p_clone.peer_count().await;
+                    let force_override = force_bft_insufficient_peers_set();
+                    if let Err(reason) = check_bft_peer_mesh_eligible(
+                        peer_count,
+                        active_set_len,
+                        force_override,
+                    ) {
+                        tracing::warn!(
+                            "L2 cold-start gate: {} — sleeping 5s, will retry once L1 mesh converges",
+                            reason
+                        );
+                        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                        continue;
+                    }
+                }
+
                 // ── Voyager fork activation (read lock first, write only if needed) ──
                 //
                 // L2 pre-flight gate (2026-04-25 incident response): refuse to

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/chain_queries.rs
+++ b/crates/sentrix-core/src/chain_queries.rs
@@ -197,6 +197,20 @@ impl Blockchain {
     pub fn chain_stats(&self) -> serde_json::Value {
         // circulating_supply = total_minted − total_burned (in sentri units)
         let circulating_sentri = self.total_minted.saturating_sub(self.accounts.total_burned);
+        // Surface the consensus mode the runtime is actually using.
+        // `voyager_activated` is the persistent on-chain flag set when
+        // activate_voyager() runs; `evm_activated` mirrors for EVM. RPC
+        // consumers (block explorers, wallets, indexers) need this to
+        // know whether to expect BFT justifications on blocks + DPoS
+        // proposer rotation. Pre-2026-04-25-evening, /chain/info had
+        // no consensus-mode field — clients had to infer mode from
+        // block-level justification presence, which was awkward and
+        // wrong for the Pioneer→Voyager transition window.
+        let consensus_mode = if self.voyager_activated {
+            "voyager"
+        } else {
+            "pioneer"
+        };
         serde_json::json!({
             "height": self.height(),
             "total_blocks": self.height() + 1, // true height from block index, not window length
@@ -212,6 +226,10 @@ impl Blockchain {
             // Expose window metadata so callers know whether the result covers the full chain history
             "window_start_block": self.chain_window_start(),
             "window_is_partial": self.chain_window_start() > 0,
+            // Consensus + EVM mode flags (added v2.1.28 post-Voyager activation)
+            "consensus_mode": consensus_mode,
+            "voyager_activated": self.voyager_activated,
+            "evm_activated": self.evm_activated,
         })
     }
 }

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/jsonrpc/sentrix.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/sentrix.rs
@@ -184,7 +184,7 @@ async fn sentrix_get_validator_set(state: &SharedState) -> DispatchResult {
             .collect();
 
         Ok(json!({
-            "consensus": "PoA",
+            "consensus": if bc.voyager_activated { "BFT" } else { "PoA" },
             "active_count": active_count,
             "total_count": bc.authority.validators.len(),
             "total_active_stake": "0x0",
@@ -337,11 +337,12 @@ async fn sentrix_get_bft_status(state: &SharedState) -> DispatchResult {
         Err(_) => return Err((-32603, "chain empty".into())),
     };
     let next_height = latest.index.saturating_add(1);
-    let consensus = if sentrix_core::blockchain::Blockchain::is_voyager_height(next_height) {
-        "BFT"
-    } else {
-        "PoA"
-    };
+    // Use runtime voyager_activated flag, NOT is_voyager_height (env-var
+    // fork-height check). Mainnet activated Voyager via chain.db flag
+    // while VOYAGER_FORK_HEIGHT stayed at u64::MAX as operational safety
+    // — the fork-height check would wrongly report PoA. (next_height is
+    // still used downstream for proposer selection, kept in scope.)
+    let consensus = if bc.voyager_activated { "BFT" } else { "PoA" };
     // Live BFT round/phase state is owned by the validator loop's
     // BftEngine and not yet published into Blockchain. For now we expose
     // the chain-level finality view (last block carrying a BFT

--- a/crates/sentrix-rpc/src/routes/chain.rs
+++ b/crates/sentrix-rpc/src/routes/chain.rs
@@ -45,8 +45,15 @@ pub(super) async fn get_finalized_height(
             }));
         }
     };
-    let next_height = latest.index.saturating_add(1);
-    let bft_active = sentrix_core::blockchain::Blockchain::is_voyager_height(next_height);
+    // BFT activity follows the runtime `voyager_activated` flag, NOT the
+    // `is_voyager_height` fork-height check. `is_voyager_height` only
+    // returns true when `next_height >= VOYAGER_FORK_HEIGHT` env var,
+    // but mainnet activated Voyager via the chain.db `voyager_activated`
+    // flag (set by activate_voyager()) while VOYAGER_FORK_HEIGHT remained
+    // at u64::MAX as an operational safety. The fork-height check would
+    // wrongly report `consensus=PoA` while runtime is actually BFT.
+    let bft_active = bc.voyager_activated;
+    let _ = latest.index.saturating_add(1); // formerly used for is_voyager_height
 
     // Fallback to latest when BFT is active but no justified block sits
     // in the sliding window yet. Mirrors `sentrix_getFinalizedHeight`

--- a/crates/sentrix-rpc/src/routes/ops.rs
+++ b/crates/sentrix-rpc/src/routes/ops.rs
@@ -21,9 +21,16 @@ pub(super) static START_TIME: std::sync::OnceLock<std::time::Instant> = std::syn
 pub static PEER_BLOCK_SAVE_FAILS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
-pub(super) async fn root() -> Json<serde_json::Value> {
-    let chain_id = sentrix_core::blockchain::get_chain_id();
-    let consensus = if chain_id == 7119 { "PoA" } else { "BFT" };
+pub(super) async fn root(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    // Read the runtime consensus state from chain.db's persistent
+    // voyager_activated flag rather than the chain_id heuristic. The
+    // old `chain_id == 7119 ? PoA : BFT` mapping was wrong post-2026-04-25
+    // when mainnet (7119) activated Voyager. RPC consumers (block
+    // explorers, wallets) need accurate consensus mode.
+    let bc = state.read().await;
+    let chain_id = bc.chain_id;
+    let consensus = if bc.voyager_activated { "BFT" } else { "PoA" };
+    drop(bc);
     Json(serde_json::json!({
         "name": "Sentrix",
         "version": env!("CARGO_PKG_VERSION"),
@@ -79,7 +86,8 @@ pub async fn sentrix_status(State(state): State<SharedState>) -> Json<serde_json
         .as_secs();
     let bc = state.read().await;
     let chain_id = bc.chain_id;
-    let consensus = if chain_id == 7119 { "PoA" } else { "BFT" };
+    // Same fix as root() — runtime flag, not chain_id heuristic.
+    let consensus = if bc.voyager_activated { "BFT" } else { "PoA" };
     let latest = bc.latest_block().ok().cloned();
     let (latest_height, latest_hash, latest_timestamp) = latest
         .as_ref()

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.28"
+version = "2.1.29"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.27"
+version = "2.1.28"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.26"
+version = "2.1.27"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
User flagged /sentrix_status still showing PoA after Voyager active. Multiple RPC handlers hardcoded chain_id==7119?PoA:BFT or used is_voyager_height (env-fork check). All now read bc.voyager_activated. v2.1.29.