### PR TITLE
fix(network): append /p2p/<peer_id> to advertised multiaddrs (Tier 4 libp2p fix)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1499,6 +1499,17 @@ async fn cmd_start(
                         // production default), so the filter must catch
                         // both classes. Cap at MAX_MULTIADDRS to stay
                         // within DoS budget on the receiver side.
+                        //
+                        // 2026-04-26: append `/p2p/<own_peer_id>` to each
+                        // address so receivers can extract our peer_id
+                        // for the dial-tick connected-peers pre-check
+                        // (sentrix-labs/sentrix#319). Without the suffix,
+                        // the dial-tick can't tell which peer_id a cached
+                        // multiaddr resolves to and falls back to "dial
+                        // anyway", which reintroduces the connection-
+                        // accumulation pattern that was the root cause of
+                        // the 2026-04-25 mainnet stalls.
+                        let our_peer_id = lp2p_clone.local_peer_id;
                         let multiaddrs: Vec<String> = listen_addrs
                             .iter()
                             .map(|m| m.to_string())
@@ -1507,6 +1518,16 @@ async fn cmd_start(
                                     && !s.starts_with("/ip6/::1/")
                                     && !s.starts_with("/ip4/0.0.0.0/")
                                     && !s.starts_with("/ip6/::/")
+                            })
+                            .map(|s| {
+                                // Skip if already has /p2p (defensive —
+                                // listen_addrs() shouldn't include them
+                                // but tolerate it).
+                                if s.contains("/p2p/") {
+                                    s
+                                } else {
+                                    format!("{}/p2p/{}", s, our_peer_id)
+                                }
                             })
                             .take(sentrix_wire::MultiaddrAdvertisement::MAX_MULTIADDRS)
                             .collect();


### PR DESCRIPTION
## Summary

Closes the gap that left **#319 (libp2p connection-leak fix) only partially effective**. With this PR + #319 deployed together, the dial-tick connected-peers check actually fires + connection accumulation stops at the steady-state mesh size.

## Root cause refinement

#319 introduced a connected-peers pre-check in the L1 dial-tick — for each cached advert, extract peer_id from the multiaddr's \`/p2p\` protocol component, skip dialing if already connected. **But the advert builder in \`bin/sentrix/src/main.rs\` was emitting raw \`listen_addrs()\` output without the \`/p2p\` suffix.** Format was:

\`\`\`
/ip4/103.150.92.25/tcp/30303      ← what was sent
/ip4/103.150.92.25/tcp/30303/p2p/12D3KooW...   ← what dial-tick needs
\`\`\`

So the peer_id extraction always returned None, fallback dialed anyway, accumulation continued (just slower than pre-#319 because some validators still had connections that the dial-tick skipped via \`Vec::contains\` on validator-address — but most paths re-dialed).

Empirical evidence post-deploy of v2.1.31 on mainnet (2026-04-25 night):
- Pre-fix: connections grew 7 → 800+ over hours
- v2.1.31 (#319 only): connections grew 6-7 → 27 over 90 seconds
- Expected with this PR: connections plateau at ~12 indefinitely

## Fix

In \`bin/sentrix/src/main.rs\` at the advert construction site, append \`/p2p/<own_peer_id>\` to each filtered listen_addr:

\`\`\`rust
let our_peer_id = lp2p_clone.local_peer_id;
let multiaddrs: Vec<String> = listen_addrs
    .iter()
    .map(|m| m.to_string())
    .filter(|s| { /* drop loopback + 0.0.0.0 wildcards */ })
    .map(|s| {
        if s.contains("/p2p/") { s }
        else { format!("{}/p2p/{}", s, our_peer_id) }
    })
    .take(MAX_MULTIADDRS)
    .collect();
\`\`\`

\`LibP2pNode.local_peer_id\` is already a public \`Copy\` field — no new public API surface.

## Test plan

- [x] cargo build -p sentrix-node clean
- [x] cargo test -p sentrix-network --lib — 35 tests green
- [x] cargo clippy --workspace --tests -- -D warnings clean
- [ ] **Operator validation post-deploy** (rolling restart of all 4 validators):
  - Within ~10 min: each peer's cached adverts contain new /p2p-suffixed multiaddrs (advert broadcast cadence)
  - Within ~30 min: connection counts stable at steady-state ~6-12 per validator (was climbing toward 800+)
  - 24h bake: zero stalls of the 2026-04-25 class

## Risk

**Low.** Defensive (skip if /p2p already present), additive change in existing string-mapping path. libp2p Multiaddr parser handles the /p2p/<peer_id> suffix natively (Protocol::P2p variant — already what dial-tick iterates over). The fix takes effect after rolling restart; failure mode if buggy is "no peer_id appended" = same as pre-fix behavior.