### PR TITLE
docs: tokenomics v2 fork ACTIVE end-to-end on mainnet (h=640800)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [2.1.39] — 2026-04-26 — Tokenomics v2 fork (BTC-parity halving + 315M cap)
+## [2.1.39] — 2026-04-26 — Tokenomics v2 fork (BTC-parity halving + 315M cap) — **ACTIVE on mainnet**
 
-> **Consensus fork.** Re-targets emission curve to BTC-parity 4-year halving (126M blocks at 1s) + raises MAX_SUPPLY from 210M to 315M. Closes the v1 math gap (geometric series asymptoted at 84M from mining → 147M effective max, not the 210M originally documented). Side benefit: validator runway extended to ~year 20, premine ratio drops 30% nominal → 20% (industry-leading optics).
+> **Consensus fork — ACTIVE end-to-end on mainnet since h=640800 (2026-04-26 evening).** Both consensus dispatch (cap enforcement, halving math) and RPC display (`/chain/info` `max_supply_srx`) now report v2 schedule. Re-targets emission curve to BTC-parity 4-year halving (126M blocks at 1s) + raises MAX_SUPPLY from 210M to 315M. Closes the v1 math gap (geometric series asymptoted at 84M from mining → 147M effective max, not the 210M originally documented). Side benefit: validator runway extended to ~year 20, premine ratio drops 30% nominal → 20% (industry-leading optics).
 
 ### Added (consensus)
 
@@ -29,14 +29,16 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - v1 tokenomics math gap. With v1 constants (1 SRX × 42M halving), geometric series asymptoted at 84M from mining + 63M premine = 147M effective max — the 210M cap was unreachable. v2 (1 SRX × 126M × 2 = 252M from mining + 63M premine = 315M) closes the gap.
 
-### Activation procedure (operator-driven)
+### Activation procedure (operator-driven, EXECUTED 2026-04-26 evening)
 
-1. Build v2.1.39 binary (docker bullseye, glibc 2.31 compat)
-2. Deploy to all 4 mainnet validators (rolling restart NOT recommended — use halt-all + simultaneous-start to avoid jail-state divergence; see "2026-04-26 evening incident" below)
-3. Set `TOKENOMICS_V2_HEIGHT=<height>` in each validator's systemd EnvironmentFile (e.g., `/etc/sentrix/sentrix-node.env`). Use future height with ~2-hour buffer
-4. Halt all + simultaneous start (do NOT roll)
-5. Wait for chain to reach fork height — consensus auto-switches at the configured block, no operator action needed at the moment of fork
-6. Verify post-fork: `/chain/info` reports `max_supply_srx: 315000000`, `next_block_reward_srx: 1.0` (era 0 of v2 schedule)
+1. ✅ Build v2.1.39 binary (docker bullseye, glibc 2.31 compat)
+2. ✅ Deploy to all 4 mainnet validators
+3. ✅ Set `TOKENOMICS_V2_HEIGHT=640800` in each validator's systemd EnvironmentFile (`/etc/sentrix/sentrix-node.env`, etc.)
+4. ✅ Halt all + simultaneous start (per `feedback_mainnet_restart_cascade_jailing.md` rule)
+5. ✅ Chain reached fork height h=640800 — consensus auto-switched
+6. ✅ Verified post-fork: `/chain/info` reports `max_supply_srx: 315000000`, `next_block_reward_srx: 1.0`
+
+**Display-fix binary swap (~h=646200, evening):** Initial v2.1.39 binary was built before PR #337 merged (RPC display fix). Mainnet was running consensus-fork-correct binary but display layer reported stale 210M. Resolved via halt-all + simultaneous-start binary swap to v2.1.39+#337 binary. Procedure: SCP new binary → halt all 4 → cp-stage-mv replace → simultaneous start → verify display flipped. Clean recovery, ~5 min downtime, no jail divergence.
 
 ### Tests
 - `test_tokenomics_v2_fork_boundary_no_reward_jump` — verifies smooth halving transition at fork moment (no reward jump up or down)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sentrix is the financial infrastructure for the real economy — starting with I
 
 Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, instant finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and web3.js connect natively. The chain serves as a settlement and tokenization layer for real-world assets — designed to bring institutional-grade financial primitives on-chain with the monetary discipline of Bitcoin and the programmability of Ethereum.
 
