### PR TITLE
feat(consensus): Phase D Step 1+2 — system tx helper for JailEvidenceBundle (fork-gated, dormant)

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -785,6 +785,69 @@ impl Blockchain {
         total_validator_count.saturating_mul(2).saturating_add(2) / 3
     }
 
+    /// Phase D: build a JailEvidenceBundle system transaction for the given
+    /// boundary height, if one should be emitted. Returns:
+    /// - `None` if pre-fork (JAIL_CONSENSUS_HEIGHT not reached)
+    /// - `None` if `next_height` is not an epoch boundary
+    /// - `None` if local LivenessTracker shows no validators meeting the
+    ///   downtime threshold (Q3-A: skip emission for empty bundles)
+    /// - `Some(tx)` otherwise: a fully-formed system tx with PROTOCOL_TREASURY
+    ///   sender, empty signature, JSON-encoded `StakingOp::JailEvidenceBundle`
+    ///
+    /// The proposer's block_producer calls this at build_block time. Peers
+    /// recompute via `compute_jail_evidence` in dispatch (see block_executor)
+    /// and reject the block if the evidence diverges.
+    ///
+    /// `next_height` is the height the proposer is about to produce (NOT the
+    /// current chain head). The boundary check uses `next_height`.
+    /// `block_timestamp` is the timestamp the proposer chose for the block.
+    pub fn build_jail_evidence_system_tx(
+        &self,
+        next_height: u64,
+        block_timestamp: u64,
+    ) -> Option<Transaction> {
+        // Gate 1: post-fork only
+        if !Self::is_jail_consensus_height(next_height) {
+            return None;
+        }
+        // Gate 2: epoch boundary only
+        if !sentrix_staking::epoch::EpochManager::is_epoch_boundary(next_height) {
+            return None;
+        }
+        // Gate 3: must have evidence (Q3-A: skip emission for empty bundles)
+        let active_set = self.stake_registry.active_set.clone();
+        let evidence = self.slashing.compute_jail_evidence(&active_set);
+        if evidence.is_empty() {
+            return None;
+        }
+
+        // Compute epoch metadata for the bundle
+        let epoch =
+            sentrix_staking::epoch::EpochManager::epoch_for_height(next_height);
+        let epoch_length = sentrix_staking::epoch::EPOCH_LENGTH;
+        let epoch_start_block = epoch.saturating_mul(epoch_length);
+        let epoch_end_block = next_height; // boundary block IS the end
+
+        let op = sentrix_primitives::transaction::StakingOp::JailEvidenceBundle {
+            epoch,
+            epoch_start_block,
+            epoch_end_block,
+            evidence,
+        };
+
+        match Transaction::new_jail_evidence_bundle(op, next_height, block_timestamp) {
+            Ok(tx) => Some(tx),
+            Err(e) => {
+                tracing::error!(
+                    "build_jail_evidence_system_tx: failed to build tx at h={}: {}",
+                    next_height,
+                    e
+                );
+                None
+            }
+        }
+    }
+
     /// Tokenomics v2: max supply for a given height (fork-aware).
     /// Pre-fork: 210M (`MAX_SUPPLY`). Post-fork: 315M (`MAX_SUPPLY_V2`).
     pub fn max_supply_for(&self, height: u64) -> u64 {
@@ -2980,6 +3043,126 @@ mod tests {
         assert!(!Blockchain::is_bft_gate_relax_height(u64::MAX - 1));
         // Default-disabled gate = pre-fork behavior.
         assert_eq!(Blockchain::min_active_for_bft(1_000_000, 4), 4);
+    }
+
+    /// Phase D: build_jail_evidence_system_tx returns None pre-fork
+    /// regardless of epoch boundary or evidence state.
+    #[test]
+    fn test_build_jail_evidence_system_tx_none_pre_fork() {
+        unsafe {
+            std::env::remove_var("JAIL_CONSENSUS_HEIGHT");
+        }
+        let bc = Blockchain::new("admin".to_string());
+        // Pre-fork (default): even at epoch boundary, returns None
+        let boundary = sentrix_staking::epoch::EPOCH_LENGTH - 1;
+        let tx = bc.build_jail_evidence_system_tx(boundary, 1_700_000_000);
+        assert!(tx.is_none(), "pre-fork must return None");
+    }
+
+    /// Phase D: build_jail_evidence_system_tx returns None at non-boundary
+    /// heights even post-fork.
+    #[test]
+    fn test_build_jail_evidence_system_tx_none_non_boundary() {
+        // SAFETY: env-var mutation in tests; CI runs single-threaded.
+        unsafe {
+            std::env::set_var("JAIL_CONSENSUS_HEIGHT", "0");
+        }
+        let bc = Blockchain::new("admin".to_string());
+        // h=100 is not an epoch boundary (EPOCH_LENGTH = 28800)
+        let tx = bc.build_jail_evidence_system_tx(100, 1_700_000_000);
+        assert!(tx.is_none(), "non-boundary must return None");
+        unsafe {
+            std::env::remove_var("JAIL_CONSENSUS_HEIGHT");
+        }
+    }
+
+    /// Phase D: with no jailed/downtime validators, even at epoch boundary
+    /// post-fork, returns None (Q3-A: skip emission for empty bundle).
+    #[test]
+    fn test_build_jail_evidence_system_tx_none_no_evidence() {
+        unsafe {
+            std::env::set_var("JAIL_CONSENSUS_HEIGHT", "0");
+        }
+        let bc = Blockchain::new("admin".to_string());
+        let boundary = sentrix_staking::epoch::EPOCH_LENGTH - 1;
+        // Fresh chain has empty active_set + no liveness data, so
+        // compute_jail_evidence returns empty Vec.
+        let tx = bc.build_jail_evidence_system_tx(boundary, 1_700_000_000);
+        assert!(
+            tx.is_none(),
+            "boundary post-fork with no evidence must return None"
+        );
+        unsafe {
+            std::env::remove_var("JAIL_CONSENSUS_HEIGHT");
+        }
+    }
+
+    /// Phase D: with downtime evidence at epoch boundary post-fork, helper
+    /// returns Some(tx) — sender PROTOCOL_TREASURY, empty signature, JSON-
+    /// encoded JailEvidenceBundle that survives Transaction::verify().
+    #[test]
+    fn test_build_jail_evidence_system_tx_some_with_evidence() {
+        use sentrix_primitives::transaction::{PROTOCOL_TREASURY, StakingOp};
+
+        unsafe {
+            std::env::set_var("JAIL_CONSENSUS_HEIGHT", "0");
+        }
+
+        let mut bc = Blockchain::new("admin".to_string());
+
+        // Inject a validator into active_set + populate full liveness window
+        // entirely with MISSED records → triggers is_downtime predicate.
+        let downer = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string();
+        bc.stake_registry.active_set = vec![downer.clone()];
+        let window = sentrix_staking::slashing::LIVENESS_WINDOW;
+        for h in 0..window {
+            bc.slashing.liveness.record(&downer, h, false);
+        }
+        assert!(bc.slashing.liveness.is_downtime(&downer));
+
+        let boundary = sentrix_staking::epoch::EPOCH_LENGTH - 1;
+        let tx = bc
+            .build_jail_evidence_system_tx(boundary, 1_700_000_000)
+            .expect("post-fork boundary with downtime must emit");
+
+        // Auth fields: PROTOCOL_TREASURY sender, empty sig+pubkey
+        assert_eq!(tx.from_address, PROTOCOL_TREASURY);
+        assert_eq!(tx.to_address, PROTOCOL_TREASURY);
+        assert_eq!(tx.amount, 0);
+        assert_eq!(tx.fee, 0);
+        assert!(tx.signature.is_empty());
+        assert!(tx.public_key.is_empty());
+
+        // Payload round-trips
+        assert!(tx.is_jail_evidence_bundle_tx());
+
+        // verify() must succeed for system tx (Phase D special-case)
+        tx.verify().expect("system tx verify must pass");
+
+        // Decode the bundle, sanity-check fields
+        let op: StakingOp = serde_json::from_str(&tx.data).unwrap();
+        match op {
+            StakingOp::JailEvidenceBundle {
+                epoch,
+                epoch_start_block,
+                epoch_end_block,
+                evidence,
+            } => {
+                assert_eq!(
+                    epoch,
+                    sentrix_staking::epoch::EpochManager::epoch_for_height(boundary)
+                );
+                assert_eq!(epoch_start_block, 0);
+                assert_eq!(epoch_end_block, boundary);
+                assert_eq!(evidence.len(), 1);
+                assert_eq!(evidence[0].validator, downer);
+            }
+            _ => panic!("expected JailEvidenceBundle variant"),
+        }
+
+        unsafe {
+            std::env::remove_var("JAIL_CONSENSUS_HEIGHT");
+        }
     }
 }
 // fake addr 0x1234567890abcdef1234567890abcdef12345678

