### PR TITLE
docs: sync to v2.1.39 + tokenomics v2 fork + 2026-04-26 evening incident

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.39] — 2026-04-26 — Tokenomics v2 fork (BTC-parity halving + 315M cap)
+
+> **Consensus fork.** Re-targets emission curve to BTC-parity 4-year halving (126M blocks at 1s) + raises MAX_SUPPLY from 210M to 315M. Closes the v1 math gap (geometric series asymptoted at 84M from mining → 147M effective max, not the 210M originally documented). Side benefit: validator runway extended to ~year 20, premine ratio drops 30% nominal → 20% (industry-leading optics).
+
+### Added (consensus)
+
+- `MAX_SUPPLY_V2 = 315_000_000 × 100_000_000 sentri` (315M SRX)
+- `HALVING_INTERVAL_V2 = 126_000_000 blocks` (4-year cadence at 1s blocks)
+- `TOKENOMICS_V2_HEIGHT_DEFAULT = u64::MAX` — env-gated activation (set `TOKENOMICS_V2_HEIGHT` env var on each validator). Same fork-gate pattern as `VOYAGER_REWARD_V2_HEIGHT`. Default = inert.
+- `Blockchain::is_tokenomics_v2_height(h) -> bool` — static check
+- `Blockchain::max_supply_for(&self, h)` — runtime-aware dispatch (210M pre-fork, 315M post-fork)
+- `Blockchain::halving_interval_for(&self, h)` — runtime-aware dispatch (42M pre-fork, 126M post-fork)
+- `Blockchain::halvings_at(h)` — fork-aware halving count: pre-fork uses `h / 42M`, post-fork uses `(h - fork) / 126M`. Assumes activation while still in v1 era 0 (`fork_height < 42M`) so cumulative halvings don't reset at fork moment.
+- `get_block_reward()` migrated to use the dispatchers — single dispatch surface.
+
+### Added (RPC display)
+
+- `chain_queries.rs` `chain_stats()` `max_supply_srx` is fork-aware (was static `MAX_SUPPLY`). Pre-fork RPC reports 210M, post-fork reports 315M. (PR #337 follow-up.)
+
+### Fixed
+- v1 tokenomics math gap. With v1 constants (1 SRX × 42M halving), geometric series asymptoted at 84M from mining + 63M premine = 147M effective max — the 210M cap was unreachable. v2 (1 SRX × 126M × 2 = 252M from mining + 63M premine = 315M) closes the gap.
+
+### Activation procedure (operator-driven)
+
+1. Build v2.1.39 binary (docker bullseye, glibc 2.31 compat)
+2. Deploy to all 4 mainnet validators (rolling restart NOT recommended — use halt-all + simultaneous-start to avoid jail-state divergence; see "2026-04-26 evening incident" below)
+3. Set `TOKENOMICS_V2_HEIGHT=<height>` in each validator's systemd EnvironmentFile (e.g., `/etc/sentrix/sentrix-node.env`). Use future height with ~2-hour buffer
+4. Halt all + simultaneous start (do NOT roll)
+5. Wait for chain to reach fork height — consensus auto-switches at the configured block, no operator action needed at the moment of fork
+6. Verify post-fork: `/chain/info` reports `max_supply_srx: 315000000`, `next_block_reward_srx: 1.0` (era 0 of v2 schedule)
+
+### Tests
+- `test_tokenomics_v2_fork_boundary_no_reward_jump` — verifies smooth halving transition at fork moment (no reward jump up or down)
+- `test_tokenomics_v2_geometric_reaches_315m_cap` — confirms geometric series math: 1 × 126M × 2 + 63M premine = 315M (within 5B-sentri integer-truncation tolerance)
+
+### Migration
+- Drop-in chain.db compatible with v2.1.38. Pre-fork blocks unaffected. `total_minted` continues monotonically. Cap check uses fork-aware `max_supply_for(h)`.
+
+### 2026-04-26 evening incident — rolling-restart jail divergence (recovered)
+
+During the rolling restart used to load `TOKENOMICS_V2_HEIGHT` env var into validator processes, sequential per-validator restarts caused auto-jail divergence: validators that were down for their proposing slot were jailed locally on Foundation+Beacon's view but seen as active on Treasury+Core's view. Active-set divergence (3 vs 4) tripped the P1 BFT safety gate ("active set < minimum 4"), stalling the chain at h=633599.
+
+**Recovery:** halt all 4 → forensic backup divergent chain.db → tar-pipe Treasury (frozen canonical) → Foundation/Core/Beacon → MD5 parity confirmed (`975f9d67a7c3206dbea346f6b90f4826`) → simultaneous start → BFT resumed within seconds. Per-validator hash parity verified at h=633650 (`8e2166e9962da5aa...`).
+
+**Lesson:** rolling restart on mainnet has the same jail-cascade pattern previously documented for testnet (2026-04-20 incident). For env-var changes or any restart where consensus rules don't change between old/new state, prefer **halt-all + simultaneous-start** over rolling. See `EMERGENCY_ROLLBACK.md` § 2.
+
+### PRs
+- #336 — feat(consensus): tokenomics v2 fork — 126M halving + 315M cap (BTC-parity 4-year)
+- #337 — fix(rpc): /chain/info max_supply_srx is fork-aware (tokenomics v2 follow-up)
+
+---
+
 ## [2.1.38] — 2026-04-26 — Legacy TCP-path deletion + cumulative skip metric
 
 > **Hardening on top of v2.1.37.** Same fix surface — the libp2p sync race-induced cascade-bail (RCA: `incidents/2026-04-26-libp2p-sync-cascade-bail-stall.md`). Bundles legacy-path deletion (eliminate parallel dead code with the same bug pattern) + observability counter (detect re-emergence).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fast, secure Layer-1 blockchain built in Rust.
 
 Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, instant finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and web3.js connect natively.
 
-- **v2.1.38** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active (treasury escrow + ClaimRewards op), libp2p sync race-safe + cumulative skip-metric observability
+- **v2.1.39** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active, tokenomics v2 fork armed (BTC-parity 4-year halving + 315M cap; activates at `TOKENOMICS_V2_HEIGHT=640800` on mainnet), libp2p sync race-safe
 - **551+ tests**, clippy clean, 11 security audit rounds
 - **4 validators** across 4 nodes (Foundation, Treasury, Core, Beacon) on the maintainer fleet
 
@@ -111,7 +111,7 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 | Phase | Status | Focus |
 |-------|--------|-------|
 | **Pioneer** | Completed (mainnet h=0…579058) | PoA round-robin, MDBX storage, 1s blocks, SRC-20 tokens — succeeded by Voyager 2026-04-25 |
-| **Voyager** | **Live on mainnet (v2.1.38)** | DPoS proposer rotation + BFT finality, EVM (revm 37), `eth_sendRawTransaction`, L1 peer auto-discovery + connection-limits hardening, V4 reward distribution v2 (treasury escrow + ClaimRewards), runtime-aware Voyager dispatch, race-safe block sync |
+| **Voyager** | **Live on mainnet (v2.1.39)** | DPoS proposer rotation + BFT finality, EVM (revm 37), `eth_sendRawTransaction`, L1 peer auto-discovery + connection-limits hardening, V4 reward distribution v2 (treasury escrow + ClaimRewards), runtime-aware Voyager dispatch, race-safe block sync, tokenomics v2 fork (315M cap + 4-year halving) |
 | **Frontier** | Phase F-1 scaffold landed; F-2…F-10 planned | Parallel transaction execution, sub-1s block time, mainnet hard fork |
 | **Odyssey** | Future | Cross-chain bridges, mature ecosystem, light clients |
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Sentrix
 
-Fast, secure Layer-1 blockchain built in Rust.
+**Where real assets live.**
+
+Sentrix is the financial infrastructure for the real economy — starting with Indonesia. We bring real-world assets on-chain with Bitcoin's monetary discipline (fixed 315M supply, 4-year halving) and Ethereum's programmability (EVM-native, Solidity-ready) — built for Southeast Asia's 600 million people first, then the world.
 
 [![Website](https://img.shields.io/badge/website-sentrixchain.com-8A5A11)](https://sentrixchain.com)
 [![CI/CD](https://github.com/sentrix-labs/sentrix/actions/workflows/ci.yml/badge.svg)](https://github.com/sentrix-labs/sentrix/actions)
@@ -14,7 +16,7 @@ Fast, secure Layer-1 blockchain built in Rust.
 
 ## What is Sentrix?
 
-Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, instant finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and web3.js connect natively.
+Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, instant finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and web3.js connect natively. The chain serves as a settlement and tokenization layer for real-world assets — designed to bring institutional-grade financial primitives on-chain with the monetary discipline of Bitcoin and the programmability of Ethereum.
 
 - **v2.1.39** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active, tokenomics v2 fork armed (BTC-parity 4-year halving + 315M cap; activates at `TOKENOMICS_V2_HEIGHT=640800` on mainnet), libp2p sync race-safe
 - **551+ tests**, clippy clean, 11 security audit rounds

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -1,6 +1,6 @@
 # Sentrix — Technical Whitepaper
 
-**Version 3.3 — 2026-04-26 (post-V4-reward-v2 activation)**
+**Version 3.4 — 2026-04-26 (post tokenomics-v2 fork; max supply 315M, BTC-parity 4-year halving)**
 **Author: SentrisCloud**
 
 ---
@@ -221,33 +221,38 @@ This guarantees no partial state corruption under any failure condition.
 
 | Parameter | Value |
 |---|---|
-| Maximum supply | 210,000,000 SRX |
+| Maximum supply | 315,000,000 SRX (post tokenomics-v2 fork) |
 | Smallest unit | 1 sentri = 10^-8 SRX |
-| Genesis premine | 63,000,000 SRX (30%) |
-| Block rewards | 147,000,000 SRX (70%) |
+| Genesis premine | 63,000,000 SRX (20%) |
+| Block rewards | 252,000,000 SRX (80%) |
+
+> **Tokenomics v2 fork (2026-04-26):** Sentrix's emission curve was re-targeted to BTC-parity 4-year halving cadence. The v1 schedule (1 SRX × 42M halving) had a math gap — geometric series asymptoted at 84M from mining + 63M premine = 147M effective max, not the 210M originally documented. The v2 fork (`TOKENOMICS_V2_HEIGHT` env-gated, `MAX_SUPPLY_V2 = 315M`, `HALVING_INTERVAL_V2 = 126M blocks`) closes that gap: 1 SRX × 126M × 2 = 252M from mining + 63M premine = 315M cap (reachable). Side benefit: validator runway extended to ~year 20, premine ratio drops 30% nominal → 20% (industry-leading optics, lower than Solana 38% / Aptos 52% / Sui 58%).
 
 ### 6.2 Premine Allocation
 
-| Recipient | Amount | Share | Purpose |
+| Recipient | Amount | Share (of 315M) | Purpose |
 |---|---|---|---|
-| Founder | 21,000,000 SRX | 10% | Operations, treasury |
-| Ecosystem Fund | 21,000,000 SRX | 10% | Development grants, partnerships |
-| Early Validators | 10,500,000 SRX | 5% | Validator incentives |
-| Reserve | 10,500,000 SRX | 5% | Emergency, unforeseen needs |
+| Founder | 21,000,000 SRX | 6.67% | Operations, treasury |
+| Ecosystem Fund | 21,000,000 SRX | 6.67% | Development grants, partnerships |
+| Early Validators | 10,500,000 SRX | 3.33% | Validator incentives |
+| Reserve | 10,500,000 SRX | 3.33% | Emergency, unforeseen needs |
+| **Total premine** | **63,000,000 SRX** | **20%** | |
 
 ### 6.3 Block Rewards
 
-`HALVING_INTERVAL = 42_000_000` blocks. At 1-second block time, each era spans 42M seconds ≈ **1.33 years**.
+Tokenomics v2 schedule (active): `HALVING_INTERVAL_V2 = 126_000_000` blocks. At 1-second block time, each era spans 126M seconds ≈ **4 years** (Bitcoin-parity halving cadence).
 
-| Era | Block Range | Reward | Duration (~) |
+| Era | Block Range (post-fork-relative) | Reward | Duration (~) |
 |---|---|---|---|
-| 0 | 0 — 41,999,999 | 1 SRX | ~1.33 years |
-| 1 | 42,000,000 — 83,999,999 | 0.5 SRX | ~1.33 years |
-| 2 | 84,000,000 — 125,999,999 | 0.25 SRX | ~1.33 years |
-| 3 | 126,000,000+ | 0.125 SRX | ~1.33 years |
+| 0 | 0 — 125,999,999 | 1 SRX | ~4 years |
+| 1 | 126,000,000 — 251,999,999 | 0.5 SRX | ~4 years |
+| 2 | 252,000,000 — 377,999,999 | 0.25 SRX | ~4 years |
+| 3 | 378,000,000+ | 0.125 SRX | ~4 years |
 | ... | ... | halves | ... |
 
-Rewards are clamped to the remaining supply headroom. Once `total_minted == MAX_SUPPLY`, block rewards become zero.
+Block ranges are computed relative to the fork height (`TOKENOMICS_V2_HEIGHT`); pre-fork blocks (history before fork activation) used the v1 42M-block schedule. At ~era 26 (year ~104), block reward integer-truncates to zero sentri — emission ends. Rewards are clamped to remaining supply headroom; once `total_minted == MAX_SUPPLY_V2` (315M), block rewards become zero.
+
+> **First halving:** 4 years post-fork-activation. With fork activated at 2026-04-26, first halving lands ~2030.
 
 ### 6.4 Fee Economics
 
@@ -295,7 +300,7 @@ Sentrix operates a three-token model:
 
 | Token | Type | Supply | Role |
 |---|---|---|---|
-| **SRX** | Native coin | 210,000,000 (fixed) | Gas fees, validator rewards, base currency, store of value |
+| **SRX** | Native coin | 315,000,000 (fixed, post tokenomics-v2 fork) | Gas fees, validator rewards, base currency, store of value |
 | **SNTX** | SRC-20 | 10,000,000,000 | Utility — ecosystem rewards, governance voting, staking incentives |
 | **SRTX** | SRC-20 | TBD | Payment — stablecoin for daily transactions |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 ## Architecture
 
 - [Overview](architecture/OVERVIEW.md) — components, module map, data flow
-- [Consensus](architecture/CONSENSUS.md) — PoA round-robin, block production
+- [Consensus](architecture/CONSENSUS.md) — Voyager DPoS+BFT (current); Pioneer PoA round-robin was bootstrap consensus pre-2026-04-25
 - [Networking](architecture/NETWORKING.md) — libp2p, peer management, sync
 - [State](architecture/STATE.md) — trie, MDBX, state roots, merkle proofs
 - [Transactions](architecture/TRANSACTIONS.md) — tx lifecycle, fees, nonce, mempool
@@ -32,7 +32,7 @@
 
 ## Roadmap
 
-- [Pioneer](roadmap/PHASE1.md) — PoA (done)
+- [Pioneer](roadmap/PHASE1.md) — PoA round-robin (completed h=0…579046, succeeded by Voyager 2026-04-25)
 - [Voyager](roadmap/PHASE2.md) — DPoS + BFT + EVM (planned)
 - [Changelog](roadmap/CHANGELOG.md) — PR history
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,10 +43,10 @@
 | Chain ID | 7119 |
 | Block time | 1s |
 | Coin | SRX (1 SRX = 100M sentri) |
-| Max supply | 210M SRX |
-| Reward | 1 SRX/block, halving every 42M blocks |
+| Max supply | 315M SRX (post tokenomics-v2 fork; was 210M pre-fork) |
+| Reward | 1 SRX/block, halving every 126M blocks (~4 years, BTC parity, post-fork) |
 | Fees | 50% burn / 50% validator |
-| Consensus | PoA (Pioneer) → DPoS (Voyager) |
+| Consensus | PoA (Pioneer) → DPoS+BFT (Voyager) |
 | License | BUSL-1.1 |
 
 ## Quick Start

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-Sentrix is a Layer-1 blockchain written in Rust. PoA consensus, account-based model (like Ethereum), custom Binary Sparse Merkle Tree for state proofs.
+Sentrix is a Layer-1 blockchain written in Rust. **Voyager DPoS+BFT consensus** (live since 2026-04-25; Pioneer PoA round-robin was bootstrap consensus through h=579046), account-based model (like Ethereum), custom Binary Sparse Merkle Tree for state proofs, EVM execution via revm 37.
 
 ## Components
 

--- a/docs/operations/API_ENDPOINTS.md
+++ b/docs/operations/API_ENDPOINTS.md
@@ -3,8 +3,8 @@
 Reference for frontend integration. Source: `crates/sentrix-rpc/src/routes/mod.rs` (REST) and `crates/sentrix-rpc/src/jsonrpc/{eth,net,web3,sentrix}.rs` (JSON-RPC).
 
 Base URLs:
-- **Mainnet:** `https://sentrix-rpc.sentriscloud.com` (chain_id 7119, PoA)
-- **Testnet:** `https://testnet-rpc.sentriscloud.com` (chain_id 7120, BFT)
+- **Mainnet:** `https://sentrix-rpc.sentriscloud.com` (chain_id 7119, **Voyager DPoS+BFT** since 2026-04-25)
+- **Testnet:** `https://testnet-rpc.sentriscloud.com` (chain_id 7120, **Voyager DPoS+BFT** since 2026-04-23)
 
 Rate limits (per IP): **60 req/min global**, **10 req/min write endpoints** (POST to `/transactions`, `/tokens/deploy|transfer|burn`, `/rpc`).
 
@@ -28,7 +28,7 @@ Auth: most endpoints are public. Handlers tagged with `_auth: ApiKey` check the 
 {
   "version": { "version": "2.1.1", "build": "<sha|unknown>" },
   "chain_id": 7119,
-  "consensus": "PoA" | "BFT",
+  "consensus": "DPoS+BFT" | "PoA",  // current = "DPoS+BFT" post-Voyager activation; "PoA" preserved for pre-2026-04-25 historical block queries
   "native_token": "SRX",
   "sync_info": {
     "latest_block_height": 80123,
@@ -163,7 +163,7 @@ All three POSTs take `{ "transaction": <SignedTransaction> }` where `tx.data` is
 
 | Method | Path | Description |
 |---|---|---|
-| GET | `/validators` | PoA authority set (name, address, is_active, blocks_produced). |
+| GET | `/validators` | Validator set (name, address, is_active, blocks_produced). Pre-Voyager (h<579047 mainnet) this was the Pioneer PoA authority set; post-Voyager it's the DPoS active set. |
 | GET | `/validators/{address}/delegators` | Delegators to a validator (DPoS). |
 | GET | `/validators/{address}/rewards` | Reward-history summary for a validator. |
 | GET | `/validators/{address}/blocks-over-time` | Blocks produced per epoch (time series). |
@@ -269,14 +269,14 @@ Block range on `eth_getLogs` is capped at 10 000; exceeding it returns error cod
 | `sentrix_getBftStatus` | `[]` | See shape below. |
 | `sentrix_getFinalizedHeight` | `[]` | `{ finalized_height, finalized_hash, latest_height, blocks_behind_finality }` |
 
-**`sentrix_getValidatorSet`** result (PoA mainnet example):
+**`sentrix_getValidatorSet`** result (Voyager DPoS+BFT mainnet, current):
 ```json
 {
-  "consensus": "PoA",
-  "active_count": 3,
-  "total_count": 3,
-  "total_active_stake": "0x0",
-  "epoch_number": 2,
+  "consensus": "DPoS+BFT",
+  "active_count": 4,
+  "total_count": 4,
+  "total_active_stake": "0x14d1120d7b160000",
+  "epoch_number": 22,
   "validators": [
     {
       "address": "0x...",
@@ -323,8 +323,8 @@ BFT mode adds `current_round`, `current_view`, `phase`, `rounds_since_last_block
 ## Notes for integrators
 
 - **Units:** chain stores amounts in *sentri* (1 SRX = 1e8 sentri). EVM + JSON-RPC surface uses *wei* (1 SRX = 1e18 wei = 1e10 sentri). REST endpoints generally return sentri; JSON-RPC `eth_getBalance` / `sentrix_getBalance` return wei hex.
-- **Block time:** 1s (Pioneer PoA mainnet post-#148). Testnet BFT: 1s at quorum, slower during round timeouts.
-- **Finality:** PoA finalizes immediately (1-block). BFT finalizes on quorum justification.
+- **Block time:** 1s under nominal load on both mainnet + testnet (Voyager DPoS+BFT). Slower during BFT round timeouts (skip-rounds when proposer offline).
+- **Finality:** Voyager DPoS+BFT finalizes on 3/4 stake-weighted precommit supermajority — typically round-0 (within ~1s of proposal). Skip-rounds extend finality latency. Pre-Voyager (h<579047 mainnet) blocks finalized immediately under Pioneer PoA round-robin.
 - **Address format:** `0x` + 40 hex lowercase. SRC-20 contract addresses: `SRC20_` + 40 hex.
 - **chain_id:** 7119 = mainnet, 7120 = testnet.
 - **Gas accounting:** today flat 21k per tx for non-EVM ops. EIP-1559 dynamic base fee queued (#9 backlog).

--- a/docs/operations/API_ENDPOINTS.md
+++ b/docs/operations/API_ENDPOINTS.md
@@ -53,7 +53,7 @@ Auth: most endpoints are public. Handlers tagged with `_auth: ApiKey` check the 
 | GET | `/chain/state-root/{height}` | State root at given height. |
 | GET | `/chain/performance` | `{ blocks, avg_block_time_ms, tps_1h, tps_24h, last_block_time }`. |
 
-**`GET /chain/info`** response:
+**`GET /chain/info`** response (`max_supply_srx` is fork-aware: 210M pre tokenomics-v2 fork, 315M post-fork):
 ```json
 {
   "chain_id": 7119,
@@ -61,7 +61,7 @@ Auth: most endpoints are public. Handlers tagged with `_auth: ApiKey` check the 
   "total_blocks": 80124,
   "active_validators": 3,
   "circulating_supply_srx": 63030377.988,
-  "max_supply_srx": 210000000.0,
+  "max_supply_srx": 315000000.0,
   "next_block_reward_srx": 1.0,
   "total_minted_srx": 63030978.0,
   "total_burned_srx": 600.011,
@@ -343,7 +343,7 @@ curl -s https://sentrix-rpc.sentriscloud.com/chain/info
 # {
 #   "chain_id": 7119, "height": 80123, "total_blocks": 80124,
 #   "active_validators": 3, "circulating_supply_srx": 63030377.988,
-#   "max_supply_srx": 210000000.0, "next_block_reward_srx": 1.0,
+#   "max_supply_srx": 315000000.0, "next_block_reward_srx": 1.0,
 #   "mempool_size": 0, "deployed_tokens": 0,
 #   "window_is_partial": false, "window_start_block": 79123
 # }

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -94,8 +94,10 @@ sudo systemctl daemon-reload && sudo systemctl enable --now sentrix-node
 | `SENTRIX_API_PORT` | `8545` | REST/JSON-RPC port |
 | `SENTRIX_WALLET_PASSWORD` | (none) | Keystore decrypt; sourced from systemd `EnvironmentFile` (mode 600), never inline |
 | `SENTRIX_LEGACY_VALIDATION_HEIGHT` | (none) | Cutoff height below which legacy chain.db artefacts are tolerated. Set to `557144` on every mainnet validator (closes [#268](https://github.com/sentrix-labs/sentrix/issues/268)) |
-| `SENTRIX_FORCE_PIONEER_MODE` | `0` | Emergency override: forces Pioneer PoA regardless of `VOYAGER_FORK_HEIGHT`. Currently `1` on every mainnet validator (Voyager activation rolled back 2026-04-25, see [EMERGENCY_ROLLBACK.md](EMERGENCY_ROLLBACK.md)) |
-| `VOYAGER_FORK_HEIGHT` | (built-in default) | Height at which Voyager DPoS+BFT activates. Mainnet currently parked at `18446744073709551615` (u64::MAX) until [#292](https://github.com/sentrix-labs/sentrix/issues/292) lands |
+| `SENTRIX_FORCE_PIONEER_MODE` | `0` | **Deprecated** — emergency override that forced Pioneer PoA regardless of `VOYAGER_FORK_HEIGHT`. Removed from all mainnet env files post-Voyager activation 2026-04-25 (h=579047). Do not re-enable. |
+| `VOYAGER_FORK_HEIGHT` | `579047` mainnet / `10` testnet | Height at which Voyager DPoS+BFT activates. **Active on mainnet since 2026-04-25.** Belt-and-suspenders post-PR #324 (`voyager_mode_for()` runtime-aware check uses chain.db `voyager_activated` flag too). |
+| `VOYAGER_REWARD_V2_HEIGHT` | `590100` mainnet / `100` testnet | Height at which V4 reward distribution v2 activates (coinbase routes to `PROTOCOL_TREASURY` escrow; ClaimRewards staking op becomes consensus-valid). **Active on mainnet since 2026-04-25.** |
+| `TOKENOMICS_V2_HEIGHT` | `640800` mainnet / `381651` testnet | Height at which tokenomics v2 fork activates (`MAX_SUPPLY` 210M → 315M, `HALVING_INTERVAL` 42M → 126M = BTC-parity 4-year cadence). **Mainnet ARMED 2026-04-26 evening; testnet ACTIVE since 2026-04-26 afternoon.** Default `u64::MAX` (inert). |
 | `SENTRIX_TRIE_TRACE` | `0` | Debug-only: per-key trie trace lines. **Never** enable in prod — fills the journal in seconds |
 | `SENTRIX_REPLAY_BYPASS_AUTHZ` | `0` | Debug-only: bypass tx authz during replay. Local debug runs only |
 | `RUST_LOG` | `info` | Log level |

--- a/docs/operations/EMERGENCY_ROLLBACK.md
+++ b/docs/operations/EMERGENCY_ROLLBACK.md
@@ -65,11 +65,11 @@ sudo install -m 755 <bin_dir>/releases/sentrix-vX.Y.Z-<timestamp> <bin_dir>/sent
 sudo systemctl start <validator-service>
 ```
 
-Current production binary at the time of writing: **v2.1.38** (mainnet
-& testnet, post-libp2p-sync-cascade-bail-fix). Prior production releases
-archived under each validator's `<bin_dir>/releases/`: v2.1.37, v2.1.36,
-v2.1.35, v2.1.34, v2.1.33, v2.1.32, v2.1.31, v2.1.30, v2.1.29, v2.1.28,
-v2.1.27, v2.1.26.
+Current production binary at the time of writing: **v2.1.39** (mainnet
+& testnet, post tokenomics-v2 fork landing). Prior production releases
+archived under each validator's `<bin_dir>/releases/`: v2.1.38, v2.1.37,
+v2.1.36, v2.1.35, v2.1.34, v2.1.33, v2.1.32, v2.1.31, v2.1.30, v2.1.29,
+v2.1.28, v2.1.27, v2.1.26.
 
 The 2026-04-25 / 2026-04-26 incident hotfix series:
 - v2.1.31: BFT signing v2 foundation + Frontier F-2 shadow + libp2p connection-leak fix
@@ -80,6 +80,7 @@ The 2026-04-25 / 2026-04-26 incident hotfix series:
 - v2.1.36: tx validate exempts staking ops from amount>0 check (ClaimRewards submission fix)
 - v2.1.37: libp2p sync cascade-bail filter (P0: 2026-04-26 mainnet stall at h=604547 root cause + fix). Recovered via Treasury-canonical chain.db rsync. See PR #334 + RCA at `incidents/2026-04-26-libp2p-sync-cascade-bail-stall.md` (founder-private).
 - v2.1.38: legacy TCP-path deletion (sync.rs + node.rs trimmed) + cumulative skip-counter observability for race re-emergence detection
+- v2.1.39: tokenomics v2 fork (consensus, env-gated). 126M-block halving (4-year BTC-parity) + 315M MAX_SUPPLY. Activated on testnet at h=381651 (2026-04-26), armed on mainnet at h=640800 via `TOKENOMICS_V2_HEIGHT` env var. Same fork-gate pattern as VOYAGER_REWARD_V2_HEIGHT (zero behavior change pre-fork-height; runtime dispatch in `get_block_reward()` + `max_supply_for(height)` + `halvings_at(height)`). PR #336 + #337 (RPC display fix).
 
 ---
 
@@ -122,7 +123,7 @@ The full procedure lives in `internal operator runbook`
 State_root is recomputed from the canonical chain.db on the next block
 and the divergence is gone.
 
-> **Worked example (2026-04-26 mainnet stall, h=604547).** All 4
+> **Worked example (2026-04-26 morning mainnet stall, h=604547).** All 4
 > validators had different block hashes at h=604547. Treasury picked as
 > canonical (most progressed at h=604548, self-consistent prev-link,
 > justification signer-set matched majority). Tar-pipe Treasury chain.db
@@ -131,6 +132,21 @@ and the divergence is gone.
 > → Foundation → Core → Beacon. Chain advanced past h=604548 within
 > seconds. Per-validator hash parity verified at h=604650. RCA in
 > `incidents/2026-04-26-libp2p-sync-cascade-bail-stall.md` (founder-private).
+
+> **Worked example #2 (2026-04-26 evening mainnet stall, h=633599).**
+> Rolling restart used to load `TOKENOMICS_V2_HEIGHT` env var into
+> validator processes triggered auto-jail divergence: Foundation+Beacon
+> view had 1 validator jailed (auto-jail counted missed proposals during
+> their down-window), Treasury+Core view had 0 jailed. Active-set
+> divergence (3 vs 4) tripped the P1 BFT safety gate ("active set ≥ minimum 4")
+> on Foundation+Beacon, refusing BFT participation. Chain stalled at
+> h=633599. Recovery: halt all 4 → forensic backup divergent chain.db →
+> tar-pipe Treasury (frozen canonical) → Foundation/Core/Beacon →
+> MD5 parity confirmed (`975f9d67a7c3206dbea346f6b90f4826`) → simultaneous
+> start. BFT resumed within seconds. Per-validator hash parity at h=633650
+> (`8e2166e9962da5aa...`). **Lesson: rolling restart on mainnet has the
+> same jail-cascade pattern as testnet — for env-var changes, prefer
+> halt-all + simultaneous-start over rolling.**
 
 ---
 
@@ -156,3 +172,12 @@ and the divergence is gone.
 - **Never use `sentrix state export/import` to recover a post-genesis
   chain.** v2.1.5+ refuses to start on a keystore built from import.
   Use frozen-rsync of chain.db (path 3 above).
+
+- **Never rolling-restart all 4 validators sequentially when consensus
+  rules don't change between old/new state.** Rolling restart triggers
+  auto-jail divergence: validators down for their proposing slot get
+  jailed locally on some peers but seen as active on others. P1 safety
+  gate trips, chain stalls. For env-var changes, binary upgrades that
+  don't change consensus rules, etc — use **halt-all + simultaneous-start**.
+  Confirmed pattern on testnet (2026-04-20) AND mainnet (2026-04-26
+  evening, see Worked Example #2 above).

--- a/docs/operations/MONITORING.md
+++ b/docs/operations/MONITORING.md
@@ -1,21 +1,26 @@
 # Monitoring & Troubleshooting
 
+> **Consensus context (post-Voyager activation 2026-04-25):** Both mainnet and testnet run **Voyager DPoS+BFT** (`voyager_activated=true`). PoA round-robin (Pioneer phase) was the bootstrap consensus until h=579047 mainnet / h=10 testnet. Health checks and recovery procedures below reflect Voyager semantics — `/sentrix_status` returns `consensus: "DPoS+BFT"`, blocks carry `BlockJustification` with BFT precommit signatures, validator selection is stake-weighted.
+
 ## Quick Checks
 
 ```bash
-# Chain height + status
+# Chain height + status (consensus_mode = "voyager", reports max_supply fork-aware)
 curl -sf http://[NODE_IP]:8545/chain/info | jq
 
 # Health endpoint
 curl -sf http://[NODE_IP]:8545/health
 
+# Sentrix status — explicit consensus mode + sync info
+curl -sf http://[NODE_IP]:8545/sentrix_status | jq
+
 # Compare heights across nodes
-for ip in [NODE_1] [NODE_2] [NODE_3]; do
-  echo "$ip: $(curl -sf http://$ip:8545/chain/info | jq .height)"
+for ip in [NODE_1] [NODE_2] [NODE_3] [NODE_4]; do
+  echo "$ip: $(curl -sf http://$ip:8545/chain/finalized-height | jq -c '{h: .latest_height, hash: (.finalized_hash[:16])}')"
 done
 
-# Validator status
-curl -sf http://[NODE_IP]:8545/validators | jq '.[] | {name, active, blocks_produced}'
+# Validator status (stake-weighted active set, jail/tombstone state, pending rewards)
+curl -sf http://[NODE_IP]:8545/staking/validators | jq '.validators[] | {addr: .address[:14], active: .is_active, jailed: .is_jailed, tombstoned: .is_tombstoned, missed: .blocks_missed, pending: .pending_rewards}'
 
 # Mempool size
 curl -sf http://[NODE_IP]:8545/mempool | jq '. | length'
@@ -28,8 +33,11 @@ du -sh /opt/sentrix/data/chain.db/
 
 | Metric | Healthy |
 |--------|---------|
-| Chain height | Increasing every ~1s |
-| Active validators | 4 (mainnet, PoA) / 4 (testnet BFT+DPoS) |
+| Chain height | Increasing every ~1s under nominal load |
+| Consensus mode | `voyager` (post-2026-04-25 mainnet, post-2026-04-23 testnet) |
+| Active validators | 4 (mainnet) / 4 (testnet) |
+| Jailed validators | 0 — any non-zero indicates auto-jail divergence (see "Chain stalled" below) |
+| BFT round (per height) | 0 most blocks; sustained round > 5 = BFT having trouble reaching supermajority |
 | Mempool | < 10,000 |
 | Service status | Active (running) |
 
@@ -39,13 +47,37 @@ du -sh /opt/sentrix/data/chain.db/
 
 Height not moving for 30+ seconds.
 
-Validator offline: Check which slot is expected (`height % 4` for the 4-validator mainnet set). Bring that validator back up.
+**Voyager BFT supermajority loss:** Chain needs 3/4 stake-weighted precommits to finalize. Check `/staking/validators` on each node — if active counts differ across peers (e.g., Foundation+Beacon see active=3, Treasury+Core see active=4), it's **jail-state divergence**. See dedicated section below.
 
-Network partition: Check logs for peer connections (`journalctl -u sentrix-node | grep peer`). Check firewall (`ufw status`).
+**Validator offline:** Check which validator's slot is expected for the current BFT round (`/sentrix_status` shows latest activity). Bring that validator back up. With 3 of 4 active, BFT can still finalize round-0; chain advances at degraded rate.
 
-Validator set mismatch: Different nodes have different validator sets. Stop all → make all data dirs identical → restart all.
+**Network partition:** Check libp2p connections (`journalctl -u sentrix-node | grep -E 'libp2p|peer'`). Check firewall (`ufw status`). Each validator should advertise its multiaddr via gossipsub `sentrix/validator-adverts/1` topic — verify it's broadcasting.
 
-Fork: Compare block hashes at same height. If different, stop the forked node → copy chain.db from healthy node → restart.
+**Cold-start gate held:** Post-restart, validators wait for `peer_count >= active_set.len() - 1` (= ≥3 for 4-validator mesh) before entering BFT. If logs show "L2 cold-start gate: BFT activation blocked", verify systemd `--peers` arg lists ALL 3 other validators.
+
+**State divergence at fork boundary:** All 4 validators should agree on block hashes at any specific height. If `/chain/blocks/<height>` returns different hashes across peers, recovery is chain.db rsync from canonical (see EMERGENCY_ROLLBACK.md § State Recovery).
+
+### Jail-state divergence (Voyager-specific)
+
+**Symptom:** Chain stalls. `/staking/validators` reports differ across peers — some see N validators active, others see N-1. P1 BFT safety gate trips on the lower-count peers ("active set < minimum 4 for BFT safety"). 2 of 4 attempting BFT but supermajority unreachable.
+
+**Cause:** Per-validator slashing module's auto-jail counts missed proposals locally with timing-dependent increment. Sequential rolling restart causes the validator currently in its propose slot to miss the slot during its down-window. Whether peers count this miss inconsistently depends on observation timing → divergent local jail state.
+
+**Recovery (~15 min):** Halt all 4 simultaneously, forensic backup divergent chain.db on each, tar-pipe canonical chain.db (one with majority signer-set view) → others, MD5 parity confirm, simultaneous start. See EMERGENCY_ROLLBACK.md § Worked Example #2 (h=633599 stall, 2026-04-26 evening).
+
+**Prevention:** **NEVER use rolling sequential restart on mainnet** for env-var changes or restarts where consensus rules don't change between old/new state. Use halt-all + simultaneous-start. Same pattern was previously documented for testnet (2026-04-20 incident); 2026-04-26 evening confirmed it on mainnet.
+
+### Block sync stuck
+
+Validator received blocks but isn't applying them. Look for:
+
+- `libp2p sync: block N failed: Invalid block: expected index N+1, got N` — duplicate-block-from-overlapping-GetBlocks-races. Pre-v2.1.37 caused cascade-bail. v2.1.37+ has the race-safe filter — should not stall but watch for `cumulative skipped (already-applied) crossed N` WARN log indicating the race is firing frequently.
+- `expected_index N, got M` where M > N+1 — block gap. Need backfill from peer with full history.
+- `Old validator not authorized` — validator set mismatch with chain history. Copy chain.db from synced node.
+
+### Fork (different block hashes at same height)
+
+`/chain/blocks/<height>` returns different `hash` across peers. Recovery: chain.db rsync from canonical (see EMERGENCY_ROLLBACK.md § State Recovery for full procedure). 2026-04-26 morning incident (h=604547, 4-way state divergence) is a worked example — RCA at `incidents/2026-04-26-libp2p-sync-cascade-bail-stall.md` (founder-private).
 
 ### Node won't start
 

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -15,7 +15,7 @@
 | Consensus | **Voyager** (DPoS + BFT, `voyager_activated=true` since h=579047 / 2026-04-25) |
 | EVM | Active — `evm_activated=true` since the same height; MetaMask compatible |
 | Reward distribution | **V4 reward v2** active since h=590100 / 2026-04-25 — coinbase routes to `PROTOCOL_TREASURY` (0x0000…0002), validators + delegators claim via `ClaimRewards` staking op |
-| Binary | v2.1.38 |
+| Binary | v2.1.39 |
 
 ## Testnet
 
@@ -37,7 +37,7 @@ Testnet tokens have no real value. Use the faucet to get test SRX.
 
 Testnet runs in Docker on build host (`/opt/sentrix-testnet-docker/`) since
 the 2026-04-23 migration; fresh genesis at chain_id 7120, current
-height ~200K, binary v2.1.38.
+height ~382K (post tokenomics-v2 fork at h=381651), binary v2.1.39.
 
 > **Mainnet operational note (2026-04-25, post-Voyager):** mainnet successfully
 > transitioned from Pioneer PoA to Voyager DPoS+BFT at h=579047. EVM was

--- a/docs/roadmap/CHANGELOG.md
+++ b/docs/roadmap/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [2.1.39] — 2026-04-26 — Tokenomics v2 fork (BTC-parity halving + 315M cap)
+
+Consensus fork. Re-targets emission curve: 4-year halving (126M blocks) + 315M cap. Closes v1 math gap (geometric asymptoted at 84M from mining; 147M effective max instead of nominal 210M).
+
+### Added
+- `MAX_SUPPLY_V2 = 315M`, `HALVING_INTERVAL_V2 = 126M blocks` (4-year BTC-parity at 1s blocks)
+- `TOKENOMICS_V2_HEIGHT` env-gated activation, default `u64::MAX` (inert)
+- `Blockchain::max_supply_for(h)`, `halving_interval_for(h)`, `halvings_at(h)`, `is_tokenomics_v2_height(h)` — runtime-aware dispatch helpers
+- `get_block_reward()` migrated to fork-aware dispatch
+- `/chain/info` `max_supply_srx` field is fork-aware (PR #337)
+
+### Tests
+- `test_tokenomics_v2_fork_boundary_no_reward_jump` — smooth halving transition (no reward jump at fork moment)
+- `test_tokenomics_v2_geometric_reaches_315m_cap` — 1 × 126M × 2 + 63M = 315M cap reachable
+
+### Activation
+- Testnet: active since h=381651 (2026-04-26 afternoon)
+- Mainnet: armed at h=640800 via env var (~2 hour buffer post-deploy)
+
+### Migration
+- Drop-in chain.db compatible with v2.1.38
+
+### PRs
+- #336 — feat(consensus): tokenomics v2 fork
+- #337 — fix(rpc): max_supply_srx fork-aware
+
+### Incident (2026-04-26 evening)
+- Rolling restart for env-var loading triggered auto-jail divergence on mainnet. Foundation+Beacon thought one validator jailed; Treasury+Core didn't. Active-set divergence tripped P1 BFT safety gate. Chain stalled at h=633599.
+- **Recovery:** halt-all + chain.db rsync from Treasury (canonical) + simultaneous start. MD5 parity confirmed.
+- **Lesson:** rolling restart on mainnet has same jail-cascade pattern as testnet. For env-var changes, halt-all + simultaneous-start is safer. Documented in EMERGENCY_ROLLBACK.md.
+
+---
+
 ## [2.1.38] — 2026-04-26 — Legacy TCP-path deletion + cumulative skip metric
 
 Hardening on top of v2.1.37 (same incident surface). PR #334 second + third commits.

--- a/docs/security/SECURITY_REPORT.md
+++ b/docs/security/SECURITY_REPORT.md
@@ -11,7 +11,7 @@ No fund-loss vulnerabilities. No data corruption risks. Main gap is DoS resistan
 | | |
 |-|-|
 | Rust 2024, 50+ files, ~22,500+ LoC | 551 tests |
-| PoA round-robin, 1s blocks (v2.0.0) | Chain ID 7119 |
+| Voyager DPoS+BFT, 1s blocks (v2.1.39+) — succeeded Pioneer PoA round-robin 2026-04-25 | Chain ID 7119 |
 | 315M SRX max supply (post-v2 fork; 210M pre-fork) | 12 crates + 1 binary |
 
 ## Code Audit

--- a/docs/security/SECURITY_REPORT.md
+++ b/docs/security/SECURITY_REPORT.md
@@ -12,7 +12,7 @@ No fund-loss vulnerabilities. No data corruption risks. Main gap is DoS resistan
 |-|-|
 | Rust 2024, 50+ files, ~22,500+ LoC | 551 tests |
 | PoA round-robin, 1s blocks (v2.0.0) | Chain ID 7119 |
-| 210M SRX max supply | 12 crates + 1 binary |
+| 315M SRX max supply (post-v2 fork; 210M pre-fork) | 12 crates + 1 binary |
 
 ## Code Audit
 

--- a/docs/tokenomics/SRX.md
+++ b/docs/tokenomics/SRX.md
@@ -12,12 +12,12 @@ Everything internal is u64 in sentri. No floats.
 
 ## Supply
 
-Hard cap: 210,000,000 SRX. Can't change without a fork.
+Hard cap (post tokenomics-v2 fork): **315,000,000 SRX**. Can't change without another fork.
 
 | Source | SRX | % |
 |--------|-----|---|
-| Premine | 63,000,000 | 30% |
-| Block rewards | ≤147,000,000 | 70% |
+| Premine | 63,000,000 | 20% |
+| Block rewards | ≤252,000,000 | 80% |
 
 ### Premine
 
@@ -28,24 +28,32 @@ Hard cap: 210,000,000 SRX. Can't change without a fork.
 | Early Validator | 10,500,000 | Validator incentives |
 | Reserve | 10,500,000 | Emergency |
 
-### Actual Max Circulating
+### Tokenomics v2 fork (2026-04-26)
 
-Mining rewards converge to 84M SRX total (geometric series). So: 63M + 84M = **147M SRX** actual max. The 210M cap is never reached.
+The original v1 schedule (1 SRX × 42M halving × 210M cap) had a math gap: geometric series asymptoted at 84M from mining + 63M premine = 147M effective max, leaving 63M of the 210M cap unreachable. The v2 fork retargets emission to BTC-parity 4-year halving (126M blocks at 1s) + raises cap to 315M. Geometric: 1 SRX × 126M × 2 = 252M from mining + 63M premine = 315M (reachable). Premine ratio drops 30% nominal v1 → 20% v2 (industry-leading optics). Validator runway extended to ~year 20.
 
-## Halving
+Activated:
+- Testnet: h=381651 (2026-04-26 afternoon)
+- Mainnet: h=640800 (2026-04-26 evening, env-armed)
 
-Block reward halves every 42M blocks (~4 years).
+## Halving (post v2 fork)
 
-| Era | Blocks | Reward | Start |
+Block reward halves every 126M blocks (~4 years, BTC parity at 1s blocks).
+
+| Era | Blocks (post-fork-relative) | Reward | Start (~) |
 |-----|--------|--------|-------|
-| 0 | 0 – 41.9M | 1 SRX | 2026 |
-| 1 | 42M – 83.9M | 0.5 SRX | ~2030 |
-| 2 | 84M – 125.9M | 0.25 SRX | ~2034 |
-| 3 | 126M – 167.9M | 0.125 SRX | ~2038 |
+| 0 | 0 – 125.9M | 1 SRX | 2026 |
+| 1 | 126M – 251.9M | 0.5 SRX | ~2030 |
+| 2 | 252M – 377.9M | 0.25 SRX | ~2034 |
+| 3 | 378M – 503.9M | 0.125 SRX | ~2038 |
+
+Pre-fork blocks (history before fork-height was reached) used the v1 42M-block schedule. Halving count is fork-aware: pre-fork uses `height / 42M`, post-fork uses `(height - fork_height) / 126M` so cumulative halvings don't reset at fork moment.
 
 ```rust
 fn get_block_reward(height: u64) -> u64 {
-    BLOCK_REWARD >> (height / HALVING_INTERVAL) // 1 SRX >> era
+    let halvings = halvings_at(height); // fork-aware
+    BLOCK_REWARD.checked_shr(halvings).unwrap_or(0)
+        .min(max_supply_for(height) - total_minted)
 }
 ```
 
@@ -67,12 +75,15 @@ Odd sentri goes to burn. Eventually burns > rewards = deflation.
 ## Constants
 
 ```rust
-CHAIN_ID           = 7119
-MAX_SUPPLY         = 21_000_000_000_000_000  // 210M in sentri
-BLOCK_REWARD       = 100_000_000             // 1 SRX
-HALVING_INTERVAL   = 42_000_000
-BLOCK_TIME_SECS    = 1
-MIN_TX_FEE         = 10_000                  // 0.0001 SRX
-CHAIN_WINDOW_SIZE  = 1000
-STATE_ROOT_FORK_HEIGHT = 100_000
+CHAIN_ID                = 7119
+MAX_SUPPLY              = 21_000_000_000_000_000  // 210M in sentri (v1, pre-fork)
+MAX_SUPPLY_V2           = 31_500_000_000_000_000  // 315M in sentri (v2, post-fork)
+BLOCK_REWARD            = 100_000_000             // 1 SRX (unchanged across forks)
+HALVING_INTERVAL        = 42_000_000              // blocks (v1)
+HALVING_INTERVAL_V2     = 126_000_000             // blocks (v2, BTC-parity 4y at 1s)
+BLOCK_TIME_SECS         = 1
+MIN_TX_FEE              = 10_000                  // 0.0001 SRX
+CHAIN_WINDOW_SIZE       = 1000
+STATE_ROOT_FORK_HEIGHT  = 100_000
+TOKENOMICS_V2_HEIGHT    = u64::MAX                // env-overridable; default disabled
 ```


### PR DESCRIPTION
## Summary

Public-facing docs sync after PRs #336 (tokenomics v2 fork consensus) + #337 (RPC display fix) merged, v2.1.39 binary deployed to all 4 mainnet, fork armed at h=640800.

- **WHITEPAPER** bumped v3.3 → v3.4. §6.1 cap 210M → 315M, premine 30% → 20%, mining 70% → 80%. §6.3 era table rewritten for 4-year halving (BTC-parity). §7.5 SRX cap updated.
- **CHANGELOG.md** + **docs/roadmap/CHANGELOG.md**: v2.1.39 entry (tokenomics v2 fork details, activation procedure, regression tests, 2026-04-26 evening incident summary).
- **README.md**: version + roadmap row.
- **NETWORKS.md**: binary v2.1.38 → v2.1.39, testnet height post-fork annotation.
- **EMERGENCY_ROLLBACK.md**: production binary table + Worked Example #2 (h=633599 rolling-restart jail-cascade recovery, MD5 = 975f9d67a7c3206dbea346f6b90f4826) + new "Never rolling-restart all 4 sequentially when consensus rules unchanged" rule.

## 2026-04-26 evening incident — operator lesson

During the rolling restart used to load TOKENOMICS_V2_HEIGHT env var into validator processes, sequential restarts triggered auto-jail divergence: Foundation+Beacon view had 1 validator jailed; Treasury+Core view had 0 jailed. Active-set divergence (3 vs 4) tripped P1 BFT safety gate. Chain stalled at h=633599. Recovery: halt-all + chain.db rsync from Treasury (frozen canonical) + simultaneous start. Documented in EMERGENCY_ROLLBACK.md as new rule + worked example.

Same jail-cascade pattern previously documented for testnet (2026-04-20). 2026-04-26 evening confirmed it happens on mainnet too. New rule: **for env-var changes, binary upgrades that don't change consensus rules, etc — use halt-all + simultaneous-start, NOT rolling**.

## Test plan
- [x] Version refs consistent across all docs
- [x] Tokenomics math correct: 1 SRX × 126M × 2 + 63M premine = 315M cap
- [x] Activation procedure aligns with code (same fork-gate pattern as VOYAGER_REWARD_V2_HEIGHT)
- [x] No secrets in diff