### PR TITLE
fix(core): migrate remaining is_voyager_height callsites to voyager_mode_for

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1699,7 +1699,11 @@ async fn cmd_start(
                 // activation proceeds automatically.
                 if !voyager_activated {
                     let bc = shared_clone.read().await;
-                    if Blockchain::is_voyager_height(bc.height().saturating_add(1)) {
+                    // 2026-04-26: voyager_mode_for() runtime-aware check.
+                    // For activation transition (voyager_activated == false),
+                    // env-var fork-height drives activation. After activation
+                    // the runtime flag takes over via voyager_mode_for's OR.
+                    if bc.voyager_mode_for(bc.height().saturating_add(1)) {
                         let active_set_len = bc.stake_registry.active_set.len();
                         drop(bc);
 

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -985,7 +985,8 @@ impl Blockchain {
 
             // Execute EVM transaction if present (data field starts with "EVM:")
             // tx_index skips coinbase at slot 0 — first real tx is index 1.
-            if tx.is_evm_tx() && Self::is_voyager_height(self.height()) {
+            // 2026-04-26: use voyager_mode_for() runtime-aware check (see #324).
+            if tx.is_evm_tx() && self.voyager_mode_for(self.height()) {
                 let tx_index = (block
                     .transactions
                     .iter()

--- a/crates/sentrix-rpc/src/jsonrpc/sentrix.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/sentrix.rs
@@ -76,8 +76,12 @@ async fn sentrix_get_validator_set(state: &SharedState) -> DispatchResult {
     // blocks. "Consensus mode" detection: if the next block lands
     // post-Voyager, use the DPoS path; otherwise use PoA.
     let next_height = bc.latest_block().map(|b| b.index + 1).unwrap_or(1);
-    let is_dpos = sentrix_core::blockchain::Blockchain::is_voyager_height(next_height)
-        && !bc.stake_registry.validators.is_empty();
+    // 2026-04-26: use voyager_mode_for() runtime-aware check instead of
+    // static is_voyager_height(). Same env-var-default-u64::MAX foot-gun
+    // that bit validate_block — stale RPC reporting "is_dpos=false" when
+    // chain runtime says voyager_activated=true. See incident
+    // founder-private/incidents/2026-04-26-voyager-fork-height-env-bug.md.
+    let is_dpos = bc.voyager_mode_for(next_height) && !bc.stake_registry.validators.is_empty();
 
     if is_dpos {
         let active: std::collections::HashSet<String> =
@@ -406,7 +410,8 @@ async fn sentrix_get_finalized_height(state: &SharedState) -> DispatchResult {
         Err(_) => return Err((-32603, "chain empty".into())),
     };
     let next_height = latest.index.saturating_add(1);
-    let bft = sentrix_core::blockchain::Blockchain::is_voyager_height(next_height);
+    // 2026-04-26: voyager_mode_for() — see comment at line ~78 in this file.
+    let bft = bc.voyager_mode_for(next_height);
     let (finalized_height, finalized_hash) = if !bft {
         (latest.index, latest.hash.clone())
     } else {


### PR DESCRIPTION
Defensive follow-up to #324. Migrates RPC reporting + EVM check + validator-loop activation check from static is_voyager_height to runtime-aware voyager_mode_for. Mainnet on v2.1.34 stable; defer deploy to next bundle.