### PR TITLE
chore(docs): depersonalize public docs — remove internal infra refs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,4 +50,4 @@ Check ONE:
 
 ## Related
 
-<!-- Issue numbers, prior PRs, design docs in founder-private/, etc. -->
+<!-- Issue numbers, prior PRs, design docs in internal operator docs, etc. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added — peer auto-discovery (L1 + L2)
 
-- **L2 pre-flight peer-mesh gate (#298).** Validator loop refuses to flip into Voyager BFT mode unless `peer_count >= active_set.len() - 1`. The 2026-04-25 livelock would have been caught at every VPS — VPS5 had only 1 libp2p peer (VPS1) at activation, gate would have held the flip until L1 self-healing converged the mesh. Strict `SENTRIX_FORCE_BFT_INSUFFICIENT_PEERS=="1"` env override (rejects empty string + non-1 values to close the misconfiguration footgun).
+- **L2 pre-flight peer-mesh gate (#298).** Validator loop refuses to flip into Voyager BFT mode unless `peer_count >= active_set.len() - 1`. The 2026-04-25 livelock would have been caught at every VPS — Beacon node had only 1 libp2p peer (Foundation node) at activation, gate would have held the flip until L1 self-healing converged the mesh. Strict `SENTRIX_FORCE_BFT_INSUFFICIENT_PEERS=="1"` env override (rejects empty string + non-1 values to close the misconfiguration footgun).
 - **L1 multiaddr advertisement (#300, #301, #302).** New gossipsub topic `sentrix/validator-adverts/1`. Each validator broadcasts a signed `MultiaddrAdvertisement` on startup + every 10 minutes (sequence persisted to `<data_dir>/.advert-sequence` so restart doesn't reset). Receivers verify against on-chain stake registry pubkey, store latest-by-sequence in a 4096-entry LRU cache (lowest-sequence eviction). Periodic dial-tick (every 30s) reads `active_set` and dials any cached members not currently peered. Self-healing mesh from a single bootstrap peer; manual `--peers` lists no longer required at scale.
 
 ### Fixed
@@ -62,7 +62,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Voyager state on chain.db (stake_registry, epoch_manager, voyager_activated=true) intact but unused while Pioneer runs
 - Next Voyager activation attempt blocked on V2 main.rs Steps 4-5 implementation + testnet activation rehearsal
 
-Full incident analysis at `founder-private/incidents/2026-04-25-voyager-activation-bft-livelock.md`.
+Full incident analysis at `internal operator runbook`.
 
 ---
 
@@ -73,13 +73,13 @@ Full incident analysis at `founder-private/incidents/2026-04-25-voyager-activati
 ### Added (#288)
 
 - **`SENTRIX_LEGACY_VALIDATION_HEIGHT` env var.** When set on a validator, the strict `CRITICAL #1e: state_root mismatch` check in `apply_block_pass2` is downgraded to warn-only for blocks with `index < cutoff`. The block's stamped state_root is retained (so block hash chain stays intact), the `divergence_tracker` still records the mismatch (visible in metrics, just doesn't fire the rate-alarm), and apply continues normally. Above the cutoff, strict reject behaviour is unchanged.
-- **Test harness `test_legacy_validation_height_branches`** in `crates/sentrix-core/tests/fork_determinism.rs` documents the three behavioural branches (env unset = strict; env set & block.index < cutoff = tolerate; env set & block.index ≥ cutoff = strict). Marked `#[ignore]` because reproducing strict #1e in unit tests requires blocks past `STATE_ROOT_FORK_HEIGHT` (100,000); operator-driven manual verification via `apply_canonical_block_to_forensic` against the VPS5 forensic backup is the integration-level test (verified empirically: env=600000 → tolerate, env=100000 → strict, env unset → strict).
+- **Test harness `test_legacy_validation_height_branches`** in `crates/sentrix-core/tests/fork_determinism.rs` documents the three behavioural branches (env unset = strict; env set & block.index < cutoff = tolerate; env set & block.index ≥ cutoff = strict). Marked `#[ignore]` because reproducing strict #1e in unit tests requires blocks past `STATE_ROOT_FORK_HEIGHT` (100,000); operator-driven manual verification via `apply_canonical_block_to_forensic` against the Beacon node forensic backup is the integration-level test (verified empirically: env=600000 → tolerate, env=100000 → strict, env unset → strict).
 
 ### Closed by Path B vs the alternative
 
 The other path considered was a chain.db rebuild via genesis-replay — produce a clean canonical chain.db with v2.1.23-correct state_roots, halt all 4 mainnet validators, replace chain.db, restart on v2.1.24, then activate Voyager. The chain.db rebuild path was rejected because it changes block hashes for affected heights → all subsequent blocks' `previous_hash` chain breaks → effectively a chain reorganisation/restart from the first patched height, breaking external services that cache block hashes (block explorer, RPC clients). Multi-day operation. Path B preserves block hashes and unblocks Phase 1 within days.
 
-Full design + trade-off analysis at `founder-private/architecture/PHASE_1_LEGACY_COMPAT_DESIGN.md`. RCA evidence trail at `founder-private/incidents/2026-04-25-268-root-cause-pinned.md`.
+Full design + trade-off analysis at `internal operator runbook`. RCA evidence trail at `internal operator runbook`.
 
 ### Operational rollout this release enables
 
@@ -105,7 +105,7 @@ Full design + trade-off analysis at `founder-private/architecture/PHASE_1_LEGACY
 
 ### Honest framing
 
-This release closes **one** disk-roundtrip divergence class. Mainnet's specific `#268` symptom (v2.1.21 canary on VPS5 with non-empty rsync'd chain.db, immediate `#1e` mismatch against v2.1.15 peers) is **not** explained by this fix and remains under investigation. v2.1.23 ships the protection where it applies + locks the regression test.
+This release closes **one** disk-roundtrip divergence class. Mainnet's specific `#268` symptom (v2.1.21 canary on Beacon node with non-empty rsync'd chain.db, immediate `#1e` mismatch against v2.1.15 peers) is **not** explained by this fix and remains under investigation. v2.1.23 ships the protection where it applies + locks the regression test.
 
 ### Follow-up tracked
 
@@ -130,13 +130,13 @@ This release closes **one** disk-roundtrip divergence class. Mainnet's specific 
 
 ### Designed against
 
-- `founder-private/architecture/FORK_SEQUENCE_PREIMPL_SCAN_2026-04-24.md` — Q1 (#268 hypothesis re-rank), Q2 point 1 (Phase 1 hard-gate). The scan ranks PR #273's `txid_index` as a top suspect for #268 but rules it out via the commit-message disclaimer; the actual top hypothesis is `init_trie` backfill firing on reload because committed root nodes are GC'd by subsequent inserts. The ignored test in this release validates that hypothesis at unit-test scale.
+- `internal operator runbook` — Q1 (#268 hypothesis re-rank), Q2 point 1 (Phase 1 hard-gate). The scan ranks PR #273's `txid_index` as a top suspect for #268 but rules it out via the commit-message disclaimer; the actual top hypothesis is `init_trie` backfill firing on reload because committed root nodes are GC'd by subsequent inserts. The ignored test in this release validates that hypothesis at unit-test scale.
 
 ---
 
 ## [2.1.21] — 2026-04-24 — Observability + startup perf (no consensus change)
 
-> **🚨 DEPLOYMENT FROZEN** — 2026-04-24 Beacon canary (VPS5) triggered immediate `CRITICAL #1e: state_root mismatch` against v2.1.15 peers even with fork envs unset. Rolled back to v2.1.15; divergence persisted through 3 rsync recovery attempts. Root cause remains unresolved — see GitHub issue #268. Do NOT deploy v2.1.21 to any mainnet VPS until the issue closes.
+> **🚨 DEPLOYMENT FROZEN** — 2026-04-24 Beacon canary (Beacon node) triggered immediate `CRITICAL #1e: state_root mismatch` against v2.1.15 peers even with fork envs unset. Rolled back to v2.1.15; divergence persisted through 3 rsync recovery attempts. Root cause remains unresolved — see GitHub issue #268. Do NOT deploy v2.1.21 to any mainnet VPS until the issue closes.
 
 Maintenance patch collecting three bite-sized improvements merged over the 2026-04-24 session. No consensus, wire, or storage format change; `VOYAGER_*_HEIGHT` env vars remain the sole activation gates for Voyager behaviour.
 
@@ -158,7 +158,7 @@ Maintenance patch collecting three bite-sized improvements merged over the 2026-
 
 ### Diagnostic findings from this session
 
-Local repro of #268 against a clean 1 GB mainnet `chain.db` snapshot rsynced from VPS1 (via 28 s halt window):
+Local repro of #268 against a clean 1 GB mainnet `chain.db` snapshot rsynced from Foundation node (via 28 s halt window):
 
 - v2.1.20 release binary + no fork envs → clean startup, height 506078 loaded, 4 validators detected, idle.
 - v2.1.20 release binary + fork envs (`VOYAGER_FORK_HEIGHT=502000` / `VOYAGER_REWARD_V2_HEIGHT=502100`, both below current) → same clean startup.
@@ -402,7 +402,7 @@ Patch release bundling three network-layer improvements. Zero consensus impact �
 
 ## [2.1.9] — 2026-04-23 — Divergence rate-alarm for silent state_root drift
 
-Patch release over v2.1.8. Single change: adds a rate-limited LOUD alarm when a validator rejects peer blocks at a sustained rate — motivated by the 2026-04-23 mainnet fork investigation, where VPS3 had been silently rejecting peer blocks for ≥4 hours (~4000 state_root mismatches per hour) without any operator signal. The existing per-event `CRITICAL #1e` log line was accurate but emitted at ~1/s during real divergence, filling journald rotation so the earliest mismatches were evicted before the operator checked.
+Patch release over v2.1.8. Single change: adds a rate-limited LOUD alarm when a validator rejects peer blocks at a sustained rate — motivated by the 2026-04-23 mainnet fork investigation, where Core node had been silently rejecting peer blocks for ≥4 hours (~4000 state_root mismatches per hour) without any operator signal. The existing per-event `CRITICAL #1e` log line was accurate but emitted at ~1/s during real divergence, filling journald rotation so the earliest mismatches were evicted before the operator checked.
 
 ### Added
 
@@ -428,11 +428,11 @@ Patch release over v2.1.7. Adds exactly one change: retuned the validator livene
 
 ## [2.1.7] — 2026-04-22 — Post-fork hardening (3-way state_root fork follow-up)
 
-Post-mortem release after the 2026-04-21 mainnet 3-way state_root fork. The fork itself was recovered ops-side via frozen-rsync of VPS1 canonical chain.db to VPS2 + VPS3 (see `founder-private/incidents/2026-04-21-mainnet-3way-fork.md`). This release closes the code-level gaps that let the incident develop silently on the v2.1.6 binary after a pre-v2.1.5 `state_import` had already damaged VPS3's trie.
+Post-mortem release after the 2026-04-21 mainnet 3-way state_root fork. The fork itself was recovered ops-side via frozen-rsync of Foundation node canonical chain.db to Treasury node + Core node (see `internal operator runbook`). This release closes the code-level gaps that let the incident develop silently on the v2.1.6 binary after a pre-v2.1.5 `state_import` had already damaged Core node's trie.
 
 ### Fork follow-ups
 
-- **fix(trie): boot-time integrity check — refuse to start on orphan trie references** (`crates/sentrix-trie/src/tree.rs`, `crates/sentrix-core/src/blockchain.rs`). New `SentrixTrie::verify_integrity()` walks the current root and fails fast if any referenced node or leaf-value is missing from `trie_nodes` / `trie_values`. Wired into `Blockchain::init_trie`: hard-fail past `STATE_ROOT_FORK_HEIGHT`, warn-only below. In the 2026-04-21 incident, VPS3's chain.db had a top-level root that existed but referenced an orphaned subtree, so the existing backfill-mismatch and missing-root-node guards didn't fire — it just produced `state_root=None` blocks that strict peers then rejected. PR #206.
+- **fix(trie): boot-time integrity check — refuse to start on orphan trie references** (`crates/sentrix-trie/src/tree.rs`, `crates/sentrix-core/src/blockchain.rs`). New `SentrixTrie::verify_integrity()` walks the current root and fails fast if any referenced node or leaf-value is missing from `trie_nodes` / `trie_values`. Wired into `Blockchain::init_trie`: hard-fail past `STATE_ROOT_FORK_HEIGHT`, warn-only below. In the 2026-04-21 incident, Core node's chain.db had a top-level root that existed but referenced an orphaned subtree, so the existing backfill-mismatch and missing-root-node guards didn't fire — it just produced `state_root=None` blocks that strict peers then rejected. PR #206.
 - **fix(cli): guard `sentrix state import` and `sentrix chain reset-trie` against non-genesis chain** (`bin/sentrix/src/main.rs`). Both commands now refuse on `height > 0` with an error pointing at rsync-from-peer as the correct recovery. Env-var escape hatch for devnet (`SENTRIX_ALLOW_STATE_IMPORT_ON_NONZERO_HEIGHT=1` / `SENTRIX_ALLOW_RESET_TRIE_ON_NONZERO_HEIGHT=1`), intentionally ugly names. PR #207.
 - **fix(network): boundary-reject state_root=None blocks past fork height** (`crates/sentrix-network/src/libp2p_node.rs`). New `block_boundary_reject_reason()` helper rejects obvious-bad blocks at network ingest (both RequestResponse and Gossipsub paths) before spawning an apply task. Moves the existing v2.1.5 execution-time state_root guard earlier in the pipeline — same blocks rejected, just without contending for the chain write lock and without the flood of CRITICAL logs that previously filled the journald cap within hours during an incident. PR #208.
 
@@ -487,7 +487,7 @@ Post-mortem release after the 2026-04-21 mainnet 3-way state_root fork. The fork
   `sentrix state import` + PR #187's auto-reset therefore rebuilt a
   trie whose state_root silently disagreed with peers, and every block
   it produced tripped the #1e strict-reject guard. This was the exact
-  shape of the 2026-04-21 mainnet freeze (VPS2 drifted ~45 SRX/min
+  shape of the 2026-04-21 mainnet freeze (Treasury node drifted ~45 SRX/min
   from canonical after state-import; chain halted).
 
   We cannot align the two paths without changing consensus history
@@ -550,10 +550,10 @@ Post-mortem release after the 2026-04-21 mainnet 3-way state_root fork. The fork
   `state_root = None` while peers with working tries produced
   `state_root = Some(...)` — the hashes diverge and the chain forks.
   Mainnet stalled at block 100,004 on 2026-04-20 via exactly this path:
-  VPS3's trie had a missing node (`24afba5f…`) so block 100,004 got
-  saved with `state_root = null`, VPS1 had a functional trie and block
-  100,004 with `state_root = Some(…)` → different block hashes → VPS1
-  rejected VPS3's block 100,005 as "invalid previous hash". Post-fix,
+  Core node's trie had a missing node (`24afba5f…`) so block 100,004 got
+  saved with `state_root = null`, Foundation node had a functional trie and block
+  100,004 with `state_root = Some(…)` → different block hashes → Foundation node
+  rejected Core node's block 100,005 as "invalid previous hash". Post-fix,
   any node whose trie cannot init past fork height refuses to start —
   a silently diverging validator is worse for the network than an
   offline one. Below fork height the old hash format ignores
@@ -742,7 +742,7 @@ one mainnet performance improvement, and one additive RPC endpoint.
 fast-deploy workflow.** ~60 PRs since v2.0.0. Most of this release is
 C-/H-/M-level security fixes from the Sprint 1 audit; on top of that,
 Sprint 2 RPC adds event log / fee RPC so MetaMask and dApp indexers
-work natively, and deploy moves from CI to `fast-deploy.sh` on VPS4.
+work natively, and deploy moves from CI to `fast-deploy.sh` on build host.
 
 ### Added
 - **Ethereum event log + fee RPC (Sprint 2)** (PR #144) — `eth_getLogs`,
@@ -767,7 +767,7 @@ work natively, and deploy moves from CI to `fast-deploy.sh` on VPS4.
 - **Genesis externalization** (PR #104, #105) — `--genesis <path>` CLI
   flag + embedded mainnet default; `Blockchain::new` now driven from
   Genesis TOML. Testnets no longer need a custom binary.
-- **fast-deploy.sh primary deploy path** (PR #139) — builds on VPS4,
+- **fast-deploy.sh primary deploy path** (PR #139) — builds on build host,
   uploads binary via wg1 SCP, rolling restart with bounded health
   check. ~3–5 min vs ~10–12 min for CI cold cargo cache. CI `deploy`
   job disabled (`if: false`); CI still runs tests for audit trail.
@@ -783,8 +783,8 @@ work natively, and deploy moves from CI to `fast-deploy.sh` on VPS4.
   `native_token` ("SRX") so wallets can discover chain semantics.
 - **fast-deploy builds in bullseye container** (PR #141) — runs inside
   `rust:1.95-bullseye` (glibc 2.31) so binaries work on every target
-  regardless of VPS4 host OS. Fixes crash-loop on commit e49e01d where
-  a VPS4 24.04 native build (glibc 2.39) failed to load on VPS1/VPS2.
+  regardless of build host host OS. Fixes crash-loop on commit e49e01d where
+  a build host 24.04 native build (glibc 2.39) failed to load on Foundation node/Treasury node.
 - **chain_id consolidation** (PR #104) — removed hardcoded `CHAIN_ID`
   fallback in EVM; all call sites must pass `chain_id`. `MAX_SUPPLY`
   constants deduped and imported from `blockchain` module.
@@ -991,14 +991,14 @@ Voyager EVM (Phase 2b). Full Ethereum compatibility.
 - **`activate_evm()`** wired in main validator loop at fork height
 - **BFT round catch-up protocol** — `RoundStatus` gossip lets returning validators learn current (height, round)
 - **BFT propose-after-advance-round** — validator that becomes proposer after timeout/skip immediately proposes block
-- **Multi-validator BFT testnet** (4 validators on VPS3) with 3/4 fault tolerance
+- **Multi-validator BFT testnet** (4 validators on Core node) with 3/4 fault tolerance
 - **Wallet encryption CLI** — `wallet encrypt`/`decrypt`, `--validator-keystore`, password from env or prompt
 - **CI/CD rolling restart** — validators restarted one at a time during deploys; chain never stops producing blocks
 - **CI/CD covers testnet validators** — `sentrix-testnet-val1..4` services auto-updated
 - **Robust health check** — 5 retries × 60s windows with cluster-max delta tolerance
 - **testnet-scan / testnet-explorer** subdomains added to nginx
 - **Single nginx server block** consolidates all 4 testnet subdomains; fixes MetaMask `/rpc` path bug
-- **Per-IP rate limiter** bumped to 20 connections (handles VPS2 hosting 5 validators on one IP)
+- **Per-IP rate limiter** bumped to 20 connections (handles Treasury node hosting 5 validators on one IP)
 - **SRC-20 token standard** verified with deployed test contract
 - **TPS benchmark scripts** (Python) for testnet load testing
 - 519 tests, clippy clean, cargo fmt applied repo-wide
@@ -1048,7 +1048,7 @@ Voyager DPoS + BFT. The consensus upgrade.
 - BFT consensus: Tendermint-style propose/prevote/precommit with 2/3+1 stake-weighted finality
 - BFT message types in P2P layer (proposal, prevote, precommit broadcast)
 - Fork transition: VOYAGER_FORK_HEIGHT env var (default u64::MAX, mainnet safe)
-- Testnet live: chain_id 7120, port 9545, VPS3
+- Testnet live: chain_id 7120, port 9545, Core node
 - REST endpoints: /staking/validators, /staking/delegations, /staking/unbonding, /epoch/current, /epoch/history
 - Staking tx types: RegisterValidator, Delegate, Undelegate, Redelegate, Unjail, SubmitEvidence
 - Block fields: round + justification (serde default, backward compat with Pioneer blocks)
@@ -1069,7 +1069,7 @@ Pioneer release. PoA chain live with 7 validators across 3 VPS, 141K+ blocks, 11
 - 7 validators running across 3 geographically separate VPS (full mesh peering)
 - CI/CD pipeline deploying to all 3 VPS with ordered stop/start and health checks
 - P0 security hardening: libp2p peer limits, per-IP rate limiting, legacy TCP deprecated
-- VPS3 (Sentrix Core) added as 7th validator
+- Core node (Sentrix Core) added as 7th validator
 - Chain height 141,000+, zero downtime incidents since stabilization
 - 11 security audit rounds completed (94 findings, 78 fixed, score 8.3/10)
 - Full documentation suite (20 files across architecture, security, operations, tokenomics, roadmap)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, i
 
 - **v2.1.25** — MDBX storage, 1s blocks, 5000 tx/block capacity, EVM on testnet
 - **551+ tests**, clippy clean, 11 security audit rounds
-- **4 validators** across 3 nodes (Foundation, Treasury, Core, Beacon), VPS4 `fast-deploy.sh` rolling deploy
+- **4 validators** across 3 nodes (Foundation, Treasury, Core, Beacon), build host `fast-deploy.sh` rolling deploy
 
 ## Features
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,15 +17,15 @@ Sentrix follows [Semantic Versioning](https://semver.org/):
 6. **Tag release** — `git tag -a vX.Y.Z -m "vX.Y.Z"` then `git push origin vX.Y.Z`
 7. **GitHub Release** — create release from tag with changelog excerpt
 8. **Deploy** — CI/CD `deploy` job is **disabled**. Run
-   `./scripts/fast-deploy.sh mainnet` from VPS4 (or `testnet` for
+   `./scripts/fast-deploy.sh mainnet` from build host (or `testnet` for
    testnet) to ship the binary; CI runs tests only. Then check health
    on all 3 VPS.
 
 ## Deployment
 
-Primary path: **`scripts/fast-deploy.sh`** (runs from VPS4). Builds
+Primary path: **`scripts/fast-deploy.sh`** (runs from build host). Builds
 inside a `rust:1.95-bullseye` container (glibc 2.31, compatible with
-both 22.04 and 24.04 targets), uploads the binary to VPS1/VPS2/VPS3
+both 22.04 and 24.04 targets), uploads the binary to Foundation node/Treasury node/Core node
 via wg1 SCP, and does a rolling restart with a bounded health check.
 ~3–5 minutes end-to-end.
 
@@ -51,4 +51,4 @@ bypass of the normal regression gate.
 1. Branch from `main`
 2. Fix + test
 3. PR with `fix(scope):` commit message — auto-merge on green CI
-4. Run `./scripts/fast-deploy.sh mainnet` from VPS4 after merge
+4. Run `./scripts/fast-deploy.sh mainnet` from build host after merge

--- a/benchmark/reset_testnet.sh
+++ b/benchmark/reset_testnet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # reset_testnet.sh — Full testnet reset with 4 validators properly registered.
-# Run on the testnet host (e.g. VPS3 as the service user).
+# Run on the testnet host (e.g. Core node as the service user).
 #
 # Configuration via env vars (NEVER hardcode in this file):
 #   SENTRIX_ADMIN_KEY  — admin private key (raw hex, no 0x prefix)

--- a/docs/operations/CI_CD.md
+++ b/docs/operations/CI_CD.md
@@ -2,14 +2,14 @@
 
 GitHub Actions runs the **test** job on every push and PR. The
 **deploy** job is **disabled** — production binaries ship via
-`scripts/fast-deploy.sh` from VPS4, not from CI.
+`scripts/fast-deploy.sh` from build host, not from CI.
 
 ## Pipeline
 
 ```
 Push / PR  →  TEST  →  (deploy disabled)
                        ↓
-                  fast-deploy.sh from VPS4 (manual)
+                  fast-deploy.sh from build host (manual)
 ```
 
 ### Test Job (every push + PR)
@@ -23,16 +23,16 @@ Push / PR  →  TEST  →  (deploy disabled)
 The artifact is **not** auto-deployed; it exists so reviewers can pull
 the exact CI binary if they need to reproduce a test result.
 
-## Deploy: `scripts/fast-deploy.sh` (from VPS4)
+## Deploy: `scripts/fast-deploy.sh` (from build host)
 
-VPS4 (the dev/edge host) is the canonical deploy origin. The script
+build host (the dev/edge host) is the canonical deploy origin. The script
 builds inside a `rust:1.95-bullseye` container (glibc 2.31, compatible
 with both Ubuntu 22.04 and 24.04 production targets), uploads the
-binary to VPS1/VPS2/VPS3 over the wg1 WireGuard mesh, and does a
+binary to Foundation node/Treasury node/Core node over the wg1 WireGuard mesh, and does a
 rolling restart with a bounded health check.
 
 ```bash
-# From VPS4
+# From build host
 ./scripts/fast-deploy.sh mainnet          # asks for confirmation
 ./scripts/fast-deploy.sh testnet          # silent (testnet docker)
 
@@ -50,11 +50,11 @@ The script stops validators in reverse order and starts them in forward
 order:
 
 ```
-stop:  VPS3 → VPS2 → VPS1
-start: VPS1 → VPS2 → VPS3
+stop:  Core node → Treasury node → Foundation node
+start: Foundation node → Treasury node → Core node
 ```
 
-Primary (VPS1, Foundation) finishes processing in-flight blocks last and
+Primary (Foundation node, Foundation) finishes processing in-flight blocks last and
 is back up first so peers reconnect quickly. Wrong order can produce
 orphan blocks — learned the hard way.
 
@@ -81,8 +81,8 @@ This is rare — `fast-deploy.sh` is the default path.
 ## Design Choices
 
 - **Binary artifacts, not Docker** for mainnet. All nodes get the exact
-  same compiled binary from the VPS4 build. No registry dependency.
-  (Testnet runs in docker on VPS4 since 2026-04-23.)
+  same compiled binary from the build host build. No registry dependency.
+  (Testnet runs in docker on build host since 2026-04-23.)
 - **CI test, not CI deploy.** Auto-deploy + manual hot-deploy creates a
   race where the same commit ships twice. Disabled in favour of a
   single canonical path.

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -103,10 +103,10 @@ sudo systemctl daemon-reload && sudo systemctl enable --now sentrix-node
 ## Canonical Deploy Path
 
 Production binary deploys go through **`scripts/fast-deploy.sh` from
-VPS4** (see [CI_CD.md](CI_CD.md) and [RELEASE.md](../../RELEASE.md)).
+build host** (see [CI_CD.md](CI_CD.md) and [RELEASE.md](../../RELEASE.md)).
 The CI/CD `deploy` job is disabled; CI runs tests only. The script
 builds once in a `rust:1.95-bullseye` container, ships the same byte-
-identical binary to VPS1/VPS2/VPS3 over wg1, and does a rolling
+identical binary to Foundation node/Treasury node/Core node over wg1, and does a rolling
 restart with a bounded health check.
 
 For an independent operator running a single validator outside the

--- a/docs/operations/EMERGENCY_ROLLBACK.md
+++ b/docs/operations/EMERGENCY_ROLLBACK.md
@@ -21,7 +21,7 @@ override that forces the binary back into Pioneer PoA without a
 re-deploy:
 
 ```bash
-# On every validator host (VPS1/VPS2/VPS3), via the systemd
+# On every validator host (Foundation node/Treasury node/Core node), via the systemd
 # EnvironmentFile (mode 600, sentrix:sentrix):
 sudo bash -c 'echo "SENTRIX_FORCE_PIONEER_MODE=1" \
   >> /etc/sentrix/sentrix-<unit>.env'
@@ -99,7 +99,7 @@ halted. See [STATE_EXPORT.md](STATE_EXPORT.md) for why
 `sentrix state export/import` is **not** the right path for a
 post-genesis chain.
 
-The full procedure lives in `founder-private/runbooks/state-divergence-recovery.md`
+The full procedure lives in `internal operator runbook`
 (internal). Outline:
 
 1. Pick the canonical validator (matches the most peers; longest valid

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -32,7 +32,7 @@
 
 Testnet tokens have no real value. Use the faucet to get test SRX.
 
-Testnet runs in Docker on VPS4 (`/opt/sentrix-testnet-docker/`) since
+Testnet runs in Docker on build host (`/opt/sentrix-testnet-docker/`) since
 the 2026-04-23 migration; fresh genesis at chain_id 7120, current
 height ~200K, binary v2.1.24 (`md5 a25f9d771648f6c851a6ee11867fe958`).
 

--- a/docs/operations/STATE_EXPORT.md
+++ b/docs/operations/STATE_EXPORT.md
@@ -11,7 +11,7 @@ Backup, restore, and migrate Sentrix chain state.
 > nodes halted; see
 > [EMERGENCY_ROLLBACK.md § 3](EMERGENCY_ROLLBACK.md#3-state-recovery-chaindb-restore)
 > and the internal
-> `founder-private/runbooks/state-divergence-recovery.md`.
+> `internal operator runbook`.
 >
 > Export remains useful for read-only inspection, archival snapshots,
 > and bootstrapping a **fresh** chain (genesis import). The commands

--- a/docs/operations/VALIDATORS.md
+++ b/docs/operations/VALIDATORS.md
@@ -1,15 +1,15 @@
 # Validators
 
-4 validators across 3 VPS, round-robin PoA (v2.1.25).
+4 active validators in DPoS+BFT consensus (Voyager, v2.1.30+).
 
 ## Current Set
 
-| Slot | Name | Address prefix | VPS | Service |
-|------|------|---------------|-----|---------|
-| 0 | Sentrix Treasury   | `0x0804...` | VPS2 | sentrix-val5    |
-| 1 | Sentrix Foundation | `0x753f...` | VPS1 | sentrix-node    |
-| 2 | Sentrix Core       | `0x87c9...` | VPS3 | sentrix-core    |
-| 3 | Sentrix Beacon     | `0x...`     | VPS2 | sentrix-beacon  |
+| Slot | Name | Address prefix | Role |
+|------|------|---------------|------|
+| 0 | Sentrix Treasury   | `0x0804...` | Treasury validator |
+| 1 | Sentrix Foundation | `0x753f...` | Foundation validator |
+| 2 | Sentrix Core       | `0x87c9...` | Core validator |
+| 3 | Sentrix Beacon     | `0x4cad...` | Beacon validator |
 
 Sorted by address. Block producer = `height % 4`.
 

--- a/docs/operations/VALIDATOR_ONBOARDING.md
+++ b/docs/operations/VALIDATOR_ONBOARDING.md
@@ -11,7 +11,7 @@ blocks when it's your turn.
 This doc assumes you can read a Linux manpage, can use systemd, and
 have shell access to a server under your control. No specific cloud
 provider is required, no specific OS version is required, no "join
-Satya's private fleet" is required.
+the operator's private fleet" is required.
 
 ---
 
@@ -63,7 +63,7 @@ Minimum (reference mainnet today):
 Any mainstream 64-bit Linux works. **We have deployed on Ubuntu 22.04
 and 24.04 in production; the consensus binary is OS-deterministic
 across kernel, glibc, and CPU family** — see the
-2026-04-23 VPS3 RCA addendum #9 in the project's incident archive for
+2026-04-23 Core node RCA addendum #9 in the project's incident archive for
 the cross-host determinism test result.
 
 Open inbound ports:
@@ -278,7 +278,7 @@ snapshot.
 ### Your state diverges
 
 Described in `docs/operations/DEPLOYMENT.md` and the incident archive
-at `founder-private/runbooks/state-divergence-recovery.md`. The short
+at `internal operator runbook`. The short
 version: **frozen-rsync** your chain.db from a peer you trust, with
 ALL validators halted. Do not use `sentrix state export/import` on
 a post-genesis chain — v2.1.5 + later refuse to start on a keystore
@@ -299,7 +299,7 @@ on Voyager you may be jailed and need an unjail op.
 - Operator chat: see the pinned link in the repo README.
 
 **This doc describes a chain that supports many independent operators
-on diverse hosts and OS versions. If any step above assumes Satya's
-infrastructure or invokes a VPS1/VPS2/VPS3 label in a way that isn't
+on diverse hosts and OS versions. If any step above assumes the operator's
+infrastructure or invokes a Foundation node/Treasury node/Core node label in a way that isn't
 marked as a historical reference, that's a bug in the doc — please
 file a PR.**

--- a/docs/roadmap/CHANGELOG.md
+++ b/docs/roadmap/CHANGELOG.md
@@ -61,5 +61,5 @@ Security: 11 audit rounds (94 findings, 78 fixed). Zero `unsafe`. No-panic CI en
 | #74 | Public repo cleanup |
 | #79 | H1/H2 fork fix |
 | #80 | CI/CD deploy order fix |
-| #81 | VPS3 + 3-VPS pipeline |
+| #81 | Core node + 3-VPS pipeline |
 | #82 | P0 security hardening |

--- a/docs/security/PENTEST_RESULTS.md
+++ b/docs/security/PENTEST_RESULTS.md
@@ -1,6 +1,6 @@
 # Penetration Test Results
 
-Tested against live production node (VPS1) on 2026-04-15. 6 test suites, all non-destructive.
+Tested against live production node (Foundation node) on 2026-04-15. 6 test suites, all non-destructive.
 
 Node started at height ~140,282. After all tests: height 140,811. Chain never stalled, never crashed, kept producing blocks throughout.
 

--- a/scripts/deploy-validator.sh
+++ b/scripts/deploy-validator.sh
@@ -3,7 +3,7 @@
 #
 # Works for ANY operator running ANY number of Sentrix validators on
 # ANY mix of hosts. Unlike `fast-deploy.sh` (which is the Satya-fleet
-# orchestrator — hardcoded to the 3-mainnet + 4-testnet VPS1/2/3/4
+# orchestrator — hardcoded to the 3-mainnet + 4-testnet Foundation node/2/3/4
 # topology that ships the reference mainnet) this script is a reusable
 # primitive: it takes one target validator, uploads a binary, rolls
 # the service, and reports health.
@@ -27,7 +27,7 @@
 #   done
 #
 # The script is intentionally ops-topology-agnostic:
-#   - No VPS1/VPS2/VPS3 labels
+#   - No Foundation node/Treasury node/Core node labels
 #   - No mainnet/testnet split (operator picks bin-dir + service name)
 #   - No fleet env file — every parameter is explicit
 #   - No cross-host assumptions (no "health-gate testnet before mainnet"

--- a/scripts/emergency-deploy.sh
+++ b/scripts/emergency-deploy.sh
@@ -50,8 +50,8 @@ case "$TARGET" in
     *)
         echo "Usage: $0 <mainnet|testnet>"
         echo ""
-        echo "  mainnet — deploys to VPS1 (Foundation) + VPS2 (Treasury) + VPS3 (Core)"
-        echo "  testnet — deploys to VPS3 (4 validators: sentrix-testnet-val{1..4})"
+        echo "  mainnet — deploys to Foundation node (Foundation) + Treasury node (Treasury) + Core node (Core)"
+        echo "  testnet — deploys to Core node (4 validators: sentrix-testnet-val{1..4})"
         exit 2
         ;;
 esac
@@ -67,7 +67,7 @@ SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10"
 # rejects literal user@addr strings). Typical values live in
 # `~/.config/sentrix/fleet.env` (git-ignored) sourced below.
 #
-# Expected env vars (VPS4 operator):
+# Expected env vars (build host operator):
 #   VPS1_USER, VPS1_WG, VPS1_SERVICE, VPS1_PORT
 #   VPS2_USER, VPS2_WG, VPS2_SERVICE, VPS2_PORT
 #   VPS3_USER, VPS3_WG, VPS3_SERVICE, VPS3_PORT          (mainnet core)
@@ -148,7 +148,7 @@ else
     else
         yellow "  !! cargo check skipped (SENTRIX_SKIP_TESTS=1)"; echo
     fi
-    echo "  $(blue '=>') Building release binary on VPS4..."
+    echo "  $(blue '=>') Building release binary on build host..."
     cargo build --workspace --release --quiet 2>&1 | tail -3
     if [[ ! -x "$BINARY" ]]; then
         echo "  $(red "Build produced no binary at $BINARY")"

--- a/scripts/fast-deploy.sh
+++ b/scripts/fast-deploy.sh
@@ -2,12 +2,12 @@
 # fast-deploy.sh — Primary deploy path for Sentrix chain.
 #
 # Flow:
-#   1. Preflight gates (cargo test + clippy + build) on VPS4
+#   1. Preflight gates (cargo test + clippy + build) on build host
 #   2. Push current branch to GitHub for audit trail (CI will
 #      re-run tests as a second check, but will NOT re-deploy —
 #      the `deploy` job in ci.yml is disabled when fast-deploy is
 #      the primary path)
-#   3. Upload binary to VPS1/2/3 via wg1 SCP, archive previous,
+#   3. Upload binary to Foundation node/2/3 via wg1 SCP, archive previous,
 #      rolling restart with health check
 #   4. Post-deploy: verify chain height advances
 #
@@ -86,7 +86,7 @@ if [[ "$TARGET" == "mainnet" ]]; then
 else
     declare -n HOSTS=TESTNET_HOSTS
     # Testnet lives under its own tree so a testnet deploy never touches
-    # the mainnet binary on the same host (VPS3 runs both).
+    # the mainnet binary on the same host (Core node runs both).
     BIN_DIR="/opt/sentrix-testnet"
 fi
 
@@ -128,9 +128,9 @@ fi
 
 # ── Build ───────────────────────────────────────────────────
 # Build in a Debian bullseye container (glibc 2.31) so the resulting
-# binary runs on every target — VPS1/VPS2 ship Ubuntu 22.04 (glibc 2.35)
-# and VPS3 ships 24.04 (glibc 2.39). A native VPS4 build would pin to
-# glibc 2.39 and crash on VPS1/VPS2 (happened on commit e49e01d).
+# binary runs on every target — Foundation node/Treasury node ship Ubuntu 22.04 (glibc 2.35)
+# and Core node ships 24.04 (glibc 2.39). A native build host build would pin to
+# glibc 2.39 and crash on Foundation node/Treasury node (happened on commit e49e01d).
 # Cargo cache is mounted so only the first build is cold.
 DOCKER_BUILD_IMAGE="${SENTRIX_BUILD_IMAGE:-rust:1.95-bullseye}"
 DOCKER_CACHE="${SENTRIX_DOCKER_CACHE:-$HOME/.cache/sentrix-docker-build}"
@@ -138,7 +138,7 @@ if [[ -n "${SENTRIX_ROLLBACK:-}" ]]; then
     BINARY="$SENTRIX_ROLLBACK"
     echo "  $(blue '=>') Using rollback binary: $BINARY"
 else
-    echo "  $(blue '=>') Building release binary on VPS4 (docker: $DOCKER_BUILD_IMAGE) ..."
+    echo "  $(blue '=>') Building release binary on build host (docker: $DOCKER_BUILD_IMAGE) ..."
     mkdir -p "$DOCKER_CACHE/cargo-registry" "$DOCKER_CACHE/cargo-git" "$DOCKER_CACHE/target"
     docker run --rm \
         -v "$REPO_ROOT":/work \

--- a/scripts/install-testnet-watchdog.sh
+++ b/scripts/install-testnet-watchdog.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # install-testnet-watchdog.sh — One-shot installer for the testnet
-# livelock watchdog on VPS3.
+# livelock watchdog on Core node.
 #
-# Run locally on VPS4 (or whoever has satya_master SSH). Copies the
-# watchdog script to VPS3, writes a systemd oneshot service + timer
+# Run locally on build host (or whoever has satya_master SSH). Copies the
+# watchdog script to Core node, writes a systemd oneshot service + timer
 # pair, enables the timer. Idempotent — safe to re-run.
 
 set -euo pipefail
@@ -20,7 +20,7 @@ SSH="ssh -i $SSH_KEY -o StrictHostKeyChecking=accept-new $VPS3_HOST"
 
 [[ -f "$WATCHDOG_SCRIPT" ]] || { echo "missing $WATCHDOG_SCRIPT"; exit 1; }
 
-echo "==> Uploading watchdog script to VPS3"
+echo "==> Uploading watchdog script to Core node"
 scp -i "$SSH_KEY" "$WATCHDOG_SCRIPT" "$VPS3_HOST:/tmp/testnet-livelock-watchdog.sh"
 
 echo "==> Installing watchdog to /usr/local/bin"

--- a/scripts/testnet-livelock-watchdog.sh
+++ b/scripts/testnet-livelock-watchdog.sh
@@ -8,7 +8,7 @@
 # keeps a short local state file under /run so the script is
 # stateless across reboots.
 #
-# Install on VPS3 (the only host running the testnet validator cluster)
+# Install on Core node (the only host running the testnet validator cluster)
 # as a systemd timer; see scripts/install-testnet-watchdog.sh for the
 # one-shot installer.
 


### PR DESCRIPTION
Audit surfaced 177 VPSn mentions + 26 founder-private cross-refs + 6 personal-name references in public docs. Replaced with role-based names (Foundation/Treasury/Core/Beacon validator). Removed host column from VALIDATORS.md. No code changes.