### PR TITLE
docs: add sentrixchain.com canonical URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Fast, secure Layer-1 blockchain built in Rust.
 
+[![Website](https://img.shields.io/badge/website-sentrixchain.com-8A5A11)](https://sentrixchain.com)
 [![CI/CD](https://github.com/sentrix-labs/sentrix/actions/workflows/ci.yml/badge.svg)](https://github.com/sentrix-labs/sentrix/actions)
 [![Release](https://img.shields.io/github/v/release/sentrix-labs/sentrix)](https://github.com/sentrix-labs/sentrix/releases/latest)
 [![Tests](https://img.shields.io/badge/tests-551%2B%20passing-brightgreen)](https://github.com/sentrix-labs/sentrix/actions)
@@ -61,7 +62,7 @@ curl http://localhost:8545/health
 | RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
 | Chain ID | `7120` |
 | Symbol | `SRX` |
-| Explorer | `https://sentrixscan.sentriscloud.com` (toggle to Testnet in UI) |
+| Explorer | `https://scan.sentrixchain.com` (toggle to Testnet in UI) |
 
 Full guide: [docs/operations/METAMASK.md](docs/operations/METAMASK.md). Deploy a smart contract via Remix: [docs/operations/SMART_CONTRACT_GUIDE.md](docs/operations/SMART_CONTRACT_GUIDE.md). EVM internals: [docs/architecture/EVM.md](docs/architecture/EVM.md).
 
@@ -97,10 +98,12 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 | **Consensus** | DPoS + BFT (4 validators) | DPoS + BFT (4 validators) |
 | **Block time** | 1 second | 1 second |
 | **EVM** | Active — MetaMask compatible | Active — MetaMask compatible |
-| **Explorer** | [sentrixscan.sentriscloud.com](https://sentrixscan.sentriscloud.com) | [sentrixscan.sentriscloud.com](https://sentrixscan.sentriscloud.com) (same unified UI, toggle Testnet) |
+| **Explorer** | [scan.sentrixchain.com](https://scan.sentrixchain.com) | [scan.sentrixchain.com](https://scan.sentrixchain.com) (same unified UI, toggle Testnet) |
 
+**Website:** [sentrixchain.com](https://sentrixchain.com)
+**Faucet:** [faucet.sentrixchain.com](https://faucet.sentrixchain.com) (testnet)
 **Wallet:** [sentrix-wallet.sentriscloud.com](https://sentrix-wallet.sentriscloud.com)
-**Faucet:** [faucet.sentriscloud.com](https://faucet.sentriscloud.com)
+**Docs:** [sentrixchain.com/docs/faucet](https://sentrixchain.com/docs/faucet)
 **Telegram:** [t.me/SentrixCommunity](https://t.me/SentrixCommunity)
 
 ## Roadmap


### PR DESCRIPTION
## Summary

Adds canonical sentrixchain.com URLs to the project README, replacing the legacy `*.sentriscloud.com` references for user-facing endpoints.

**Changes:**
- New **Website** badge → `https://sentrixchain.com`
- MetaMask quickstart Explorer → `https://scan.sentrixchain.com`
- Network table Explorer → `scan.sentrixchain.com` (mainnet + testnet)
- Add **Website** + **Faucet** + **Docs** quick-links pointing to `sentrixchain.com` subdomains
- RPC URLs unchanged (still `*.sentriscloud.com` until `rpc.sentrixchain.com` policy is decided)

**Why:** Sentrixchain.com went DNS-live 2026-04-26 with subdomain routing for scan/faucet/docs/validators. Updating the highest-traffic README accelerates Google's discovery of sentrixchain.com as the canonical chain domain (currently 0 GSC-indexed pages).

## Test plan
- [ ] README renders correctly on github.com
- [ ] All sentrixchain.com links resolve (200 / proper redirect)
- [ ] No broken `sentrixscan.sentriscloud.com` references remain in user-facing sections