--- a/crates/sentrix-primitives/src/transaction.rs
+++ b/crates/sentrix-primitives/src/transaction.rs
@@ -245,6 +245,44 @@ impl Transaction {
         tx
     }
 
+    /// Phase D: build a system-emitted JailEvidenceBundle transaction. Sender
+    /// is `PROTOCOL_TREASURY`; signature/public_key empty (auth via Pass-1
+    /// recompute-and-compare in dispatch). The op payload is JSON-encoded
+    /// `StakingOp::JailEvidenceBundle`. This tx is only valid in finalized
+    /// blocks at epoch boundaries when post-fork.
+    pub fn new_jail_evidence_bundle(
+        op: StakingOp,
+        block_index: u64,
+        block_timestamp: u64,
+    ) -> SentrixResult<Self> {
+        // Defensive: only accept the JailEvidenceBundle variant
+        if !matches!(op, StakingOp::JailEvidenceBundle { .. }) {
+            return Err(SentrixError::InvalidTransaction(
+                "new_jail_evidence_bundle: op must be StakingOp::JailEvidenceBundle".into(),
+            ));
+        }
+        let data = serde_json::to_string(&op).map_err(|e| {
+            SentrixError::InvalidTransaction(format!(
+                "new_jail_evidence_bundle: serialize failed: {e}"
+            ))
+        })?;
+        let mut tx = Self {
+            txid: String::new(),
+            from_address: PROTOCOL_TREASURY.to_string(),
+            to_address: PROTOCOL_TREASURY.to_string(),
+            amount: 0,
+            fee: 0,
+            nonce: block_index,
+            data,
+            timestamp: block_timestamp,
+            chain_id: 0,
+            signature: String::new(),
+            public_key: String::new(),
+        };
+        tx.txid = tx.compute_txid();
+        Ok(tx)
+    }
+
     pub fn is_coinbase(&self) -> bool {
         self.from_address == COINBASE_ADDRESS
     }
