### PR TITLE
chore: release v2.1.32 — Tier 4 libp2p fix (/p2p/<peer_id> in adverts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.32] — 2026-04-26 — libp2p Tier 4 fix: /p2p/<peer_id> in advert multiaddrs
+
+> **🟢 Closes the gap from v2.1.31's partial libp2p fix.** With this release, the dial-tick connected-peers pre-check actually fires (was falling back to "dial anyway" because cached advert multiaddrs lacked `/p2p/<peer_id>` suffix). Connection accumulation should now plateau at the steady-state mesh size (~6-12 per validator for the 4-validator mainnet) instead of climbing toward gossipsub-thrashing thresholds.
+
+### Fixed (#321)
+
+- **Advert builder appends `/p2p/<own_peer_id>` to each broadcast multiaddr** — `bin/sentrix/src/main.rs` advert construction site. `LibP2pNode.local_peer_id` (already public Copy field) is read at advert build time + suffixed onto each filtered listen_addr. Defensive: skip the suffix if the address already contains "/p2p/" (listen_addrs() shouldn't return such, but tolerate it).
+- **Net effect when paired with v2.1.31's #319 fix**: peer_id extraction in the dial-tick connected-peers pre-check actually returns `Some(peer_id)` instead of always `None`. Validators stop re-dialing peers they're already connected to. Connection pool stops accumulating. The 2026-04-25 mainnet stall pattern (h=583002, h=585217, h=590000-area, h=592192) should not recur once all 4 validators run v2.1.32.
+
+### Empirical signal
+
+| Build | Connection growth pattern (4-validator mainnet) |
+|---|---|
+| v2.1.30 (pre-fix) | 7 → 800+ over hours, periodic stall |
+| v2.1.31 (#319 only, partial) | 6-7 → 27 over 90 seconds, slower stall |
+| v2.1.32 (this PR) | Expected: plateau at ~6-12 indefinitely |
+
+Operator validation: monitor `ss -tn state established '( sport = :30303 or dport = :30303 )' \| wc -l` across 24 hours. Pre-fix this counter climbed monotonically; post-fix should sit in a tight band.
+
+### Migration
+
+- Drop-in chain.db compatible with v2.1.31.
+- Per-validator deploy: rolling restart picks up new binary. Within ~10 min, advert broadcasts will carry the new /p2p suffix; within ~30 min, full mesh-stable steady state (allowing for advert gossip propagation + peers picking up new cached entries).
+
+---
+
 ## [2.1.31] — 2026-04-25 — Late-night ship: BFT signing v2 foundation + Frontier F-2 shadow + libp2p connection-leak fix + V4 reward v2 fork activated
 
 > **🟢 Three substantial improvements landed late on 2026-04-25, plus the V4 reward v2 mainnet fork activated at h=590100.** The libp2p connection leak fix is the most operationally important — it closes the root cause of two production stalls earlier in the day.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "anyhow",
  "axum",
@@ -4894,14 +4894,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4944,14 +4944,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "bincode",
  "blake3",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.31"
+version = "2.1.32"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.31"
+version = "2.1.32"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Workspace 2.1.31 → 2.1.32. Bundles #321 (Tier 4 libp2p fix: appends /p2p/<own_peer_id> to advert multiaddrs so #319's dial-tick connected-peers pre-check actually fires). Closes the partial-fix gap. Expected: connection accumulation plateaus at steady-state mesh size after deploy + 30 min mesh-stable convergence.