### PR TITLE
chore: release v2.1.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.33] — 2026-04-26 — Voyager auth runtime-aware fix + connection_limits hardening
+
+> **🟢 Closes the 2026-04-26 mainnet stall root cause** (env-var-defaulted `VOYAGER_FORK_HEIGHT=u64::MAX` + `validate_block` static check ⇒ Pioneer-auth rejection of valid Voyager skip-round blocks). Plus bundles the connection_limits Behaviour for max-1-established-per-peer enforcement.
+
+### Fixed (#324)
+
+- **`Blockchain::voyager_mode_for(height)` runtime-aware check.** New instance method that ORs the env-var fork-height check with the chain.db `voyager_activated` runtime flag. `validate_block` (both Pass-1 read-only at line 117-132 and Pass-2 commit at line 364-374) migrated to use it. Result: post-Voyager-activation chains accept Voyager blocks correctly regardless of env var state.
+- **Why this matters:** the original static `is_voyager_height(height)` reads `VOYAGER_FORK_HEIGHT` env var with default `u64::MAX`. When set/defaulted to u64::MAX, returns false for any height. Pre-activation that's the correct mainnet-safe-default; post-activation it's a foot-gun. validate_block falling into Pioneer auth rejected legitimate Voyager skip-round blocks (locked-block re-propose at round N has validator field of round-N proposer, not Pioneer round-robin's round-0 proposer).
+- **Operator hot-fix on production fleet** (set `VOYAGER_FORK_HEIGHT=579047` to make the static check work) becomes belt-and-suspenders; no longer load-bearing.
+
+### Added (#323)
+
+- **`connection_limits::Behaviour` wired into SentrixBehaviour** with `max_established_per_peer(Some(1))`. Defence-in-depth for the dial-tick connected-peers pre-check (#319 + #321). Even if both sides converge a duplicate (simultaneous bidirectional dials crossing on the wire), the swarm rejects the late connection at the libp2p layer. Three layers together prevent connection accumulation:
+  1. #319: dial-tick skips dialing peers already in connected set
+  2. #321: validator adverts include `/p2p/<peer_id>` so #319's check actually works
+  3. THIS: even if #319/#321 miss a duplicate, swarm enforces 1-per-peer
+
+### Operational note
+
+After the v2.1.32 deploy attempt earlier today (rolled back due to env-var bug surfacing under load), the v2.1.33 release bundles all the cumulative work since v2.1.31:
+- v2.1.32 fix (#321 /p2p suffix)
+- v2.1.33 hardening (#323 connection_limits + #324 voyager_mode_for)
+
+Mainnet currently runs v2.1.31 + operator env hot-fix. Deploying this release per-validator rolling restart picks up the runtime-aware voyager check (bug-fix-in-perpetuity) plus the libp2p hardening (kills the connection accumulation pattern that caused the day's two earlier stalls).
+
+### Migration
+
+- Drop-in chain.db compatible with v2.1.31 / v2.1.32.
+- Per-validator rolling restart picks up new binary. `VOYAGER_FORK_HEIGHT=579047` env var on production fleet stays as belt-and-suspenders (harmless).
+- After deploy + 30 min mesh-stable convergence, expected: connection counts plateau at ~6-12 per validator, BFT round-0 finalize rate ~1/s, no skip rounds under nominal load.
+
+---
+
 ## [2.1.32] — 2026-04-26 — libp2p Tier 4 fix: /p2p/<peer_id> in advert multiaddrs
 
 > **🟢 Closes the gap from v2.1.31's partial libp2p fix.** With this release, the dial-tick connected-peers pre-check actually fires (was falling back to "dial anyway" because cached advert multiaddrs lacked `/p2p/<peer_id>` suffix). Connection accumulation should now plateau at the steady-state mesh size (~6-12 per validator for the 4-validator mainnet) instead of climbing toward gossipsub-thrashing thresholds.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "anyhow",
  "axum",
@@ -4894,14 +4894,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4944,14 +4944,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "bincode",
  "blake3",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.32"
+version = "2.1.33"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.32"
+version = "2.1.33"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Workspace 2.1.32 → 2.1.33. Bundles #324 (voyager_mode_for runtime-aware check, closes 2026-04-26 stall root cause) + #323 (connection_limits Behaviour max_established_per_peer=1). After deploy: env hot-fix becomes belt-and-suspenders; libp2p connection accumulation prevented at swarm layer.