### PR TITLE
chore: scrub CLAUDE.md references from public source files

### DIFF
--- a/audits/consensus-computed-jail-design.md
+++ b/audits/consensus-computed-jail-design.md
@@ -147,7 +147,7 @@ Fallback: if fork mechanism has bug, env var lets us roll back per-validator (se
 - Phase D (mainnet activation): 1 day operator action
 - **Total calendar: 4-6 weeks**
 
-Per consensus discipline (CLAUDE.md): each phase = separate PR with regression test, fresh-brain review, no self-merge.
+Per consensus discipline (operator runbook): each phase = separate PR with regression test, fresh-brain review, no self-merge.
 
 ---
 

--- a/audits/reward-distribution-flow-audit-2026-04-27.md
+++ b/audits/reward-distribution-flow-audit-2026-04-27.md
@@ -144,7 +144,7 @@ For tonight (autonomous mode): defer fix. The bug is latent (not actively diverg
 - Mainnet deploy (halt-all + simultaneous-start for state-mutation change)
 - Ideally testnet bake first
 
-Per CLAUDE.md hard limit #2 (fresh-brain review for consensus-touching), do NOT ship in this session.
+Per consensus discipline (fresh-brain review for consensus-touching), do NOT ship in this session.
 
 ---
 

--- a/audits/sentrix-production-readiness-audit-2026-04-27.md
+++ b/audits/sentrix-production-readiness-audit-2026-04-27.md
@@ -96,7 +96,7 @@ Per round: ~44s
 
 **Symptom:** When BFT can't finalize at height N (proposer offline, nil-majority), validators continue trying. Each validator stages a different block locally. Their local chain.db state diverges. After 5+ min stuck, MD5 of `mdbx.dat` differs across all validators.
 
-**Why:** Per CLAUDE.md state-recovery rules, "state_root stamping at apply time" means each validator stamps its own state_root. If state_roots already differ (e.g., stale auto-jail counter), block hashes differ for the same proposer + prev_hash, leading to permanent divergence even after recovery.
+**Why:** Per state-recovery rules (operator runbook), "state_root stamping at apply time" means each validator stamps its own state_root. If state_roots already differ (e.g., stale auto-jail counter), block hashes differ for the same proposer + prev_hash, leading to permanent divergence even after recovery.
 
 **Implication:** Recovery from any stall REQUIRES chain.db rsync from canonical (well-tested today, ~5-10 min downtime). Not feasible at scale (multi-validator network can't ask each operator to rsync from others).
 

--- a/docs/roadmap/CHANGELOG.md
+++ b/docs/roadmap/CHANGELOG.md
@@ -127,7 +127,7 @@ Pivotal release: mainnet hard-fork from Pioneer (PoA round-robin) to Voyager (DP
 ### Changed
 - WHITEPAPER bumped to v3.2 with new §2.5 Voyager DPoS+BFT design + §2.6 L1/L2 peer auto-discovery sections.
 - `SENTRIX_FORCE_PIONEER_MODE` removed from all env files.
-- CLAUDE.md trimmed to ~25 incident-earned rules.
+- Internal operator runbooks trimmed to ~25 incident-earned rules.
 
 ### Fixed
 - Issue #268 (legacy block tolerance) closed via `SENTRIX_LEGACY_VALIDATION_HEIGHT=557144`.


### PR DESCRIPTION
CLAUDE.md is the AI-assistant guide in founder-private (operator-internal), not a public project doc. Earlier audit + changelog entries referenced it as if normal project doc.

Replaced with generic terms ('operator runbooks', 'consensus discipline').

Source files scrubbed in this PR:
- 3 audit docs in `audits/`
- 1 entry in `docs/roadmap/CHANGELOG.md`

Also scrubbed (via `gh pr edit`, no code change): 5 merged PR descriptions (#350, #351, #355, #356, #360).

Same opsec category as 'no VPS identifiers in public' rule.