@@ -253,6 +291,23 @@ impl Transaction {
     /// Format: data starts with "EVM:" and signature contains the original RLP-encoded tx.
     pub fn is_evm_tx(&self) -> bool {
         self.data.starts_with("EVM:")
+    }
+
+    /// Returns true if this tx carries a `StakingOp::JailEvidenceBundle` payload.
+    /// Used by Phase D consensus-jail emission — system-emitted txs at epoch
+    /// boundaries when post-fork. Auth via PROTOCOL_TREASURY sender + Pass-1
+    /// recompute-and-compare in dispatch.
+    pub fn is_jail_evidence_bundle_tx(&self) -> bool {
+        // Cheap pre-check: StakingOp uses #[serde(tag = "op", rename_all =
+        // "snake_case")], so the variant tag in JSON is "jail_evidence_bundle".
+        if !self.data.contains("\"jail_evidence_bundle\"") {
+            return false;
+        }
+        // Only accept if payload is well-formed StakingOp::JailEvidenceBundle
+        matches!(
+            serde_json::from_str::<StakingOp>(&self.data),
+            Ok(StakingOp::JailEvidenceBundle { .. })
+        )
     }
 
     // Canonical signing payload uses BTreeMap for deterministic key ordering across all nodes
@@ -312,6 +367,25 @@ impl Transaction {
         // signature recovery. The original RLP-encoded tx is stored in `signature`
         // for re-verification at block validation time.
         if self.is_evm_tx() {
+            return Ok(());
+        }
+
+        // Phase D: system-emitted JailEvidenceBundle txs (consensus-applied
+        // jail decisions) bypass signature verification. Authorization model:
+        // - tx.from_address == PROTOCOL_TREASURY (system actor)
+        // - tx.data is JSON-encoded StakingOp::JailEvidenceBundle
+        // - signature + public_key empty
+        // - dispatch (block_executor) verifies evidence cryptographically by
+        //   recomputing from local LivenessTracker — non-matching evidence
+        //   rejects the block at Pass-1
+        // Auth via consensus: this op type only valid in finalized blocks
+        // (BFT supermajority signs block, all participants verified evidence).
+        if self.from_address == PROTOCOL_TREASURY && self.is_jail_evidence_bundle_tx() {
+            if !self.signature.is_empty() || !self.public_key.is_empty() {
+                return Err(SentrixError::InvalidTransaction(
+                    "JailEvidenceBundle system tx must not have signature or public_key".into(),
+                ));
+            }
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary

Phase D foundation. Implements the system-tx auth model (**Q1 → Option B** from `audits/consensus-jail-phase-d-scoping.md`) plus the proposer-side helper to build a `JailEvidenceBundle` system transaction.

**Ships INERT code**: nothing calls `build_jail_evidence_system_tx` yet (Step 3 wires block_producer in a follow-up). With `JAIL_CONSENSUS_HEIGHT` default = `u64::MAX`, helper is unreachable on production paths. **Safe to merge.**

## Changes

### sentrix-primitives
- `Transaction::new_jail_evidence_bundle()` — builds system tx (sender=`PROTOCOL_TREASURY`, sig/pubkey empty, data=JSON-encoded `StakingOp::JailEvidenceBundle`)
- `Transaction::is_jail_evidence_bundle_tx()` — payload sniff matching serde tag `"jail_evidence_bundle"`
- `Transaction::verify()` — Phase D special-case: `PROTOCOL_TREASURY` sender + JailEvidenceBundle data + empty sig/pubkey ⇒ passes. **Auth via consensus**: dispatch (block_executor) recomputes evidence locally and rejects the block if it diverges.

### sentrix-core
- `Blockchain::build_jail_evidence_system_tx(next_height, ts) -> Option<Transaction>`
  - `None` pre-fork
  - `None` at non-boundary heights
  - `None` if no validators meet jail threshold (Q3-A: skip empty bundles)
  - `Some(tx)` at epoch-boundary post-fork with downtime evidence

## Tests

4 new tests, all pass. Full suite green: **47 primitives + 201 core**, clippy clean.

## NOT in this PR

Steps 3-7 (block_producer wiring, Pass-1 presence check, 4-validator integ test, testnet bake, mainnet activation) — separate PRs after Q1 confirmation. Gate stays disabled.

## Test plan

- [x] `cargo test -p sentrix-core --lib build_jail_evidence_system_tx -- --test-threads=1` (4/4)
- [x] `cargo test -p sentrix-primitives --lib` (47/47)
- [x] `cargo test -p sentrix-core --lib` (201/201)
- [x] `cargo clippy -p sentrix-primitives -p sentrix-core -- -D warnings`

Refs: `audits/consensus-jail-phase-d-scoping.md` (Q1 Option B, Step 1, Step 2)