### PR TITLE
docs(roadmap): sync PHASE2 to ACTIVE, add PHASE3 Frontier, log v2.1.30 + v2.1.36 in roadmap CHANGELOG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "anyhow",
  "axum",
@@ -4894,14 +4894,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4944,14 +4944,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "bincode",
  "blake3",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.35"
+version = "2.1.36"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/docs/roadmap/CHANGELOG.md
+++ b/docs/roadmap/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## [2.1.36] — 2026-04-26 — V4 reward v2 + 14 PR marathon
+
+Single-night marathon (PRs #316–#331; binaries v2.1.31 → v2.1.36). All 4 mainnet validators on v2.1.36 in Voyager DPoS+BFT.
+
+### Added
+- **V4 reward distribution v2** active since h=590100. Coinbase 1 SRX/block routes to `PROTOCOL_TREASURY` (`0x0000…0002`) escrow; validators + delegators claim via `StakingOp::ClaimRewards` (no-amount staking op with apply-time treasury credit). Stake-weighted delegator share supported, slashing applies to `pending_rewards` before claim.
+- **`tools/claim-rewards/`** — standalone Cargo binary. Reads 64-hex privkey from stdin, queries pending via `/staking/validators`, builds + submits ClaimRewards tx. Proven end-to-end on Core validator.
+- **`docs/operations/CLAIM_REWARDS.md`** — operator guide (mechanism diagrams, query/submit/verify procedure, failure modes).
+- **`/staking/validators`** JSON-RPC field `pending_rewards` per validator.
+- **`SwarmCommand::GetConnectedPeers`** + `LibP2pHandle::connected_peers()` — used by L1 dial-tick to skip already-connected peers.
+- **`connection_limits::Behaviour`** in libp2p swarm (`max_established_per_peer = 2`, env-overridable). Caps connection accumulation between validator pairs.
+- **L1 multiaddr `/p2p/<peer_id>` suffix** — appended to validator advert multiaddrs so receiving validators can extract `peer_id` for `dial_known()` short-circuit.
+- **Frontier Phase F-2 shadow-mode wiring** (`SENTRIX_FRONTIER_F2_SHADOW=1`) — `build_batches` observer in `apply_block_pass2`, read-only.
+- **BFT signing v2 Phase 1 foundation** — `signing_payload_for_height(...)` dispatch helper + low-S enforcement scaffold (Phase 2 call-site refactor pending dedicated session).
+- **`docs/roadmap/PHASE3.md`** — Frontier roadmap (F-1✅, F-2✅, F-3 → F-10 pending; ~6-8 weeks calendar).
+
+### Changed
+- **PHASE2.md rewritten** from "Planned" to "ACTIVE on mainnet since 2026-04-25" — three pillars (DPoS + BFT + EVM), V4 reward subsystem, network hardening summary.
+- **Voyager dispatch is now runtime-aware** — `Blockchain::voyager_mode_for(&self, height)` ORs env `VOYAGER_FORK_HEIGHT` with chain.db `voyager_activated`. Production callsites in `block_executor.rs` (validate_block + EVM tx check) + `jsonrpc/sentrix.rs` (getValidatorSet + getFinalizedHeight) migrated. Closes the env-var-default-`u64::MAX` foot-gun that caused validate_block to fall into Pioneer auth post-restart.
+- **Mempool tx validation** exempts staking ops from `amount > 0` check (alongside existing token-op + EVM-tx exemptions). Allows ClaimRewards (`amount=0`, `to=PROTOCOL_TREASURY`).
+- **Bootstrap-peers symmetric on all 4 systemd units** — each validator now lists all 3 others in `--peers`. Post-restart mesh self-heals without parallel-restart recovery.
+- WHITEPAPER bumped to v3.3 with new §2.7 V4 Reward Distribution section.
+- Public docs synced to v2.1.36 (README, NETWORKS, EMERGENCY_ROLLBACK).
+
+### Fixed
+- **VOYAGER_FORK_HEIGHT env default `u64::MAX` bug** — caused h=597524 stall (`is_voyager_height()` returned false → validate_block fell into Pioneer auth → rejected Voyager skip-round blocks as "Unauthorized validator"). Fixed via PR #324 (`voyager_mode_for` runtime check) + operator hot-fix (env=579047). Incident report: `incidents/2026-04-26-voyager-fork-height-env-bug.md` (founder-private).
+- **libp2p connection accumulation** — 4-tier hardening: dial-tick connected-peers pre-check (#319) + advert `/p2p/` suffix (#321) + connection_limits cap (#323) + max-per-peer 1→2 hotfix (#326).
+- **`fast-deploy.sh REPO_ROOT`** broken after script moved to founder-private — added `SENTRIX_REPO` env-var override.
+- **`cp ETXTBSY`** when overwriting running executable — switched to cp-to-tmp-stage-then-mv-rename pattern.
+
+### Notes
+- `is_voyager_height()` static check kept for test compatibility (production callsites all migrated to `voyager_mode_for()`).
+- BFT signing v2 Phase 2 (~31 mechanical call-site changes) deferred to dedicated fresh-brain session per consensus discipline.
+
+---
+
+## [2.1.30] — 2026-04-25 — Voyager DPoS+BFT + EVM activation
+
+Pivotal release: mainnet hard-fork from Pioneer (PoA round-robin) to Voyager (DPoS+BFT) at h=579047. EVM (revm 37) activated in same window.
+
+### Added
+- **Voyager DPoS+BFT consensus** active on mainnet since h=579047. 4 validators (Foundation, Treasury, Core, Beacon), stake-weighted active set, 28800-block epochs, 3-phase Tendermint-style BFT (propose / prevote / precommit) with skip-round proposer rotation. `BlockJustification` carries supermajority precommits.
+- **EVM** active since h=579060 (`evm_activated=true`). MetaMask compatibility (`eth_sendRawTransaction`, `eth_call`, `eth_getBalance`, etc); 0.1 sentri/gas, 30M block gas limit, chain ID 7119/7120.
+- **L1 multiaddr advertisements** — `sentrix/validator-adverts/1` gossipsub topic; signed `MultiaddrAdvertisement` broadcasts every 10 min; auto-dial. Self-healing mesh from a single bootstrap peer.
+- **L2 cold-start gate** — validator loop refuses BFT entry until `peer_count >= active_set.len() - 1`. Closes the activation #1 livelock cause.
+- **`/sentrix_status` + `/chain/info`** consensus reporting fields (`consensus_mode`, `voyager_activated`, `evm_activated`).
+- **Frontier Phase F-1 type scaffold** (`AccountKey`, `TxAccess`, `Batch`, `derive_access`, `build_batches` stubs).
+
+### Changed
+- WHITEPAPER bumped to v3.2 with new §2.5 Voyager DPoS+BFT design + §2.6 L1/L2 peer auto-discovery sections.
+- `SENTRIX_FORCE_PIONEER_MODE` removed from all env files.
+- CLAUDE.md trimmed to ~25 incident-earned rules.
+
+### Fixed
+- Issue #268 (legacy block tolerance) closed via `SENTRIX_LEGACY_VALIDATION_HEIGHT=557144`.
+- Issue #292 (RPC string consensus reporting) closed.
+
+### Migration notes
+- Hard-fork at h=579047 — pre-fork blocks (Pioneer PoA) carry forward in chain.db; post-fork blocks (Voyager DPoS+BFT) require active set sync via `/staking/validators`.
+
+---
+
 ## [1.0.0] — 2026-04-15
 
 Pioneer release. v1.0.0 tagged and published.

--- a/docs/roadmap/PHASE2.md
+++ b/docs/roadmap/PHASE2.md
@@ -1,51 +1,85 @@
-# Voyager — DPoS + BFT + EVM (Planned)
+# Voyager — DPoS + BFT + EVM (LIVE on mainnet)
 
-> Design finalized. Not implemented yet. Target: Q3 2026.
-> Voyager is the next network phase after Pioneer.
+> **Status: ACTIVE on mainnet since 2026-04-25 (h=579047).** Both networks (mainnet chain_id 7119, testnet chain_id 7120) run Voyager DPoS+BFT with EVM (revm 37) enabled.
 
-## Three Things
+Voyager succeeded Pioneer (PoA round-robin, blocks 0…579046 on mainnet) as the consensus + execution engine. The transition was a hard-fork at h=579047 — `voyager_activated=true` flag set on chain.db, all 4 mainnet validators migrated together via parallel restart with the L2 cold-start gate ensuring mesh-stable BFT entry.
 
-### 1. DPoS
+## Three Pillars (live)
 
-Replace admin-appointed validators with stake-weighted selection.
+### 1. DPoS Validator Selection
 
-- Min self-stake: 15,000 SRX
-- Active set: top 100 by `self_stake + delegated_stake`
-- Epoch: 28,800 blocks (~1 day) — validator set recalculated at boundary
-- Slashing: 1-5% for downtime, 20% + permaban for double-signing
-- Commission: validators set their own rate (5-20%)
+Stake-weighted active set, replacing the admin-appointed Pioneer authority.
+
+- **Self-stake minimum:** 15,000 SRX (`MIN_SELF_STAKE`)
+- **Active set:** top 100 validators by `self_stake + delegated_stake × commission_factor`. Currently 4 active on mainnet (Foundation, Treasury, Core, Beacon).
+- **Epoch:** 28,800 blocks (~1 day at 1s block time) — validator set recalculated at boundary; jailing/slashing committed.
+- **Slashing:**
+  - Downtime: 1-5% gradual, scales with offline duration
+  - Double-signing: 20% + permanent ban (tombstoned)
+  - Submitted via `StakingOp::SubmitEvidence` from any active validator
+- **Commission:** each validator sets their own rate (current default 10%, range 5-20%)
 
 ### 2. BFT Finality
 
-After a block is produced, validators vote. 2/3+ votes = block is final, can't be reorged. With 100 validators, need 67+ votes.
+After a proposer drafts a block, all active validators vote in two phases (Tendermint-style):
 
-### 3. EVM via revm
+- **Round 0:** Propose → Prevote → Precommit. If 2/3+1 stake-weighted precommits land in the round window, block finalizes.
+- **Skip rounds:** if quorum not reached, round advances; proposer rotates per `(height + round) % active_set.len()`. Locked-block re-propose preserves PoLC integrity across rounds.
+- **Justifications:** each finalized block carries a `BlockJustification` with the precommit signatures that finalized it. Light clients verify finality by checking justifications against the on-chain stake registry.
 
-Smart contracts in Solidity. Using [revm](https://github.com/bluealloy/revm) (Paradigm's EVM, used by reth). Battle-tested, pure Rust, audited.
+For a 4-validator mesh, supermajority threshold = 3 of 4 (75%). Mainnet routinely finalizes round-0 at 1 block/sec under nominal load.
 
-Gas pricing: 0.1 sentri/gas. Block gas limit: 30M. Transfer ≈ 0.000021 SRX.
+### 3. EVM via revm 37
 
-Why revm and not custom VM: DPoS + BFT is already hard. EVM compatibility gives immediate access to existing tooling. Custom VM can wait for Odyssey if demand justifies it.
+Solidity smart contracts via [revm](https://github.com/bluealloy/revm) (Paradigm's EVM, used by Reth/Erigon). Pure Rust, battle-tested, currently on revm 37.
 
-## TODO
+- **Activation:** `evm_activated=true` set 2026-04-25 in the same window as Voyager activation (h=579060).
+- **Gas pricing:** 0.1 sentri/gas; block gas limit 30M; basic transfer ≈ 0.000021 SRX.
+- **MetaMask compatibility:** `eth_sendRawTransaction`, `eth_call`, `eth_getBalance`, `eth_estimateGas`, `eth_getCode`, `eth_getStorageAt` all supported. Chain ID 7119 mainnet, 7120 testnet.
+- **Tx encoding:** `data` field starting with `EVM:` routes through revm; otherwise standard Sentrix tx.
 
-- [ ] DPoS: stake registry, delegation, epoch logic, commission, rewards, unbonding, slashing
-- [ ] BFT: block signatures, vote collection, 2/3+ threshold, fork choice
-- [ ] EVM: revm integration, gas metering, gas limit, eth_call, eth_estimateGas
+## V4 Reward Distribution (active subsystem)
 
-## Migration
+Layered onto Voyager since h=590100 (2026-04-25). Pre-V4 the proposing validator was credited 1 SRX direct; post-V4 the reward routes to `PROTOCOL_TREASURY` (`0x0000000000000000000000000000000000000002`) escrow.
 
-No chain reset. Protocol upgrade at a predetermined fork height. Existing 7 Pioneer validators grandfathered in. Staking opens for new validators.
+```
+block produced → coinbase 1 SRX → PROTOCOL_TREASURY (escrow)
+                                   ↓
+            ClaimRewards staking op ← validator/delegator
+                                   ↓ (apply-time)
+                  TREASURY → claimer balance
+                  pending_rewards reset to 0
+```
 
-## Prerequisites
+Why:
+- Stake-weighted delegator share (delegators earn pro-rata from validator's commission carve-out without manual accounting)
+- Slashing applies to `pending_rewards` before claim — misbehavior reduces accumulated reward, not yet-paid balance
+- Audit trail visible via `/staking/validators` JSON-RPC
 
-- [x] P0 security (peer limits, rate limiting)
-- [ ] Block-level validator signatures
-- [ ] Fork choice rule
-- [ ] State root rollback mechanism
+See [docs/operations/CLAIM_REWARDS.md](../operations/CLAIM_REWARDS.md) for the operator guide.
 
-## Future Phases
+## Network Hardening
 
-**Frontier (Q4 2026, if needed):** Ecosystem expansion, dApps, real users. Sharding only if >1K TPS demand proven.
+The 2026-04-25 / 2026-04-26 marathon shipped substantial network hardening alongside Voyager activation:
 
-**Odyssey (2027+, if demand):** Full public chain, cross-chain bridges. Custom VM with parallel execution if EVM proves insufficient. Would need external audit (Zellic/Trail of Bits).
+- **L1 multiaddr advertisements** (v2.1.26+): each validator broadcasts a signed `MultiaddrAdvertisement` on the `sentrix/validator-adverts/1` gossipsub topic at startup + every 10 minutes; receivers cache + dial. Self-healing mesh from a single bootstrap peer.
+- **L2 cold-start gate** (v2.1.27): validator loop refuses to enter BFT mode unless `peer_count >= active_set.len() - 1`. Closes the cold-start race that caused the 2026-04-25 activation #1 livelock.
+- **Connection-leak fixes** (v2.1.31-v2.1.34): dial-tick connected-peers pre-check + `/p2p/<peer_id>` in advert multiaddrs + `connection_limits::Behaviour` cap (max 2 established per peer). Closes the connection-accumulation pattern.
+- **Runtime-aware Voyager dispatch** (v2.1.33): `voyager_mode_for(&self, height)` ORs env-var fork-height check with chain.db `voyager_activated` runtime flag. Closes the env-var-default-`u64::MAX` foot-gun that caused validate_block to fall into Pioneer auth.
+
+## Operations
+
+- **Mainnet:** 4 validators (Foundation, Treasury, Core, Beacon). Each lists all 3 others in systemd `--peers` for clean cold-start convergence.
+- **Testnet:** 4 validators in Docker on the build host. Same Voyager+EVM+V4 stack as mainnet; chain_id 7120; height ~200K+.
+- **Binary:** v2.1.36 across both networks.
+- **RPC reporting:** `/sentrix_status` returns `consensus: "DPoS+BFT"`; `/chain/info` exposes `consensus_mode`, `voyager_activated`, `evm_activated`; `/staking/validators` returns per-validator `pending_rewards`.
+
+## Outstanding Voyager work (defence-in-depth, not blocking)
+
+- **BFT signing v2** (chain_id in signing payload + low-S enforcement) — hard-fork-gated. Phase 1 foundation shipped, Phase 2 call-site refactor pending dedicated session. Defence-in-depth — closes cross-chain BFT vote replay vulnerability before external validator onboarding.
+- **External validator onboarding tooling** — DPoS open registration is live (15,000 SRX self-stake floor). Operator runbook + automation polish before opening to third parties.
+- **ClaimRewards CLI** (alongside the existing `tools/claim-rewards/` standalone binary) — direct `sentrix validator claim-rewards` subcommand for ergonomic operator UX.
+
+## What's Next: Frontier
+
+See [PHASE3.md](./PHASE3.md). Frontier targets parallel transaction execution + sub-1s block time + ecosystem expansion via mainnet hard fork. Phase F-1 type scaffold + F-2 shadow-mode wiring already in main; F-3 onward (real parallel apply) ~6-8 weeks calendar.

--- a/docs/roadmap/PHASE3.md
+++ b/docs/roadmap/PHASE3.md
@@ -1,0 +1,58 @@
+# Frontier — Parallel Execution + Ecosystem (Planned, in early implementation)
+
+> **Status:** Phase F-1 type-scaffold and Phase F-2 shadow-mode wiring landed in `main`. Phases F-3 → F-10 (real parallel apply + testnet bake + mainnet activation) are calendar work, ~6-8 weeks. Mainnet hard-fork required at activation.
+
+Frontier extends Voyager with three goals:
+
+1. **Parallel transaction execution** — apply non-conflicting txs in a block concurrently rather than strictly sequentially
+2. **Sub-1s block time** — tighter consensus + faster apply enables shorter rounds
+3. **Ecosystem expansion** — third-party validators onboard, dApps deploy via the mature EVM surface, real-user scaling
+
+## Phase Plan
+
+| Phase | What | Status |
+|---|---|---|
+| F-1 | Type-system scaffold (`AccountKey`, `TxAccess`, `Batch`, `derive_access`, `build_batches` stubs) | ✅ Landed (PR #305) |
+| F-2 | Shadow-mode wiring — `SENTRIX_FRONTIER_F2_SHADOW=1` env-gated `build_batches` observer in `apply_block_pass2`, read-only | ✅ Landed (PR #318) |
+| F-3 | Real parallel-apply replacing the shadow log: actual batch apply + conflict detection + abort/retry path | 🟡 Pending |
+| F-4 | Conflict-graph builder — derives read/write access per tx from EVM trace; builds dependency graph | 🟡 Pending |
+| F-5 | Determinism property tests promoted from `#[ignore]` to gating (`parallel_apply_matches_sequential_apply`, `build_batches_is_deterministic_across_1000_runs`) | 🟡 Pending |
+| F-6 | Mainnet shadow-mode comparison — apply both sequential + parallel, log divergence, prove byte-equivalence over weeks | 🟡 Pending |
+| F-7 | Hard-fork height schedule + activation runbook | 🟡 Pending |
+| F-8 | Sub-1s block time tuning (`BLOCK_TIME_SECS = 0.5? 0.25?` — depends on parallel apply latency under load) | 🟡 Pending |
+| F-9 | Testnet bake (~2 weeks under load) | 🟡 Pending |
+| F-10 | Mainnet activation | 🟡 Pending |
+
+## Why This Order
+
+Each phase pins a different invariant:
+
+- F-1 pins the **type contract** (callers can rely on `Batch::tx_indices` etc) without changing runtime
+- F-2 pins the **plumbing** — `apply_block_pass2` calls into the F-1 module without trusting its output
+- F-3 pins the **semantic correctness** — parallel apply produces the same state-root as sequential apply
+- F-4 pins the **conflict model** — accurate read/write set extraction is a security property (mis-detection = state corruption)
+- F-5 pins the **non-flakiness** — deterministic batching across runs is a consensus property
+- F-6 pins the **production correctness** — months of mainnet shadow run with zero divergence before activation
+- F-7-F-10 are activation mechanics
+
+## Risk Profile
+
+Frontier is the highest-risk phase yet because parallel apply touches consensus state directly. Pioneer/Voyager were execution-engine swaps with clean before/after invariants; Frontier introduces concurrency into the apply path itself. Mistakes here = state divergence (= chain split = manual recovery).
+
+The phase plan above is built around minimizing this risk via shadow-mode comparison: by F-6, the parallel path runs against every block on mainnet, but the sequential path is still the canonical state-root source. Only after weeks of zero-divergence shadow do we flip the canonical pointer.
+
+## What Frontier is NOT
+
+- **Not a sharding upgrade.** Throughput improvement comes from parallel apply within blocks, not from horizontal partitioning. Sharding would be a separate Odyssey-class change.
+- **Not a chain reset.** Hard-fork height activates new rules; existing chain.db carries forward.
+- **Not a custom VM.** EVM via revm continues. Parallel execution wraps revm calls; doesn't replace them.
+
+## Carryover (post-Frontier, future)
+
+- Cross-chain bridges (target: Odyssey)
+- Light clients (target: Odyssey)
+- Sharding if throughput demand justifies (target: Odyssey, evidence-driven decision)
+
+## What's Next After Frontier: Odyssey
+
+See [internal roadmap]. Odyssey is the long-horizon "fully public chain with mature ecosystem" phase. Cross-chain interop, light clients, possibly sharding, hardware wallet integrations, on-chain governance. No firm timeline — driven by ecosystem maturity rather than calendar.


### PR DESCRIPTION
## Summary

- **PHASE2.md rewritten** from "Planned. Not implemented yet." → "ACTIVE on mainnet since 2026-04-25 (h=579047)". Covers all three Voyager pillars (DPoS, BFT, EVM), the V4 reward distribution v2 subsystem (active since h=590100), and the network-hardening sweep (L1 multiaddrs, L2 cold-start gate, libp2p connection-leak fixes, runtime-aware Voyager dispatch).
- **PHASE3.md added** — Frontier roadmap. F-1 type scaffold + F-2 shadow-mode wiring landed; F-3 → F-10 (~6-8 weeks calendar) outlined with risk profile + why-shadow-mode-first.
- **docs/roadmap/CHANGELOG.md** caught up from v1.0.0 (2026-04-15) → v2.1.30 (Voyager + EVM activation) → v2.1.36 (V4 reward v2 + 14 PR marathon).
- **Cargo.lock** bumped 2.1.35 → 2.1.36 to match workspace Cargo.toml — was left stale by the v2.1.36 release PR.

Docs-only sweep. No runtime behavior change.

## Test plan
- [x] PHASE2.md renders cleanly + all internal links resolve (PHASE3.md, CLAIM_REWARDS.md)
- [x] CHANGELOG.md retains existing v1.0.0 + v0.1.0 sections, prepends new v2.x entries
- [x] Cargo.lock workspace-version consistency
- [x] No secrets in diff