### PR TITLE
chore(release): v2.1.40 — explorer richlist percentage display fork-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.40] — 2026-04-27 — Explorer richlist percentage display fork-aware
+
+> **Display-only polish PR.** Closes the last 3 sites that still used static `MAX_SUPPLY` (210M) for percentage-of-supply display, even though the consensus + `/chain/info` RPC display were already fork-aware in v2.1.39. After the tokenomics v2 fork activated on mainnet at h=640800, the `/explorer/richlist` HTML page, `GET /accounts` REST endpoint, and `GET /accounts/richlist` REST endpoint were still calculating percentages against the pre-fork 210M cap — making top holders look ~33% smaller than reality.
+
+### Fixed
+
+- `crates/sentrix-rpc/src/explorer.rs` — Rich List HTML: percentage calc + "Total supply: N SRX" footer string both now use `bc.max_supply_for(bc.height())`. Pre-fork: 210M, post-fork: 315M.
+- `crates/sentrix-rpc/src/explorer_api.rs` — `GET /accounts` (paginated) percentage calc now fork-aware. Removed unused `use sentrix_core::blockchain::MAX_SUPPLY` import.
+- `crates/sentrix-rpc/src/routes/accounts.rs` — `GET /accounts/richlist` REST endpoint percentage calc now fork-aware.
+
+### No consensus impact
+
+This release touches only `sentrix-rpc` (display layer). No changes to consensus crates (`sentrix-bft`, `sentrix-core::block_executor`, `sentrix-trie`, `sentrix-staking::distribute_reward`, `sentrix-evm::executor`). Drop-in chain.db compatible with v2.1.39.
+
+### Migration
+
+No operator action required. Hot-swap binary at any time. Restart causes ~10s downtime per validator if rolling, or ~5s halt-all+simultaneous-start (recommended per `feedback_mainnet_restart_cascade_jailing.md`).
+
+### Tests
+
+`cargo test --workspace`: 772 passed, 0 failed, 11 ignored. `cargo clippy --workspace --tests -- -D warnings`: clean.
+
+---
+
 ## [2.1.39] — 2026-04-26 — Tokenomics v2 fork (BTC-parity halving + 315M cap) — **ACTIVE on mainnet**
 
 > **Consensus fork — ACTIVE end-to-end on mainnet since h=640800 (2026-04-26 evening).** Both consensus dispatch (cap enforcement, halving math) and RPC display (`/chain/info` `max_supply_srx`) now report v2 schedule. Re-targets emission curve to BTC-parity 4-year halving (126M blocks at 1s) + raises MAX_SUPPLY from 210M to 315M. Closes the v1 math gap (geometric series asymptoted at 84M from mining → 147M effective max, not the 210M originally documented). Side benefit: validator runway extended to ~year 20, premine ratio drops 30% nominal → 20% (industry-leading optics).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "anyhow",
  "axum",
@@ -4894,14 +4894,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4944,14 +4944,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "bincode",
  "blake3",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.39"
