### PR TITLE
chore(docs): sync all public docs to v2.1.30 — Voyager mainnet active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,85 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.30] — 2026-04-25 — Voyager mainnet active, RPC consensus reporting fixed
+
+> **🟢 Mainnet now reports `consensus: "DPoS+BFT"` correctly across every endpoint.** v2.1.30 is the canonical release on mainnet and testnet after the Voyager activation sequence completed. Source tree depersonalized of internal infrastructure references in the same window.
+
+### Fixed (#310)
+
+- **RPC consensus string `"BFT"` → `"DPoS+BFT"`** across `routes/ops.rs` (`/`, `/sentrix_status`), `routes/chain.rs` (`/chain/finalized-height`), `jsonrpc/sentrix.rs` (`sentrix_status`, `sentrix_consensus`, `sentrix_getFinalizedHeight`, `sentrix_getValidators`). The shorter `"BFT"` was technically incomplete — Sentrix runs DPoS proposer rotation on top of BFT finality, and the public string should reflect both layers. Five call sites updated; no schema break (string-typed field).
+
+### Changed (#311, #312)
+
+- **Public repo depersonalized.** Removed internal infrastructure references (host nicknames, operator handles, private path conventions) from public docs, source comments, scripts, CI workflows, and tests. No behavioural change — comment cleanup only. The depersonalization audit covered `docs/`, `crates/`, `bin/`, `scripts/`, `.github/workflows/`, and integration tests.
+
+### Operational state on this release
+
+- **Mainnet:** `consensus_mode="voyager"`, `voyager_activated=true`, `evm_activated=true`, height ~580K, 4 validators in DPoS+BFT.
+- **Testnet:** same flags, height ~200K.
+- **Source ↔ deployed parity:** workspace `Cargo.toml` reads `version = "2.1.30"`; mainnet validators run a binary built from this same tree.
+
+---
+
+## [2.1.29] — 2026-04-25 — EVM mainnet activation
+
+> **🟢 EVM activated on mainnet in the same window as the Voyager flip.** `Blockchain::activate_evm()` ran once, `evm_activated=true` persisted to chain.db, and `eth_sendRawTransaction` started accepting raw Ethereum transactions on chain ID 7119. Mainnet now mirrors the testnet EVM surface.
+
+### Operational change (no code in this release; activation triggered via admin tooling)
+
+- `evm_activated` flag flipped from `false` to `true` on every mainnet validator's chain.db.
+- All existing mainnet accounts back-filled with `code_hash = EMPTY_CODE_HASH` and `storage_root = EMPTY_STORAGE_ROOT` per `activate_evm()`.
+- `eth_call`, `eth_sendRawTransaction`, `eth_estimateGas`, `eth_getCode`, `eth_getStorageAt` accepted on mainnet RPC.
+- `chain_stats()` JSON now reports `evm_activated: true` at `/chain/info`.
+
+### Migration
+
+- No operator action required for nodes already on v2.1.28+ — flag is read from chain.db at every loop iteration.
+- Wallets / explorers / contract tooling configured for testnet now work on mainnet by changing chain ID 7120 → 7119.
+
+---
+
+## [2.1.28] — 2026-04-25 — Voyager mainnet activation (re-attempt #2 successful) + RPC consensus-mode exposure
+
+> **🟢 Voyager DPoS+BFT activated on mainnet at h=579047.** Second attempt converged after the v2.1.26 / v2.1.27 peer-mesh fixes shipped. `consensus_mode` now exposed on `/chain/info` so block explorers, wallets, and indexers can stop inferring mode from block-level justification presence.
+
+### Added
+
+- **`consensus_mode`, `voyager_activated`, `evm_activated` fields on `chain_stats()`.** Surfaces the consensus engine the runtime is actually using to RPC consumers. Pre-fix, `/chain/info` had no consensus-mode field — clients had to infer mode from justification presence on blocks, which was awkward and wrong for the Pioneer→Voyager transition window.
+- **`bc.voyager_activated` runtime flag drives RPC handlers.** Replaces the `chain_id == 7119 ? PoA : BFT` heuristic and the `is_voyager_height()` env-var fork-height check in 4 places (`routes/ops.rs`, `routes/chain.rs`, `jsonrpc/sentrix.rs` × 2). The fork-height check was returning `consensus=PoA` while runtime was actually BFT, because mainnet activated Voyager via the `voyager_activated` chain.db flag while `VOYAGER_FORK_HEIGHT` stayed at `u64::MAX` for operational safety.
+
+### Operational change
+
+- `voyager_activated=true` set on every mainnet validator's chain.db. Validator loops migrated from Pioneer PoA round-robin to DPoS proposer rotation under 3-phase BFT.
+- `SENTRIX_FORCE_PIONEER_MODE` env override removed from every mainnet validator's env file (was the v2.1.25 emergency rollback flag from the first activation attempt).
+- Mainnet height at activation: 579047. Pioneer ran from genesis through h=579046.
+
+### Recovery context
+
+- Activation #2 itself converged cleanly after the v2.1.27 cold-start gate fixed the BFT entry race that contributed to the activation #1 livelock. State divergence at h=578006 during the second attempt's brief mesh-flap was recovered via frozen-rsync from a canonical peer (chain.db only — `identity/node_keypair` and `wallets/sentrix-node.keystore` restored from forensic backup; **lesson: never rsync whole data dir, chain.db only**).
+
+### Known issues
+
+- BFT signing v2 (chain_id in signing payload + low-S enforcement) **still deferred** per `audits/bft-signing-fork-design.md`. Hard-fork gated; implementation deferred to a dedicated session. Defence-in-depth, not blocking.
+
+---
+
+## [2.1.27] — 2026-04-25 — L2 cold-start gate (close cold-start BFT entry race)
+
+> **🟢 Closes the cold-start race where a validator restarting with `voyager_activated=true` already in chain.db could enter BFT before the L1 mesh re-converged.** v2.1.26's L2 gate only fired on activation transitions; this hotfix adds a second gate at the top of the validator loop that fires every iteration when `voyager_activated=true`.
+
+### Fixed (#307)
+
+- **Cold-start BFT entry gate.** `bin/sentrix/src/main.rs` validator loop now checks `peer_count >= active_set.len() - 1` at the top of every loop iteration when `voyager_activated=true`, not only at the activation transition. A validator that crashed/restarted with `voyager_activated=true` already persisted to chain.db would otherwise enter BFT immediately on cold start, before L1 multiaddr advertisements re-converged the mesh — same livelock failure mode as the original 2026-04-25 incident, just triggered by restart instead of fork-height crossing. Gate uses the same `check_bft_peer_mesh_eligible` + `force_bft_insufficient_peers_set` helpers introduced in v2.1.26 (strict `=="1"` env override, no empty-string bypass).
+
+### Migration
+
+- Drop-in chain.db compatible with v2.1.26.
+- No new env vars required.
+- Operational note: `SENTRIX_FORCE_BFT_INSUFFICIENT_PEERS=1` remains the emergency override for both gates (activation transition and cold-start). Reject any validator setting it via env file leakage.
+
+---
+
 ## [2.1.26] — 2026-04-25 — Bug-fix sweep + L1/L2 peer auto-discovery + Frontier scaffold
 
 > **Operational rollup of 9 PRs landed after the 2026-04-25 Voyager activation incident.** Addresses the actual root cause (peer mesh partition — `--peers` config not scaling), ships defensive guards across the consensus + EVM + storage paths, lays the wire-format foundation for the Frontier-fork parallel transaction execution work. **Mainnet stays in Pioneer mode (`SENTRIX_FORCE_PIONEER_MODE=1`) for this release** — Voyager activation re-attempt remains gated on the BFT signing v2 fork (`audits/bft-signing-fork-design.md`) and a coordinated testnet rehearsal (`runbooks/voyager-mesh-rehearsal.md`).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Fast, secure Layer-1 blockchain built in Rust.
 
 Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, instant finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and web3.js connect natively.
 
