### PR TITLE
docs: sync public docs to v2.1.38 + 2026-04-26 stall RCA worked example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.38] — 2026-04-26 — Legacy TCP-path deletion + cumulative skip metric
+
+> **Hardening on top of v2.1.37.** Same fix surface — the libp2p sync race-induced cascade-bail (RCA: `incidents/2026-04-26-libp2p-sync-cascade-bail-stall.md`). Bundles legacy-path deletion (eliminate parallel dead code with the same bug pattern) + observability counter (detect re-emergence).
+
+### Removed
+
+- `crates/sentrix-network/src/sync.rs` deleted entirely (158 LOC, zero production callers; legacy TCP path superseded by libp2p in PR #82).
+- `crates/sentrix-network/src/node.rs` trimmed 645 → 36 LOC. Kept only `NodeEvent`, `SharedBlockchain`, `DEFAULT_PORT` (still imported by `libp2p_node.rs` + `bin/sentrix/main.rs`). Deleted: raw-TCP `Node` struct + impl, `Message` enum, `Peer` struct, `SharedPeers` type, `MAX_MESSAGE_SIZE`, `MAX_CONNECTIONS_PER_IP`, `RATE_LIMIT_WINDOW`, `MAX_PEERS`, `ConnectionCounts`, full test module.
+
+Both deleted sites had the same `for block in batch` cascade-bail pattern that caused the v2.1.36 stall — carrying the dead code with a known bug invited future regressions.
+
+### Added
+
+- `static SYNC_SKIPPED_TOTAL: AtomicU64` in `libp2p_node.rs` accumulates duplicate-block skips across handler invocations.
+- Threshold-crossing WARN log at 10/100/1k/10k/100k cumulative skipped → surfaces re-emergence of the concurrent-GetBlocks race so operators can grep for `cumulative skipped (already-applied) crossed` and decide when to ship single-flight coalescing.
+- Existing per-batch INFO log preserved (`synced N blocks ... skipped K already-applied`).
+
+### Migration
+
+- Drop-in chain.db compatible with v2.1.37.
+
+---
+
+## [2.1.37] — 2026-04-26 — libp2p sync cascade-bail fix (mainnet stall RCA)
+
+> **P0 hotfix.** Mainnet stalled at h=604547 for ~1h 45min on 2026-04-26 morning. Root cause: `libp2p_node.rs` BlocksResponse handler bailed on the first already-applied block in a batch and dropped the rest of valid forward blocks in the same response. Concurrent GetBlocks paths (periodic `sync_interval` + `TriggerSync` + reactive chain-on-full-batch) all read `our_height` and ask `from: our_height+1`. Responses overlap. Cumulative drift over thousands of sync rounds → 4-way chain.db divergence at h=604547 across the 4 mainnet validators.
+
+### Fixed
+
+- **`crates/sentrix-network/src/libp2p_node.rs`** BlocksResponse loop: filter `block.index <= chain.height()` BEFORE `add_block_from_peer`. Skip duplicates silently, keep applying forward blocks. Loop only breaks on real validation errors (gap, bad signature, etc.).
+
+### Tests
+
+- `test_libp2p_sync_loop_skips_duplicates_and_applies_remaining` in `crates/sentrix-core/tests/fork_determinism.rs`: chain at h=3 receives racy batch `[b2, b3, b4, b5]`. Pre-fix: bails on b2 with "expected 4 got 2", chain stalls at h=3. Post-fix: skipped=2 synced=2, chain advances to h=5.
+
+### Recovery (operator-driven)
+
+State divergence at h=604547 was the cumulative effect of the bug, not directly fixed by the binary patch. Recovery procedure:
+
+1. Forensic backup divergent chain.db on each validator (`chain.db.divergent-604547-<ts>/`)
+2. Treasury picked as canonical (most progressed at h=604548, self-consistent prev-link, signer-set matched majority)
+3. Tar-pipe Treasury chain.db → Foundation, Core, Beacon (tar-over-ssh, no-same-owner)
+4. MD5 parity confirmed across all 4 (`mdbx.dat` md5 = `567c7165301fff7e95ded23d03df63cd`)
+5. v2.1.37 binary deployed (docker bullseye, glibc 2.31)
+6. Rolling restart: Treasury → Foundation → Core → Beacon
+7. Chain advanced past h=604548 within seconds; per-validator hash parity verified at h=604650
+
+### Migration
+
+- Drop-in chain.db compatible with v2.1.36, but if your validator is divergent from the canonical at any height, follow the chain.db rsync procedure documented in `docs/operations/EMERGENCY_ROLLBACK.md`.
+
+---
+
 ## [2.1.36] — 2026-04-26 — tx validate: staking-op amount=0 exemption
 
 > **Hotfix**: tx validation rejected ClaimRewards (and other no-fund-movement staking ops) because the `amount > 0` check exempted only token + EVM ops, not staking ops. Surfaced 2026-04-26 when first ClaimRewards submission was rejected with `"amount must be > 0 (unless token/EVM operation)"` even though `tx.data = {"op":"claim_rewards"}` is a valid op. Fix exempts staking ops.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fast, secure Layer-1 blockchain built in Rust.
 
 Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, instant finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and web3.js connect natively.
 
-- **v2.1.36** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active (treasury escrow + ClaimRewards op)
+- **v2.1.38** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active (treasury escrow + ClaimRewards op), libp2p sync race-safe + cumulative skip-metric observability
 - **551+ tests**, clippy clean, 11 security audit rounds
 - **4 validators** across 4 nodes (Foundation, Treasury, Core, Beacon) on the maintainer fleet
 
@@ -111,7 +111,7 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 | Phase | Status | Focus |
 |-------|--------|-------|
 | **Pioneer** | Completed (mainnet h=0…579058) | PoA round-robin, MDBX storage, 1s blocks, SRC-20 tokens — succeeded by Voyager 2026-04-25 |
-| **Voyager** | **Live on mainnet (v2.1.36)** | DPoS proposer rotation + BFT finality, EVM (revm 37), `eth_sendRawTransaction`, L1 peer auto-discovery + connection-limits hardening, V4 reward distribution v2 (treasury escrow + ClaimRewards), runtime-aware Voyager dispatch |
+| **Voyager** | **Live on mainnet (v2.1.38)** | DPoS proposer rotation + BFT finality, EVM (revm 37), `eth_sendRawTransaction`, L1 peer auto-discovery + connection-limits hardening, V4 reward distribution v2 (treasury escrow + ClaimRewards), runtime-aware Voyager dispatch, race-safe block sync |
 | **Frontier** | Phase F-1 scaffold landed; F-2…F-10 planned | Parallel transaction execution, sub-1s block time, mainnet hard fork |
 | **Odyssey** | Future | Cross-chain bridges, mature ecosystem, light clients |
 

--- a/docs/operations/EMERGENCY_ROLLBACK.md
+++ b/docs/operations/EMERGENCY_ROLLBACK.md
@@ -65,10 +65,11 @@ sudo install -m 755 <bin_dir>/releases/sentrix-vX.Y.Z-<timestamp> <bin_dir>/sent
 sudo systemctl start <validator-service>
 ```
 
-Current production binary at the time of writing: **v2.1.36** (mainnet
-& testnet, post-V4-reward-v2-activation). Prior production releases
-archived under each validator's `<bin_dir>/releases/`: v2.1.35, v2.1.34,
-v2.1.33, v2.1.32, v2.1.31, v2.1.30, v2.1.29, v2.1.28, v2.1.27, v2.1.26.
+Current production binary at the time of writing: **v2.1.38** (mainnet
+& testnet, post-libp2p-sync-cascade-bail-fix). Prior production releases
+archived under each validator's `<bin_dir>/releases/`: v2.1.37, v2.1.36,
+v2.1.35, v2.1.34, v2.1.33, v2.1.32, v2.1.31, v2.1.30, v2.1.29, v2.1.28,
+v2.1.27, v2.1.26.
 
 The 2026-04-25 / 2026-04-26 incident hotfix series:
 - v2.1.31: BFT signing v2 foundation + Frontier F-2 shadow + libp2p connection-leak fix
@@ -77,6 +78,8 @@ The 2026-04-25 / 2026-04-26 incident hotfix series:
 - v2.1.34: connection_limits cap loosened 1→2 (production hotfix)
 - v2.1.35: Voyager-mode-for migration sweep + claim-rewards tool
 - v2.1.36: tx validate exempts staking ops from amount>0 check (ClaimRewards submission fix)
+- v2.1.37: libp2p sync cascade-bail filter (P0: 2026-04-26 mainnet stall at h=604547 root cause + fix). Recovered via Treasury-canonical chain.db rsync. See PR #334 + RCA at `incidents/2026-04-26-libp2p-sync-cascade-bail-stall.md` (founder-private).
+- v2.1.38: legacy TCP-path deletion (sync.rs + node.rs trimmed) + cumulative skip-counter observability for race re-emergence detection
 
 ---
 
@@ -93,18 +96,41 @@ The full procedure lives in `internal operator runbook`
 (internal). Outline:
 
 1. Pick the canonical validator (matches the most peers; longest valid
-   chain at consensus root).
+   chain at consensus root; for BFT-finalized chains, prefer the one whose
+   justification signer-set matches the majority of healthy peers).
 2. Stop **all** validators on the diverged hosts.
-3. Backup the diverged `chain.db` to a sibling directory.
-4. `rsync -aP` the canonical `chain.db` to each diverged host while
+3. Backup the diverged `chain.db` to a sibling directory:
+   `sudo cp -a <data_dir>/chain.db <data_dir>/chain.db.divergent-<height>-<ts>`
+4. Tar-pipe the canonical `chain.db` to each diverged host while
    the source is frozen (canonical node is also stopped during the
-   copy).
-5. `chown sentrix:sentrix` on the destination, ensure perms match.
-6. Start all validators **simultaneously** (or in the standard
-   primary-first order).
+   copy):
+   ```bash
+   ssh <canonical> "sudo tar -C <canonical_data_dir> -cf - chain.db" | \
+     ssh <dest> "sudo tar -C <dest_data_dir> -xf - --no-same-owner --no-same-permissions"
+   ```
+   Why tar-pipe over rsync: chain.db is a directory of MDBX files; tar
+   handles ownership normalization with `--no-same-owner` cleanly when
+   source/destination users differ.
+5. `chown -R sentriscloud:sentriscloud <data_dir>/chain.db` (or whichever
+   user owns the running daemon).
+6. **MD5 parity check** — verify all destinations have identical
+   `mdbx.dat`:
+   `sudo md5sum <data_dir>/chain.db/mdbx.dat`
+7. Start validators in the standard producer order (most-recently-active
+   first to anchor BFT round numbering, then peers).
 
 State_root is recomputed from the canonical chain.db on the next block
 and the divergence is gone.
+
+> **Worked example (2026-04-26 mainnet stall, h=604547).** All 4
+> validators had different block hashes at h=604547. Treasury picked as
+> canonical (most progressed at h=604548, self-consistent prev-link,
+> justification signer-set matched majority). Tar-pipe Treasury chain.db
+> → Foundation, Core, Beacon. MD5 parity confirmed
+> (`mdbx.dat` md5 = `567c7165301fff7e95ded23d03df63cd`). Restart Treasury
+> → Foundation → Core → Beacon. Chain advanced past h=604548 within
+> seconds. Per-validator hash parity verified at h=604650. RCA in
+> `incidents/2026-04-26-libp2p-sync-cascade-bail-stall.md` (founder-private).
 
 ---
 

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -15,7 +15,7 @@
 | Consensus | **Voyager** (DPoS + BFT, `voyager_activated=true` since h=579047 / 2026-04-25) |
 | EVM | Active — `evm_activated=true` since the same height; MetaMask compatible |
 | Reward distribution | **V4 reward v2** active since h=590100 / 2026-04-25 — coinbase routes to `PROTOCOL_TREASURY` (0x0000…0002), validators + delegators claim via `ClaimRewards` staking op |
-| Binary | v2.1.36 |
+| Binary | v2.1.38 |
 
 ## Testnet
 
@@ -37,7 +37,7 @@ Testnet tokens have no real value. Use the faucet to get test SRX.
 
 Testnet runs in Docker on build host (`/opt/sentrix-testnet-docker/`) since
 the 2026-04-23 migration; fresh genesis at chain_id 7120, current
-height ~200K, binary v2.1.36.
+height ~200K, binary v2.1.38.
 
 > **Mainnet operational note (2026-04-25, post-Voyager):** mainnet successfully
 > transitioned from Pioneer PoA to Voyager DPoS+BFT at h=579047. EVM was

--- a/docs/roadmap/CHANGELOG.md
+++ b/docs/roadmap/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [2.1.38] — 2026-04-26 — Legacy TCP-path deletion + cumulative skip metric
+
+Hardening on top of v2.1.37 (same incident surface). PR #334 second + third commits.
+
+### Removed
+- `crates/sentrix-network/src/sync.rs` deleted entirely (158 LOC, dead code).
+- `crates/sentrix-network/src/node.rs` trimmed 645 → 36 LOC. Kept only `NodeEvent`, `SharedBlockchain`, `DEFAULT_PORT`. Both deleted sites had the same `for block in batch` cascade-bail bug pattern as the v2.1.37 fix surface — eliminating dead code with a known bug rather than carrying defensive filters.
+
+### Added
+- `static SYNC_SKIPPED_TOTAL: AtomicU64` cumulative counter in `libp2p_node.rs`.
+- Threshold-crossing WARN log at 10/100/1k/10k/100k cumulative skipped — surfaces re-emergence of the concurrent-GetBlocks race so operators can decide when to ship single-flight coalescing.
+
+### Migration
+- Drop-in chain.db compatible with v2.1.37.
+
+---
+
+## [2.1.37] — 2026-04-26 — libp2p sync cascade-bail fix (mainnet stall RCA)
+
+P0 hotfix. Mainnet stalled at h=604547 for ~1h 45min on 2026-04-26 morning. PR #334 first commit.
+
+### Root cause
+`libp2p_node.rs` BlocksResponse handler bailed on the first already-applied block in a batch and dropped the rest of valid forward blocks in the same response. Concurrent GetBlocks paths (periodic `sync_interval` + `TriggerSync` + reactive chain-on-full-batch) all read `our_height` and ask `from: our_height+1`. Responses overlap. Cumulative drift over thousands of sync rounds → 4-way chain.db divergence at h=604547 across the 4 mainnet validators.
+
+### Fixed
+- `crates/sentrix-network/src/libp2p_node.rs` BlocksResponse loop: filter `block.index <= chain.height()` BEFORE `add_block_from_peer`. Skip duplicates silently, keep applying forward blocks. Loop only breaks on real validation errors.
+
+### Tests
+- `test_libp2p_sync_loop_skips_duplicates_and_applies_remaining` in `crates/sentrix-core/tests/fork_determinism.rs` — racy batch with already-applied prefix advances chain to expected height instead of stalling.
+
+### Recovery (operator-driven)
+1. Forensic backup divergent chain.db on each validator
+2. Treasury picked as canonical (most progressed, self-consistent, signer-set matched majority)
+3. Tar-pipe Treasury chain.db → Foundation, Core, Beacon
+4. MD5 parity confirmed (`mdbx.dat` md5 = `567c7165...`)
+5. v2.1.37 binary deployed (docker bullseye, glibc 2.31)
+6. Rolling restart: Treasury → Foundation → Core → Beacon
+
+### Migration
+- Drop-in chain.db compatible with v2.1.36.
+
+---
+
 ## [2.1.36] — 2026-04-26 — V4 reward v2 + 14 PR marathon
 
 Single-night marathon (PRs #316–#331; binaries v2.1.31 → v2.1.36). All 4 mainnet validators on v2.1.36 in Voyager DPoS+BFT.


### PR DESCRIPTION
## Summary

PR #334 (libp2p sync cascade-bail fix + legacy-path deletion + skip-counter metric) merged earlier; v2.1.38 binary already deployed to all 4 mainnet validators via rolling restart. This PR aligns public-facing docs with that on-disk reality.

- **CHANGELOG.md** — v2.1.38 + v2.1.37 entries (root-level changelog)
- **docs/roadmap/CHANGELOG.md** — same entries in the roadmap-specific changelog
- **README.md** — version reference v2.1.36 → v2.1.38, roadmap row notes race-safe block sync
- **docs/operations/NETWORKS.md** — binary v2.1.36 → v2.1.38 (mainnet + testnet)
- **docs/operations/EMERGENCY_ROLLBACK.md** — production binary version table refreshed + a worked example for chain.db rsync recovery using the 2026-04-26 mainnet stall (Treasury canonical pick, MD5 parity confirmation, BFT signer-set as canonical-pick heuristic). Tar-pipe procedure documented (replaces prior rsync outline; explains why tar-pipe handles MDBX directory + cross-user ownership cleanly).

Docs-only sweep. No runtime behavior change.

## Test plan
- [x] All version references consistent across CHANGELOG, README, NETWORKS, EMERGENCY_ROLLBACK
- [x] No secrets in diff
- [x] Worked example in EMERGENCY_ROLLBACK matches actually-executed recovery procedure