### PR TITLE
audits + observability: jail-cascade RCA + consensus-jail design + diagnostic logs

### DIFF
--- a/audits/consensus-computed-jail-design.md
+++ b/audits/consensus-computed-jail-design.md
@@ -1,0 +1,180 @@
+# Consensus-Computed Jail Decisions — Design Doc
+
+**Date:** 2026-04-27
+**Status:** DRAFT — design phase, no implementation
+**Estimated effort:** 4-6 weeks (design + implement + test + audit + fork-gated activation)
+**Related:** `audits/jail-cascade-root-cause-analysis.md`, fix #1, #2, #3
+
+---
+
+## Problem
+
+Current jail mechanism (`SlashingEngine::check_liveness` at epoch boundaries) is **locally-computed**: each validator independently decides jail based on its own `LivenessTracker`. Multi-source divergence (asymmetric recording paths, race conditions, replay gaps) causes per-validator stake_registry to disagree, triggering BFT stalls.
+
+**See `audits/jail-cascade-root-cause-analysis.md` for full RCA.**
+
+Even with perfect data-layer synchronization (fix #2 + replay-record patches), the model is still wrong — state mutations on consensus-relevant data should go through BFT, not local opinion.
+
+---
+
+## Goal
+
+Replace local-jail with **consensus-computed jail**: validator-set agrees on missed-block tally via BFT precommit chain, jail-trigger emitted as on-chain transaction, applied uniformly across all validators.
+
+---
+
+## High-level design
+
+### Two-phase model
+
+**Phase 1: per-block participation observation**
+
+Each finalized block contains a `participation_record` field: the BFT justification's precommit list. This is already on-chain (see `Block.justification.precommits`).
+
+No protocol change needed for Phase 1 — the data already exists in finalized blocks.
+
+**Phase 2: consensus-computed jail decision**
+
+At epoch boundary, the proposer of the boundary block includes a special `JailTransaction` in the block's transaction list. The transaction contains:
+
+```rust
+pub struct JailTransaction {
+    pub epoch: u64,
+    pub validators_to_jail: Vec<JailEvidence>,
+    pub proposer: String,
+    pub signature: Signature,
+}
+
+pub struct JailEvidence {
+    pub validator: String,
+    pub epoch_start_block: u64,
+    pub epoch_end_block: u64,
+    pub signed_count: u64,
+    pub missed_count: u64,
+    pub justification_hashes: Vec<String>,  // hashes of blocks where missed
+}
+```
+
+The proposer scans the last `LIVENESS_WINDOW` blocks' `justification.precommits`, computes per-validator signed/missed count, and includes the jail evidence in the boundary block.
+
+Other validators VERIFY the JailTransaction during Pass-1 validation:
+- Walk same blocks
+- Recompute signed/missed for each cited validator
+- Reject the block if cited evidence doesn't match their independent computation
+
+If block accepted (BFT supermajority signs justification), JailTransaction applies → validators jailed atomically across all nodes. No divergence possible because all validators verified same evidence before signing.
+
+### Edge cases
+
+- **Proposer fails to include JailTransaction when needed** — peers can detect (count mismatch) → vote nil → next round proposer includes correct evidence
+- **Proposer includes false JailTransaction** — peers reject via Pass-1 validation → block fails → next round
+- **Network split during epoch transition** — usual BFT liveness fallback (skip rounds, eventual finality)
+
+---
+
+## Activation strategy: fork-gated
+
+Roll out as new fork: `JAIL_CONSENSUS_HEIGHT_DEFAULT = u64::MAX`, env-overridable per `TOKENOMICS_V2_HEIGHT` pattern.
+
+Pre-fork: existing local-jail behavior (unchanged)
+Post-fork: new consensus-jail behavior
+
+Operators set `JAIL_CONSENSUS_HEIGHT=<future_height>` env var on each validator. Chain reaches fork height → new path activates.
+
+Old path (`SlashingEngine::check_liveness`) becomes inert post-fork (gated by `is_jail_consensus_height(h)` check).
+
+Fallback: if fork mechanism has bug, env var lets us roll back per-validator (set far-future height) without rewinding chain.
+
+---
+
+## Implementation phases
+
+### Phase A: Wire data plumbing (no behavior change)
+
+1. Add `audits/consensus-computed-jail-design.md` (this doc) — DONE
+2. Add `JailTransaction` struct + serialization in `crates/sentrix-primitives`
+3. Add Pass-1 validation for `JailTransaction` (no-op if absent — matches current behavior)
+4. Add `compute_jail_evidence_at_epoch_boundary(blockchain, height)` function in `sentrix-staking`
+5. Tests for evidence computation + serialization roundtrip
+6. PR — non-fork-activating, doesn't change runtime behavior
+
+### Phase B: Fork gate + dispatch
+
+1. Add `JAIL_CONSENSUS_HEIGHT` const + env var pattern (mirror `TOKENOMICS_V2_HEIGHT`)
+2. Add `Blockchain::is_jail_consensus_height(h)` dispatch helper
+3. Wire fork-aware dispatch:
+   - Pre-fork: `SlashingEngine::check_liveness` (current behavior)
+   - Post-fork: `JailTransaction` evidence path
+4. Pre-fork integration test: behavior unchanged
+5. Post-fork integration test: jail via consensus-applied transaction
+6. PR — fork-activating but inert (env var defaults disable)
+
+### Phase C: Testnet bake
+
+1. Set `JAIL_CONSENSUS_HEIGHT` on all 4 testnet docker validators
+2. Run for 7+ days under varied load (induce missed blocks, restart cascades, etc.)
+3. Verify jail decisions converge (no divergence) through normal operation + adversarial testing
+4. Document any edge cases discovered
+
+### Phase D: Mainnet activation
+
+1. Schedule activation height (current_height + ~1 week buffer)
+2. Set `JAIL_CONSENSUS_HEIGHT` env on all 4 mainnet validators (halt-all + simultaneous-start per discipline)
+3. Chain crosses fork height — new path active
+4. Monitor for divergence (observability metric from fix #2)
+5. Old `SlashingEngine::check_liveness` retained but gated by `is_jail_consensus_height` — defensive against fork-gate bugs
+
+---
+
+## Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Determinism bug in evidence computation | Phase A includes property tests; testnet bake exercises real network conditions |
+| Proposer can omit jail evidence | Peer validation rejects boundary block on count mismatch → next-round proposer fixes |
+| Backward-compat with chain.db | `JailTransaction` is new tx type; pre-fork chain.db has none; restore-then-fork is safe |
+| Performance regression at epoch boundary | Evidence computation is O(LIVENESS_WINDOW × validators) = O(14_400 × ~10) = 144k ops, fast |
+| Coordinated rollback if fork has bug | Env var per-validator allows individual rollback without consensus break |
+
+---
+
+## Effort estimate
+
+- Design (this doc): 1 day — DONE
+- Phase A (data plumbing PR): 5-7 days
+- Phase B (fork gate PR): 3-5 days
+- Phase C (testnet bake): 7+ days calendar (1-2 days work)
+- Phase D (mainnet activation): 1 day operator action
+- **Total calendar: 4-6 weeks**
+
+Per consensus discipline (CLAUDE.md): each phase = separate PR with regression test, fresh-brain review, no self-merge.
+
+---
+
+## Out of scope (this design)
+
+- Slashing-amount changes — keep `DOWNTIME_SLASH_BP = 100` (1% slash) unchanged
+- Tombstone (permanent ban) logic — keep current "double-sign = tombstone" path unchanged
+- Pre-Voyager validators — not relevant; Voyager is active on mainnet since h=579047
+- Self-unjail mechanism — separate concern, defer
+
+---
+
+## Open questions
+
+1. **Should JailTransaction be applied automatically by chain validation, or via explicit on-chain admin tx?** Auto via Pass-1 = simpler. Admin tx = more flexible. **Decision: auto via Pass-1** — matches consensus-mutation pattern for staking ops.
+
+2. **Should evidence include hash list of missed-block justifications, or just the count?** Hash list = prove-each-miss. Count = trust-the-proposer. **Decision: include hash list initially**, allows peers to selective-verify any subset; if perf becomes issue, can drop later.
+
+3. **What happens if 2 validators are simultaneously eligible for jail at the same epoch?** Both included in same JailTransaction (Vec<JailEvidence>). Atomic apply.
+
+4. **Does this affect existing jail/unjail RPC + CLI?** No — those still mutate stake_registry directly, just the AUTOMATIC jail path changes. Manual unjail still works as before.
+
+---
+
+## Next steps
+
+1. ☐ Operator review this design doc + decide go/no-go
+2. ☐ If go: schedule Phase A start (separate fresh-brain session)
+3. ☐ Open Phase A tracking issue on `sentrix-labs/sentrix`
+4. ☐ Begin implementation (5-7 days for Phase A, fresh-brain session)

--- a/audits/jail-cascade-root-cause-analysis.md
+++ b/audits/jail-cascade-root-cause-analysis.md
@@ -1,0 +1,152 @@
+# Jail Cascade Root Cause Analysis
+
+**Date:** 2026-04-27
+**Author:** ops investigation (post 2026-04-26 marathon, 2 jail-cascade incidents)
+**Related:** `audits/voyager-design.md`, `runbooks/jail-divergence-recovery.md`
+**Status:** Investigation findings; informs upcoming fixes #2, #3, #4
+
+---
+
+## Problem statement
+
+Mainnet experienced 2 jail-cascade stalls on 2026-04-26 within hours:
+- Evening h=633599 — triggered by rolling restart for env-var rollout
+- Night h=662399 — triggered by NORMAL operation (no operator action)
+
+In both cases, **one validator** had divergent stake_registry view (saw `0x87c9...` jailed, while the other 3 saw it active). P1 BFT safety gate fired on the divergent validator (`active_set < minimum`), refusing BFT participation. Other validators reached nil-majority (no proposal converging), chain stalled.
+
+Recovery via chain.db rsync from canonical (Treasury) takes ~5-10 min and is well-tested.
+
+But **why does the divergence form in the first place?**
+
+---
+
+## Slashing architecture summary
+
+`crates/sentrix-staking/src/slashing.rs`:
+
+- `LivenessTracker` — per-validator sliding window of `(height, signed)` records, max `LIVENESS_WINDOW = 14_400` blocks (~4 hours at 1s blocks)
+- `is_downtime(validator)` returns `true` when:
+  1. window is full (≥14400 records), AND
+  2. `signed_count < MIN_SIGNED_PER_WINDOW (4_320)` (= <30% signed)
+- `check_liveness()` runs at **epoch boundaries** only — iterates active_set, calls `is_downtime`, if true: `slash + jail + reset window`
+- `record_block_signatures(active_set, signers, height)` records each validator's signed/missed status for ONE block
+
+The DATA layer is **deterministic in principle**: given identical `(active_set, signers, height)` calls across all validators, all `LivenessTracker` instances should be byte-identical, producing identical jail decisions.
+
+**The bug is in the RECORDING PATH coverage, not the data layer itself.**
+
+---
+
+## Root cause: asymmetric `record_block_signatures` coverage
+
+`record_block_signatures` is called from exactly **two sites** in `bin/sentrix/src/main.rs`:
+
+1. **Self-produced finalize** (line ~2045) — when this validator proposed and BFT finalized
+2. **Peer-finalize via BFT** (line ~2454) — when this validator received another's block + finalized via BFT round
+
+It is **NOT called from**:
+- `libp2p sync` BlocksResponse handler (when catching up via `GetBlocks` requests)
+- chain.db rsync recovery (chain.db is wholesale replaced; LivenessTracker IS persisted via `#[serde(default)]` on the Blockchain struct, but we don't replay-record on recovery)
+- Block replay during startup (LivenessTracker is restored from MDBX state blob, not rebuilt)
+
+### What this means in practice
+
+**Scenario: Validator B goes offline for 1 hour.**
+
+| Step | Validator A (online) | Validator B (offline → online) |
+|---|---|---|
+| Block N | self-produces or peer-finalizes → `record_block_signatures(active, signers, N)` | (offline, no record) |
+| Block N+1...N+3600 | continues recording | (offline) |
+| Block N+3601 | continues | starts up, loads chain.db, **LivenessTracker has stale state from before downtime** |
+| Block N+3602 | self-produces or peer-finalizes → record | (gap in B's records — never recorded N..N+3600) |
+
+When epoch boundary fires:
+- A's `LivenessTracker` for `0xValB`: 14400 records, all signed-or-missed properly
+- B's `LivenessTracker` for `0xValA`: gap of 3600 entries between pre-downtime and post-recovery records
+
+The gap matters because:
+- `LivenessTracker.records` is a `Vec<LivenessRecord>` per validator
+- Gap fills in as new records arrive
+- After recovery, B's records list grows again → eventually has 14400 entries — but those 14400 represent a different time window than A's
+
+**The two LivenessTrackers compute different `is_downtime` results** at the same epoch boundary because they're looking at different 14400-block windows.
+
+### Verification path
+
+To prove this hypothesis empirically, observability metric (fix #2) would log per-validator-per-block "expected signers vs actual signers" — divergence in this list across validators = smoking gun.
+
+---
+
+## Root cause: jail decision is locally-computed, not consensus-coordinated
+
+Even if `LivenessTracker` were perfectly synchronized via observability + replay-record patches, **the jail decision itself runs locally** at epoch boundaries:
+
+```rust
+// In main.rs validator loop, called at epoch boundary on EACH validator independently:
+let slashed = slashing.check_liveness(&mut bc.stake_registry, &active_set, height);
+```
+
+Each validator independently:
+1. Checks its own LivenessTracker for downtime
+2. If found, calls `stake_registry.slash + jail` directly on its own state
+
+This is a **state mutation without consensus**. There's no BFT vote on "should we jail validator X". Each validator decides locally based on its own LivenessTracker.
+
+**Even with perfectly-synchronized LivenessTrackers**, edge cases would still cause divergence:
+- Race condition at epoch boundary (different validators process the boundary block at slightly different times)
+- One validator panics/crashes mid-`check_liveness` (slashes some validators, jails some, then restarts and replays — inconsistent partial state)
+- Genesis edge cases (early validators with incomplete window)
+
+The CORRECT model: jail decisions should be a **consensus-applied transaction**, like any other state change. See fix #4.
+
+---
+
+## P1 BFT safety gate: a related issue
+
+Once jail divergence forms, the P1 BFT safety gate AMPLIFIES it:
+
+```rust
+// validator loop refuses BFT when:
+if active_set.len() < MIN_ACTIVE_FOR_BFT {  // = 4 for our 4-validator network
+    skip BFT round  // chain stalls
+}
+```
+
+For a 4-validator network, gate threshold = 4 (need ALL active). One jail = stall.
+
+This was **conservative-correct** for cold-start protection (don't enter BFT until all validators online). But during steady-state operation, when 1 validator gets locally-jailed, the gate prevents the other 3 from making progress — even though they technically have 3/4 supermajority.
+
+Per BFT theory, supermajority threshold for finality is `⌈2/3⌉ + 1 = 3` for a 4-validator network. The gate's `≥4` requirement is stricter than what BFT actually needs.
+
+Relaxing the gate (fix #3) doesn't fix the underlying jail divergence, but provides **liveness margin** while we work on the deeper fixes.
+
+---
+
+## Investigation queue (now informs PRs #2, #3, #4)
+
+### Short-term (operability / observability)
+
+- **#2 Observability metric** — Add per-validator tracing log + Prometheus counter for signed/missed per epoch. Detect divergence early before threshold crosses, allows operator to halt-all-rsync preemptively.
+- **#3 Relax P1 BFT safety gate** — `≥active_set.len()` → `≥⌈2/3⌉ × active_set.len() + 1` (= matches BFT supermajority). Liveness margin for transient jail divergence. Defer until 5+ validators is a reasonable position too.
+
+### Medium-term (data-layer fix)
+
+- **Replay-record on libp2p sync** — call `record_block_signatures` from BlocksResponse apply path with the block's justification.precommits (if Voyager-active height). Closes the gap-during-downtime issue.
+- **Replay-record on startup** — when loading chain.db at boot, walk the last 14400 finalized blocks + replay-record liveness. One-shot reconstruction of LivenessTracker.
+
+### Long-term (model fix)
+
+- **#4 Consensus-computed jail decisions** — emit jail-trigger as a BFT-finalized transaction, not as local decision at epoch boundary. Each validator votes "I observed X miss Y blocks" via the precommit chain. Aggregator (BFT engine) applies jail only when 2/3+1 supermajority agrees. This is the **right** model — eliminates divergence by design.
+
+---
+
+## Operational mitigation (current procedure)
+
+Until fixes ship, when jail divergence is detected (per-validator `active_count` differs):
+
+1. Use `runbooks/jail-divergence-recovery.md` — minimal-scope chain.db rsync from canonical (Treasury) to divergent validator
+2. Recovery time ~5-10 min including libp2p mesh re-convergence
+3. Pattern proven 2x on 2026-04-26 (evening h=633599 + night h=662399)
+
+This is acceptable for a 4-validator Foundation-operated network. Once external validators onboard, the determinism+consensus-compute fix (#4) becomes critical — can't ask third-party operators to chain.db rsync each other.

--- a/crates/sentrix-staking/src/slashing.rs
+++ b/crates/sentrix-staking/src/slashing.rs
@@ -343,6 +343,13 @@ impl SlashingEngine {
 
     /// Record block production for liveness tracking.
     /// `proposer` signed, everyone else in active_set should also have signed (voted).
+    ///
+    /// Per-validator signed/missed counts emitted as DEBUG-level tracing every
+    /// EPOCH_LENGTH boundary. Use with `RUST_LOG=sentrix_staking::slashing=debug`
+    /// to detect jail-counter divergence across the fleet (each validator's log
+    /// should show identical signed/missed for any given height — divergence is
+    /// the smoking-gun signature of the 2026-04-26 jail-cascade pattern).
+    /// See `audits/jail-cascade-root-cause-analysis.md`.
     pub fn record_block_signatures(
         &mut self,
         active_set: &[String],
@@ -352,6 +359,23 @@ impl SlashingEngine {
         for validator in active_set {
             let signed = signers.contains(validator);
             self.liveness.record(validator, height, signed);
+        }
+
+        // Periodic per-validator participation snapshot (every 1000 blocks)
+        // for fleet-wide correlation. Low-volume — only emits on a 0.1%
+        // sampling cadence to avoid log flood. Full per-validator counts.
+        if height.is_multiple_of(1000) {
+            for validator in active_set {
+                let (signed_count, missed_count) = self.liveness.get_stats(validator);
+                tracing::debug!(
+                    target: "sentrix_staking::slashing",
+                    height,
+                    validator = %validator,
+                    signed = signed_count,
+                    missed = missed_count,
+                    "jail counter snapshot"
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Bundles 3 related deliverables for the 2026-04-26 jail-cascade pattern (2 mainnet stalls in one day, root cause analysis below).

## What's in this PR

### 1. `audits/jail-cascade-root-cause-analysis.md` (NEW)

Identifies root cause of the jail-cascade pattern. Two-fold:
- **Asymmetric recording paths**: `record_block_signatures` called from validator-loop finalize paths but NOT from libp2p sync apply path → LivenessTracker gaps after sync recovery → divergent jail decisions across validators
- **Locally-computed jail decision**: `SlashingEngine::check_liveness` mutates stake_registry directly at epoch boundaries based on local LivenessTracker, no consensus coordination

Fully diagnoses the divergence pattern observed in 2 incidents:
- Evening h=633599 (after rolling restart for env-var rollout)
- Night h=662399 (during NORMAL operation, no operator action)

### 2. `audits/consensus-computed-jail-design.md` (NEW)

Proposes `JailTransaction` model: epoch-boundary proposer includes `JailEvidence` in block, peers Pass-1-validate independently, applies as consensus on-chain transaction. Fork-gated via `JAIL_CONSENSUS_HEIGHT` env var pattern.

4-phase rollout (4-6 weeks calendar): A data plumbing → B fork gate → C testnet bake → D mainnet activation.

This is the **right model** — deterministic by design.

### 3. Observability metric (`crates/sentrix-staking/src/slashing.rs`)

Adds DEBUG-level `tracing::debug!` snapshot of per-validator `(signed_count, missed_count)` every 1000 blocks. With `RUST_LOG=sentrix_staking::slashing=debug`, divergence in this log across the fleet is the smoking-gun signature of jail-cascade.

Operators can:
1. Tail logs across all 4 validators
2. Diff per-validator counts at same heights
3. If diverging, halt-all-rsync **preemptively** before BFT stall fires

No behavior change — purely additive logging.

## Why combined into one PR

Per consensus discipline"one conceptual change per PR" rule — these 3 are bundled because they're all **investigation outputs + diagnostic instrumentation**, no behavior change. The actual jail-cascade fix (gate relaxation, replay-record, consensus-jail) ships in separate PRs (#3 BFT gate relax, future Phase A/B/C/D for #4).

## Test plan

- [x] `cargo test -p sentrix-staking`: 88 passed, 0 failed
- [x] `cargo build --workspace`: clean
- [x] `cargo clippy --workspace -- -D warnings`: clean (no new warnings)
- [ ] Post-merge: deploy v2.1.41 to mainnet, verify DEBUG log output every 1000 blocks
- [ ] Manual diff: run `journalctl -u sentrix-node -g 'jail counter snapshot'` on each validator, compare per-validator counts at same heights
