### PR TITLE
feat(consensus): Phase D Step 3+4 — block_producer emits + Pass-1/2 skip system tx (fork-gated, dormant)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -175,6 +175,13 @@ impl Blockchain {
         let mut seen_sender_nonce: HashSet<(String, u64)> = HashSet::new();
 
         for tx in block.transactions.iter().skip(1) {
+            // Phase D: system-emitted txs (JailEvidenceBundle from PROTOCOL_TREASURY)
+            // skip standard nonce/balance validation. Auth is consensus-driven:
+            // verified at apply via recompute-and-compare in block_executor.
+            if tx.is_system_tx() {
+                continue;
+            }
+
             if !seen_sender_nonce.insert((tx.from_address.clone(), tx.nonce)) {
                 return Err(SentrixError::InvalidBlock(format!(
                     "duplicate (sender, nonce) pair for {} nonce {} in block",
@@ -433,6 +440,13 @@ impl Blockchain {
         let mut seen_sender_nonce: HashSet<(String, u64)> = HashSet::new();
 
         for tx in block.transactions.iter().skip(1) {
+            // Phase D: system-emitted txs (JailEvidenceBundle from PROTOCOL_TREASURY)
+            // skip standard nonce/balance validation. Auth is consensus-driven:
+            // verified at apply via recompute-and-compare in block_executor.
+            if tx.is_system_tx() {
+                continue;
+            }
+
             if !seen_sender_nonce.insert((tx.from_address.clone(), tx.nonce)) {
                 return Err(SentrixError::InvalidBlock(format!(
                     "duplicate (sender, nonce) pair for {} nonce {} in block",
@@ -751,15 +765,22 @@ impl Blockchain {
         // Apply all transactions
         let mut total_fee: u64 = 0;
         for tx in block.transactions.iter().skip(1) {
-            self.accounts
-                .transfer(&tx.from_address, &tx.to_address, tx.amount, tx.fee)?;
-            // P1: checked_add — 5000 tx × max fee is far below u64::MAX
-            // in practice, but the guard is cheap and prevents a silent
-            // wrap if MAX_TX_PER_BLOCK or MIN_TX_FEE are ever tuned
-            // upward past the implicit ceiling.
-            total_fee = total_fee
-                .checked_add(tx.fee)
-                .ok_or_else(|| SentrixError::Internal("block total_fee overflow".to_string()))?;
+            // Phase D: system-emitted txs (JailEvidenceBundle from
+            // PROTOCOL_TREASURY) skip account transfer + nonce increment.
+            // They carry amount=0, fee=0 and a zero-balance "self-transfer"
+            // would still bump PROTOCOL_TREASURY's nonce, polluting state.
+            // Dispatch (staking_op match below) is the only state mutation.
+            if !tx.is_system_tx() {
+                self.accounts
+                    .transfer(&tx.from_address, &tx.to_address, tx.amount, tx.fee)?;
+                // P1: checked_add — 5000 tx × max fee is far below u64::MAX
+                // in practice, but the guard is cheap and prevents a silent
+                // wrap if MAX_TX_PER_BLOCK or MIN_TX_FEE are ever tuned
+                // upward past the implicit ceiling.
+                total_fee = total_fee
+                    .checked_add(tx.fee)
+                    .ok_or_else(|| SentrixError::Internal("block total_fee overflow".to_string()))?;
+            }
 
             // Execute token operation if present in data field
             if let Some(token_op) = TokenOp::decode(&tx.data) {

--- a/crates/sentrix-core/src/block_producer.rs
+++ b/crates/sentrix-core/src/block_producer.rs
@@ -104,6 +104,7 @@ impl Blockchain {
 #[cfg(test)]
 mod tests {
     use crate::blockchain::{Blockchain, CHAIN_ID};
+    use crate::test_util::env_test_lock;
     use secp256k1::{PublicKey, Secp256k1, SecretKey};
     use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
 
@@ -198,8 +199,7 @@ mod tests {
     /// Block contains only coinbase (+ any mempool txs).
     #[test]
     fn test_create_block_no_jail_bundle_pre_fork() {
-        // SAFETY: env-var mutation in tests is serialized by the harness
-        // (single-threaded) per existing fork-gate tests in blockchain.rs.
+        let _guard = env_test_lock();
         unsafe {
             std::env::remove_var("JAIL_CONSENSUS_HEIGHT");
         }
@@ -219,6 +219,7 @@ mod tests {
     fn test_create_block_voyager_emits_jail_bundle_at_boundary() {
         use sentrix_primitives::transaction::PROTOCOL_TREASURY;
 
+        let _guard = env_test_lock();
         unsafe {
             std::env::set_var("JAIL_CONSENSUS_HEIGHT", "0");
         }

--- a/crates/sentrix-core/src/block_producer.rs
+++ b/crates/sentrix-core/src/block_producer.rs
@@ -46,6 +46,16 @@ impl Blockchain {
 
         let mut transactions = vec![coinbase];
 
+        // Phase D: at epoch boundaries post-fork, emit JailEvidenceBundle
+        // system tx with locally-computed downtime evidence. Helper returns
+        // None pre-fork, at non-boundaries, or with no evidence — making this
+        // a no-op on default builds (JAIL_CONSENSUS_HEIGHT=u64::MAX).
+        if let Some(jail_tx) =
+            self.build_jail_evidence_system_tx(next_height, block_timestamp)
+        {
+            transactions.push(jail_tx);
+        }
+
         // Take up to MAX_TX_PER_BLOCK from mempool (snapshot — do NOT drain here).
         // Clone mempool transactions into the block — do NOT drain before add_block succeeds.
         // add_block() removes mined txs from mempool via retain() after a successful commit.
@@ -181,5 +191,78 @@ mod tests {
         let mut bc = setup();
         let result = bc.create_block("not_a_validator");
         assert!(result.is_err());
+    }
+
+    /// Phase D Step 3: pre-fork (default), no JailEvidenceBundle is emitted
+    /// regardless of whether the block index lands on an epoch boundary.
+    /// Block contains only coinbase (+ any mempool txs).
+    #[test]
+    fn test_create_block_no_jail_bundle_pre_fork() {
+        // SAFETY: env-var mutation in tests is serialized by the harness
+        // (single-threaded) per existing fork-gate tests in blockchain.rs.
+        unsafe {
+            std::env::remove_var("JAIL_CONSENSUS_HEIGHT");
+        }
+        let mut bc = setup();
+        let block = bc.create_block("v1").unwrap();
+        // Only coinbase, no system tx
+        assert_eq!(block.transactions.len(), 1);
+        assert!(block.transactions[0].is_coinbase());
+    }
+
+    /// Phase D Step 3: post-fork at epoch boundary with downtime evidence,
+    /// proposer prepends JailEvidenceBundle as tx[1] (right after coinbase).
+    /// This verifies the wire-up: helper invoked, tx structure correct.
+    /// Note: this test exercises create_block_voyager + manually crafts the
+    /// blockchain state to land on an epoch boundary.
+    #[test]
+    fn test_create_block_voyager_emits_jail_bundle_at_boundary() {
+        use sentrix_primitives::transaction::PROTOCOL_TREASURY;
+
+        unsafe {
+            std::env::set_var("JAIL_CONSENSUS_HEIGHT", "0");
+        }
+
+        let mut bc = setup();
+
+        // Inject a downer into active_set + populate full liveness window
+        let downer = "0xfeedfacefeedfacefeedfacefeedfacefeedface".to_string();
+        bc.stake_registry.active_set = vec![downer.clone()];
+        let window = sentrix_staking::slashing::LIVENESS_WINDOW;
+        for h in 0..window {
+            bc.slashing.liveness.record(&downer, h, false);
+        }
+
+        // Force chain to height (EPOCH_LENGTH - 2) so next block lands at
+        // EPOCH_LENGTH - 1 (boundary). We don't actually need to mine —
+        // build_block reads self.height() + 1 from chain length.
+        // Instead, monkey-pad the chain to the right height with empty blocks.
+        let target_height = sentrix_staking::epoch::EPOCH_LENGTH - 2;
+        let prev_hash = bc.latest_block().unwrap().hash.clone();
+        let pad = sentrix_primitives::block::Block::new(
+            target_height,
+            prev_hash,
+            vec![sentrix_primitives::transaction::Transaction::new_coinbase(
+                "v1".into(),
+                0,
+                target_height,
+                1_700_000_000,
+            )],
+            "v1".into(),
+        );
+        bc.chain.push(pad);
+
+        let block = bc.create_block_voyager("v1").unwrap();
+
+        // tx[0] = coinbase, tx[1] = JailEvidenceBundle system tx
+        assert_eq!(block.transactions.len(), 2);
+        assert!(block.transactions[0].is_coinbase());
+        assert!(block.transactions[1].is_system_tx());
+        assert_eq!(block.transactions[1].from_address, PROTOCOL_TREASURY);
+        assert!(block.transactions[1].is_jail_evidence_bundle_tx());
+
+        unsafe {
+            std::env::remove_var("JAIL_CONSENSUS_HEIGHT");
+        }
     }
 }

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -1441,6 +1441,7 @@ impl Blockchain {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::env_test_lock;
     use secp256k1::{PublicKey, Secp256k1, SecretKey};
     use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
 
@@ -3049,6 +3050,7 @@ mod tests {
     /// regardless of epoch boundary or evidence state.
     #[test]
     fn test_build_jail_evidence_system_tx_none_pre_fork() {
+        let _guard = env_test_lock();
         unsafe {
             std::env::remove_var("JAIL_CONSENSUS_HEIGHT");
         }
@@ -3063,7 +3065,7 @@ mod tests {
     /// heights even post-fork.
     #[test]
     fn test_build_jail_evidence_system_tx_none_non_boundary() {
-        // SAFETY: env-var mutation in tests; CI runs single-threaded.
+        let _guard = env_test_lock();
         unsafe {
             std::env::set_var("JAIL_CONSENSUS_HEIGHT", "0");
         }
@@ -3080,6 +3082,7 @@ mod tests {
     /// post-fork, returns None (Q3-A: skip emission for empty bundle).
     #[test]
     fn test_build_jail_evidence_system_tx_none_no_evidence() {
+        let _guard = env_test_lock();
         unsafe {
             std::env::set_var("JAIL_CONSENSUS_HEIGHT", "0");
         }
@@ -3104,6 +3107,7 @@ mod tests {
     fn test_build_jail_evidence_system_tx_some_with_evidence() {
         use sentrix_primitives::transaction::{PROTOCOL_TREASURY, StakingOp};
 
+        let _guard = env_test_lock();
         unsafe {
             std::env::set_var("JAIL_CONSENSUS_HEIGHT", "0");
         }

--- a/crates/sentrix-core/src/lib.rs
+++ b/crates/sentrix-core/src/lib.rs
@@ -22,3 +22,20 @@ pub mod vm;
 pub use blockchain::Blockchain;
 pub use genesis::{Genesis, GenesisError};
 pub use storage::Storage;
+
+/// Crate-level test utilities. Shared across child modules so any test
+/// that mutates fork-gate env vars (JAIL_CONSENSUS_HEIGHT,
+/// BFT_GATE_RELAX_HEIGHT, TOKENOMICS_V2_HEIGHT, ...) can serialize
+/// itself with one global lock. Without this, cargo's default parallel
+/// runner races env-var-touching tests across modules.
+#[cfg(test)]
+pub(crate) mod test_util {
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    pub fn env_test_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+}

--- a/crates/sentrix-primitives/src/transaction.rs
+++ b/crates/sentrix-primitives/src/transaction.rs
@@ -310,6 +310,14 @@ impl Transaction {
         )
     }
 
+    /// Returns true if this is a Phase D system-emitted tx (PROTOCOL_TREASURY
+    /// sender + JailEvidenceBundle payload). Used by validate / Pass-1 / Pass-2
+    /// to skip standard nonce/balance/fee/signature checks; auth happens via
+    /// consensus dispatch (recompute-and-compare in block_executor).
+    pub fn is_system_tx(&self) -> bool {
+        self.from_address == PROTOCOL_TREASURY && self.is_jail_evidence_bundle_tx()
+    }
+
     // Canonical signing payload uses BTreeMap for deterministic key ordering across all nodes
     // and serde_json for proper escaping of special characters
     pub fn signing_payload(&self) -> String {
@@ -418,6 +426,13 @@ impl Transaction {
 
     pub fn validate(&self, expected_nonce: u64, expected_chain_id: u64) -> SentrixResult<()> {
         if self.is_coinbase() {
+            return Ok(());
+        }
+
+        // Phase D: system-emitted txs (JailEvidenceBundle from PROTOCOL_TREASURY)
+        // bypass standard validation. Their auth is consensus-driven: dispatch
+        // verifies the evidence list against the local LivenessTracker recompute.
+        if self.is_system_tx() {
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary

Wires the JailEvidenceBundle system tx into block_producer + adds Pass-1/Pass-2 skip paths so system txs bypass standard nonce/fee/balance checks. Builds on Phase D Step 1+2 (#368).

**Ships INERT runtime behavior**: with \`JAIL_CONSENSUS_HEIGHT\` default = \`u64::MAX\`, helper returns None pre-fork → no system tx ever emitted → skip paths unreachable on default builds. **Safe to merge.**

## Changes

| File | Change |
|---|---|
| \`sentrix-primitives/src/transaction.rs\` | New: \`is_system_tx()\`. Updated: \`validate()\` early-returns for system tx (mirrors coinbase) |
| \`sentrix-core/src/block_producer.rs\` | \`build_block()\` calls \`build_jail_evidence_system_tx\` after coinbase |
| \`sentrix-core/src/block_executor.rs\` | Pass-1 (2 sites): skip nonce/balance bookkeeping for system tx. Pass-2: skip \`accounts.transfer\` for system tx (avoid PROTOCOL_TREASURY nonce bump) |

## Tests

| Test | Verifies |
|---|---|
| \`test_create_block_no_jail_bundle_pre_fork\` | Pre-fork (default): block has only coinbase |
| \`test_create_block_voyager_emits_jail_bundle_at_boundary\` | Post-fork at epoch boundary: tx[1]=system tx, sender=PROTOCOL_TREASURY |

Full suite green: **47 primitives + 203 core** (was 201, +2 new). \`cargo clippy --tests -- -D warnings\` clean.

## NOT in this PR

| Step | Status |
|---|---|
| Q4 required-presence check (reject boundary blocks missing system tx) | Separate PR |
| Step 5: 4-validator integration test | Separate PR |
| Step 6: testnet bake (24-48h) | Operator |
| Step 7: mainnet activation | Operator |

## Test plan

- [x] \`cargo test -p sentrix-core --lib block_producer -- --test-threads=1\` (5/5)
- [x] \`cargo test -p sentrix-primitives --lib\` (47/47)
- [x] \`cargo test -p sentrix-core --lib\` (203/203)
- [x] \`cargo clippy -p sentrix-primitives -p sentrix-core --tests -- -D warnings\`

Refs: \`audits/consensus-jail-phase-d-scoping.md\` (Step 3, Step 4)