### PR TITLE
chore(scripts): drop VPS labels from fast-deploy comments

### DIFF
--- a/scripts/fast-deploy.sh
+++ b/scripts/fast-deploy.sh
@@ -76,12 +76,11 @@ fi
 source "$FLEET_ENV"
 
 # Per-host entry format: "user@host:service:port:bin_dir"
-# bin_dir defaults to /opt/sentrix for hosts that don't override it.
-# Sentrix mainnet is co-tenant-free per validator-isolation policy:
-# Foundation (VPS1) + Treasury (VPS2) live at /opt/sentrix; Core (VPS3)
-# at /opt/core; Beacon (VPS5) at /opt/beacon. Each role's bin_dir is
-# loaded from fleet.env (FOUNDATION_BIN_DIR, etc.) with a /opt/sentrix
-# fallback for backward compatibility with legacy fleet.env files.
+# Each mainnet role's bin_dir is loaded from fleet.env (FOUNDATION_BIN_DIR,
+# TREASURY_BIN_DIR, CORE_BIN_DIR, BEACON_BIN_DIR) with role-appropriate
+# defaults below. Defaults reflect the current mainnet layout: Foundation
+# and Treasury live at /opt/sentrix, Core at /opt/core, Beacon at
+# /opt/beacon. Override per role only if the on-disk layout changes.
 declare -A MAINNET_HOSTS=(
     [foundation]="${FOUNDATION_USER}@${FOUNDATION_WG}:${FOUNDATION_SERVICE}:${FOUNDATION_PORT}:${FOUNDATION_BIN_DIR:-/opt/sentrix}"
     [treasury]="${TREASURY_USER}@${TREASURY_WG}:${TREASURY_SERVICE}:${TREASURY_PORT}:${TREASURY_BIN_DIR:-/opt/sentrix}"


### PR DESCRIPTION
## Summary

Follow-up to PRs #311 + #312 (public-repo depersonalization). The fast-deploy.sh refactor in PR #314 reintroduced \`VPS1\`/\`VPS2\`/\`VPS3\`/\`VPS5\` labels in two comment lines explaining the role-to-bin_dir map. Replaced with role-only language so the public repo stays consistent with the depersonalization sweep.

No code change. Comment-only edit.

## What's still flagged

A separate audit found stale references to the renamed test file \`rca_vps3_env_repro.rs\` (now \`rca_env_repro.rs\`) in three Rust files' doc comments:
- \`crates/sentrix-core/src/block_executor.rs:314\`
- \`crates/sentrix-core/tests/rca_env_repro.rs\` (multiple)
- \`crates/sentrix-core/tests/fork_determinism.rs\` (multiple)

Those are stale-rename artifacts from the file move, not introduced by PR #314. Will be cleaned up in a separate follow-up PR.

\`.github/workflows/ci.yml\` still uses \`VPS{1..5}_SSH_KEY\` GitHub secret names — kept intentionally with TODO comment per PR #312; rename requires repo owner settings access.

## Test plan

- [x] \`grep -nE "VPS[0-9]|vps[0-9]" scripts/fast-deploy.sh\` returns nothing
- [x] \`bash -n scripts/fast-deploy.sh\` passes