### PR TITLE
chore(audit): scrub stale URLs + outdated branding refs

### DIFF
--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -105,7 +105,7 @@ The activation was a non-fork operator-side env var flip (`VOYAGER_REWARD_V2_HEI
 DPoS+BFT consensus assumes the validator mesh is well-connected. Sentrix ships two layers of self-healing peer discovery:
 
 - **L1 multiaddr advertisements.** Validators broadcast signed `MultiaddrAdvertisement` messages on the `sentrix/validator-adverts/1` gossipsub topic at startup + every 10 minutes. Receivers verify against on-chain stake registry pubkeys and store latest-by-sequence in a 4096-entry LRU cache. A periodic dial-tick (every 30s) reads `active_set` and dials any cached members not currently peered. Sequence numbers are persisted to `<data_dir>/.advert-sequence` so restarts don't reset the newer-wins ordering.
-- **L2 cold-start gate.** The validator loop refuses to enter BFT mode unless `peer_count ≥ active_set.len() − 1`. The gate fires every loop iteration when `voyager_activated=true` (not only on activation transitions), closing the cold-start race where a validator restarting with `voyager_activated=true` already in chain.db could enter BFT before the L1 mesh re-converges. Strict `SENTRIX_FORCE_BFT_INSUFFICIENT_PEERS=="1"` env override exists for emergency recovery.
+- **L2 cold-start gate.** The validator loop refuses to enter BFT mode unless `peer_count ≥ active_set.len() − 1`. The gate fires every loop iteration when `voyager_activated=true` (not only on activation transitions), closing the cold-start race where a validator restarting with `voyager_activated=true` already in chain.db could enter BFT before the L1 mesh re-converges.
 
 Together these guarantee a fresh validator joining from a single bootstrap peer converges to the full mesh within ~30s without manual `--peers` configuration.
 

--- a/crates/sentrix-rpc/src/explorer.rs
+++ b/crates/sentrix-rpc/src/explorer.rs
@@ -1080,7 +1080,7 @@ pub async fn explorer_richlist(State(state): State<SharedState>) -> Html<String>
         r#"
     {}
     <h2>Rich List — Top SRX Holders</h2>
-    <p style="color:#6b7280;font-size:13px;margin-bottom:16px">Top 50 addresses by SRX balance &nbsp;|&nbsp; Total supply: 210,000,000 SRX</p>
+    <p style="color:#6b7280;font-size:13px;margin-bottom:16px">Top 50 addresses by SRX balance &nbsp;|&nbsp; Total supply: 315,000,000 SRX</p>
     {}
     <table>
     <tr><th>Rank</th><th>Address</th><th>Balance</th><th>% of Supply</th></tr>

--- a/docs-site/docs/brand/SOCIAL_BIOS.md
+++ b/docs-site/docs/brand/SOCIAL_BIOS.md
@@ -184,7 +184,7 @@ discipline (fixed 315M supply, 4-year halving) and Ethereum's
 programmability (EVM-native, Solidity-ready) — built for
 Southeast Asia's 600 million people first, then the world.
 
-Live in production since April 2026. Built in Rust by SentrisCloud.
+Live in production since April 2026. Built in Rust by Sentrix Labs (operated by SentrisCloud).
 
 For builders:        builders@sentrixchain.com
 For partners:        partners@sentriscloud.com

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -49,4 +49,4 @@ Sentrix runs as a 14-crate Rust workspace with MDBX-backed state, libp2p network
 
 ---
 
-*Open source under BUSL-1.1, transitions to open-source after the Change Date. Built by SentrisCloud.*
+*Open source under BUSL-1.1, transitions to open-source after the Change Date. Built by Sentrix Labs (operated by SentrisCloud).*

--- a/docs-site/docs/operations/DEVELOPER_QUICKSTART.md
+++ b/docs-site/docs/operations/DEVELOPER_QUICKSTART.md
@@ -11,7 +11,7 @@ Build on Sentrix in 10 minutes. Deploy a smart contract, read chain state, and s
 | RPC URL | `https://testnet-rpc.sentrixchain.com/rpc` |
 | Chain ID | `7120` |
 | Explorer | `https://scan.sentrixchain.com` |
-| Faucet | `https://faucet.sentriscloud.com` |
+| Faucet | `https://faucet.sentrixchain.com` |
 
 ### MetaMask setup
 
@@ -25,7 +25,7 @@ Settings → Networks → Add network manually:
 | Symbol | `SRX` |
 | Block Explorer | `https://scan.sentrixchain.com` |
 
-Get test SRX from the [faucet](https://faucet.sentriscloud.com).
+Get test SRX from the [faucet](https://faucet.sentrixchain.com).
 
 ## Deploy a Smart Contract (Remix)
 

--- a/docs-site/docs/operations/DOMAINS.md
+++ b/docs-site/docs/operations/DOMAINS.md
@@ -14,7 +14,7 @@ All Sentrix services run under `sentriscloud.com`. DNS managed via Cloudflare.
 | sentrix-wallet.sentriscloud.com | Wallet UI |
 | sentrixlaunch.sentriscloud.com | Token launchpad |
 | coinblast.sentriscloud.com | CoinBlast |
-| faucet.sentriscloud.com | Testnet faucet |
+| faucet.sentrixchain.com | Testnet faucet |
 
 ## Mainnet Endpoints
 
@@ -23,7 +23,7 @@ RPC:      https://rpc.sentrixchain.com
 API:      https://api.sentrixchain.com
 Explorer: https://scan.sentrixchain.com
 Wallet:   https://sentrix-wallet.sentriscloud.com
-Faucet:   https://faucet.sentriscloud.com
+Faucet:   https://faucet.sentrixchain.com
 Chain ID: 7119
 ```
 

--- a/docs-site/docs/operations/METAMASK.md
+++ b/docs-site/docs/operations/METAMASK.md
@@ -31,7 +31,7 @@ Mainnet supports `eth_sendRawTransaction` and Solidity contract deployment since
 
 ## Get Test SRX
 
-Faucet: https://faucet.sentriscloud.com (or use a funded testnet wallet directly).
+Faucet: https://faucet.sentrixchain.com (or use a funded testnet wallet directly).
 
 ## Send SRX
 

--- a/docs-site/docs/operations/SMART_CONTRACT_GUIDE.md
+++ b/docs-site/docs/operations/SMART_CONTRACT_GUIDE.md
@@ -2,12 +2,12 @@
 
 Sentrix runs an EVM (revm 37) on both mainnet and testnet, and accepts standard Ethereum tooling. This guide walks through deploying a Solidity contract via Remix in under 5 minutes.
 
-> **Network choice:** Use **testnet** (chain ID 7120) for development — get free SRX from the [faucet](https://faucet.sentriscloud.com). Use **mainnet** (chain ID 7119) for production deployments. EVM has been live on mainnet since the 2026-04-25 Voyager activation.
+> **Network choice:** Use **testnet** (chain ID 7120) for development — get free SRX from the [faucet](https://faucet.sentrixchain.com). Use **mainnet** (chain ID 7119) for production deployments. EVM has been live on mainnet since the 2026-04-25 Voyager activation.
 
 ## Prerequisites
 
 - MetaMask installed
-- A funded testnet address (use the [faucet](https://faucet.sentriscloud.com))
+- A funded testnet address (use the [faucet](https://faucet.sentrixchain.com))
 - Browser at [remix.ethereum.org](https://remix.ethereum.org)
 
 ## 1. Connect MetaMask to Sentrix Testnet

--- a/docs/brand/SOCIAL_BIOS.md
+++ b/docs/brand/SOCIAL_BIOS.md
@@ -184,7 +184,7 @@ discipline (fixed 315M supply, 4-year halving) and Ethereum's
 programmability (EVM-native, Solidity-ready) — built for
 Southeast Asia's 600 million people first, then the world.
 
-Live in production since April 2026. Built in Rust by SentrisCloud.
+Live in production since April 2026. Built in Rust by Sentrix Labs (operated by SentrisCloud).
 
 For builders:        builders@sentrixchain.com
 For partners:        partners@sentriscloud.com

--- a/docs/operations/DEVELOPER_QUICKSTART.md
+++ b/docs/operations/DEVELOPER_QUICKSTART.md
@@ -11,7 +11,7 @@ Build on Sentrix in 10 minutes. Deploy a smart contract, read chain state, and s
 | RPC URL | `https://testnet-rpc.sentrixchain.com/rpc` |
 | Chain ID | `7120` |
 | Explorer | `https://scan.sentrixchain.com` |
-| Faucet | `https://faucet.sentriscloud.com` |
+| Faucet | `https://faucet.sentrixchain.com` |
 
 ### MetaMask setup
 
@@ -25,7 +25,7 @@ Settings → Networks → Add network manually:
 | Symbol | `SRX` |
 | Block Explorer | `https://scan.sentrixchain.com` |
 
-Get test SRX from the [faucet](https://faucet.sentriscloud.com).
+Get test SRX from the [faucet](https://faucet.sentrixchain.com).
 
 ## Deploy a Smart Contract (Remix)
 

--- a/docs/operations/DOMAINS.md
+++ b/docs/operations/DOMAINS.md
@@ -14,7 +14,7 @@ All Sentrix services run under `sentriscloud.com`. DNS managed via Cloudflare.
 | sentrix-wallet.sentriscloud.com | Wallet UI |
 | sentrixlaunch.sentriscloud.com | Token launchpad |
 | coinblast.sentriscloud.com | CoinBlast |
-| faucet.sentriscloud.com | Testnet faucet |
+| faucet.sentrixchain.com | Testnet faucet |
 
 ## Mainnet Endpoints
 
@@ -23,7 +23,7 @@ RPC:      https://rpc.sentrixchain.com
 API:      https://api.sentrixchain.com
 Explorer: https://scan.sentrixchain.com
 Wallet:   https://sentrix-wallet.sentriscloud.com
-Faucet:   https://faucet.sentriscloud.com
+Faucet:   https://faucet.sentrixchain.com
 Chain ID: 7119
 ```
 

--- a/docs/operations/METAMASK.md
+++ b/docs/operations/METAMASK.md
@@ -31,7 +31,7 @@ Mainnet supports `eth_sendRawTransaction` and Solidity contract deployment since
 
 ## Get Test SRX
 
-Faucet: https://faucet.sentriscloud.com (or use a funded testnet wallet directly).
+Faucet: https://faucet.sentrixchain.com (or use a funded testnet wallet directly).
 
 ## Send SRX
 

--- a/docs/operations/SMART_CONTRACT_GUIDE.md
+++ b/docs/operations/SMART_CONTRACT_GUIDE.md
@@ -2,12 +2,12 @@
 
 Sentrix runs an EVM (revm 37) on both mainnet and testnet, and accepts standard Ethereum tooling. This guide walks through deploying a Solidity contract via Remix in under 5 minutes.
 
-> **Network choice:** Use **testnet** (chain ID 7120) for development — get free SRX from the [faucet](https://faucet.sentriscloud.com). Use **mainnet** (chain ID 7119) for production deployments. EVM has been live on mainnet since the 2026-04-25 Voyager activation.
+> **Network choice:** Use **testnet** (chain ID 7120) for development — get free SRX from the [faucet](https://faucet.sentrixchain.com). Use **mainnet** (chain ID 7119) for production deployments. EVM has been live on mainnet since the 2026-04-25 Voyager activation.
 
 ## Prerequisites
 
 - MetaMask installed
-- A funded testnet address (use the [faucet](https://faucet.sentriscloud.com))
+- A funded testnet address (use the [faucet](https://faucet.sentrixchain.com))
 - Browser at [remix.ethereum.org](https://remix.ethereum.org)
 
 ## 1. Connect MetaMask to Sentrix Testnet


### PR DESCRIPTION
## Summary

Comprehensive outdated-content sweep across public docs + code (2026-04-26 night audit).

## What's fixed

**URL migration cleanup** — 8 sites missed by PR #342 sed sweep:
- `faucet.sentriscloud.com` → `faucet.sentrixchain.com` in 4 ops docs (× both `docs/` and `docs-site/`)

**Hardcoded supply display** (1 site):
- `crates/sentrix-rpc/src/explorer.rs:1083` — Rich List page footer "Total supply: 210,000,000 SRX" → 315M (post-fork accurate)
- ⚠️ NOT fixed in this PR: percentage calculations on `explorer_api.rs:151` + `routes/accounts.rs:94` still use static `MAX_SUPPLY` (need fork-aware refactor — deferred to v2.1.40 polish PR per PROMPT.md carryover)

**Stale env var ref** (1 site):
- `WHITEPAPER.md` §2.6 — removed `SENTRIX_FORCE_BFT_INSUFFICIENT_PEERS` reference (env var removed post-Voyager mainnet activation; cold-start gate is now unreachable in practice)

**Brand attribution refinement** (3 sites):
- `docs-site/docs/intro.md` — "Built by SentrisCloud" → "Built by Sentrix Labs (operated by SentrisCloud)"
- `docs/brand/SOCIAL_BIOS.md` + `docs-site/` copy — same refinement on "Built in Rust by SentrisCloud"

Per brand architecture: `sentrix-labs` = protocol dev org, `sentriscloud` = operating company. Protocol attribution should credit Sentrix Labs.

## Diff stats

```
13 files changed, 19 insertions(+), 19 deletions(-)
```

No code behavior change. Doc accuracy + brand consistency only.

## Test plan

- [x] `find docs docs-site -name "*.md" | xargs grep -l faucet.sentriscloud.com` returns nothing
- [x] No remaining "Built by SentrisCloud" (excluding "operated by" phrase)
- [x] WHITEPAPER no longer references removed env var
- [ ] After merge: `scripts/deploy-docs.sh` rebuild + redeploy docs-site (auto post-merge or manual)