### PR TITLE
chore: release v2.1.31 — libp2p connection-leak fix + ship rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.31] — 2026-04-25 — Late-night ship: BFT signing v2 foundation + Frontier F-2 shadow + libp2p connection-leak fix + V4 reward v2 fork activated
+
+> **🟢 Three substantial improvements landed late on 2026-04-25, plus the V4 reward v2 mainnet fork activated at h=590100.** The libp2p connection leak fix is the most operationally important — it closes the root cause of two production stalls earlier in the day.
+
+### Fixed (#319)
+
+- **L1 dial-tick connection leak** — `bin/sentrix/src/main.rs:1550-1581`. The dial-tick comment claimed `connect_peer` was idempotent ("duplicate dials to an already-connected peer are no-ops at the swarm level") — that's FALSE in libp2p 0.56 / libp2p-swarm 0.47. Every `swarm.dial()` enqueues a fresh pending connection regardless of existing connection state. Every 30s tick × 3 active peers × N hours = unbounded accumulation. After a few hours each validator reached 568-918 active TCP connections (vs expected ~6-12 for a 4-validator mesh), gossipsub heartbeat thrashed mesh on the oversized pool, BFT request_response messages dropped mid-round, and consensus deadlocked. **Fix**: new `LibP2pNode::connected_peers() -> HashSet<PeerId>` query (uses libp2p's native `swarm.connected_peers()`) + dial-tick now snapshots connected set once per tick + skips active-set members whose multiaddr's `/p2p/<peer_id>` suffix is already in the connected set. Falls back to dialing if multiaddr lacks `/p2p/` suffix (legacy advert format compatibility). Two production stalls (h=583002, h=585217) directly attributable to this bug; recovery procedure was "parallel restart of all 4 validators" which clears the pool.
+- **`max_established_per_peer(1)` defence-in-depth** deferred — libp2p-swarm 0.47 `Config` doesn't expose it directly; needs the `connection_limits::Behaviour` wired into `SentrixBehaviour`. Tracked as follow-up. The dial-tick fix above is sufficient on its own to stop accumulation.
+
+### Added (#317 — BFT signing v2 foundation)
+
+- **`BFT_SIGNING_V2_FORK_HEIGHT = u64::MAX`** constant (inert; v2 path never fires until operators flip it in a coordinated fork ceremony).
+- **`BFT_V2_MAGIC = 0x20`** magic byte (distinct from existing 0x01-0x04 message domain separators + 0x10 for MultiaddrAdvertisement).
+- **`signing_payload_v2(..., chain_id)`** variants on `Proposal`, `Prevote`, `Precommit`, `RoundStatus`. Each prepends `[0x20][chain_id BE u64]` to the v1 payload layout.
+- **`signing_payload_for_height(...)`** dispatch helper that picks v1 or v2 based on the height parameter.
+- 7 new tests pinning v2 wire-format invariants + cross-chain replay protection + dispatch inertness with default `u64::MAX` fork height.
+
+This closes Bug A from `audits/bft-signing-fork-design.md`: cross-chain BFT vote replay where a mainnet (7119) signature can verify on testnet (7120) at the same height/round/hash. The specific exploit (nil-vote replay where `block_hash="NIL"` is byte-identical across chains) is fixed under v2 — chain_id in the signed payload makes mainnet-NIL ≠ testnet-NIL. **Phase 2 (call-site refactor) deferred** to a dedicated session per consensus discipline. Phase 5 (operator activation flip) is operator ceremony, separate.
+
+### Added (#318 — Frontier F-2 shadow-mode wiring)
+
+- **`SENTRIX_FRONTIER_F2_SHADOW=1`** env var gate in `apply_block_pass2`. When set, the F-1 scaffold's `build_batches` is called over each block's non-coinbase transactions and the result is logged via `tracing::info!` under target `frontier::f2_shadow`. Read-only — does NOT mutate state. Sequential apply still drives block execution.
+- Default OFF — env-var read uses `std::env::var_os().is_some_and(...)` which short-circuits without allocation when missing.
+- Calibration step before F-3 (real parallel apply). Lets operators observe scheduler determinism on real chain traffic without committing to parallel execution.
+
+### Operational change (no code in this release for the V4 fork)
+
+- **V4 reward v2 mainnet fork ACTIVATED at h=590100.** `VOYAGER_REWARD_V2_HEIGHT=590100` set on all 4 mainnet validators, rolling restart, fork crossed at 04:27:04 local. Behaviour from h=590100 onwards:
+  - Coinbase 1 SRX/block routes to `PROTOCOL_TREASURY` (`0x0000000000000000000000000000000000000002`) instead of validator address
+  - `reset_reward_accumulators_for_fork_activation` fired once at h=590100 (cleared pre-fork pending_rewards + delegator_rewards to maintain the supply invariant `accounts[TREASURY] == sum(pending_rewards) + sum(delegator_rewards)`)
+  - Validators + delegators must now use the `ClaimRewards` staking op to transfer earned share from treasury to their balance
+  - Treasury accumulating ~1 SRX/block as designed (verified post-fork: 458 SRX at h=590562, 462 blocks past fork; ~4-block sample-timing lag)
+
+### Migration
+
+- Drop-in chain.db compatible with v2.1.30.
+- Pre-deploy: ensure `VOYAGER_REWARD_V2_HEIGHT` is consistent across all 4 validator env files (already set during fork ceremony — kept).
+- Per-validator deploy: rolling restart picks up new binary. The libp2p connection-leak fix takes effect immediately on the validator that restarts; full fleet benefit when all 4 are upgraded.
+
+---
+
 ## [2.1.30] — 2026-04-25 — Voyager mainnet active, RPC consensus reporting fixed
 
 > **🟢 Mainnet now reports `consensus: "DPoS+BFT"` correctly across every endpoint.** v2.1.30 is the canonical release on mainnet and testnet after the Voyager activation sequence completed. Source tree depersonalized of internal infrastructure references in the same window.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "anyhow",
  "axum",
