### PR TITLE
feat(consensus): Phase A data plumbing for consensus-computed jail

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -980,6 +980,23 @@ impl Blockchain {
                         // submitter IS the offender in this naive shape).
                         // Follow-up: separate submitter + offender fields.
                     }
+                    StakingOp::JailEvidenceBundle { .. } => {
+                        // Phase A (data plumbing): no-op until Phase B wires
+                        // the consensus-jail dispatch. Once dispatch lands,
+                        // this branch will:
+                        //   1. Verify evidence by recomputing per-validator
+                        //      signed_count + missed_count against the cited
+                        //      epoch range (block range from chain).
+                        //   2. If verified: mark cited validators as jailed
+                        //      (deterministic on-chain state mutation).
+                        //   3. If verification mismatch: reject the block
+                        //      (Pass-1 invariant violation).
+                        //
+                        // Activation gated by JAIL_CONSENSUS_HEIGHT env var
+                        // (separate from BFT_GATE_RELAX_HEIGHT). Default:
+                        // u64::MAX (disabled). Wire Plan: Phase B.
+                        // See `audits/consensus-computed-jail-design.md`.
+                    }
                 }
             }
 

--- a/crates/sentrix-primitives/src/transaction.rs
+++ b/crates/sentrix-primitives/src/transaction.rs
@@ -100,6 +100,36 @@ pub enum StakingOp {
         signature_a: String,
         signature_b: String,
     },
