### PR TITLE
chore(docs): sync public docs to v2.1.36 + V4 reward distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Fast, secure Layer-1 blockchain built in Rust.
 
 Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, instant finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and web3.js connect natively.
 
-- **v2.1.30** — MDBX storage, 1s blocks, 5000 tx/block capacity, EVM live on mainnet (Voyager active since 2026-04-25)
+- **v2.1.36** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active (treasury escrow + ClaimRewards op)
 - **551+ tests**, clippy clean, 11 security audit rounds
 - **4 validators** across 4 nodes (Foundation, Treasury, Core, Beacon) on the maintainer fleet
 
@@ -108,7 +108,7 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 | Phase | Status | Focus |
 |-------|--------|-------|
 | **Pioneer** | Completed (mainnet h=0…579058) | PoA round-robin, MDBX storage, 1s blocks, SRC-20 tokens — succeeded by Voyager 2026-04-25 |
-| **Voyager** | **Live on mainnet (v2.1.30)** | DPoS proposer rotation + BFT finality, EVM (revm 37), `eth_sendRawTransaction`, L1 peer auto-discovery, L2 cold-start gate |
+| **Voyager** | **Live on mainnet (v2.1.36)** | DPoS proposer rotation + BFT finality, EVM (revm 37), `eth_sendRawTransaction`, L1 peer auto-discovery + connection-limits hardening, V4 reward distribution v2 (treasury escrow + ClaimRewards), runtime-aware Voyager dispatch |
 | **Frontier** | Phase F-1 scaffold landed; F-2…F-10 planned | Parallel transaction execution, sub-1s block time, mainnet hard fork |
 | **Odyssey** | Future | Cross-chain bridges, mature ecosystem, light clients |
 
@@ -116,6 +116,7 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 
 - [Architecture](docs/architecture/) — consensus, state, networking, transactions
 - [Operations](docs/operations/) — deployment, CI/CD, monitoring, validators
+- [Claim Rewards](docs/operations/CLAIM_REWARDS.md) — how validators + delegators claim escrowed rewards from `PROTOCOL_TREASURY`
 - [Security](docs/security/) — audit reports, attack vectors, pentest results
 - [Tokenomics](docs/tokenomics/) — SRX economics, staking, token standards
 - [Roadmap](docs/roadmap/) — phase details, changelog

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -1,6 +1,6 @@
 # Sentrix — Technical Whitepaper
 
-**Version 3.2 — 2026-04-25 (post-Voyager mainnet activation)**
+**Version 3.3 — 2026-04-26 (post-V4-reward-v2 activation)**
 **Author: SentrisCloud**
 
 ---
@@ -75,6 +75,30 @@ Voyager replaces Pioneer's authority-based round-robin with a stake-weighted act
 - **EVM gating.** Voyager activation also flips `evm_activated=true`, enabling `eth_sendRawTransaction` and Solidity contract deployment via revm 37.
 
 Voyager activated on mainnet at h=579047 on 2026-04-25 after Pioneer ran from genesis through h=579046.
+
+### 2.7 V4 Reward Distribution (active mainnet)
+
+Pre-V4 (Pioneer + early Voyager): coinbase 1 SRX/block credited directly to the proposing validator's balance.
+
+Post-V4 (active on mainnet since h=590100, 2026-04-25): coinbase routes to `PROTOCOL_TREASURY` (`0x0000000000000000000000000000000000000002`). Validators and their delegators accumulate stake-weighted shares in `pending_rewards` accumulators. Funds are released to claimers via the `StakingOp::ClaimRewards` transaction:
+
+```
+Pre-V4:  block produced → coinbase 1 SRX → validator balance
+Post-V4: block produced → coinbase 1 SRX → PROTOCOL_TREASURY
+                                            ↓ (escrow)
+                          ClaimRewards tx ← validator/delegator
+                                            ↓
+                          PROTOCOL_TREASURY → claimer balance
+                          pending_rewards reset to 0
+```
+
+Why the change:
+- Stake-weighted delegation share — delegators earn pro-rata from validator's commission carve-out without manual accounting
+- Slashing applies to pending_rewards before claim — validator misbehavior reduces accumulated reward, not yet-paid balance
+- On-chain audit trail — `pending_rewards` per validator is queryable via `/staking/validators` JSON-RPC endpoint
+- Treasury fund growth visible — total `PROTOCOL_TREASURY` balance reflects unclaimed escrow at any height
+
+The activation was a non-fork operator-side env var flip (`VOYAGER_REWARD_V2_HEIGHT=590100`); code path was already staged in v2.1.30+ binaries. At fork height, `reset_reward_accumulators_for_fork_activation()` fired once to clear pre-V4 accumulator state, then the new path took effect for all subsequent blocks.
 
 ### 2.6 Peer Mesh (L1 + L2 self-healing)
 

