### PR TITLE
fix(rpc): /chain/info max_supply_srx is fork-aware (tokenomics v2 follow-up)

### DIFF
--- a/crates/sentrix-core/src/chain_queries.rs
+++ b/crates/sentrix-core/src/chain_queries.rs
@@ -1,6 +1,6 @@
 // chain_queries.rs - Sentrix — Chain query methods
 
-use crate::blockchain::{Blockchain, MAX_SUPPLY};
+use crate::blockchain::Blockchain;
 use sentrix_primitives::transaction::TokenOp;
 
 impl Blockchain {
@@ -215,7 +215,7 @@ impl Blockchain {
             "height": self.height(),
             "total_blocks": self.height() + 1, // true height from block index, not window length
             "total_minted_srx": self.total_minted as f64 / 100_000_000.0,
-            "max_supply_srx": MAX_SUPPLY as f64 / 100_000_000.0,
+            "max_supply_srx": self.max_supply_for(self.height()) as f64 / 100_000_000.0,
             "total_burned_srx": self.accounts.total_burned as f64 / 100_000_000.0,
             "circulating_supply_srx": circulating_sentri as f64 / 100_000_000.0,
             "mempool_size": self.mempool.len(),


### PR DESCRIPTION
PR #336 follow-up. Single-line display fix.

\`/chain/info\` was reporting \`max_supply_srx: 210000000\` post-fork on testnet even though consensus rule was using \`MAX_SUPPLY_V2 = 315M\`. Source: \`chain_queries.rs:218\` referenced the static \`MAX_SUPPLY\` constant instead of the new fork-aware \`max_supply_for(height)\` helper.

Display layer only — zero consensus impact.

## Test plan
- [x] cargo check workspace clean
- [x] Verified on testnet during PR #336 bake