### PR TITLE
fix(network): L1 dial-tick skip already-connected peers (closes connection leak)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1548,14 +1548,36 @@ async fn cmd_start(
                     }
 
                     // Dial any active-set members we have cached but
-                    // aren't currently peered with. Caller (libp2p) is
-                    // idempotent — duplicate dials to an already-
-                    // connected peer are no-ops at the swarm level.
+                    // aren't currently peered with.
+                    //
+                    // CONNECTION-LEAK FIX (2026-04-25 incident): the
+                    // previous comment claimed `connect_peer` was idempotent
+                    // ("duplicate dials to an already-connected peer are
+                    // no-ops"). That turned out to be FALSE in libp2p
+                    // 0.56 / libp2p-swarm 0.47 — every `swarm.dial()`
+                    // enqueues a fresh pending connection regardless of
+                    // existing connection state. Without a connected-peers
+                    // pre-check, this loop accumulated 568-918 pending +
+                    // established connections per validator over a few
+                    // hours, gossipsub mesh thrashed on the oversized pool,
+                    // and BFT request_response messages dropped mid-round
+                    // → consensus deadlock (h=583002, h=585217 stalls).
+                    //
+                    // Snapshot connected peers ONCE per tick, then skip any
+                    // active-set member whose libp2p peer_id is already in
+                    // the set. The peer_id is extracted from the cached
+                    // multiaddr's `/p2p/<peer_id>` suffix (which validators
+                    // include when broadcasting their advertisement).
+                    // Multiaddrs without a peer_id suffix fall back to
+                    // dialing (rare; only happens for legacy adverts from
+                    // pre-PR #300 binaries that no longer exist on the
+                    // production fleet).
                     let active_set: Vec<String> = {
                         let bc = shared_clone.read().await;
                         bc.stake_registry.active_set.clone()
                     };
                     if !active_set.is_empty() {
+                        let connected = lp2p_clone.connected_peers().await;
                         let cached = lp2p_clone.list_cached_adverts().await;
                         for advert in &cached {
                             if advert.validator == wallet.address {
@@ -1569,6 +1591,23 @@ async fn cmd_start(
                             if let Some(ma_str) = advert.multiaddrs.first()
                                 && let Ok(ma) = ma_str.parse::<libp2p::Multiaddr>()
                             {
+                                // Skip if we already have an established
+                                // connection to this peer (the leak fix).
+                                let already_connected = ma.iter().any(|proto| {
+                                    if let libp2p::multiaddr::Protocol::P2p(peer_id) = proto {
+                                        connected.contains(&peer_id)
+                                    } else {
+                                        false
+                                    }
+                                });
+                                if already_connected {
+                                    tracing::trace!(
+                                        "L1: skip dial — {} already connected (advert seq={})",
+                                        &advert.validator[..12.min(advert.validator.len())],
+                                        advert.sequence
+                                    );
+                                    continue;
+                                }
                                 tracing::debug!(
                                     "L1: dialing {} at {} (cached advert seq={})",
                                     &advert.validator[..12.min(advert.validator.len())],

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -93,6 +93,17 @@ enum SwarmCommand {
     /// periodic dial-tick in the validator loop to decide which
     /// active-set members it can reach.
     ListCachedAdverts(tokio::sync::oneshot::Sender<Vec<MultiaddrAdvertisement>>),
+    /// Snapshot of currently-connected peer IDs. Used by the L1 dial-
+    /// tick to skip peers we already have an established connection
+    /// with — without this check, every tick re-dials every active-set
+    /// member regardless of connection state, which causes pending
+    /// connections to accumulate in the swarm pool over hours and
+    /// eventually triggers gossipsub mesh thrashing → BFT livelock
+    /// (incident 2026-04-25, two stalls). The dial-tick comment used
+    /// to claim libp2p deduplicates duplicate dials at the swarm
+    /// level — that turned out to be false in libp2p 0.56; each
+    /// `swarm.dial()` enqueues a fresh pending connection.
+    GetConnectedPeers(tokio::sync::oneshot::Sender<HashSet<PeerId>>),
 }
 
 // ── Public handle ────────────────────────────────────────
@@ -282,6 +293,27 @@ impl LibP2pNode {
         }
     }
 
+    /// Returns the set of currently-connected peer IDs.
+    ///
+    /// Used by the L1 dial-tick in the validator loop to skip peers
+    /// already in an established connection — without this check, every
+    /// 30s tick re-dials every active-set member, and pending dial
+    /// attempts accumulate over hours. See incident
+    /// `founder-private/incidents/2026-04-25-libp2p-connection-thrashing.md`.
+    pub async fn connected_peers(&self) -> HashSet<PeerId> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if self
+            .cmd_tx
+            .send(SwarmCommand::GetConnectedPeers(tx))
+            .await
+            .is_ok()
+        {
+            rx.await.unwrap_or_default()
+        } else {
+            HashSet::new()
+        }
+    }
+
     /// Returns the swarm's current listen addresses (after bind completes).
     ///
     /// Useful for:
@@ -418,6 +450,13 @@ async fn run_swarm(
         })
         .map_err(|e| SentrixError::NetworkError(format!("behaviour init: {e}")))?
         // Keep connections alive indefinitely — don't close idle connections.
+        // Per-peer connection limit (1 established per peer_id) is a
+        // FOLLOW-UP HARDENING — libp2p-swarm 0.47 Config doesn't expose it
+        // directly; needs the `connection_limits::Behaviour` wired into
+        // SentrixBehaviour. Tracked as a secondary fix for the 2026-04-25
+        // libp2p connection thrashing incident; the primary fix (dial-tick
+        // connected-peers pre-check below) is sufficient on its own to
+        // stop the accumulation pattern observed.
         .with_swarm_config(|cfg| {
             cfg.with_idle_connection_timeout(std::time::Duration::from_secs(u64::MAX))
         })
@@ -556,6 +595,14 @@ async fn run_swarm(
                                 tracing::warn!("libp2p reconnect dial {} failed: {}", addr, e);
                             }
                         }
+                    }
+                    Some(SwarmCommand::GetConnectedPeers(reply)) => {
+                        // Snapshot of currently-connected peer_ids.
+                        // `swarm.connected_peers()` is the post-handshake
+                        // set; matches what `verified_peers` would expose
+                        // for our SentrixBehaviour.
+                        let peers: HashSet<PeerId> = swarm.connected_peers().copied().collect();
+                        let _ = reply.send(peers);
                     }
                     Some(SwarmCommand::TriggerSync) => {
                         // Backlog #4 auto-resync: ask the first verified peer


### PR DESCRIPTION
## Summary

Root-cause fix for the 2026-04-25 mainnet libp2p connection thrashing. **Two production stalls today** (h=583002, h=585217) traced back to this single bug.

## Root cause

L1 peer auto-discovery dial-tick at \`bin/sentrix/src/main.rs:1550-1581\` calls \`swarm.dial(multiaddr)\` every 30s for each active-set member. The previous comment claimed \`connect_peer\` was idempotent — *"duplicate dials to an already-connected peer are no-ops at the swarm level"*.

**That comment is wrong.** In libp2p 0.56 / libp2p-swarm 0.47, every \`swarm.dial()\` enqueues a fresh pending connection regardless of existing connection state. Symptom:

- Every 30s tick × 3 active peers × N hours = unbounded accumulation
- After a few hours: 568-918 active TCP connections per validator on the libp2p port
- Gossipsub heartbeat (300ms) thrashes mesh membership on the oversized pool
- BFT request_response messages drop mid-round (connection a message was sent on dies before response arrives)
- Consensus deadlocks (rounds skip-spin, no supermajority)
- Recovery: parallel \`systemctl restart\` flushes pool, mainnet resumes

## Fix

1. New \`LibP2pNode::connected_peers() -> HashSet<PeerId>\` query — uses libp2p's native \`swarm.connected_peers()\` to snapshot the post-handshake peer set.
2. Dial-tick now:
   - Snapshots \`connected\` set ONCE per tick
   - For each cached advert, checks whether the multiaddr's \`/p2p/<peer_id>\` suffix is in \`connected\`
   - Skip-dial if already connected; only dial when actually disconnected
3. Fallback: multiaddrs without a \`/p2p/\` suffix still dial (rare legacy advert format from pre-PR #300 binaries; no longer on production fleet)

## What's NOT in this PR

- \`max_established_per_peer(1)\` (secondary suspect from the deep-dive investigation). libp2p-swarm 0.47 \`Config\` doesn't expose it directly — needs \`connection_limits::Behaviour\` wired into \`SentrixBehaviour\`. Follow-up PR. The primary fix in this PR is sufficient on its own to stop accumulation.

## Test plan

- [x] \`cargo build -p sentrix-network\` clean
- [x] \`cargo test -p sentrix-network --lib\` — 35 tests green (no regression in existing 2-node handshake test)
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [ ] **Operator validation post-deploy**: monitor active TCP connection count on each validator over 6-24 hours after deploying this PR. Expected: count stays in the ~6-20 range indefinitely instead of climbing into the hundreds.

\`\`\`bash
# Per-VPS connection count check
ssh <validator> "ss -tn state established '( sport = :30303 or dport = :30303 )' | wc -l"
\`\`\`

## Risk

**Medium-low.** Touches the validator loop's dial path, which is consensus-adjacent (L1 peer discovery feeds the L2 cold-start gate that feeds BFT). But:
- The change is ADDITIVE — same dial logic with a connected-peers pre-filter on top
- If the new pre-filter has a bug, worst case is "skip a dial we should have made" → peer never reconnects → L2 gate holds BFT, chain stalls (recovery: parallel restart, same as today)
- Falls back to dialing if peer_id can't be extracted from multiaddr (legacy format compatibility)
- All 35 existing network tests pass unchanged