-- **v2.1.25** — MDBX storage, 1s blocks, 5000 tx/block capacity, EVM on testnet
+- **v2.1.30** — MDBX storage, 1s blocks, 5000 tx/block capacity, EVM live on mainnet (Voyager active since 2026-04-25)
 - **551+ tests**, clippy clean, 11 security audit rounds
 - **4 validators** across 3 nodes (Foundation, Treasury, Core, Beacon), build host `fast-deploy.sh` rolling deploy
 
@@ -23,10 +23,10 @@ Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, i
 
 | | |
 |---|---|
-| **Consensus** | PoA round-robin (mainnet) + DPoS/BFT (testnet) |
-| **Finality** | Instant — BFT 2/3+1 vote-based on testnet |
+| **Consensus** | DPoS + BFT (mainnet & testnet) — Voyager active |
+| **Finality** | Instant — BFT 2/3+1 vote-based |
 | **Storage** | libmdbx — memory-mapped B+ tree (used by Reth/Erigon) |
-| **EVM** | revm 37 — Solidity contracts, MetaMask compatible (testnet) |
+| **EVM** | revm 37 — Solidity contracts, MetaMask compatible (mainnet & testnet) |
 | **State** | Binary Sparse Merkle Tree (BLAKE3 + SHA-256) with proofs |
 | **Tokens** | SRC-20 native + SRC-20 (ERC-20 via EVM) |
 | **Network** | libp2p + Noise XX + Kademlia + Gossipsub |