--- a/docs/operations/CLAIM_REWARDS.md
+++ b/docs/operations/CLAIM_REWARDS.md
@@ -1,0 +1,128 @@
+# Claim Rewards
+
+Validators (and post-fork their delegators) accumulate `pending_rewards` in the `PROTOCOL_TREASURY` escrow on every block they help produce. To move those funds into a spendable balance, submit a `ClaimRewards` staking-op transaction.
+
+## Status
+
+Active on mainnet since h=590100 (2026-04-25). Default behaviour for v2.1.30+ binaries when `VOYAGER_REWARD_V2_HEIGHT` env var is set on the validator.
+
+## Mechanism
+
+```
+Pre-V4 fork (h<590100):
+  block produced → coinbase 1 SRX → validator balance (direct credit)
+
+Post-V4 fork (h≥590100):
+  block produced → coinbase 1 SRX → PROTOCOL_TREASURY
+                                     ↓ (escrow, queryable)
+                                     ↓
+                  ClaimRewards tx ← validator/delegator
+                                     ↓ (apply-time)
+                  PROTOCOL_TREASURY → claimer balance
+                  pending_rewards reset to 0
+```
+
+`PROTOCOL_TREASURY` = `0x0000000000000000000000000000000000000002`.
+
+## When to claim
+
+There is no deadline — accumulated rewards stay in escrow indefinitely. But:
+
+- Slashing reduces `pending_rewards` before claim: misbehavior only takes from yet-to-be-claimed share
+- Holding period reset: claiming triggers fresh accumulation cycle
+- Operational liquidity: claimed SRX is spendable; escrowed SRX is not
+
+Practical pattern: claim weekly or monthly, depending on accrual rate vs gas economics.
+
+## Query pending rewards
+
+```bash
+curl -sf https://sentrix-rpc.sentriscloud.com/staking/validators | jq '.validators[] | {address, pending_rewards, total_stake}'
+```
+
+Output (per validator):
+```json
+{
+  "address": "0x753f2f68829fbe76a0132295624f48b27ce2e2d9",
+  "pending_rewards": 375500000000,
+  "total_stake": 1500000000000
+}
+```
+
+`pending_rewards` is in sentri (1 SRX = 100,000,000 sentri).
+
+## Submit a claim
+
+The reference `tools/claim-rewards/` binary accepts the validator's secret key on stdin and submits a properly-encoded `StakingOp::ClaimRewards` transaction:
+
+```bash
+# Build it (one-time, on a host with the workspace + Rust toolchain)
+cd /path/to/sentrix/tools/claim-rewards
+cargo build --release
+# Binary: ./target/release/claim-rewards
+
+# Submit (interactive — privkey stays in process memory; never logged)
+echo "<64-hex-privkey>" | ./target/release/claim-rewards \
+  --rpc       https://sentrix-rpc.sentriscloud.com \
+  --chain-id  7119
+
+# Add --dry-run to build + sign without POSTing (for verification)
+```
+
+Mainnet chain ID is `7119`; testnet is `7120`.
+
+## Tx shape
+
+Under the hood, `ClaimRewards` is a `StakingOp`-encoded transaction:
+
+| Field | Value |
+|---|---|
+| `from_address` | The claimer (validator or delegator address) |
+| `to_address` | `PROTOCOL_TREASURY` (`0x0000…0002`) |
+| `amount` | `0` — the apply-time treasury credit handles fund movement; `tx.amount` is unused |
+| `fee` | `MIN_TX_FEE` (10,000 sentri = 0.0001 SRX) |
+| `data` | `{"op":"claim_rewards"}` (JSON-encoded `StakingOp::ClaimRewards`) |
+| `chain_id` | 7119 (mainnet) or 7120 (testnet) |
+| `signature` | secp256k1 ECDSA over canonical signing payload |
+
+## After the claim
+
+Within 1-2 blocks (roughly 1-2 seconds at 1s block time):
+
+1. Mempool admits the tx
+2. Proposer includes it in the next block
+3. Block apply runs `ClaimRewards` dispatch:
+   - Validator's `pending_rewards` and any delegator share is summed into `total_claim`
+   - `accounts.transfer(PROTOCOL_TREASURY → claimer, total_claim, fee=0)`
+   - Validator's `pending_rewards` reset to 0
+4. Subsequent blocks accumulate fresh `pending_rewards`
+
+Verify post-claim:
+
+```bash
+# Pending should be 0
+curl -sf https://sentrix-rpc.sentriscloud.com/staking/validators | \
+  jq '.validators[] | select(.address=="0x<your-addr>") | .pending_rewards'
+
+# Balance should have grown by claimed amount minus MIN_TX_FEE
+curl -sf -X POST https://sentrix-rpc.sentriscloud.com/rpc \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x<your-addr>","latest"],"id":1}'
+```
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `validator … not found in active set` | Address derived from the privkey isn't a registered validator | Verify privkey corresponds to the validator address |
+| `nothing to claim — pending_rewards = 0` | Already claimed, or no blocks produced yet | Wait for accumulation; no action |
+| `insufficient balance for MIN_TX_FEE` | Claimer balance < 10,000 sentri | Top up balance manually; the fee is taken from balance, not pending_rewards |
+| `wrong chain_id` (HTTP 400) | `--chain-id` mismatch with target network | Use 7119 for mainnet, 7120 for testnet |
+| `nonce too low` | A previous tx from same address is still in mempool | Wait for inclusion or check tx status |
+
+## Security
+
+- The `claim-rewards` binary reads privkey from stdin only — never from CLI args or env vars (those would leak to process listings or shell history).
+- Pipe directly from a wallet decryptor; never write privkey to a file.
+- Run on a host with strict access controls (validator host or operator workstation behind 2FA).
+- Privkey stays in process memory during signing only; not logged, not written to disk.

