### PR TITLE
chore(release): v2.1.41 — jail-cascade observability + fork-gated BFT gate relaxation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.41] — 2026-04-27 — Jail-cascade observability + fork-gated BFT safety gate relaxation
+
+> **Liveness fix bundle for the jail-cascade pattern.** Two mainnet stalls on 2026-04-26 (h=633599 evening, h=662399 night) traced to per-validator stake_registry divergence (one validator sees another as jailed, others see active). The P1 BFT safety gate then refused to participate (active < MIN_BFT_VALIDATORS=4), stalling the chain.
+>
+> This release ships:
+> 1. **Observability metric** — DEBUG-level tracing snapshot of per-validator (signed_count, missed_count) every 1000 blocks. Operators can diff per-validator counts via `journalctl -u sentrix-node -g 'jail counter snapshot'` to detect divergence early.
+> 2. **Fork-gated BFT safety gate relaxation** — new `BFT_GATE_RELAX_HEIGHT` env var (default `u64::MAX` = disabled). Pre-fork: gate uses `MIN_BFT_VALIDATORS (=4)` (current behavior, unchanged on default). Post-fork: gate uses `⌈2/3 × total⌉` supermajority (= 3 for 4-validator network = 1-jail tolerance).
+>
+> **Default behavior is unchanged.** Operators must explicitly set `BFT_GATE_RELAX_HEIGHT=<height>` on each validator to activate the relaxation. Coordinated rollout required (testnet bake, then mainnet halt-all + simultaneous-start with env var).
+
+### Added
+
+- `crates/sentrix-staking/src/slashing.rs` — DEBUG tracing per-validator participation snapshot every 1000 blocks (PR #350)
+- `crates/sentrix-core/src/blockchain.rs`:
+  - `BFT_GATE_RELAX_HEIGHT_DEFAULT = u64::MAX` const
+  - `get_bft_gate_relax_height()` env reader
+  - `Blockchain::is_bft_gate_relax_height(h) -> bool` static check
+  - `Blockchain::min_active_for_bft(h, total) -> usize` dispatch helper
+  - 2 regression tests: `test_bft_gate_relax_fork_threshold`, `test_bft_gate_relax_disabled_by_default`
+- `bin/sentrix/src/main.rs` — P1 BFT safety gate uses `min_active_for_bft(h, total)` lookup
+- `audits/jail-cascade-root-cause-analysis.md` — full RCA (asymmetric record_block_signatures, locally-computed jail decision)
+- `audits/consensus-computed-jail-design.md` — long-term fix design (4-6 weeks: JailTransaction model)
+- `runbooks/jail-divergence-recovery.md` (founder-private) — operator recovery procedure
+
+### Migration
+
+Drop-in chain.db compatible with v2.1.40. Hot-swap binary at any time. Behavior unchanged until operator sets `BFT_GATE_RELAX_HEIGHT` env var.
+
+To activate (after testnet bake):
+```
+# Set env on each validator's systemd EnvironmentFile, choose height in future
+BFT_GATE_RELAX_HEIGHT=<future_height>
+# Halt all + simultaneous-start (per feedback_mainnet_restart_cascade_jailing)
+```
+
+Pre-activation chain operates exactly as v2.1.40. Post-activation: chain stays live with active=3 of total=4.
+
+### Tests
+
+`cargo test --workspace`: 774 passed, 0 failed, 11 ignored (was 772 in v2.1.40, +2 new regression tests). Clippy clean.
+
+### Related
+
+- 2 incidents recovered via chain.db rsync from canonical (`incidents/2026-04-26-evening-rolling-restart-jail-cascade-stall.md`, `incidents/2026-04-26-night-jail-divergence-stall-h662399.md`)
+- Long-term fix (consensus-computed jail) is the real solution; this release is mitigation while that ships (4-6 weeks)
+
+### PRs
+
+- #350 — audit + observability + design docs (merged 2026-04-27)
+- #351 — fork-gated BFT safety gate relaxation (merged 2026-04-27, fresh-brain reviewed by autonomous session, regression tests added)
+
+---
+
 ## [2.1.40] — 2026-04-27 — Explorer richlist percentage display fork-aware
 
 > **Display-only polish PR.** Closes the last 3 sites that still used static `MAX_SUPPLY` (210M) for percentage-of-supply display, even though the consensus + `/chain/info` RPC display were already fork-aware in v2.1.39. After the tokenomics v2 fork activated on mainnet at h=640800, the `/explorer/richlist` HTML page, `GET /accounts` REST endpoint, and `GET /accounts/richlist` REST endpoint were still calculating percentages against the pre-fork 210M cap — making top holders look ~33% smaller than reality.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "bincode",
  "hex",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "anyhow",
  "axum",
@@ -4894,14 +4894,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4944,14 +4944,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "bincode",
  "blake3",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.40"
+version = "2.1.41"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.40"
+version = "2.1.41"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Version bump to v2.1.41 packaging the jail-cascade fix bundle that's already merged in PRs #350 + #351:

- **Observability** (PR #350): DEBUG-level per-validator participation snapshot every 1000 blocks
- **Audit + design docs** (PR #350): RCA + consensus-jail design (4-6 week implementation)
- **Fork-gated BFT gate relaxation** (PR #351): `BFT_GATE_RELAX_HEIGHT` env var, default disabled

Behavior on default v2.1.41 binary = identical to v2.1.40. Activation requires operator to set `BFT_GATE_RELAX_HEIGHT=<height>` env var (post-testnet-bake).

Binary already deployed to all 4 mainnet validators via halt-all + simultaneous-start (sha256 `74bd3cd6...`, md5 `decccd13...`). Chain healthy post-deploy, advancing normally.

Tests: 774 pass, 0 fail. Clippy clean.