### PR TITLE
docs(audit): libp2p resilience + reward distribution flow audits (items #2 + #3)

### DIFF
--- a/audits/libp2p-resilience-audit-2026-04-27.md
+++ b/audits/libp2p-resilience-audit-2026-04-27.md
@@ -1,0 +1,141 @@
+# libp2p Resilience Audit — 2026-04-27
+
+**Scope:** `crates/sentrix-network/src/libp2p_node.rs`
+**Triggered by:** mainnet jail-induction test 2026-04-27 — stopping 1 of 4 validators caused 5+ minute chain stall, not recovered until rsync recovery
+
+---
+
+## verified_peers lifecycle
+
+**Add path** (handshake completion):
+- Line 1164 (inbound handshake) — after our peer sends Handshake, we verify chain_id + height matches
+- Line 1611 (outbound handshake reply) — after we receive their Handshake response, we insert
+
+**Remove path** (line 768-769 in ConnectionClosed handler):
+```rust
+if num_established == 0 {
+    verified_peers.remove(&peer_id);
+    let _ = event_tx.send(NodeEvent::PeerDisconnected(peer_id.to_string())).await;
+}
+```
+
+This is **correct in theory** — only remove when all connections to that peer are gone. Bidirectional dialing creates 2 connections per peer pair; libp2p prunes duplicates. The `num_established == 0` guard prevents orphaning the surviving connection.
+
+**Observation:** This lifecycle is sound. Removing 1 peer should NOT cascade to remove others. So why did peer_count hit 0 during testing?
+
+---
+
+## Hypothesis: brief peer_count=0 during peer-stop event
+
+**What we observed (mainnet test, 2026-04-27 ~6:25 WIB):**
+- Stopped Beacon (vps5) at T=0
+- Other 3 validators: peer_count expected 2 (Foundation+Treasury+Core seeing each other minus Beacon)
+- Logs showed nil-precommit for h=690613 across ~10 rounds (5 minutes)
+- Eventually chain stalled despite 3 online validators
+
+**Possible causes (all need deeper investigation):**
+
+1. **libp2p kademlia query churn** — When Beacon disconnect, kademlia may issue node-lookup queries to refresh routing table. These queries hold connections briefly. If the lookup fails or times out, connection state may flap.
+
+2. **Connection-limit eviction race** — `MAX_LIBP2P_PEERS` cap (line 1127) rejects new connections if at limit. If kademlia opens transient connections + hits limit, real peer connections may be evicted.
+
+3. **Identify protocol re-runs** — When peer disconnects, identify may run on remaining peers, briefly setting them to "unverified" state. peer_count is `verified_peers.len()` so unverified = 0.
+
+4. **request_response queue drainage** — When validator A sends BFT proposal to peer B (offline), the request_response queue on A may hold onto pending sends. If the queue fills, may block sends to OTHER peers.
+
+5. **Gossipsub mesh re-formation** — When peer leaves gossipsub mesh, `MeshConsumed`/`MeshLow` events fire. Mesh may temporarily exclude other peers during re-formation.
+
+---
+
+## Specific quick-win investigations (next session)
+
+### Investigation A: instrument peer_count timing
+
+Add tracing log on every `verified_peers.insert/remove` with timestamp. Correlate with BFT skip-round events to see if peer_count drops below 2 transiently when 1 of 4 validators offline.
+
+```rust
+// Before insert/remove:
+tracing::info!(
+    target: "libp2p::peers",
+    "verified_peers: {} → {} ({})",
+    before_count, after_count,
+    if added { "add" } else { "remove" }
+);
+```
+
+Effort: 1 hour. Output: definitive evidence whether peer_count drops to 0 during peer-leave event.
+
+### Investigation B: dump all BFT request_response delivery failures
+
+When BFT proposal/prevote/precommit fails to deliver via request_response, log it with target peer. Currently failures are silent (return Ok-ish at outer layer).
+
+```rust
+// In on_rr_event response handler:
+if let Some(failure) = response.failure {
+    tracing::warn!(
+        target: "bft::network",
+        "BFT message {kind} failed to deliver to {peer}: {failure}"
+    );
+}
+```
+
+Effort: 1-2 hours. Output: which validators saw which deliveries fail. May reveal whether stall is "votes never sent" vs "votes lost in transit".
+
+### Investigation C: kademlia bootstrap interaction
+
+Check if `KadBootstrap` (random walk) is triggered by ConnectionClosed events and if so, whether it disrupts existing connections.
+
+Effort: 0.5-1 day code reading + testing.
+
+---
+
+## Quick-win fixes (low risk, defer-friendly)
+
+### Fix 1: Aggressive reconnect on peer-down
+
+When peer goes down, immediately schedule a reconnect attempt rather than waiting for kad routing table to age out. Current `reconnect_peers` (line 262) is manual-trigger only.
+
+**Pseudocode:**
+```rust
+// In ConnectionClosed handler when num_established == 0:
+if active_set.contains(&peer_id_to_addr(&peer_id)) {
+    // This peer is in our known active set — try to reconnect
+    schedule_reconnect_attempt(peer_id, delay = 5s);
+}
+```
+
+Effort: 4-6 hours. Risk: none if delay > 0 and rate-limited.
+
+### Fix 2: Tune libp2p connection-keepalive
+
+Current keepalive may be too aggressive (kills idle connections). For BFT validators that may have <1 message/second between rounds, keepalive should be longer.
+
+Effort: 1-2 hours code reading + tuning.
+
+### Fix 3: Dedicated BFT request_response retry
+
+Currently BFT messages have a built-in rebroadcast (#1d). But that's for proposer-side. Vote messages from non-proposers don't have retry logic — if delivery fails, vote is lost.
+
+**Proposal:** add `BftMessageQueue` that retries up to N times on delivery failure for prevote/precommit messages.
+
+Effort: 1-2 days. Potentially significant impact.
+
+---
+
+## Why this stayed broken
+
+Chain has been operational with this behavior for weeks. The asymmetric recording bug (PR #356) MASKED some symptoms because validators eventually agreed via block re-broadcast. With asymmetric recording fixed, partial-mesh scenarios are more likely to expose libp2p issues that were previously hidden.
+
+In other words: today's PR #356 made jail-divergence less likely, but exposed deeper libp2p resilience gaps that were always there.
+
+---
+
+## Recommendation
+
+Item 2 from production-readiness audit (libp2p resilience) requires:
+- 0.5-1 day investigation A + B (instrumentation)
+- Run a fresh-brain test with that instrumentation
+- Identify which sub-cause is actually firing
+- Then apply targeted quick-win fix (3-5 days total)
+
+Until then: **avoid stopping individual validators on mainnet.** Use halt-all + simultaneous-start for any operational change. This is the same advice from `feedback_mainnet_restart_cascade_jailing.md` memory + RECENTLY confirmed validity in 2026-04-27 mainnet test.

--- a/audits/reward-distribution-flow-audit-2026-04-27.md
+++ b/audits/reward-distribution-flow-audit-2026-04-27.md
@@ -1,0 +1,164 @@
+# Reward Distribution Flow Audit — 2026-04-27
+
+**Scope:** verify reward flow is deterministic across all block-apply paths
+**Triggered by:** Production-readiness audit identified `distribute_reward` is only called from main.rs validator-finalize paths but blocks can also be applied via libp2p sync paths (gossip + catch-up), creating asymmetric application
+
+---
+
+## Reward flow architecture (V4 reward v2, active since h=590100)
+
+### 1. Block production: coinbase tx routes to PROTOCOL_TREASURY
+
+`bin/sentrix/src/main.rs` block-production path:
+- Validator produces block with coinbase transaction
+- Coinbase pays block_reward (1 SRX) to `PROTOCOL_TREASURY` (0x0000…0002), NOT to producing validator directly
+- Treasury accumulates rewards on every block
+
+This is consensus-state mutation: `accounts.transfer(coinbase_source, PROTOCOL_TREASURY, reward, 0)`. Deterministic — every validator applying the same block transitions PROTOCOL_TREASURY balance identically.
+
+✅ **Coinbase-to-treasury: deterministic across all apply paths.**
+
+### 2. Reward distribution: distribute_reward updates accumulators
+
+`bc.stake_registry.distribute_reward(proposer, signers, reward, fee)` is called from:
+- main.rs:2105 (self-produced block, BFT-finalize handler)
+- main.rs:2510 (peer-produced block, BFT-finalize handler)
+
+**NOT called from:**
+- libp2p gossip apply path (libp2p_node.rs:847)
+- libp2p direct apply path (libp2p_node.rs:1207)
+- libp2p sync catch-up path (libp2p_node.rs:1499)
+
+**What distribute_reward does:**
+- Updates `stake_registry.validators[X].pending_rewards` accumulator (per validator's share of reward)
+- Updates `stake_registry.delegator_rewards[X]` accumulator (per delegator's share via validator commission)
+
+This is LOCAL STATE on each validator — it's the validator's own accumulator tracking. Critically, **`pending_rewards` and `delegator_rewards` ARE part of stake_registry which IS part of Blockchain consensus state**.
+
+❓ **Question:** is distribute_reward a deterministic state mutation or a local-only bookkeeping?
+
+### 3. Claim path: ClaimRewards drains accumulator → balance
+
+`StakingOp::ClaimRewards` apply (block_executor.rs:848) takes:
+- `tx.from_address` = claimer
+- Drains `take_delegator_rewards(claimer)` (delegator portion)
+- Drains `validators[claimer].pending_rewards` (validator portion)
+- `accounts.transfer(PROTOCOL_TREASURY, claimer, total_claim, 0)` — moves treasury → claimer balance
+
+This IS a consensus state mutation (transaction in chain). All validators applying the same ClaimRewards tx transition the same way.
+
+✅ **Claim is deterministic.**
+
+---
+
+## The bug: distribute_reward asymmetric application
+
+Here's the issue:
+
+**Scenario:** Validator B is offline, comes back, syncs blocks N..N+1000 from peers via libp2p.
+
+**Validator A** (online during N..N+1000): finalized blocks via BFT, called `distribute_reward` for each → updated its OWN stake_registry accumulators
+
+**Validator B** (offline → online via sync): applied blocks via `add_block_from_peer` → state changes from coinbase tx happened (treasury balance updated) BUT `distribute_reward` was NOT called → stake_registry accumulators NOT updated
+
+**State diff after sync:**
+- A's `stake_registry.validators[X].pending_rewards` = correct (incremented each block)
+- B's `stake_registry.validators[X].pending_rewards` = wrong (never incremented for blocks N..N+1000)
+
+When user submits ClaimRewards tx:
+- A applies tx → drains A's local accumulator → claimer gets correct amount
+- B applies tx → drains B's local (under-accumulated) accumulator → claimer gets less
+
+**This is divergent state mutation.** Different validators would credit different balances for the same ClaimRewards tx, breaking consensus.
+
+❌ **Reward distribution is NOT deterministic across apply paths.**
+
+---
+
+## Severity
+
+**Currently masked because:**
+1. Validators rarely catch up via libp2p sync after long downtime (operators do chain.db rsync recovery instead, which copies the canonical's stake_registry state wholesale)
+2. ClaimRewards is rare (no auto-claims yet, must be manually submitted)
+3. The drift between validators may be small if downtime is short
+
+**Severity rating: HIGH** (latent consensus-divergence bug, would manifest under long-running multi-validator network)
+
+---
+
+## Fix design
+
+Same pattern as PR #356 (asymmetric record_block_signatures fix). Add `distribute_reward` call to libp2p apply paths.
+
+### Approach 1: Inline in libp2p_node.rs (3 sites)
+
+Add after each successful `add_block_from_peer`:
+
+```rust
+if let Some(j) = &block.justification {
+    let proposer = &block.validator;
+    let signers: Vec<(String, u64)> = j.precommits.iter()
+        .map(|p| (p.validator.clone(), p.stake_weight))
+        .collect();
+    let reward = chain.get_block_reward();
+    let validator_fee = 0;
+    let _ = chain.stake_registry.distribute_reward(proposer, &signers, reward, validator_fee);
+}
+```
+
+Risk: **HIGHER than PR #356** because this is monetary state mutation, not just LivenessTracker bookkeeping. Mistake here = double-distributed rewards or missed-distributed rewards.
+
+### Approach 2: Move distribute_reward inside add_block_with_source (centralized)
+
+Refactor: instead of caller-driven distribution, make it part of the block-apply pipeline. add_block_impl computes proposer + signers from block.justification + calls distribute_reward internally, ONCE per block-apply.
+
+Then main.rs validator-finalize paths can REMOVE their explicit distribute_reward calls (now handled at apply time).
+
+**Pros:** single source of truth — reward distribution happens exactly once per block-apply, regardless of whether self-produce or peer-receive or libp2p-sync
+**Cons:** refactor touches consensus-critical code; needs careful regression tests
+
+### Approach 3: Add deterministic apply-time hook (CLEANEST)
+
+Add `Blockchain::apply_block_post_hook(&mut self, block: &Block)` method that runs deterministic bookkeeping after every successful block apply (regardless of source). Call from add_block_impl after successful Pass-2 apply.
+
+Hook does:
+1. record_block_signatures (if block has justification)
+2. distribute_reward (if block has justification)
+3. epoch_manager.record_block (always)
+
+Caller paths simplify. Remove ad-hoc bookkeeping from main.rs (now centralized).
+
+**Pros:** one chokepoint, deterministic, tested in unit tests
+**Cons:** larger refactor; touches multiple call sites
+
+---
+
+## Recommendation
+
+**Phase 1 (quick fix, ~1 day):** Approach 1 — add distribute_reward to 3 libp2p paths. Same pattern as PR #356. Tests for each path. Risk-managed.
+
+**Phase 2 (refactor, ~3-5 days):** Approach 3 — centralize via apply_block_post_hook. Remove duplicate logic in main.rs. Cleaner long-term.
+
+For tonight (autonomous mode): defer fix. The bug is latent (not actively divergent under current operational pattern of chain.db rsync recovery). Phase 1 fix needs:
+- Careful design (which call sites change, test coverage)
+- Mainnet deploy (halt-all + simultaneous-start for state-mutation change)
+- Ideally testnet bake first
+
+Per CLAUDE.md hard limit #2 (fresh-brain review for consensus-touching), do NOT ship in this session.
+
+---
+
+## Investigation queue
+
+- [ ] Confirm distribute_reward is missing from libp2p apply paths empirically
+- [ ] Test: stop validator, restart, force libp2p sync, claim rewards, check if amount matches what other validators would credit
+- [ ] Implement Approach 1 fix (5-7 hours implementation + testing)
+- [ ] Eventually: refactor to Approach 3 (single chokepoint)
+
+Same pattern issue applies to:
+- `epoch_manager.record_block(reward)` — only called from main.rs validator-finalize paths, not libp2p apply
+- May affect epoch-boundary calculations on validators that catch up via libp2p
+
+This category of bug ("validator-loop-only bookkeeping that should be applied to all blocks regardless of source") is the parent class of the asymmetric recording bug. PR #356 fixed one instance (record_block_signatures). This audit identifies 2 more (distribute_reward, epoch_manager).
+
+**Long-term fix:** Approach 3 (apply_block_post_hook) eliminates the entire bug class structurally.


### PR DESCRIPTION
Items 2+3 from production-readiness audit. **Investigation only — no code changes.** Documented findings + concrete next steps for fresh-brain sessions.

## libp2p resilience audit
- 5 hypotheses for transient peer_count=0 observed in 2026-04-27 mainnet test
- Specific quick-win investigations + fixes documented with effort estimates
- Recommendation: Investigation A+B (instrumentation, ~3h) before Fix 1/2/3

## Reward distribution audit
- Identified DIFFERENT instance of same asymmetric-application bug class as PR #356
- distribute_reward NOT called from libp2p apply paths → latent consensus-divergence bug
- Also affects epoch_manager.record_block
- Severity: HIGH (latent — currently masked by chain.db rsync recovery procedure)
- Recommendation: Phase 1 quick fix (1 day) → Phase 2 refactor (3-5 days, single chokepoint)

## Why not shipped tonight

Reward fix is consensus-state mutation. Per consensus discipline (fresh-brain review for consensus-touching), needs proper review session.

This PR is documentation only.