@@ -94,9 +94,9 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 |---|---|---|
 | **Chain ID** | 7119 | 7120 |
 | **RPC** | [sentrix-rpc.sentriscloud.com](https://sentrix-rpc.sentriscloud.com) | [testnet-rpc.sentriscloud.com](https://testnet-rpc.sentriscloud.com) |
-| **Consensus** | PoA (4 validators) | DPoS + BFT (4 validators) |
+| **Consensus** | DPoS + BFT (4 validators) | DPoS + BFT (4 validators) |
 | **Block time** | 1 second | 1 second |
-| **EVM** | Disabled | Active — MetaMask compatible |
+| **EVM** | Active — MetaMask compatible | Active — MetaMask compatible |
 | **Explorer** | [sentrixscan.sentriscloud.com](https://sentrixscan.sentriscloud.com) | [sentrixscan.sentriscloud.com](https://sentrixscan.sentriscloud.com) (same unified UI, toggle Testnet) |
 
 **Wallet:** [sentrix-wallet.sentriscloud.com](https://sentrix-wallet.sentriscloud.com)
@@ -107,10 +107,10 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 
 | Phase | Status | Focus |
 |-------|--------|-------|
-| **Pioneer** | Live (mainnet v2.1.25) | PoA consensus, MDBX storage, 1s blocks, SRC-20 tokens |
-| **Voyager** | Live (testnet, chain_id 7120) | DPoS + BFT finality, EVM (revm 37), eth_sendRawTransaction |
-| **Frontier** | Planned | Mainnet hard fork, parallel execution, ecosystem |
-| **Odyssey** | Future | Cross-chain, mature ecosystem |
+| **Pioneer** | Completed (mainnet h=0…579058) | PoA round-robin, MDBX storage, 1s blocks, SRC-20 tokens — succeeded by Voyager 2026-04-25 |
+| **Voyager** | **Live on mainnet (v2.1.30)** | DPoS proposer rotation + BFT finality, EVM (revm 37), `eth_sendRawTransaction`, L1 peer auto-discovery, L2 cold-start gate |
+| **Frontier** | Phase F-1 scaffold landed; F-2…F-10 planned | Parallel transaction execution, sub-1s block time, mainnet hard fork |
+| **Odyssey** | Future | Cross-chain bridges, mature ecosystem, light clients |
 
 ## Documentation
 

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -1,13 +1,13 @@
 # Sentrix — Technical Whitepaper
 
-**Version 3.1 — 2026-04-25**
+**Version 3.2 — 2026-04-25 (post-Voyager mainnet activation)**
 **Author: SentrisCloud**
 
 ---
 
 ## Abstract
 
-Sentrix is a Layer-1 blockchain engineered for fast, deterministic settlement. Built from scratch in Rust as a 14-crate workspace, it delivers 1-second blocks, Ethereum-compatible addressing, an MDBX-backed state layer, and a native fungible token standard (SRC-20). The chain runs a two-phase consensus design: **Pioneer** (Proof of Authority round-robin) on mainnet today, with **Voyager** (Delegated Proof of Stake + BFT finality + EVM execution) already live on testnet and pending mainnet activation.
+Sentrix is a Layer-1 blockchain engineered for fast, deterministic settlement. Built from scratch in Rust as a 14-crate workspace, it delivers 1-second blocks, Ethereum-compatible addressing, an MDBX-backed state layer, and a native fungible token standard (SRC-20). The chain transitioned through a two-phase consensus design: **Pioneer** (Proof of Authority round-robin) bootstrapped the network from genesis, and **Voyager** (Delegated Proof of Stake + BFT finality + EVM execution) is now active on both mainnet (since 2026-04-25, h=579047) and testnet.
 
 ---
 
@@ -37,13 +37,15 @@ This mirrors the path taken by successful chains like BNB Chain (PoA → DPoS) a
 
 ---
 
-## 2. Consensus: Proof of Authority
+## 2. Consensus
 
-### 2.1 Validator Selection
+> **Mainnet status (2026-04-25 onward):** mainnet runs Voyager (DPoS + BFT finality). The Pioneer PoA design described in §2.1–§2.4 below is retained for historical reference — it is the consensus engine that produced blocks 0…579046 before the Voyager fork. Voyager's DPoS proposer rotation + 3-phase BFT (Propose → Prevote → Precommit) is the active engine; see §2.5 for the live design.
+
+### 2.1 Validator Selection (Pioneer, historical)
 
 Validators are authorized by the chain administrator. Each validator is identified by an Ethereum-compatible address derived from an ECDSA secp256k1 keypair.
 
-### 2.2 Round-Robin Scheduling
+### 2.2 Round-Robin Scheduling (Pioneer, historical)
 
 Block production follows a deterministic round-robin schedule:
 
@@ -57,9 +59,31 @@ Validators are sorted by address (ascending) to ensure all nodes agree on the sc
 
 Block time is **1 second** (`BLOCK_TIME_SECS = 1`). Each validator produces one block per round. Mainnet runs **4 active validators** in round-robin (`expected_producer = sorted_validators[height % 4]`), so each validator produces a block every 4 seconds. `MIN_ACTIVE_VALIDATORS = 1` keeps the chain advancing even when 3 of 4 validators are offline; `MIN_BFT_VALIDATORS = 4` is the BFT-quorum threshold under Voyager.
 
-### 2.4 Finality
+### 2.4 Pioneer Finality (historical)
 
-Blocks achieve **instant finality** upon production. There is no fork choice rule, no uncle blocks, and no reorganization. A block produced by the authorized validator is final.
+Under Pioneer, blocks achieved **instant finality** upon production. There was no fork choice rule, no uncle blocks, and no reorganization. A block produced by the authorized validator was final by construction.
+
+### 2.5 Voyager — DPoS + BFT (active mainnet engine)
+
+Voyager replaces Pioneer's authority-based round-robin with a stake-weighted active set + 3-phase BFT vote protocol:
+
+- **Validator set selection.** Open registration with a 15,000 SRX self-stake floor. Top 100 validators by stake score (self-stake + delegations × commission factor) form the `active_set`. Epoch rotation evicts non-performers.
+- **Proposer rotation.** Same `active_set[height % len()]` deterministic rule as Pioneer, applied over the live stake-ranked set instead of the admin-curated set.
+- **3-phase BFT round.** Propose → Prevote → Precommit. A block is committed when ≥ 2/3+1 of stake-weighted precommits are gathered. Locked-block-repropose handles partial-supermajority cases without forking.
+- **Justifications.** Each committed block carries a `justification` field with the precommit signatures that finalised it. `sentrix_getFinalizedHeight` returns the height of the newest justified block; light clients verify finality by checking justifications against the on-chain stake registry.
+- **Slashing.** Double-sign and prolonged offline trigger automatic stake slashing under `crates/sentrix-staking/`. Slash evidence is submitted on-chain via the `SubmitEvidence` staking op.
+- **EVM gating.** Voyager activation also flips `evm_activated=true`, enabling `eth_sendRawTransaction` and Solidity contract deployment via revm 37.
+
+Voyager activated on mainnet at h=579047 on 2026-04-25 after Pioneer ran from genesis through h=579046.
+
+### 2.6 Peer Mesh (L1 + L2 self-healing)
+
+DPoS+BFT consensus assumes the validator mesh is well-connected. Sentrix ships two layers of self-healing peer discovery:
+
+- **L1 multiaddr advertisements.** Validators broadcast signed `MultiaddrAdvertisement` messages on the `sentrix/validator-adverts/1` gossipsub topic at startup + every 10 minutes. Receivers verify against on-chain stake registry pubkeys and store latest-by-sequence in a 4096-entry LRU cache. A periodic dial-tick (every 30s) reads `active_set` and dials any cached members not currently peered. Sequence numbers are persisted to `<data_dir>/.advert-sequence` so restarts don't reset the newer-wins ordering.
+- **L2 cold-start gate.** The validator loop refuses to enter BFT mode unless `peer_count ≥ active_set.len() − 1`. The gate fires every loop iteration when `voyager_activated=true` (not only on activation transitions), closing the cold-start race where a validator restarting with `voyager_activated=true` already in chain.db could enter BFT before the L1 mesh re-converges. Strict `SENTRIX_FORCE_BFT_INSUFFICIENT_PEERS=="1"` env override exists for emergency recovery.
+
+Together these guarantee a fresh validator joining from a single bootstrap peer converges to the full mesh within ~30s without manual `--peers` configuration.
 
 ---
 
@@ -331,27 +355,28 @@ Chain ID `7119` (`0x1bcf`) is registered for Sentrix mainnet; `7120` is the test
 
 | Phase | Status | Key Features |
 |---|---|---|
-| **Pioneer (PoA)** | LIVE | PoA round-robin engine, MDBX state, SentrixTrie, libp2p networking, SRC-20, JSON-RPC, security audits V1–V11 |
-| **Voyager (DPoS+BFT+EVM)** | TESTNET LIVE / MAINNET PENDING | DPoS staking, BFT finality, EVM execution. Active on testnet since 2026-04-23. Mainnet activation pending V2 main.rs wiring (GitHub #292). |
-| **Frontier** | FUTURE | dApp ecosystem expansion, real-user scaling, validator decentralization |
+| **Pioneer (PoA)** | COMPLETED (h=0…579046) | PoA round-robin engine, MDBX state, SentrixTrie, libp2p networking, SRC-20, JSON-RPC, security audits V1–V11. Succeeded by Voyager 2026-04-25. |
+| **Voyager (DPoS+BFT+EVM)** | **LIVE — mainnet & testnet** | DPoS staking, BFT finality, EVM execution. Active on testnet since 2026-04-23. Mainnet active since 2026-04-25 at h=579047 with `voyager_activated=true` and `evm_activated=true`. L1 peer auto-discovery + L2 cold-start gate self-heal the validator mesh. |
+| **Frontier** | SCAFFOLDED (Phase F-1 in main); F-2…F-10 planned | Mainnet hard fork to introduce parallel transaction execution, sub-1s block time, ecosystem expansion. Implementation tracked in `audits/frontier-mainnet-phase-implementation-plan.md`. |
 | **Odyssey** | FUTURE | Cross-chain bridges, mature ecosystem, full public chain |
 
 ---
 
-## 13. Current State (2026-04-25)
+## 13. Current State (2026-04-25, post-Voyager mainnet activation)
 
 | Item | Value |
 |---|---|
-| Mainnet binary | v2.1.25 |
-| Testnet binary | v2.1.24 |
-| Mainnet height | ~558,000+ |
+| Mainnet binary | v2.1.30 |
+| Testnet binary | v2.1.30 |
+| Mainnet height | ~580,000+ |
 | Mainnet block time | 1 second |
-| Mainnet validators | 4 active (Foundation, Treasury, Core, Beacon) on Pioneer round-robin |
-| Mainnet mode | Pioneer with `SENTRIX_FORCE_PIONEER_MODE=1` emergency override (Voyager activation rolled back same-day; tracked in GitHub #292) |
-| Testnet | 4 validators, Voyager DPoS+BFT+EVM ACTIVE since 2026-04-23 docker migration, fresh genesis, h~200K |
+| Mainnet validators | 4 active (Foundation, Treasury, Core, Beacon) — DPoS proposer rotation under BFT finality |
+| Mainnet consensus | **Voyager** (`consensus_mode="voyager"`, `voyager_activated=true`, `evm_activated=true`). Activated 2026-04-25 at h=579047 after the second activation attempt converged successfully. |
+| Mainnet RPC | Reports `consensus: "DPoS+BFT"` on `/sentrix_status` and `/chain/finalized-height`; `chain_stats()` exposes `consensus_mode`, `voyager_activated`, `evm_activated` flags. |
+| Testnet | 4 validators, Voyager DPoS+BFT+EVM active since 2026-04-23 docker migration, fresh genesis, h ~200K. |
 | Workspace | 14 Rust crates (`crates/sentrix-*`) + binary at `bin/sentrix/src/main.rs` |
 | Storage backend | MDBX (libmdbx) |
-| Tests | 500+ unit + 16 integration |
+| Tests | 551+ unit + 16+ integration |
 
 ---
 

--- a/docs/architecture/EVM.md
+++ b/docs/architecture/EVM.md
@@ -4,17 +4,19 @@ Sentrix runs the Ethereum Virtual Machine via [revm](https://github.com/blueallo
 
 ## Status
 
-- **Mainnet:** EVM disabled (`VOYAGER_EVM_HEIGHT=u64::MAX`)
-- **Testnet:** EVM active since block 752
+- **Mainnet:** EVM **active** since 2026-04-25 (h=579047), `evm_activated=true` set by `Blockchain::activate_evm()` during the Voyager mainnet activation. `chain_stats()` exposes the flag at `/chain/info`.
+- **Testnet:** EVM active since block 752.
 
 ## Activation
 
-EVM activates at the block height set by `VOYAGER_EVM_HEIGHT`. At that height:
+EVM activation is a one-shot operator step (or fork-height triggered) that calls `Blockchain::activate_evm()`. Once it runs:
 
-1. `Blockchain::activate_evm()` runs once
+1. `evm_activated=true` is persisted to chain.db
 2. All existing accounts get `code_hash = EMPTY_CODE_HASH` and `storage_root = EMPTY_STORAGE_ROOT`
 3. `eth_call`, `eth_sendRawTransaction`, etc. start accepting EVM transactions
 4. Block executor routes any tx with `data` field starting with `EVM:` through revm
+
+Mainnet activated at h=579047 (2026-04-25). Testnet activated at h=752 on the 2026-04-23 docker migration.
 
 ## Account Model
 

--- a/docs/operations/EMERGENCY_ROLLBACK.md
+++ b/docs/operations/EMERGENCY_ROLLBACK.md
@@ -83,10 +83,10 @@ sudo chmod +x /opt/sentrix/sentrix
 sudo systemctl start sentrix-<unit>
 ```
 
-Current production binary at the time of writing: **v2.1.25**
-(`md5 5ad7804c0d7e68f8cab47872f7dbc7ac`). Prior good release on
-mainnet: v2.1.24 (`md5 a25f9d771648f6c851a6ee11867fe958`, also the
-testnet binary).
+Current production binary at the time of writing: **v2.1.30** (mainnet
+& testnet, post-Voyager activation). Prior production releases archived
+under `/opt/sentrix/releases/` per validator: v2.1.29, v2.1.28, v2.1.27,
+v2.1.26, v2.1.25 (Pioneer-mode emergency hotfix).
 
 ---
 

--- a/docs/operations/METAMASK.md
+++ b/docs/operations/METAMASK.md
@@ -1,6 +1,6 @@
 # MetaMask Setup
 
-Sentrix Testnet is fully MetaMask-compatible (chain ID 7120). Mainnet (chain ID 7119) currently runs Pioneer PoA without EVM — MetaMask will read balances but contracts won't deploy until the Voyager hard fork activates EVM.
+Sentrix is fully MetaMask-compatible on both networks. Mainnet (chain ID 7119) and Testnet (chain ID 7120) both run Voyager DPoS+BFT consensus with EVM enabled — MetaMask reads balances, signs transactions, and deploys Solidity contracts on either network.
 
 ## Add Sentrix Testnet to MetaMask
 
@@ -17,7 +17,7 @@ Sentrix Testnet is fully MetaMask-compatible (chain ID 7120). Mainnet (chain ID 
 
 3. Save. Switch to "Sentrix Testnet" in the network dropdown.
 
-## Add Sentrix Mainnet (read-only for now)
+## Add Sentrix Mainnet
 
    | Field | Value |
    |-------|-------|
@@ -26,6 +26,8 @@ Sentrix Testnet is fully MetaMask-compatible (chain ID 7120). Mainnet (chain ID 
    | **Chain ID** | `7119` |
    | **Currency Symbol** | `SRX` |
    | **Block Explorer URL** | `https://sentrixscan.sentriscloud.com` |
+
+Mainnet supports `eth_sendRawTransaction` and Solidity contract deployment since the 2026-04-25 Voyager activation. Use mainnet for production deployments and testnet for development.
 
 ## Get Test SRX
 

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -10,9 +10,11 @@
 | P2P port | 30303 |
 | API port | 8545 |
 | Block time | 1s |
-| Validators | 4 (PoA round-robin: Foundation, Treasury, Core, Beacon) |
+| Validators | 4 (DPoS proposer rotation under BFT finality: Foundation, Treasury, Core, Beacon) |
 | Native coin | SRX |
-| Mode | Pioneer (forced via `SENTRIX_FORCE_PIONEER_MODE=1`; see ops note below) |
+| Consensus | **Voyager** (DPoS + BFT, `voyager_activated=true` since h=579047 / 2026-04-25) |
+| EVM | Active — `evm_activated=true` since the same height; MetaMask compatible |
+| Binary | v2.1.30 |
 
 ## Testnet
 
@@ -34,16 +36,15 @@ Testnet tokens have no real value. Use the faucet to get test SRX.
 
 Testnet runs in Docker on build host (`/opt/sentrix-testnet-docker/`) since
 the 2026-04-23 migration; fresh genesis at chain_id 7120, current
-height ~200K, binary v2.1.24 (`md5 a25f9d771648f6c851a6ee11867fe958`).
+height ~200K, binary v2.1.30.
 
-> **Mainnet operational note (2026-04-25):** mainnet currently runs
-> forced Pioneer (`SENTRIX_FORCE_PIONEER_MODE=1` env override on every
-> validator) after a Voyager activation attempt at h=557244 livelocked
-> on V2 BFT wiring. Voyager mainnet activation is **blocked by issue
-> [#292](https://github.com/sentrix-labs/sentrix/issues/292)**. Until
-> #292 lands, `VOYAGER_FORK_HEIGHT=18446744073709551615` (u64::MAX)
-> keeps the Voyager fork inert. Mainnet binary: v2.1.25
-> (`md5 5ad7804c0d7e68f8cab47872f7dbc7ac`).
+> **Mainnet operational note (2026-04-25, post-Voyager):** mainnet successfully
+> transitioned from Pioneer PoA to Voyager DPoS+BFT at h=579047. EVM was
+> activated in the same window. The first activation attempt at h=557244
+> livelocked on a peer-mesh partition; root cause was fixed in v2.1.26
+> (L1 multiaddr advertisements + L2 cold-start gate per PRs #297–#306)
+> and v2.1.27 (cold-start race PR #307). The `SENTRIX_FORCE_PIONEER_MODE`
+> emergency override is no longer set on any mainnet validator.
 
 ## Connecting
 

--- a/docs/operations/SMART_CONTRACT_GUIDE.md
+++ b/docs/operations/SMART_CONTRACT_GUIDE.md
@@ -1,8 +1,8 @@
 # Deploying Smart Contracts to Sentrix
 
-Sentrix testnet runs an EVM (revm 37) and accepts standard Ethereum tooling. This guide walks through deploying a Solidity contract via Remix in under 5 minutes.
+Sentrix runs an EVM (revm 37) on both mainnet and testnet, and accepts standard Ethereum tooling. This guide walks through deploying a Solidity contract via Remix in under 5 minutes.
 
-> **Mainnet:** EVM is currently disabled. Deploy on testnet for now.
+> **Network choice:** Use **testnet** (chain ID 7120) for development — get free SRX from the [faucet](https://faucet.sentriscloud.com). Use **mainnet** (chain ID 7119) for production deployments. EVM has been live on mainnet since the 2026-04-25 Voyager activation.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Mainnet successfully activated Voyager DPoS+BFT at h=579047 on 2026-04-25 and EVM (revm 37) in the same window, but the README, WHITEPAPER, NETWORKS, EMERGENCY_ROLLBACK, EVM, METAMASK, and SMART_CONTRACT_GUIDE docs all still claimed mainnet was running Pioneer PoA with EVM disabled. This sweep brings every public-facing doc in line with reality.

## What changed

| File | Was | Now |
|---|---|---|
| `README.md` | Roadmap: Pioneer "Live (mainnet v2.1.25)", Voyager "Live (testnet)". EVM "Disabled" on mainnet. | Roadmap: Pioneer "Completed (h=0…579046)", Voyager "Live on mainnet (v2.1.30)". EVM active both networks. |
| `WHITEPAPER.md` | v3.1, abstract said Voyager "pending mainnet activation". §2 was Pioneer-only. §12 Roadmap "TESTNET LIVE / MAINNET PENDING". §13 said Pioneer with FORCE_PIONEER override. | v3.2, abstract says Pioneer→Voyager transition completed. §2.5 documents live DPoS+BFT design. §2.6 documents L1/L2 peer auto-discovery. §12/§13 synced. |
| `docs/architecture/EVM.md` | Status: "Mainnet: EVM disabled" | Status: Mainnet EVM active since h=579047 |
| `docs/operations/METAMASK.md` | "Mainnet currently runs Pioneer PoA without EVM" | Both networks support EVM |
| `docs/operations/SMART_CONTRACT_GUIDE.md` | "Mainnet: EVM is currently disabled" | Network-choice guidance (testnet=dev, mainnet=prod) |
| `docs/operations/NETWORKS.md` | Mainnet "Pioneer (forced)", binary v2.1.25 | Mainnet Voyager + EVM active, binary v2.1.30 |
| `docs/operations/EMERGENCY_ROLLBACK.md` | "Current production binary: v2.1.25" | "Current production binary: v2.1.30" |
| `CHANGELOG.md` | Topped at v2.1.26 | Added v2.1.27 (cold-start gate), v2.1.28 (Voyager mainnet activation #2 + RPC consensus-mode fields), v2.1.29 (EVM mainnet activation), v2.1.30 (RPC consensus string DPoS+BFT + depersonalization). Historical entries v2.1.26 and below untouched. |

## Test plan

- [ ] Re-run grep audit — no remaining outdated claims:
  - [ ] `grep -nE "PoA \(4 validators\)|Live \(mainnet v2\.1\.25\)" README.md` returns nothing
  - [ ] `grep -nE "MAINNET PENDING|forced Pioneer" WHITEPAPER.md` returns nothing
  - [ ] `grep -nE "EVM disabled|EVM is currently disabled" docs/architecture/EVM.md docs/operations/SMART_CONTRACT_GUIDE.md` returns nothing
  - [ ] `grep -nE "Pioneer PoA without EVM|read-only for now" docs/operations/METAMASK.md` returns nothing
  - [ ] `grep -nE "binary v2\.1\.2[45]" docs/operations/NETWORKS.md` returns nothing
- [ ] Cross-check live mainnet RPC matches new claims:
  - [ ] `curl -s https://sentrix-rpc.sentriscloud.com/sentrix_status | jq '.consensus, .version.version'` returns `"DPoS+BFT"` + `"2.1.30"`
  - [ ] `curl -s https://sentrix-rpc.sentriscloud.com/chain/info | jq '{consensus_mode, voyager_activated, evm_activated}'` returns `{voyager, true, true}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)