### PR TITLE
fix(network): loosen max_established_per_peer 1 → 2 (v2.1.34 hotfix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/src/behaviour.rs
+++ b/crates/sentrix-network/src/behaviour.rs
@@ -104,14 +104,25 @@ fn env_bool(key: &str, default: bool) -> bool {
 /// Build the gossipsub config used by both `new` and `new_with_keypair`.
 /// Reads all tunables via env vars; see the module-level comment above for
 /// the full parameter list + recommended values per mesh size.
-/// Build the connection-limits behaviour. Caps established connections
-/// per peer at 1 — defence-in-depth alongside the L1 dial-tick connected-
-/// peers pre-check (#319 + #321). Other limits left at defaults
-/// (unbounded) so we don't accidentally cap total connections below the
-/// active-set + peer-discovery floor.
+/// Build the connection-limits behaviour.
+///
+/// `max_established_per_peer` caps redundant connections per peer_id.
+/// Set to 2 (not 1): allows ONE simultaneous-bidirectional-dial dup
+/// while still preventing unbounded accumulation. v2.1.33 first set
+/// this to 1 — production observation: too restrictive on the
+/// 4-validator mainnet mesh, gossipsub propagation became too sparse,
+/// BFT block rate dropped from ~1/s to ~1/20s with 2-3 skip rounds
+/// per validator per minute. Raising to 2 restores normal block rate
+/// while still enforcing the no-accumulation invariant (cap is at
+/// 2 per peer, not unbounded). Override via SENTRIX_MAX_CONN_PER_PEER
+/// env if a future operator wants to tune; default 2 is mainnet-safe.
 fn build_connection_limits_behaviour() -> libp2p::connection_limits::Behaviour {
     use libp2p::connection_limits::{Behaviour, ConnectionLimits};
-    Behaviour::new(ConnectionLimits::default().with_max_established_per_peer(Some(1)))
+    let max_per_peer: u32 = std::env::var("SENTRIX_MAX_CONN_PER_PEER")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2);
+    Behaviour::new(ConnectionLimits::default().with_max_established_per_peer(Some(max_per_peer)))
 }
 
 fn gossipsub_config() -> gossipsub::Config {

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.33"
+version = "2.1.34"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
v2.1.33 production observation: 1-per-peer too restrictive for 4-validator mesh, block rate dropped to ~3/min from target 60/min. Raising to 2 restores normal rate while still preventing accumulation. SENTRIX_MAX_CONN_PER_PEER env override added.