@@ -4894,14 +4894,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4944,14 +4944,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "bincode",
  "blake3",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.30"
+version = "2.1.31"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.30"
+version = "2.1.31"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Workspace version bump 2.1.30 → 2.1.31 across all crate Cargo.toml files. Bundles three already-merged improvements (#317, #318, #319) into a release tag + adds the V4 reward v2 mainnet fork activation narrative to CHANGELOG.

## What's already merged into main + bundled in this release

| PR | What |
|---|---|
| #319 | libp2p L1 dial-tick connected-peers pre-check — closes the connection-accumulation root cause behind today's two production stalls |
| #317 | BFT signing v2 foundation — chain_id in payload variants, gated FORK_HEIGHT=u64::MAX inert |
| #318 | Frontier F-2 shadow-mode wiring — env-gated build_batches observer, read-only |

## Operational change captured

V4 reward v2 mainnet fork activated at h=590100 (~1hr after env var was set). Treasury accumulating ~1 SRX/block as designed; ClaimRewards model now live. Verified post-fork: treasury balance 458 SRX at h=590562 (462 blocks past fork; ~4-block sample-timing lag).

## Test plan

- [x] cargo check clean post-version-bump
- [x] All three bundled PRs already passed individual test plans (#317: 85 sentrix-bft tests + 7 new v2 tests; #318: 193 sentrix-core tests; #319: 35 sentrix-network tests)
- [ ] **Operator validation post-deploy**: monitor active TCP connection count on each validator over 6-24h. Expected: stays ~6-20 indefinitely (was climbing into 800+ before).

## Deploy note

Mainnet currently runs v2.1.30. This PR + tag will be deployed via fast-deploy from founder-private. Per-validator rolling restart picks up the libp2p fix immediately; full fleet benefit when all 4 are upgraded.