### PR TITLE
fix(primitives): tx validate exempts staking ops from amount>0 check (v2.1.36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.36] — 2026-04-26 — tx validate: staking-op amount=0 exemption
+
+> **Hotfix**: tx validation rejected ClaimRewards (and other no-fund-movement staking ops) because the `amount > 0` check exempted only token + EVM ops, not staking ops. Surfaced 2026-04-26 when first ClaimRewards submission was rejected with `"amount must be > 0 (unless token/EVM operation)"` even though `tx.data = {"op":"claim_rewards"}` is a valid op. Fix exempts staking ops.
+
+### Fixed
+
+- **`Transaction::validate` allows `amount=0` for staking ops**. `crates/sentrix-primitives/src/transaction.rs:328`. The check now reads:
+  ```rust
+  if self.amount == 0
+      && !TokenOp::is_token_op(&self.data)
+      && !self.is_evm_tx()
+      && !StakingOp::is_staking_op(&self.data)
+  ```
+  Affects `ClaimRewards` (most common), `Unjail`, `SubmitEvidence` — the variants that don't move funds via `tx.amount` (apply-time treasury credit handles it).
+
+### Migration
+
+- Drop-in chain.db compatible with v2.1.35.
+
+---
+
 ## [2.1.35] — 2026-04-26 — voyager_mode_for migration sweep + claim-rewards tool
 
 > **Maintenance release.** Bundles defensive migrations of remaining `is_voyager_height` callsites (#327) plus the new `tools/claim-rewards` standalone binary (#328). No consensus or chain-state changes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-primitives/src/transaction.rs
+++ b/crates/sentrix-primitives/src/transaction.rs
@@ -324,10 +324,22 @@ impl Transaction {
             )));
         }
 
-        // amount=0 is allowed for token operations and EVM contract calls (data field carries op/calldata)
-        if self.amount == 0 && !TokenOp::is_token_op(&self.data) && !self.is_evm_tx() {
+        // amount=0 is allowed for token operations, EVM contract calls,
+        // AND staking operations (data field carries op/calldata). The
+        // staking-op exemption was missed when StakingOp dispatch landed —
+        // surfaced 2026-04-26 when the first ClaimRewards tx was rejected
+        // here despite being a valid op (data = `{"op":"claim_rewards"}`).
+        // ClaimRewards specifically has tx.amount=0 because the apply-time
+        // payout transfers from PROTOCOL_TREASURY → claimer; no on-tx
+        // amount needed. Same exemption applies to other no-fund-movement
+        // staking ops (Unjail, SubmitEvidence).
+        if self.amount == 0
+            && !TokenOp::is_token_op(&self.data)
+            && !self.is_evm_tx()
+            && !StakingOp::is_staking_op(&self.data)
+        {
             return Err(SentrixError::InvalidTransaction(
-                "amount must be > 0 (unless token/EVM operation)".to_string(),
+                "amount must be > 0 (unless token/EVM/staking operation)".to_string(),
             ));
         }
 

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.35"
+version = "2.1.36"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Hotfix: ClaimRewards (+ Unjail, SubmitEvidence) submissions rejected by mempool validate because amount=0 exemption missed staking ops. Surfaced trying first claim today.