### PR TITLE
chore(docs): chain subdomain migration — *.sentriscloud.com → *.sentrixchain.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1225,7 +1225,7 @@ work natively, and deploy moves from CI to `fast-deploy.sh` on build host.
 ### Added
 - sentrix-storage crate integrated into sentrix-trie + sentrix-core
 - Cloudflare Origin Certificate for *.sentriscloud.com
-- sentrixscan.sentriscloud.com explorer (nginx proxy)
+- scan.sentrixchain.com explorer (nginx proxy)
 - testnet-scan.sentriscloud.com explorer
 - MPL-2.0 added to deny.toml allow-list (libmdbx)
 - Pre-commit hook allow-paths for workspace crate paths

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl http://localhost:8545/health
 | Field | Value |
 |---|---|
 | Network name | Sentrix Testnet |
-| RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
+| RPC URL | `https://testnet-rpc.sentrixchain.com/rpc` |
 | Chain ID | `7120` |
 | Symbol | `SRX` |
 | Explorer | `https://scan.sentrixchain.com` (toggle to Testnet in UI) |
@@ -96,7 +96,7 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 | | Mainnet | Testnet |
 |---|---|---|
 | **Chain ID** | 7119 | 7120 |
-| **RPC** | [sentrix-rpc.sentriscloud.com](https://sentrix-rpc.sentriscloud.com) | [testnet-rpc.sentriscloud.com](https://testnet-rpc.sentriscloud.com) |
+| **RPC** | [rpc.sentrixchain.com](https://rpc.sentrixchain.com) | [testnet-rpc.sentrixchain.com](https://testnet-rpc.sentrixchain.com) |
 | **Consensus** | DPoS + BFT (4 validators) | DPoS + BFT (4 validators) |
 | **Block time** | 1 second | 1 second |
 | **EVM** | Active — MetaMask compatible | Active — MetaMask compatible |

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -1,7 +1,7 @@
 # Sentrix — Technical Whitepaper
 
 **Version 3.4 — 2026-04-26 (post tokenomics-v2 fork; max supply 315M, BTC-parity 4-year halving)**
-**Author: SentrisCloud**
+**Author: Sentrix Labs** (operated by SentrisCloud)
 
 ---
 
@@ -443,9 +443,9 @@ See [SECURITY.md](SECURITY.md) for responsible disclosure policy.
 
 ### 14.4 Official Channels
 
-- Explorer: sentrixscan.sentriscloud.com
-- API: sentrix-api.sentriscloud.com
-- RPC: sentrix-rpc.sentriscloud.com
+- Explorer: scan.sentrixchain.com
+- API: api.sentrixchain.com
+- RPC: rpc.sentrixchain.com
 - GitHub: github.com/sentrix-labs/sentrix
 - Email: operator@sentriscloud.com
 

--- a/crates/sentrix-rpc/src/routes/ratelimit.rs
+++ b/crates/sentrix-rpc/src/routes/ratelimit.rs
@@ -5,7 +5,7 @@
 // Two limiters are layered on each request:
 // * `GlobalIpLimiter` — cap every endpoint at `SENTRIX_GLOBAL_RATE_LIMIT`
 //   (default 300 / min / IP). Raised 2026-04-21 from 60 → 300 so the
-//   block-explorer frontend (sentrixscan.sentriscloud.com) can poll the
+//   block-explorer frontend (scan.sentrixchain.com) can poll the
 //   ~8 live stats endpoints it uses without tripping the limit on a
 //   shared office / NAT IP. Reads are cheap; 300/min is still well
 //   below any realistic DoS threshold on this hardware.

--- a/docs-site/docs/architecture/EVM.md
+++ b/docs-site/docs/architecture/EVM.md
@@ -128,10 +128,10 @@ Quick add (testnet):
 
 ```
 Network Name:     Sentrix Testnet
-RPC URL:          https://testnet-rpc.sentriscloud.com/rpc
+RPC URL:          https://testnet-rpc.sentrixchain.com/rpc
 Chain ID:         7120
 Currency Symbol:  SRX
-Block Explorer:   https://sentrixscan.sentriscloud.com
+Block Explorer:   https://scan.sentrixchain.com
 ```
 
 ## Known Limitations

--- a/docs-site/docs/brand/HERO_COPY.md
+++ b/docs-site/docs/brand/HERO_COPY.md
@@ -38,8 +38,8 @@ Live h=...  |  1 second    |  4 active    |  315M SRX    |  Voyager DPoS+BFT
 
 JS to populate:
 ```js
-// Pull from sentrix-rpc.sentriscloud.com/chain/info
-const stats = await fetch('https://sentrix-rpc.sentriscloud.com/chain/info').then(r => r.json());
+// Pull from rpc.sentrixchain.com/chain/info
+const stats = await fetch('https://rpc.sentrixchain.com/chain/info').then(r => r.json());
 // { height, active_validators, max_supply_srx, consensus_mode }
 ```
 
@@ -54,7 +54,7 @@ Built in Rust · EVM-compatible · MetaMask-ready · 1s blocks · Production sin
 ```
 Devs:       npm install ethers           Connect to chain 7119
             const provider = new ethers.JsonRpcProvider(
-              "https://sentrix-rpc.sentriscloud.com/rpc"
+              "https://rpc.sentrixchain.com/rpc"
             );
 
 Validators: github.com/sentrix-labs/sentrix#run-a-validator

--- a/docs-site/docs/brand/SOCIAL_BIOS.md
+++ b/docs-site/docs/brand/SOCIAL_BIOS.md
@@ -103,8 +103,8 @@ Discussion → t.me/sentrixchain_chat
 Devs building on Sentrix. Q&A, grants program, technical
 support, ecosystem coordination.
 
-Mainnet RPC: sentrix-rpc.sentriscloud.com
-Testnet RPC: testnet-rpc.sentriscloud.com
+Mainnet RPC: rpc.sentrixchain.com
+Testnet RPC: testnet-rpc.sentrixchain.com
 Chain ID: 7119 mainnet · 7120 testnet
 EVM: Solidity contracts work natively
 

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -23,8 +23,8 @@ Sentrix is the financial infrastructure for the real economy — starting with I
 
 | | |
 |---|---|
-| **Mainnet** | Chain ID `7119` · `https://sentrix-rpc.sentriscloud.com/rpc` |
-| **Testnet** | Chain ID `7120` · `https://testnet-rpc.sentriscloud.com/rpc` |
+| **Mainnet** | Chain ID `7119` · `https://rpc.sentrixchain.com/rpc` |
+| **Testnet** | Chain ID `7120` · `https://testnet-rpc.sentrixchain.com/rpc` |
 | **Block Time** | 1 second |
 | **Consensus** | Voyager DPoS+BFT (live since April 2026) |
 | **Execution** | EVM-native (revm 37) |

--- a/docs-site/docs/operations/API_ENDPOINTS.md
+++ b/docs-site/docs/operations/API_ENDPOINTS.md
@@ -3,8 +3,8 @@
 Reference for frontend integration. Source: `crates/sentrix-rpc/src/routes/mod.rs` (REST) and `crates/sentrix-rpc/src/jsonrpc/{eth,net,web3,sentrix}.rs` (JSON-RPC).
 
 Base URLs:
-- **Mainnet:** `https://sentrix-rpc.sentriscloud.com` (chain_id 7119, **Voyager DPoS+BFT** since 2026-04-25)
-- **Testnet:** `https://testnet-rpc.sentriscloud.com` (chain_id 7120, **Voyager DPoS+BFT** since 2026-04-23)
+- **Mainnet:** `https://rpc.sentrixchain.com` (chain_id 7119, **Voyager DPoS+BFT** since 2026-04-25)
+- **Testnet:** `https://testnet-rpc.sentrixchain.com` (chain_id 7120, **Voyager DPoS+BFT** since 2026-04-23)
 
 Rate limits (per IP): **60 req/min global**, **10 req/min write endpoints** (POST to `/transactions`, `/tokens/deploy|transfer|burn`, `/rpc`).
 
@@ -339,7 +339,7 @@ Cross-check any shape by `curl`ing the live endpoint — responses are authorita
 
 ### Chain state
 ```bash
-curl -s https://sentrix-rpc.sentriscloud.com/chain/info
+curl -s https://rpc.sentrixchain.com/chain/info
 # {
 #   "chain_id": 7119, "height": 80123, "total_blocks": 80124,
 #   "active_validators": 3, "circulating_supply_srx": 63030377.988,
@@ -348,7 +348,7 @@ curl -s https://sentrix-rpc.sentriscloud.com/chain/info
 #   "window_is_partial": false, "window_start_block": 79123
 # }
 
-curl -s https://sentrix-rpc.sentriscloud.com/sentrix_status
+curl -s https://rpc.sentrixchain.com/sentrix_status
 # { "version": {"version":"2.1.1","build":"unknown"}, "chain_id": 7119,
 #   "consensus": "PoA", "native_token": "SRX",
 #   "sync_info": { "latest_block_height": 80123, ... },
@@ -357,16 +357,16 @@ curl -s https://sentrix-rpc.sentriscloud.com/sentrix_status
 
 ### Account balance + nonce (REST)
 ```bash
-curl -s https://sentrix-rpc.sentriscloud.com/accounts/0x682126f5f973bddda2c92fb0dfce8a4ba275c99b/balance
+curl -s https://rpc.sentrixchain.com/accounts/0x682126f5f973bddda2c92fb0dfce8a4ba275c99b/balance
 # { "address": "0x682126...", "balance": 664000000000 }   // in sentri
 
-curl -s https://sentrix-rpc.sentriscloud.com/accounts/0x682126f5f973bddda2c92fb0dfce8a4ba275c99b/nonce
+curl -s https://rpc.sentrixchain.com/accounts/0x682126f5f973bddda2c92fb0dfce8a4ba275c99b/nonce
 # { "address": "0x682126...", "nonce": 9 }
 ```
 
 ### Account balance (JSON-RPC, wei)
 ```bash
-curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
+curl -s -X POST https://rpc.sentrixchain.com/rpc \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","method":"eth_getBalance",
        "params":["0x682126f5f973bddda2c92fb0dfce8a4ba275c99b","latest"],"id":1}'
@@ -375,7 +375,7 @@ curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
 
 ### Latest block
 ```bash
-curl -s https://sentrix-rpc.sentriscloud.com/blocks/80123
+curl -s https://rpc.sentrixchain.com/blocks/80123
 # { "index": 80123, "hash": "f35cd...", "previous_hash": "abc...",
 #   "timestamp": 1776625635, "tx_count": 1, "validator": "0x...",
 #   "merkle_root": "...", "round": 0, "has_justification": false }
@@ -383,7 +383,7 @@ curl -s https://sentrix-rpc.sentriscloud.com/blocks/80123
 
 ### Validator set (PoA)
 ```bash
-curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
+curl -s -X POST https://rpc.sentrixchain.com/rpc \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","method":"sentrix_getValidatorSet","params":[],"id":1}'
 # {
@@ -410,7 +410,7 @@ curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
 3. Fetch nonce via JSON-RPC `eth_getTransactionCount`.
 4. `POST /tokens/deploy`:
 ```bash
-curl -s -X POST https://testnet-rpc.sentriscloud.com/tokens/deploy \
+curl -s -X POST https://testnet-rpc.sentrixchain.com/tokens/deploy \
   -H 'Content-Type: application/json' \
   -d '{
     "transaction": {
@@ -437,7 +437,7 @@ After the next block, `GET /tokens` lists the new contract at `SRC20_<40 hex>`, 
 ### Send SRX (native transfer)
 Same pattern, amount > 0 and empty `data`:
 ```bash
-curl -s -X POST https://testnet-rpc.sentriscloud.com/transactions \
+curl -s -X POST https://testnet-rpc.sentrixchain.com/transactions \
   -H 'Content-Type: application/json' \
   -d '{"transaction": { "from_address":"0x...", "to_address":"0x...",
                         "amount": 1000000000, "fee": 10000, "nonce": 3,
@@ -449,7 +449,7 @@ curl -s -X POST https://testnet-rpc.sentriscloud.com/transactions \
 
 ### Block receipts (batch)
 ```bash
-curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
+curl -s -X POST https://rpc.sentrixchain.com/rpc \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","method":"eth_getBlockReceipts","params":["latest"],"id":1}'
 # { "result": [{
@@ -463,7 +463,7 @@ curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
 
 ### EVM event logs (filter)
 ```bash
-curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
+curl -s -X POST https://rpc.sentrixchain.com/rpc \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{
         "fromBlock":"0x0","toBlock":"latest",

--- a/docs-site/docs/operations/API_REFERENCE.md
+++ b/docs-site/docs/operations/API_REFERENCE.md
@@ -2,7 +2,7 @@
 
 Complete list of Sentrix REST + JSON-RPC endpoints.
 
-Base URL: `https://testnet-rpc.sentriscloud.com` (testnet) or `https://sentrix-rpc.sentriscloud.com` (mainnet).
+Base URL: `https://testnet-rpc.sentrixchain.com` (testnet) or `https://rpc.sentrixchain.com` (mainnet).
 
 ---
 

--- a/docs-site/docs/operations/CLAIM_REWARDS.md
+++ b/docs-site/docs/operations/CLAIM_REWARDS.md
@@ -37,7 +37,7 @@ Practical pattern: claim weekly or monthly, depending on accrual rate vs gas eco
 ## Query pending rewards
 
 ```bash
-curl -sf https://sentrix-rpc.sentriscloud.com/staking/validators | jq '.validators[] | {address, pending_rewards, total_stake}'
+curl -sf https://rpc.sentrixchain.com/staking/validators | jq '.validators[] | {address, pending_rewards, total_stake}'
 ```
 
 Output (per validator):
@@ -63,7 +63,7 @@ cargo build --release
 
 # Submit (interactive — privkey stays in process memory; never logged)
 echo "<64-hex-privkey>" | ./target/release/claim-rewards \
-  --rpc       https://sentrix-rpc.sentriscloud.com \
+  --rpc       https://rpc.sentrixchain.com \
   --chain-id  7119
 
 # Add --dry-run to build + sign without POSTing (for verification)
@@ -101,11 +101,11 @@ Verify post-claim:
 
 ```bash
 # Pending should be 0
-curl -sf https://sentrix-rpc.sentriscloud.com/staking/validators | \
+curl -sf https://rpc.sentrixchain.com/staking/validators | \
   jq '.validators[] | select(.address=="0x<your-addr>") | .pending_rewards'
 
 # Balance should have grown by claimed amount minus MIN_TX_FEE
-curl -sf -X POST https://sentrix-rpc.sentriscloud.com/rpc \
+curl -sf -X POST https://rpc.sentrixchain.com/rpc \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x<your-addr>","latest"],"id":1}'
 ```

--- a/docs-site/docs/operations/DEVELOPER_QUICKSTART.md
+++ b/docs-site/docs/operations/DEVELOPER_QUICKSTART.md
@@ -8,9 +8,9 @@ Build on Sentrix in 10 minutes. Deploy a smart contract, read chain state, and s
 
 | | |
 |---|---|
-| RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
+| RPC URL | `https://testnet-rpc.sentrixchain.com/rpc` |
 | Chain ID | `7120` |
-| Explorer | `https://sentrixscan.sentriscloud.com` |
+| Explorer | `https://scan.sentrixchain.com` |
 | Faucet | `https://faucet.sentriscloud.com` |
 
 ### MetaMask setup
@@ -20,10 +20,10 @@ Settings → Networks → Add network manually:
 | Field | Value |
 |---|---|
 | Network name | `Sentrix Testnet` |
-| RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
+| RPC URL | `https://testnet-rpc.sentrixchain.com/rpc` |
 | Chain ID | `7120` |
 | Symbol | `SRX` |
-| Block Explorer | `https://sentrixscan.sentriscloud.com` |
+| Block Explorer | `https://scan.sentrixchain.com` |
 
 Get test SRX from the [faucet](https://faucet.sentriscloud.com).
 
@@ -66,7 +66,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 
 // Read-only client
 const client = createPublicClient({
-  transport: http('https://testnet-rpc.sentriscloud.com/rpc'),
+  transport: http('https://testnet-rpc.sentrixchain.com/rpc'),
 })
 
 const height = await client.getBlockNumber()
@@ -76,7 +76,7 @@ const balance = await client.getBalance({ address: '0x...' })
 const account = privateKeyToAccount('0x...')
 const wallet = createWalletClient({
   account,
-  transport: http('https://testnet-rpc.sentriscloud.com/rpc'),
+  transport: http('https://testnet-rpc.sentrixchain.com/rpc'),
 })
 
 const hash = await wallet.sendTransaction({
@@ -89,16 +89,16 @@ const hash = await wallet.sendTransaction({
 
 ```bash
 # Chain info
-curl https://testnet-rpc.sentriscloud.com/chain/info
+curl https://testnet-rpc.sentrixchain.com/chain/info
 
 # Get balance
-curl https://testnet-rpc.sentriscloud.com/accounts/0xYOUR_ADDRESS/balance
+curl https://testnet-rpc.sentrixchain.com/accounts/0xYOUR_ADDRESS/balance
 
 # List validators
-curl https://testnet-rpc.sentriscloud.com/validators
+curl https://testnet-rpc.sentrixchain.com/validators
 
 # Prometheus metrics
-curl https://testnet-rpc.sentriscloud.com/metrics
+curl https://testnet-rpc.sentrixchain.com/metrics
 ```
 
 ## JSON-RPC Methods
@@ -107,19 +107,19 @@ All standard Ethereum JSON-RPC methods are supported:
 
 ```bash
 # Chain ID
-curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
+curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
 
 # Block number
 curl -X POST -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
-  https://testnet-rpc.sentriscloud.com/rpc
+  https://testnet-rpc.sentrixchain.com/rpc
 
 # Get balance (returns wei)
 curl -X POST -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0xYOUR_ADDRESS","latest"],"id":1}' \
-  https://testnet-rpc.sentriscloud.com/rpc
+  https://testnet-rpc.sentrixchain.com/rpc
 ```
 
 Full method list: `eth_chainId`, `eth_blockNumber`, `eth_getBalance`, `eth_getTransactionCount`, `eth_getCode`, `eth_getStorageAt`, `eth_call`, `eth_estimateGas`, `eth_gasPrice`, `eth_sendRawTransaction`, `eth_getTransactionByHash`, `eth_getTransactionReceipt`, `eth_getBlockByNumber`, `eth_getBlockByHash`, `net_version`, `net_listening`.
@@ -131,7 +131,7 @@ Full method list: `eth_chainId`, `eth_blockNumber`, `eth_getBalance`, `eth_getTr
 module.exports = {
   networks: {
     sentrixTestnet: {
-      url: "https://testnet-rpc.sentriscloud.com/rpc",
+      url: "https://testnet-rpc.sentrixchain.com/rpc",
       chainId: 7120,
       accounts: [process.env.PRIVATE_KEY],
     },
@@ -142,7 +142,7 @@ module.exports = {
 ```toml
 # foundry.toml
 [rpc_endpoints]
-sentrix_testnet = "https://testnet-rpc.sentriscloud.com/rpc"
+sentrix_testnet = "https://testnet-rpc.sentrixchain.com/rpc"
 ```
 
 ## Gas Model

--- a/docs-site/docs/operations/DOMAINS.md
+++ b/docs-site/docs/operations/DOMAINS.md
@@ -7,10 +7,10 @@ All Sentrix services run under `sentriscloud.com`. DNS managed via Cloudflare.
 | Domain | What |
 |--------|------|
 | sentrix.sentriscloud.com | Landing page |
-| sentrixscan.sentriscloud.com | Block explorer |
-| sentrix-api.sentriscloud.com | REST API |
-| sentrix-rpc.sentriscloud.com | Mainnet JSON-RPC |
-| testnet-rpc.sentriscloud.com | Testnet JSON-RPC |
+| scan.sentrixchain.com | Block explorer |
+| api.sentrixchain.com | REST API |
+| rpc.sentrixchain.com | Mainnet JSON-RPC |
+| testnet-rpc.sentrixchain.com | Testnet JSON-RPC |
 | sentrix-wallet.sentriscloud.com | Wallet UI |
 | sentrixlaunch.sentriscloud.com | Token launchpad |
 | coinblast.sentriscloud.com | CoinBlast |
@@ -19,9 +19,9 @@ All Sentrix services run under `sentriscloud.com`. DNS managed via Cloudflare.
 ## Mainnet Endpoints
 
 ```
-RPC:      https://sentrix-rpc.sentriscloud.com
-API:      https://sentrix-api.sentriscloud.com
-Explorer: https://sentrixscan.sentriscloud.com
+RPC:      https://rpc.sentrixchain.com
+API:      https://api.sentrixchain.com
+Explorer: https://scan.sentrixchain.com
 Wallet:   https://sentrix-wallet.sentriscloud.com
 Faucet:   https://faucet.sentriscloud.com
 Chain ID: 7119
@@ -30,7 +30,7 @@ Chain ID: 7119
 ## Testnet Endpoints
 
 ```
-RPC:      https://testnet-rpc.sentriscloud.com
+RPC:      https://testnet-rpc.sentrixchain.com
 Chain ID: 7120
 ```
 
@@ -38,7 +38,7 @@ Chain ID: 7120
 
 Connect to testnet (for development and testing):
 ```
-RPC URL:  https://testnet-rpc.sentriscloud.com
+RPC URL:  https://testnet-rpc.sentrixchain.com
 Chain ID: 7120
 Symbol:   SRX
 ```
@@ -46,8 +46,8 @@ Symbol:   SRX
 Testnet tokens have no real value. Use the faucet to get test SRX.
 
 ```bash
-curl https://testnet-rpc.sentriscloud.com/chain/info
-curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
+curl https://testnet-rpc.sentrixchain.com/chain/info
+curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
 ```
@@ -56,7 +56,7 @@ curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
 
 Connect to mainnet:
 ```
-RPC URL:  https://sentrix-rpc.sentriscloud.com
+RPC URL:  https://rpc.sentrixchain.com
 Chain ID: 7119
 Symbol:   SRX
 ```

--- a/docs-site/docs/operations/METAMASK.md
+++ b/docs-site/docs/operations/METAMASK.md
@@ -10,10 +10,10 @@ Sentrix is fully MetaMask-compatible on both networks. Mainnet (chain ID 7119) a
    | Field | Value |
    |-------|-------|
    | **Network Name** | Sentrix Testnet |
-   | **New RPC URL** | `https://testnet-rpc.sentriscloud.com/rpc` |
+   | **New RPC URL** | `https://testnet-rpc.sentrixchain.com/rpc` |
    | **Chain ID** | `7120` |
    | **Currency Symbol** | `SRX` |
-   | **Block Explorer URL** | `https://sentrixscan.sentriscloud.com` |
+   | **Block Explorer URL** | `https://scan.sentrixchain.com` |
 
 3. Save. Switch to "Sentrix Testnet" in the network dropdown.
 
@@ -22,10 +22,10 @@ Sentrix is fully MetaMask-compatible on both networks. Mainnet (chain ID 7119) a
    | Field | Value |
    |-------|-------|
    | **Network Name** | Sentrix |
-   | **New RPC URL** | `https://sentrix-rpc.sentriscloud.com` |
+   | **New RPC URL** | `https://rpc.sentrixchain.com` |
    | **Chain ID** | `7119` |
    | **Currency Symbol** | `SRX` |
-   | **Block Explorer URL** | `https://sentrixscan.sentriscloud.com` |
+   | **Block Explorer URL** | `https://scan.sentrixchain.com` |
 
 Mainnet supports `eth_sendRawTransaction` and Solidity contract deployment since the 2026-04-25 Voyager activation. Use mainnet for production deployments and testnet for development.
 
@@ -52,12 +52,12 @@ The contract address appears in Remix and is queryable via `eth_getCode`.
 
 ```bash
 # Get deployed contract code
-curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
+curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xCONTRACT_ADDR","latest"],"id":1}'
 
 # Call a function (example: totalSupply() = 0x18160ddd)
-curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
+curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xCONTRACT_ADDR","data":"0x18160ddd"},"latest"],"id":1}'
 ```

--- a/docs-site/docs/operations/NETWORKS.md
+++ b/docs-site/docs/operations/NETWORKS.md
@@ -5,8 +5,8 @@
 | | |
 |-|-|
 | Chain ID | 7119 (0x1bcf) |
-| RPC | https://sentrix-rpc.sentriscloud.com |
-| Explorer | https://sentrixscan.sentriscloud.com |
+| RPC | https://rpc.sentrixchain.com |
+| Explorer | https://scan.sentrixchain.com |
 | P2P port | 30303 |
 | API port | 8545 |
 | Block time | 1s |
@@ -22,9 +22,9 @@
 | | |
 |-|-|
 | Chain ID | 7120 (0x1bd0) |
-| RPC | https://testnet-rpc.sentriscloud.com/rpc |
-| Explorer | https://sentrixscan.sentriscloud.com (unified UI, toggle Testnet) |
-| API | https://testnet-api.sentriscloud.com |
+| RPC | https://testnet-rpc.sentrixchain.com/rpc |
+| Explorer | https://scan.sentrixchain.com (unified UI, toggle Testnet) |
+| API | https://testnet-api.sentrixchain.com |
 | P2P port | 31303–31306 |
 | API port | 9545 |
 | Block time | 1s |
@@ -56,10 +56,10 @@ Add network manually:
 | Field | Mainnet | Testnet |
 |-------|---------|---------|
 | Network Name | Sentrix | Sentrix Testnet |
-| RPC URL | https://sentrix-rpc.sentriscloud.com | https://testnet-rpc.sentriscloud.com/rpc |
+| RPC URL | https://rpc.sentrixchain.com | https://testnet-rpc.sentrixchain.com/rpc |
 | Chain ID | 7119 | 7120 |
 | Symbol | SRX | SRX |
-| Explorer | https://sentrixscan.sentriscloud.com | https://sentrixscan.sentriscloud.com (toggle Testnet) |
+| Explorer | https://scan.sentrixchain.com | https://scan.sentrixchain.com (toggle Testnet) |
 
 ### ethers.js
 
@@ -67,10 +67,10 @@ Add network manually:
 import { JsonRpcProvider } from "ethers";
 
 // Testnet (for development)
-const provider = new JsonRpcProvider("https://testnet-rpc.sentriscloud.com");
+const provider = new JsonRpcProvider("https://testnet-rpc.sentrixchain.com");
 
 // Mainnet (for production)
-// const provider = new JsonRpcProvider("https://sentrix-rpc.sentriscloud.com");
+// const provider = new JsonRpcProvider("https://rpc.sentrixchain.com");
 
 const height = await provider.getBlockNumber();
 const balance = await provider.getBalance("0x...");
@@ -80,13 +80,13 @@ const balance = await provider.getBalance("0x...");
 
 ```bash
 # Testnet (default for development)
-curl -s https://testnet-rpc.sentriscloud.com/chain/info | jq
+curl -s https://testnet-rpc.sentrixchain.com/chain/info | jq
 
 # Mainnet (production)
-curl -s https://sentrix-rpc.sentriscloud.com/chain/info | jq
+curl -s https://rpc.sentrixchain.com/chain/info | jq
 
 # JSON-RPC
-curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
+curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
 ```

--- a/docs-site/docs/operations/SMART_CONTRACT_GUIDE.md
+++ b/docs-site/docs/operations/SMART_CONTRACT_GUIDE.md
@@ -17,10 +17,10 @@ In MetaMask → **Networks → Add network manually**:
 | Field | Value |
 |---|---|
 | Network name | `Sentrix Testnet` |
-| New RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
+| New RPC URL | `https://testnet-rpc.sentrixchain.com/rpc` |
 | Chain ID | `7120` |
 | Currency symbol | `SRX` |
-| Block explorer URL | `https://sentrixscan.sentriscloud.com` |
+| Block explorer URL | `https://scan.sentrixchain.com` |
 
 Save and switch to Sentrix Testnet. You should see your SRX balance.
 
@@ -82,7 +82,7 @@ Expand the deployed contract and call any function:
 You can also verify the deployment via the explorer:
 
 ```
-https://sentrixscan.sentriscloud.com/tx/<your-tx-hash>
+https://scan.sentrixchain.com/tx/<your-tx-hash>
 ```
 
 ## Hardhat / Foundry
@@ -93,7 +93,7 @@ Same network config:
 // hardhat.config.js
 networks: {
   sentrixTestnet: {
-    url: "https://testnet-rpc.sentriscloud.com/rpc",
+    url: "https://testnet-rpc.sentrixchain.com/rpc",
     chainId: 7120,
     accounts: [process.env.PRIVATE_KEY],
   },
@@ -103,7 +103,7 @@ networks: {
 ```toml
 # foundry.toml
 [rpc_endpoints]
-sentrix_testnet = "https://testnet-rpc.sentriscloud.com/rpc"
+sentrix_testnet = "https://testnet-rpc.sentrixchain.com/rpc"
 ```
 
 ## Gas Model

--- a/docs-site/docs/operations/VALIDATOR_ONBOARDING.md
+++ b/docs-site/docs/operations/VALIDATOR_ONBOARDING.md
@@ -210,7 +210,7 @@ peer. To become an authority:
 2. The admin runs `sentrix validator add <your-addr> "<your-name>"
    <your-pubkey> --admin-key <admin-key>`.
 3. Once added, you'll appear in `GET /chain/info → validators` and in
-   the explorer at `sentrixscan.sentriscloud.com/validators`.
+   the explorer at `scan.sentrixchain.com/validators`.
 
 Admin op is verified on-chain — your admission cannot be tampered with
 once in a block.

--- a/docs/architecture/EVM.md
+++ b/docs/architecture/EVM.md
@@ -128,10 +128,10 @@ Quick add (testnet):
 
 ```
 Network Name:     Sentrix Testnet
-RPC URL:          https://testnet-rpc.sentriscloud.com/rpc
+RPC URL:          https://testnet-rpc.sentrixchain.com/rpc
 Chain ID:         7120
 Currency Symbol:  SRX
-Block Explorer:   https://sentrixscan.sentriscloud.com
+Block Explorer:   https://scan.sentrixchain.com
 ```
 
 ## Known Limitations

--- a/docs/brand/HERO_COPY.md
+++ b/docs/brand/HERO_COPY.md
@@ -38,8 +38,8 @@ Live h=...  |  1 second    |  4 active    |  315M SRX    |  Voyager DPoS+BFT
 
 JS to populate:
 ```js
-// Pull from sentrix-rpc.sentriscloud.com/chain/info
-const stats = await fetch('https://sentrix-rpc.sentriscloud.com/chain/info').then(r => r.json());
+// Pull from rpc.sentrixchain.com/chain/info
+const stats = await fetch('https://rpc.sentrixchain.com/chain/info').then(r => r.json());
 // { height, active_validators, max_supply_srx, consensus_mode }
 ```
 
@@ -54,7 +54,7 @@ Built in Rust · EVM-compatible · MetaMask-ready · 1s blocks · Production sin
 ```
 Devs:       npm install ethers           Connect to chain 7119
             const provider = new ethers.JsonRpcProvider(
-              "https://sentrix-rpc.sentriscloud.com/rpc"
+              "https://rpc.sentrixchain.com/rpc"
             );
 
 Validators: github.com/sentrix-labs/sentrix#run-a-validator

--- a/docs/brand/SOCIAL_BIOS.md
+++ b/docs/brand/SOCIAL_BIOS.md
@@ -103,8 +103,8 @@ Discussion → t.me/sentrixchain_chat
 Devs building on Sentrix. Q&A, grants program, technical
 support, ecosystem coordination.
 
-Mainnet RPC: sentrix-rpc.sentriscloud.com
-Testnet RPC: testnet-rpc.sentriscloud.com
+Mainnet RPC: rpc.sentrixchain.com
+Testnet RPC: testnet-rpc.sentrixchain.com
 Chain ID: 7119 mainnet · 7120 testnet
 EVM: Solidity contracts work natively
 

--- a/docs/operations/API_ENDPOINTS.md
+++ b/docs/operations/API_ENDPOINTS.md
@@ -3,8 +3,8 @@
 Reference for frontend integration. Source: `crates/sentrix-rpc/src/routes/mod.rs` (REST) and `crates/sentrix-rpc/src/jsonrpc/{eth,net,web3,sentrix}.rs` (JSON-RPC).
 
 Base URLs:
-- **Mainnet:** `https://sentrix-rpc.sentriscloud.com` (chain_id 7119, **Voyager DPoS+BFT** since 2026-04-25)
-- **Testnet:** `https://testnet-rpc.sentriscloud.com` (chain_id 7120, **Voyager DPoS+BFT** since 2026-04-23)
+- **Mainnet:** `https://rpc.sentrixchain.com` (chain_id 7119, **Voyager DPoS+BFT** since 2026-04-25)
+- **Testnet:** `https://testnet-rpc.sentrixchain.com` (chain_id 7120, **Voyager DPoS+BFT** since 2026-04-23)
 
 Rate limits (per IP): **60 req/min global**, **10 req/min write endpoints** (POST to `/transactions`, `/tokens/deploy|transfer|burn`, `/rpc`).
 
@@ -339,7 +339,7 @@ Cross-check any shape by `curl`ing the live endpoint — responses are authorita
 
 ### Chain state
 ```bash
-curl -s https://sentrix-rpc.sentriscloud.com/chain/info
+curl -s https://rpc.sentrixchain.com/chain/info
 # {
 #   "chain_id": 7119, "height": 80123, "total_blocks": 80124,
 #   "active_validators": 3, "circulating_supply_srx": 63030377.988,
@@ -348,7 +348,7 @@ curl -s https://sentrix-rpc.sentriscloud.com/chain/info
 #   "window_is_partial": false, "window_start_block": 79123
 # }
 
-curl -s https://sentrix-rpc.sentriscloud.com/sentrix_status
+curl -s https://rpc.sentrixchain.com/sentrix_status
 # { "version": {"version":"2.1.1","build":"unknown"}, "chain_id": 7119,
 #   "consensus": "PoA", "native_token": "SRX",
 #   "sync_info": { "latest_block_height": 80123, ... },
@@ -357,16 +357,16 @@ curl -s https://sentrix-rpc.sentriscloud.com/sentrix_status
 
 ### Account balance + nonce (REST)
 ```bash
-curl -s https://sentrix-rpc.sentriscloud.com/accounts/0x682126f5f973bddda2c92fb0dfce8a4ba275c99b/balance
+curl -s https://rpc.sentrixchain.com/accounts/0x682126f5f973bddda2c92fb0dfce8a4ba275c99b/balance
 # { "address": "0x682126...", "balance": 664000000000 }   // in sentri
 
-curl -s https://sentrix-rpc.sentriscloud.com/accounts/0x682126f5f973bddda2c92fb0dfce8a4ba275c99b/nonce
+curl -s https://rpc.sentrixchain.com/accounts/0x682126f5f973bddda2c92fb0dfce8a4ba275c99b/nonce
 # { "address": "0x682126...", "nonce": 9 }
 ```
 
 ### Account balance (JSON-RPC, wei)
 ```bash
-curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
+curl -s -X POST https://rpc.sentrixchain.com/rpc \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","method":"eth_getBalance",
        "params":["0x682126f5f973bddda2c92fb0dfce8a4ba275c99b","latest"],"id":1}'
@@ -375,7 +375,7 @@ curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
 
 ### Latest block
 ```bash
-curl -s https://sentrix-rpc.sentriscloud.com/blocks/80123
+curl -s https://rpc.sentrixchain.com/blocks/80123
 # { "index": 80123, "hash": "f35cd...", "previous_hash": "abc...",
 #   "timestamp": 1776625635, "tx_count": 1, "validator": "0x...",
 #   "merkle_root": "...", "round": 0, "has_justification": false }
@@ -383,7 +383,7 @@ curl -s https://sentrix-rpc.sentriscloud.com/blocks/80123
 
 ### Validator set (PoA)
 ```bash
-curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
+curl -s -X POST https://rpc.sentrixchain.com/rpc \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","method":"sentrix_getValidatorSet","params":[],"id":1}'
 # {
@@ -410,7 +410,7 @@ curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
 3. Fetch nonce via JSON-RPC `eth_getTransactionCount`.
 4. `POST /tokens/deploy`:
 ```bash
-curl -s -X POST https://testnet-rpc.sentriscloud.com/tokens/deploy \
+curl -s -X POST https://testnet-rpc.sentrixchain.com/tokens/deploy \
   -H 'Content-Type: application/json' \
   -d '{
     "transaction": {
@@ -437,7 +437,7 @@ After the next block, `GET /tokens` lists the new contract at `SRC20_<40 hex>`, 
 ### Send SRX (native transfer)
 Same pattern, amount > 0 and empty `data`:
 ```bash
-curl -s -X POST https://testnet-rpc.sentriscloud.com/transactions \
+curl -s -X POST https://testnet-rpc.sentrixchain.com/transactions \
   -H 'Content-Type: application/json' \
   -d '{"transaction": { "from_address":"0x...", "to_address":"0x...",
                         "amount": 1000000000, "fee": 10000, "nonce": 3,
@@ -449,7 +449,7 @@ curl -s -X POST https://testnet-rpc.sentriscloud.com/transactions \
 
 ### Block receipts (batch)
 ```bash
-curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
+curl -s -X POST https://rpc.sentrixchain.com/rpc \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","method":"eth_getBlockReceipts","params":["latest"],"id":1}'
 # { "result": [{
@@ -463,7 +463,7 @@ curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
 
 ### EVM event logs (filter)
 ```bash
-curl -s -X POST https://sentrix-rpc.sentriscloud.com/rpc \
+curl -s -X POST https://rpc.sentrixchain.com/rpc \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{
         "fromBlock":"0x0","toBlock":"latest",

--- a/docs/operations/API_REFERENCE.md
+++ b/docs/operations/API_REFERENCE.md
@@ -2,7 +2,7 @@
 
 Complete list of Sentrix REST + JSON-RPC endpoints.
 
-Base URL: `https://testnet-rpc.sentriscloud.com` (testnet) or `https://sentrix-rpc.sentriscloud.com` (mainnet).
+Base URL: `https://testnet-rpc.sentrixchain.com` (testnet) or `https://rpc.sentrixchain.com` (mainnet).
 
 ---
 

--- a/docs/operations/CLAIM_REWARDS.md
+++ b/docs/operations/CLAIM_REWARDS.md
@@ -37,7 +37,7 @@ Practical pattern: claim weekly or monthly, depending on accrual rate vs gas eco
 ## Query pending rewards
 
 ```bash
-curl -sf https://sentrix-rpc.sentriscloud.com/staking/validators | jq '.validators[] | {address, pending_rewards, total_stake}'
+curl -sf https://rpc.sentrixchain.com/staking/validators | jq '.validators[] | {address, pending_rewards, total_stake}'
 ```
 
 Output (per validator):
@@ -63,7 +63,7 @@ cargo build --release
 
 # Submit (interactive — privkey stays in process memory; never logged)
 echo "<64-hex-privkey>" | ./target/release/claim-rewards \
-  --rpc       https://sentrix-rpc.sentriscloud.com \
+  --rpc       https://rpc.sentrixchain.com \
   --chain-id  7119
 
 # Add --dry-run to build + sign without POSTing (for verification)
@@ -101,11 +101,11 @@ Verify post-claim:
 
 ```bash
 # Pending should be 0
-curl -sf https://sentrix-rpc.sentriscloud.com/staking/validators | \
+curl -sf https://rpc.sentrixchain.com/staking/validators | \
   jq '.validators[] | select(.address=="0x<your-addr>") | .pending_rewards'
 
 # Balance should have grown by claimed amount minus MIN_TX_FEE
-curl -sf -X POST https://sentrix-rpc.sentriscloud.com/rpc \
+curl -sf -X POST https://rpc.sentrixchain.com/rpc \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x<your-addr>","latest"],"id":1}'
 ```

--- a/docs/operations/DEVELOPER_QUICKSTART.md
+++ b/docs/operations/DEVELOPER_QUICKSTART.md
@@ -8,9 +8,9 @@ Build on Sentrix in 10 minutes. Deploy a smart contract, read chain state, and s
 
 | | |
 |---|---|
-| RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
+| RPC URL | `https://testnet-rpc.sentrixchain.com/rpc` |
 | Chain ID | `7120` |
-| Explorer | `https://sentrixscan.sentriscloud.com` |
+| Explorer | `https://scan.sentrixchain.com` |
 | Faucet | `https://faucet.sentriscloud.com` |
 
 ### MetaMask setup
@@ -20,10 +20,10 @@ Settings → Networks → Add network manually:
 | Field | Value |
 |---|---|
 | Network name | `Sentrix Testnet` |
-| RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
+| RPC URL | `https://testnet-rpc.sentrixchain.com/rpc` |
 | Chain ID | `7120` |
 | Symbol | `SRX` |
-| Block Explorer | `https://sentrixscan.sentriscloud.com` |
+| Block Explorer | `https://scan.sentrixchain.com` |
 
 Get test SRX from the [faucet](https://faucet.sentriscloud.com).
 
@@ -66,7 +66,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 
 // Read-only client
 const client = createPublicClient({
-  transport: http('https://testnet-rpc.sentriscloud.com/rpc'),
+  transport: http('https://testnet-rpc.sentrixchain.com/rpc'),
 })
 
 const height = await client.getBlockNumber()
@@ -76,7 +76,7 @@ const balance = await client.getBalance({ address: '0x...' })
 const account = privateKeyToAccount('0x...')
 const wallet = createWalletClient({
   account,
-  transport: http('https://testnet-rpc.sentriscloud.com/rpc'),
+  transport: http('https://testnet-rpc.sentrixchain.com/rpc'),
 })
 
 const hash = await wallet.sendTransaction({
@@ -89,16 +89,16 @@ const hash = await wallet.sendTransaction({
 
 ```bash
 # Chain info
-curl https://testnet-rpc.sentriscloud.com/chain/info
+curl https://testnet-rpc.sentrixchain.com/chain/info
 
 # Get balance
-curl https://testnet-rpc.sentriscloud.com/accounts/0xYOUR_ADDRESS/balance
+curl https://testnet-rpc.sentrixchain.com/accounts/0xYOUR_ADDRESS/balance
 
 # List validators
-curl https://testnet-rpc.sentriscloud.com/validators
+curl https://testnet-rpc.sentrixchain.com/validators
 
 # Prometheus metrics
-curl https://testnet-rpc.sentriscloud.com/metrics
+curl https://testnet-rpc.sentrixchain.com/metrics
 ```
 
 ## JSON-RPC Methods
@@ -107,19 +107,19 @@ All standard Ethereum JSON-RPC methods are supported:
 
 ```bash
 # Chain ID
-curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
+curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
 
 # Block number
 curl -X POST -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
-  https://testnet-rpc.sentriscloud.com/rpc
+  https://testnet-rpc.sentrixchain.com/rpc
 
 # Get balance (returns wei)
 curl -X POST -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0xYOUR_ADDRESS","latest"],"id":1}' \
-  https://testnet-rpc.sentriscloud.com/rpc
+  https://testnet-rpc.sentrixchain.com/rpc
 ```
 
 Full method list: `eth_chainId`, `eth_blockNumber`, `eth_getBalance`, `eth_getTransactionCount`, `eth_getCode`, `eth_getStorageAt`, `eth_call`, `eth_estimateGas`, `eth_gasPrice`, `eth_sendRawTransaction`, `eth_getTransactionByHash`, `eth_getTransactionReceipt`, `eth_getBlockByNumber`, `eth_getBlockByHash`, `net_version`, `net_listening`.
@@ -131,7 +131,7 @@ Full method list: `eth_chainId`, `eth_blockNumber`, `eth_getBalance`, `eth_getTr
 module.exports = {
   networks: {
     sentrixTestnet: {
-      url: "https://testnet-rpc.sentriscloud.com/rpc",
+      url: "https://testnet-rpc.sentrixchain.com/rpc",
       chainId: 7120,
       accounts: [process.env.PRIVATE_KEY],
     },
@@ -142,7 +142,7 @@ module.exports = {
 ```toml
 # foundry.toml
 [rpc_endpoints]
-sentrix_testnet = "https://testnet-rpc.sentriscloud.com/rpc"
+sentrix_testnet = "https://testnet-rpc.sentrixchain.com/rpc"
 ```
 
 ## Gas Model

--- a/docs/operations/DOMAINS.md
+++ b/docs/operations/DOMAINS.md
@@ -7,10 +7,10 @@ All Sentrix services run under `sentriscloud.com`. DNS managed via Cloudflare.
 | Domain | What |
 |--------|------|
 | sentrix.sentriscloud.com | Landing page |
-| sentrixscan.sentriscloud.com | Block explorer |
-| sentrix-api.sentriscloud.com | REST API |
-| sentrix-rpc.sentriscloud.com | Mainnet JSON-RPC |
-| testnet-rpc.sentriscloud.com | Testnet JSON-RPC |
+| scan.sentrixchain.com | Block explorer |
+| api.sentrixchain.com | REST API |
+| rpc.sentrixchain.com | Mainnet JSON-RPC |
+| testnet-rpc.sentrixchain.com | Testnet JSON-RPC |
 | sentrix-wallet.sentriscloud.com | Wallet UI |
 | sentrixlaunch.sentriscloud.com | Token launchpad |
 | coinblast.sentriscloud.com | CoinBlast |
@@ -19,9 +19,9 @@ All Sentrix services run under `sentriscloud.com`. DNS managed via Cloudflare.
 ## Mainnet Endpoints
 
 ```
-RPC:      https://sentrix-rpc.sentriscloud.com
-API:      https://sentrix-api.sentriscloud.com
-Explorer: https://sentrixscan.sentriscloud.com
+RPC:      https://rpc.sentrixchain.com
+API:      https://api.sentrixchain.com
+Explorer: https://scan.sentrixchain.com
 Wallet:   https://sentrix-wallet.sentriscloud.com
 Faucet:   https://faucet.sentriscloud.com
 Chain ID: 7119
@@ -30,7 +30,7 @@ Chain ID: 7119
 ## Testnet Endpoints
 
 ```
-RPC:      https://testnet-rpc.sentriscloud.com
+RPC:      https://testnet-rpc.sentrixchain.com
 Chain ID: 7120
 ```
 
@@ -38,7 +38,7 @@ Chain ID: 7120
 
 Connect to testnet (for development and testing):
 ```
-RPC URL:  https://testnet-rpc.sentriscloud.com
+RPC URL:  https://testnet-rpc.sentrixchain.com
 Chain ID: 7120
 Symbol:   SRX
 ```
@@ -46,8 +46,8 @@ Symbol:   SRX
 Testnet tokens have no real value. Use the faucet to get test SRX.
 
 ```bash
-curl https://testnet-rpc.sentriscloud.com/chain/info
-curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
+curl https://testnet-rpc.sentrixchain.com/chain/info
+curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
 ```
@@ -56,7 +56,7 @@ curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
 
 Connect to mainnet:
 ```
-RPC URL:  https://sentrix-rpc.sentriscloud.com
+RPC URL:  https://rpc.sentrixchain.com
 Chain ID: 7119
 Symbol:   SRX
 ```

--- a/docs/operations/METAMASK.md
+++ b/docs/operations/METAMASK.md
@@ -10,10 +10,10 @@ Sentrix is fully MetaMask-compatible on both networks. Mainnet (chain ID 7119) a
    | Field | Value |
    |-------|-------|
    | **Network Name** | Sentrix Testnet |
-   | **New RPC URL** | `https://testnet-rpc.sentriscloud.com/rpc` |
+   | **New RPC URL** | `https://testnet-rpc.sentrixchain.com/rpc` |
    | **Chain ID** | `7120` |
    | **Currency Symbol** | `SRX` |
-   | **Block Explorer URL** | `https://sentrixscan.sentriscloud.com` |
+   | **Block Explorer URL** | `https://scan.sentrixchain.com` |
 
 3. Save. Switch to "Sentrix Testnet" in the network dropdown.
 
@@ -22,10 +22,10 @@ Sentrix is fully MetaMask-compatible on both networks. Mainnet (chain ID 7119) a
    | Field | Value |
    |-------|-------|
    | **Network Name** | Sentrix |
-   | **New RPC URL** | `https://sentrix-rpc.sentriscloud.com` |
+   | **New RPC URL** | `https://rpc.sentrixchain.com` |
    | **Chain ID** | `7119` |
    | **Currency Symbol** | `SRX` |
-   | **Block Explorer URL** | `https://sentrixscan.sentriscloud.com` |
+   | **Block Explorer URL** | `https://scan.sentrixchain.com` |
 
 Mainnet supports `eth_sendRawTransaction` and Solidity contract deployment since the 2026-04-25 Voyager activation. Use mainnet for production deployments and testnet for development.
 
@@ -52,12 +52,12 @@ The contract address appears in Remix and is queryable via `eth_getCode`.
 
 ```bash
 # Get deployed contract code
-curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
+curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xCONTRACT_ADDR","latest"],"id":1}'
 
 # Call a function (example: totalSupply() = 0x18160ddd)
-curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
+curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xCONTRACT_ADDR","data":"0x18160ddd"},"latest"],"id":1}'
 ```

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -5,8 +5,8 @@
 | | |
 |-|-|
 | Chain ID | 7119 (0x1bcf) |
-| RPC | https://sentrix-rpc.sentriscloud.com |
-| Explorer | https://sentrixscan.sentriscloud.com |
+| RPC | https://rpc.sentrixchain.com |
+| Explorer | https://scan.sentrixchain.com |
 | P2P port | 30303 |
 | API port | 8545 |
 | Block time | 1s |
@@ -22,9 +22,9 @@
 | | |
 |-|-|
 | Chain ID | 7120 (0x1bd0) |
-| RPC | https://testnet-rpc.sentriscloud.com/rpc |
-| Explorer | https://sentrixscan.sentriscloud.com (unified UI, toggle Testnet) |
-| API | https://testnet-api.sentriscloud.com |
+| RPC | https://testnet-rpc.sentrixchain.com/rpc |
+| Explorer | https://scan.sentrixchain.com (unified UI, toggle Testnet) |
+| API | https://testnet-api.sentrixchain.com |
 | P2P port | 31303–31306 |
 | API port | 9545 |
 | Block time | 1s |
@@ -56,10 +56,10 @@ Add network manually:
 | Field | Mainnet | Testnet |
 |-------|---------|---------|
 | Network Name | Sentrix | Sentrix Testnet |
-| RPC URL | https://sentrix-rpc.sentriscloud.com | https://testnet-rpc.sentriscloud.com/rpc |
+| RPC URL | https://rpc.sentrixchain.com | https://testnet-rpc.sentrixchain.com/rpc |
 | Chain ID | 7119 | 7120 |
 | Symbol | SRX | SRX |
-| Explorer | https://sentrixscan.sentriscloud.com | https://sentrixscan.sentriscloud.com (toggle Testnet) |
+| Explorer | https://scan.sentrixchain.com | https://scan.sentrixchain.com (toggle Testnet) |
 
 ### ethers.js
 
@@ -67,10 +67,10 @@ Add network manually:
 import { JsonRpcProvider } from "ethers";
 
 // Testnet (for development)
-const provider = new JsonRpcProvider("https://testnet-rpc.sentriscloud.com");
+const provider = new JsonRpcProvider("https://testnet-rpc.sentrixchain.com");
 
 // Mainnet (for production)
-// const provider = new JsonRpcProvider("https://sentrix-rpc.sentriscloud.com");
+// const provider = new JsonRpcProvider("https://rpc.sentrixchain.com");
 
 const height = await provider.getBlockNumber();
 const balance = await provider.getBalance("0x...");
@@ -80,13 +80,13 @@ const balance = await provider.getBalance("0x...");
 
 ```bash
 # Testnet (default for development)
-curl -s https://testnet-rpc.sentriscloud.com/chain/info | jq
+curl -s https://testnet-rpc.sentrixchain.com/chain/info | jq
 
 # Mainnet (production)
-curl -s https://sentrix-rpc.sentriscloud.com/chain/info | jq
+curl -s https://rpc.sentrixchain.com/chain/info | jq
 
 # JSON-RPC
-curl -X POST https://testnet-rpc.sentriscloud.com/rpc \
+curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
 ```

--- a/docs/operations/SMART_CONTRACT_GUIDE.md
+++ b/docs/operations/SMART_CONTRACT_GUIDE.md
@@ -17,10 +17,10 @@ In MetaMask → **Networks → Add network manually**:
 | Field | Value |
 |---|---|
 | Network name | `Sentrix Testnet` |
-| New RPC URL | `https://testnet-rpc.sentriscloud.com/rpc` |
+| New RPC URL | `https://testnet-rpc.sentrixchain.com/rpc` |
 | Chain ID | `7120` |
 | Currency symbol | `SRX` |
-| Block explorer URL | `https://sentrixscan.sentriscloud.com` |
+| Block explorer URL | `https://scan.sentrixchain.com` |
 
 Save and switch to Sentrix Testnet. You should see your SRX balance.
 
@@ -82,7 +82,7 @@ Expand the deployed contract and call any function:
 You can also verify the deployment via the explorer:
 
 ```
-https://sentrixscan.sentriscloud.com/tx/<your-tx-hash>
+https://scan.sentrixchain.com/tx/<your-tx-hash>
 ```
 
 ## Hardhat / Foundry
@@ -93,7 +93,7 @@ Same network config:
 // hardhat.config.js
 networks: {
   sentrixTestnet: {
-    url: "https://testnet-rpc.sentriscloud.com/rpc",
+    url: "https://testnet-rpc.sentrixchain.com/rpc",
     chainId: 7120,
     accounts: [process.env.PRIVATE_KEY],
   },
@@ -103,7 +103,7 @@ networks: {
 ```toml
 # foundry.toml
 [rpc_endpoints]
-sentrix_testnet = "https://testnet-rpc.sentriscloud.com/rpc"
+sentrix_testnet = "https://testnet-rpc.sentrixchain.com/rpc"
 ```
 
 ## Gas Model

--- a/docs/operations/VALIDATOR_ONBOARDING.md
+++ b/docs/operations/VALIDATOR_ONBOARDING.md
@@ -210,7 +210,7 @@ peer. To become an authority:
 2. The admin runs `sentrix validator add <your-addr> "<your-name>"
    <your-pubkey> --admin-key <admin-key>`.
 3. Once added, you'll appear in `GET /chain/info → validators` and in
-   the explorer at `sentrixscan.sentriscloud.com/validators`.
+   the explorer at `scan.sentrixchain.com/validators`.
 
 Admin op is verified on-chain — your admission cannot be tampered with
 once in a block.


### PR DESCRIPTION
## Summary

Migrates all chain-side URL references from \`*.sentriscloud.com\` (operational hosting domain) to \`*.sentrixchain.com\` (chain brand domain). Per founder-private brand architecture: sentrixchain = chain/protocol/dev side, sentriscloud = products/company/ops side.

## URL substitutions

| Old (sentriscloud) | New (sentrixchain) |
|---|---|
| sentrix-rpc.sentriscloud.com | rpc.sentrixchain.com |
| testnet-rpc.sentriscloud.com | testnet-rpc.sentrixchain.com |
| sentrixscan.sentriscloud.com | scan.sentrixchain.com |
| sentrix-api.sentriscloud.com | api.sentrixchain.com |
| testnet-api.sentriscloud.com | testnet-api.sentrixchain.com |

Sed-applied across all \`.md\` + \`.rs\` files (29 files modified).

## Backend (VPS4 Caddy)

Caddy reverse proxy on VPS4 (\`84.247.149.230\`) handles BOTH old + new hostnames during 1-week transition window. Old \`*.sentriscloud.com\` chain-side subdomains scheduled for deletion after verification period.

## Chain-side DNS state (verified live)

12 \`*.sentrixchain.com\` subdomains live + functioning:

\`\`\`
✅ rpc.sentrixchain.com         → 200 (mainnet RPC, eth_chainId 0x1bcf)
✅ testnet-rpc.sentrixchain.com → 200 (testnet RPC, eth_chainId 0x1bd0)
✅ api.sentrixchain.com          → 200 (mainnet REST API)
✅ testnet-api.sentrixchain.com → 200 (testnet REST API)
✅ scan.sentrixchain.com         → 307 (block explorer)
✅ faucet.sentrixchain.com       → 200 (testnet faucet)
✅ docs.sentrixchain.com         → 503 (placeholder, Docusaurus pending PR #341)
✅ dev.sentrixchain.com           → 503 (alias to docs)
✅ node.sentrixchain.com          → 301 (vanity, redirect to root)
✅ bridge.sentrixchain.com        → 301
✅ status.sentrixchain.com        → 301
✅ validators.sentrixchain.com   → 301
\`\`\`

## Companion changes

- ethereum-lists/chains#8265 — Chainlist registry JSONs updated to new URLs
- Caddyfile on VPS4 — both old + new hostnames served (transition window)

## Test plan
- [x] Rust workspace compiles (\`cargo check --workspace\`)
- [x] Both old + new URLs return 200 from public RPC test
- [x] Chainlist PR validation passes (\`./gradlew run\`)
- [x] No secrets in diff