### PR TITLE
docs(docs-site): scrub overclaim + drop specific RWA verticals from hero

### DIFF
--- a/docs-site/src/components/HomepageFeatures/index.tsx
+++ b/docs-site/src/components/HomepageFeatures/index.tsx
@@ -15,10 +15,10 @@ const FeatureList: FeatureItem[] = [
     icon: '🏛️',
     description: (
       <>
-        EVM-native L1 with Solidity smart contracts (revm 37). Built for real-world
-        assets — invoices, receivables, gold, real estate. Sourcify verification,
-        canonical contract suite, and token standards (ERC-20, ERC-721, SRC-721)
-        production-ready.
+        EVM-native L1 with Solidity smart contracts (revm 37). Built ground-up
+        for real-world asset use cases. EIP-1559 fee market, ERC-20 / ERC-721 /
+        SRC-721 token standards specified, MetaMask + hardhat + ethers.js ready
+        out of the box.
       </>
     ),
   },
@@ -40,7 +40,7 @@ const FeatureList: FeatureItem[] = [
       <>
         Financial infrastructure for the real economy — Indonesia first, then the
         world. 1-second blocks, 0.0001 SRX min fee, 5,000 tx per block. Built for
-        Southeast Asia's 600 million people. RWA-ready from day one.
+        Southeast Asia's 600 million people.
       </>
     ),
   },


### PR DESCRIPTION
## Summary

Apply [BRAND_POSITIONING](https://github.com/sentrix-labs/sentrix/blob/main/docs/brand) discipline to docs-site homepage hero.

## Issues fixed

**Card 1 — \"Real Asset Infrastructure\":**
- Removed specific RWA verticals (invoices, receivables, gold, real estate). Brand rule: no specific verticals in public hero until signed partnerships exist.
- Removed \"Sourcify verification\" claim — Sourcify integration is still pending (Tier 1 T1-1).
- Removed \"canonical contract suite ... production-ready\" — canonical contracts (WSRX/Multicall3/Safe-fork) still pending (Tier 1 T1-2).
- Reframed to verifiable claims: EIP-1559 fee market, ERC-20/721/SRC-721 standards specified, MetaMask + hardhat + ethers.js ready.

**Card 3 — \"Indonesia First, Global Next\":**
- Removed \"RWA-ready from day one\" — overclaim. EVM-ready ≠ RWA-ready (no oracle/identity/transfer-restriction/KYC integrations yet).
- Kept Indonesia-first positioning + concrete tech specs.

**Card 2 — \"Bitcoin Discipline\":** unchanged. All claims verifiable.

## Test plan

- [x] Local `npm run build` clean
- [ ] Run `scripts/deploy-docs.sh` after merge to push live
- [ ] Verify `https://docs.sentrixchain.com` shows updated hero (no \"invoices/receivables/gold/real estate\", no Sourcify claim, no \"RWA-ready from day one\")