+    /// Phase A: Consensus-computed jail evidence (data plumbing only —
+    /// no dispatch wired yet). Activated post `JAIL_CONSENSUS_HEIGHT` fork
+    /// (separate from BFT_GATE_RELAX_HEIGHT). At epoch boundary, the
+    /// proposer scans the last LIVENESS_WINDOW blocks' justification.precommits,
+    /// computes per-validator (signed_count, missed_count), includes the
+    /// JailEvidence list in the boundary block as this StakingOp variant.
+    /// Other validators Pass-1-validate (recompute independently from same
+    /// blocks; reject block if cited evidence doesn't match).
+    /// See `audits/consensus-computed-jail-design.md`.
+    JailEvidenceBundle {
+        epoch: u64,
+        epoch_start_block: u64,
+        epoch_end_block: u64,
+        evidence: Vec<JailEvidence>,
+    },
+}
+
+/// Phase A data type: per-validator missed-block evidence for an epoch.
+/// Self-validating: peers recompute by scanning chain for the same window
+/// and comparing signed_count and missed_count. justification_hashes lets
+/// peers selectively verify missed-block claims.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JailEvidence {
+    pub validator: String,
+    pub signed_count: u64,
+    pub missed_count: u64,
+    /// Hashes of blocks where validator was in active_set but missing
+    /// from precommits. Subset (full list optional for size; min 1 for
+    /// proof-of-evidence).
+    pub justification_hashes: Vec<String>,
 }
 
 impl StakingOp {
@@ -606,5 +636,89 @@ mod tests {
         assert!(parsed_inject["data"].as_str().unwrap().contains("attacker"));
         // The "from" field must still be the real address, not "attacker"
         assert_eq!(parsed_inject["from"], from);
+    }
+
+    // ── JailEvidenceBundle (Phase A — consensus-jail data plumbing) ──
+
+    #[test]
+    fn test_jail_evidence_bundle_encode_decode_roundtrip() {
+        let bundle = StakingOp::JailEvidenceBundle {
+            epoch: 42,
+            epoch_start_block: 590100,
+            epoch_end_block: 604499,
+            evidence: vec![
+                JailEvidence {
+                    validator: "0x87c9976d4b2e360b9fbb87e4bd5442edce2a7511".into(),
+                    signed_count: 3000,
+                    missed_count: 11400,
+                    justification_hashes: vec!["abc123".into(), "def456".into()],
+                },
+            ],
+        };
+
+        let encoded = bundle.encode().expect("encode");
+        let decoded = StakingOp::decode(&encoded).expect("decode");
+        match decoded {
+            StakingOp::JailEvidenceBundle {
+                epoch,
+                epoch_start_block,
+                epoch_end_block,
+                evidence,
+            } => {
+                assert_eq!(epoch, 42);
+                assert_eq!(epoch_start_block, 590100);
+                assert_eq!(epoch_end_block, 604499);
+                assert_eq!(evidence.len(), 1);
+                assert_eq!(
+                    evidence[0].validator,
+                    "0x87c9976d4b2e360b9fbb87e4bd5442edce2a7511"
+                );
+                assert_eq!(evidence[0].signed_count, 3000);
+                assert_eq!(evidence[0].missed_count, 11400);
+                assert_eq!(evidence[0].justification_hashes.len(), 2);
+            }
+            other => panic!("expected JailEvidenceBundle, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_jail_evidence_serialization_uses_snake_case_op_tag() {
+        let bundle = StakingOp::JailEvidenceBundle {
+            epoch: 1,
+            epoch_start_block: 0,
+            epoch_end_block: 14400,
+            evidence: vec![],
+        };
+        let encoded = bundle.encode().expect("encode");
+        // Per #[serde(tag = "op", rename_all = "snake_case")] on StakingOp,
+        // the variant tag should be "jail_evidence_bundle".
+        assert!(
+            encoded.contains("\"op\":\"jail_evidence_bundle\""),
+            "expected snake_case op tag, got: {encoded}"
+        );
+    }
+
+    #[test]
+    fn test_jail_evidence_is_staking_op() {
+        let bundle = StakingOp::JailEvidenceBundle {
+            epoch: 1,
+            epoch_start_block: 0,
+            epoch_end_block: 14400,
+            evidence: vec![],
+        };
+        let encoded = bundle.encode().expect("encode");
+        assert!(StakingOp::is_staking_op(&encoded));
+    }
+
+    #[test]
+    fn test_jail_evidence_struct_equality() {
+        let a = JailEvidence {
+            validator: "0xval1".into(),
+            signed_count: 100,
+            missed_count: 50,
+            justification_hashes: vec!["h1".into()],
+        };
+        let b = a.clone();
+        assert_eq!(a, b, "JailEvidence must implement PartialEq for testing");
     }
 }


### PR DESCRIPTION
Phase A from `audits/consensus-computed-jail-design.md`. **DATA PLUMBING ONLY — no behavior change.** Default chain operation unchanged. Wire dispatch lands in Phase B.

## Adds

1. **`JailEvidence` struct** (sentrix-primitives/transaction.rs) — per-validator (signed_count, missed_count) for an epoch with justification_hashes for selective verification

2. **`StakingOp::JailEvidenceBundle` variant** — epoch + epoch_start_block + epoch_end_block + Vec<JailEvidence>. Serializes as `op="jail_evidence_bundle"`.

3. **Pass-1 dispatch stub** in block_executor.rs — currently no-op (matches current behavior)

## Long-term goal

Replace local-jail (each validator mutates stake_registry based on its own LivenessTracker at epoch boundary, divergent under any asymmetric recording or race) with **consensus-jail** (epoch-boundary proposer includes evidence; peers verify; applied as on-chain transaction — deterministic by design).

Eliminates state_root divergence pattern observed multiple times today.

## Activation

Will be gated by `JAIL_CONSENSUS_HEIGHT` env var (separate from `BFT_GATE_RELAX_HEIGHT`). Default `u64::MAX` = disabled.

## Tests

- 779 passed (+4 new for JailEvidenceBundle), 0 failed
- cargo build clean
- cargo clippy --workspace --tests -- -D warnings: clean

## Phase B next session (fresh-brain)

- Add `compute_jail_evidence_at_epoch_boundary(blockchain, height)` in sentrix-staking
- Wire StakingOp::JailEvidenceBundle dispatch to actually verify + apply jail (consensus-applied state mutation)
- Wire epoch-boundary proposer to include JailEvidence in its block
- Tests for evidence computation + verification

## Discipline

⚠️ Adds new variant to consensus-touching enum (StakingOp). User explicitly authorized: '1,2,3 lanjut'.