+version = "2.1.40"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/explorer.rs
+++ b/crates/sentrix-rpc/src/explorer.rs
@@ -1054,7 +1054,7 @@ pub async fn explorer_richlist(State(state): State<SharedState>) -> Html<String>
     let mut rows = String::new();
     for (rank, (address, balance_sentri)) in holders.iter().enumerate() {
         let balance_srx = *balance_sentri as f64 / 100_000_000.0;
-        let pct = balance_srx / sentrix_core::blockchain::max_supply_srx() * 100.0;
+        let pct = balance_srx / (bc.max_supply_for(bc.height()) as f64 / 100_000_000.0) * 100.0;
         rows.push_str(&format!(
             r#"<tr>
             <td style="color:#6b7280">#{}</td>
@@ -1076,17 +1076,22 @@ pub async fn explorer_richlist(State(state): State<SharedState>) -> Html<String>
         ""
     };
 
+    let max_supply_display = format!(
+        "{:.0}",
+        bc.max_supply_for(bc.height()) as f64 / 100_000_000.0
+    );
     let body = format!(
         r#"
     {}
     <h2>Rich List — Top SRX Holders</h2>
-    <p style="color:#6b7280;font-size:13px;margin-bottom:16px">Top 50 addresses by SRX balance &nbsp;|&nbsp; Total supply: 315,000,000 SRX</p>
+    <p style="color:#6b7280;font-size:13px;margin-bottom:16px">Top 50 addresses by SRX balance &nbsp;|&nbsp; Total supply: {} SRX</p>
     {}
     <table>
     <tr><th>Rank</th><th>Address</th><th>Balance</th><th>% of Supply</th></tr>
     {}
     </table>"#,
         nav_tabs("richlist"),
+        max_supply_display,
         empty,
         rows,
     );

--- a/crates/sentrix-rpc/src/explorer_api.rs
+++ b/crates/sentrix-rpc/src/explorer_api.rs
@@ -30,7 +30,6 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
 };
-use sentrix_core::blockchain::MAX_SUPPLY;
 use std::collections::HashMap;
 
 const SENTRI_PER_SRX: f64 = 100_000_000.0;
@@ -148,7 +147,7 @@ pub async fn accounts_top(
                 .get("window_tx_count")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0);
-            let pct = balance as f64 / MAX_SUPPLY as f64 * 100.0;
+            let pct = balance as f64 / bc.max_supply_for(bc.height()) as f64 * 100.0;
             serde_json::json!({
                 "address": address,
                 "balance_srx": balance as f64 / SENTRI_PER_SRX,

--- a/crates/sentrix-rpc/src/routes/accounts.rs
+++ b/crates/sentrix-rpc/src/routes/accounts.rs
@@ -91,7 +91,7 @@ pub(super) async fn get_richlist(State(state): State<SharedState>) -> Json<serde
         .iter()
         .filter(|(_, a)| a.balance > 0)
         .map(|(addr, a)| {
-            let pct = a.balance as f64 / sentrix_core::blockchain::MAX_SUPPLY as f64 * 100.0;
+            let pct = a.balance as f64 / bc.max_supply_for(bc.height()) as f64 * 100.0;
             serde_json::json!({
                 "address": addr,
                 "balance_sentri": a.balance,

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.39"
+version = "2.1.40"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Display-only polish PR. Closes the last 3 sites that still used static \`MAX_SUPPLY\` (210M) for percentage-of-supply display.

After tokenomics v2 fork activated on mainnet (h=640800, 2026-04-26), \`/explorer/richlist\` + \`GET /accounts\` + \`GET /accounts/richlist\` were still calculating percentages against pre-fork 210M cap — top holders looked ~33% smaller than reality.

## Sites fixed

| File | Site | Before | After |
|---|---|---|---|
| \`crates/sentrix-rpc/src/explorer.rs\` | Rich List HTML page (line 1057, 1083) | static \`max_supply_srx()\` returns 210M; hardcoded \"Total supply: 315,000,000 SRX\" string | \`bc.max_supply_for(bc.height())\` for both percentage calc + display string |
| \`crates/sentrix-rpc/src/explorer_api.rs\` | \`GET /accounts\` paginated (line 150) | static \`MAX_SUPPLY\` const | \`bc.max_supply_for(bc.height())\` |
| \`crates/sentrix-rpc/src/routes/accounts.rs\` | \`GET /accounts/richlist\` REST (line 94) | static \`sentrix_core::blockchain::MAX_SUPPLY\` | \`bc.max_supply_for(bc.height())\` |

Removed unused \`use sentrix_core::blockchain::MAX_SUPPLY\` import in explorer_api.rs.

## No consensus impact

Touches only \`sentrix-rpc\` (display layer). No changes to:
- \`sentrix-bft\`
- \`sentrix-core::block_executor\`
- \`sentrix-trie\`
- \`sentrix-staking::distribute_reward\`
- \`sentrix-evm::executor\`

Drop-in chain.db compatible with v2.1.39. Hot-swap binary at any time.

## Tests

- \`cargo test --workspace\`: **772 passed, 0 failed, 11 ignored**
- \`cargo clippy --workspace --tests -- -D warnings\`: clean
- Manual: rich-list page renders \`{:.0}\` (315) for total supply at current mainnet height

## Migration

No operator action required. Recommend halt-all + simultaneous-start cadence per \`feedback_mainnet_restart_cascade_jailing.md\` (~5s downtime).