--- a/docs/operations/EMERGENCY_ROLLBACK.md
+++ b/docs/operations/EMERGENCY_ROLLBACK.md
@@ -65,10 +65,18 @@ sudo install -m 755 <bin_dir>/releases/sentrix-vX.Y.Z-<timestamp> <bin_dir>/sent
 sudo systemctl start <validator-service>
 ```
 
-Current production binary at the time of writing: **v2.1.30** (mainnet
-& testnet, post-Voyager activation). Prior production releases archived
-under each validator's `<bin_dir>/releases/`: v2.1.29, v2.1.28, v2.1.27,
-v2.1.26, v2.1.25 (historical Pioneer-mode emergency hotfix).
+Current production binary at the time of writing: **v2.1.36** (mainnet
+& testnet, post-V4-reward-v2-activation). Prior production releases
+archived under each validator's `<bin_dir>/releases/`: v2.1.35, v2.1.34,
+v2.1.33, v2.1.32, v2.1.31, v2.1.30, v2.1.29, v2.1.28, v2.1.27, v2.1.26.
+
+The 2026-04-25 / 2026-04-26 incident hotfix series:
+- v2.1.31: BFT signing v2 foundation + Frontier F-2 shadow + libp2p connection-leak fix
+- v2.1.32: `/p2p/<peer_id>` in advert multiaddrs (closes #319 partial-fix gap)
+- v2.1.33: voyager_mode_for runtime-aware check + connection_limits Behaviour
+- v2.1.34: connection_limits cap loosened 1→2 (production hotfix)
+- v2.1.35: Voyager-mode-for migration sweep + claim-rewards tool
+- v2.1.36: tx validate exempts staking ops from amount>0 check (ClaimRewards submission fix)
 
 ---
 

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -14,7 +14,8 @@
 | Native coin | SRX |
 | Consensus | **Voyager** (DPoS + BFT, `voyager_activated=true` since h=579047 / 2026-04-25) |
 | EVM | Active — `evm_activated=true` since the same height; MetaMask compatible |
-| Binary | v2.1.30 |
+| Reward distribution | **V4 reward v2** active since h=590100 / 2026-04-25 — coinbase routes to `PROTOCOL_TREASURY` (0x0000…0002), validators + delegators claim via `ClaimRewards` staking op |
+| Binary | v2.1.36 |
 
 ## Testnet
 
@@ -36,7 +37,7 @@ Testnet tokens have no real value. Use the faucet to get test SRX.
 
 Testnet runs in Docker on build host (`/opt/sentrix-testnet-docker/`) since
 the 2026-04-23 migration; fresh genesis at chain_id 7120, current
-height ~200K, binary v2.1.30.
+height ~200K, binary v2.1.36.
 
 > **Mainnet operational note (2026-04-25, post-Voyager):** mainnet successfully
 > transitioned from Pioneer PoA to Voyager DPoS+BFT at h=579047. EVM was


### PR DESCRIPTION
Sync public-facing docs to current production state (v2.1.36, V4 reward v2 active since 2026-04-25 h=590100). Bumps WHITEPAPER to v3.3 with new §2.7 V4 Reward Distribution section. Adds new docs/operations/CLAIM_REWARDS.md as full operator guide. Updates README + NETWORKS + EMERGENCY_ROLLBACK with current binary version + hotfix series summary.