-- **v2.1.39** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active, tokenomics v2 fork armed (BTC-parity 4-year halving + 315M cap; activates at `TOKENOMICS_V2_HEIGHT=640800` on mainnet), libp2p sync race-safe
+- **v2.1.39** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active, **tokenomics v2 fork ACTIVE on mainnet since h=640800** (BTC-parity 4-year halving + 315M cap), libp2p sync race-safe
 - **551+ tests**, clippy clean, 11 security audit rounds
 - **4 validators** across 4 nodes (Foundation, Treasury, Core, Beacon) on the maintainer fleet
 

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -97,7 +97,7 @@ sudo systemctl daemon-reload && sudo systemctl enable --now sentrix-node
 | `SENTRIX_FORCE_PIONEER_MODE` | `0` | **Deprecated** — emergency override that forced Pioneer PoA regardless of `VOYAGER_FORK_HEIGHT`. Removed from all mainnet env files post-Voyager activation 2026-04-25 (h=579047). Do not re-enable. |
 | `VOYAGER_FORK_HEIGHT` | `579047` mainnet / `10` testnet | Height at which Voyager DPoS+BFT activates. **Active on mainnet since 2026-04-25.** Belt-and-suspenders post-PR #324 (`voyager_mode_for()` runtime-aware check uses chain.db `voyager_activated` flag too). |
 | `VOYAGER_REWARD_V2_HEIGHT` | `590100` mainnet / `100` testnet | Height at which V4 reward distribution v2 activates (coinbase routes to `PROTOCOL_TREASURY` escrow; ClaimRewards staking op becomes consensus-valid). **Active on mainnet since 2026-04-25.** |
-| `TOKENOMICS_V2_HEIGHT` | `640800` mainnet / `381651` testnet | Height at which tokenomics v2 fork activates (`MAX_SUPPLY` 210M → 315M, `HALVING_INTERVAL` 42M → 126M = BTC-parity 4-year cadence). **Mainnet ARMED 2026-04-26 evening; testnet ACTIVE since 2026-04-26 afternoon.** Default `u64::MAX` (inert). |
+| `TOKENOMICS_V2_HEIGHT` | `640800` mainnet / `381651` testnet | Height at which tokenomics v2 fork activates (`MAX_SUPPLY` 210M → 315M, `HALVING_INTERVAL` 42M → 126M = BTC-parity 4-year cadence). **Mainnet ACTIVE since 2026-04-26 evening (h=640800); testnet ACTIVE since 2026-04-26 afternoon (h=381651).** Default `u64::MAX` (inert). |
 | `SENTRIX_TRIE_TRACE` | `0` | Debug-only: per-key trie trace lines. **Never** enable in prod — fills the journal in seconds |
 | `SENTRIX_REPLAY_BYPASS_AUTHZ` | `0` | Debug-only: bypass tx authz during replay. Local debug runs only |
 | `RUST_LOG` | `info` | Log level |

--- a/docs/roadmap/CHANGELOG.md
+++ b/docs/roadmap/CHANGELOG.md
@@ -17,7 +17,7 @@ Consensus fork. Re-targets emission curve: 4-year halving (126M blocks) + 315M c
 
 ### Activation
 - Testnet: active since h=381651 (2026-04-26 afternoon)
-- Mainnet: armed at h=640800 via env var (~2 hour buffer post-deploy)
+- Mainnet: ACTIVE since h=640800 (2026-04-26 evening). End-to-end verified: consensus dispatch + RPC display both report v2 schedule (315M cap, 126M-block halving)
 
 ### Migration
 - Drop-in chain.db compatible with v2.1.38


### PR DESCRIPTION
Doc-only sync. Updates stale \"ARMED\" / \"will activate\" references in 4 files to reflect the tokenomics v2 fork now being ACTIVE end-to-end on mainnet since h=640800 (2026-04-26 evening).

## Why this needed shipping

PR #336 (consensus fork) merged + deployed to mainnet at ~h=634K. PR #337 (RPC display fork-aware fix) merged AFTER initial mainnet binary was built. Initial mainnet binary had consensus fork code but display layer still pointed at static \`MAX_SUPPLY = 210M\`.

Fork transitioned at h=640800 (2026-04-26 evening) — chain auto-switched to v2 schedule as designed. Discovery: \`/chain/info\` reported \`max_supply_srx: 210M\` even at h=646000 (well past fork). Resolved via halt-all + simultaneous-start binary swap to v2.1.39+#337 at ~h=646200. Both consensus + display now reporting v2 schedule (315M cap, 126M-block halving) end-to-end.

## Files

- \`README.md\` — hero v2.1.39 line: fork status \"armed\" → \"ACTIVE\"
- \`CHANGELOG.md\` — v2.1.39 title + activation procedure (✅ DONE markers) + new paragraph describing display-fix binary swap
- \`docs/roadmap/CHANGELOG.md\` — v2.1.39 entry mainnet activation status
- \`docs/operations/DEPLOYMENT.md\` — TOKENOMICS_V2_HEIGHT env var row

## Test plan
- [x] No code changes — pure docs
- [x] All references to fork status now consistent (\"ACTIVE since h=640800\")
- [x] Worked example documented in CHANGELOG for the binary-swap recovery
- [x] No secrets in diff