### PR TITLE
docs: fix stale wallet URL + add explicit security/abuse emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 
 **Website:** [sentrixchain.com](https://sentrixchain.com)
 **Faucet:** [faucet.sentrixchain.com](https://faucet.sentrixchain.com) (testnet)
-**Wallet:** [sentrix-wallet.sentriscloud.com](https://sentrix-wallet.sentriscloud.com)
+**Wallet:** [solux.sentriscloud.com](https://solux.sentriscloud.com) (Solux web)
 **Docs:** [sentrixchain.com/docs/faucet](https://sentrixchain.com/docs/faucet)
 **Telegram:** [t.me/SentrixCommunity](https://t.me/SentrixCommunity)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,12 @@ If you discover a security vulnerability in Sentrix, we appreciate your responsi
 
 ### How to report
 
-Send an email to the maintainer address listed on the Sentrix Labs
-GitHub organization profile (<https://github.com/sentrix-labs>), or
-open a private GitHub Security Advisory at
+Email **<security@sentrixchain.com>** with the details below, or open
+a private GitHub Security Advisory at
 <https://github.com/sentrix-labs/sentrix/security/advisories/new>.
+
+For abuse reports (network-level, spam, validator misconduct):
+**<abuse@sentrixchain.com>**.
 
 Please include:
 - Description of the vulnerability


### PR DESCRIPTION
## Summary

- README.md: replace dead `sentrix-wallet.sentriscloud.com` link with the canonical `solux.sentriscloud.com` (the Solux web wallet — that subdomain was deleted in the 2026-04-26 chain-subdomain consolidation).
- SECURITY.md: previous text told vulnerability reporters to "find the maintainer address on the org profile", but the profile had no email listed. Make the canonical addresses explicit:
  - `security@sentrixchain.com` (disclosure)
  - `abuse@sentrixchain.com` (network-level abuse / validator misconduct)

Both forward to the maintainer's inbox via Cloudflare Email Routing.

## Why

A user pointed out broken/missing links and emails across the Sentrix Labs org docs. The subdomain consolidation closed several `*.sentriscloud.com` chain-related hosts; the wallet URL slipped through that pass.

## Test plan

- [ ] `curl -I https://solux.sentriscloud.com/` returns 200 (verified live during the audit — wallet service is up behind the edge proxy)
- [ ] No remaining `sentrix-wallet.sentriscloud.com` / `wallet.sentriscloud.com` refs in this repo: `git grep -n "sentrix-wallet\.sentriscloud\|wallet\.sentriscloud"` — should be empty
- [ ] SECURITY.md still links the GitHub Security Advisory route as an alternative