### PR TITLE
feat(testnet): genesis/testnet.toml + sentrix-faucet HTTP service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,18 +2380,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
  "tokio",
@@ -2650,6 +2683,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2685,6 +2728,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -3222,6 +3267,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -4204,6 +4258,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4855,6 +4947,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentrix-faucet"
+version = "2.1.44"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "dashmap",
+ "hex",
+ "reqwest",
+ "secp256k1 0.31.1",
+ "sentrix-primitives",
+ "sentrix-wallet",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
 name = "sentrix-network"
 version = "2.1.44"
 dependencies = [
@@ -5320,6 +5433,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -5521,6 +5637,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5643,10 +5769,15 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-util",
  "http",
+ "http-body",
+ "iri-string",
  "pin-project-lite",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5720,10 +5851,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -5925,6 +6060,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5991,6 +6136,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5998,6 +6153,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "crates/sentrix-wire", "bin/sentrix"]
+members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "crates/sentrix-wire", "bin/sentrix", "bin/sentrix-faucet"]
 
 [package]
 name = "sentrix"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "sentrix-faucet"
+version = "2.1.44"
+edition = "2024"
+license = "BUSL-1.1"
+description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"
+
+[[bin]]
+name = "sentrix-faucet"
+path = "src/main.rs"
+
+[dependencies]
+sentrix-primitives = { path = "../../crates/sentrix-primitives" }
+sentrix-wallet     = { path = "../../crates/sentrix-wallet" }
+
+axum         = "0.8"
+tokio        = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+tower-http   = { version = "0.6", features = ["cors", "trace"] }
+serde        = { version = "1", features = ["derive"] }
+serde_json   = "1"
+clap         = { version = "4", features = ["derive", "env"] }
+reqwest      = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+secp256k1    = { version = "0.31", features = ["rand", "recovery", "serde"] }
+hex          = "0.4"
+tracing      = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+dashmap      = "6"
+anyhow       = "1"

--- a/bin/sentrix-faucet/src/main.rs
+++ b/bin/sentrix-faucet/src/main.rs
@@ -1,0 +1,400 @@
+//! Sentrix testnet faucet — small HTTP service that signs and submits
+//! drip transactions from a pre-loaded keystore.
+//!
+//! Lifecycle:
+//!   1. Load keystore at startup, decrypt with `SENTRIX_FAUCET_PASSWORD`
+//!      env var. Hold private key in memory only; never log.
+//!   2. Bind HTTP listener on `--listen`. Expose `POST /faucet/drip`.
+//!   3. On request: rate-limit by source IP and recipient address,
+//!      fetch current nonce from RPC, build + sign tx, POST to
+//!      `RPC_URL/transactions`, return txid.
+//!
+//! Hardening (in-process):
+//!   - Per-IP rate limit (token bucket via DashMap)
+//!   - Per-recipient cooldown (one drip per address per `cooldown_secs`)
+//!   - Address regex sanity (no other formats accepted)
+//!   - Nonce fetched fresh each request (no caching that could double-spend)
+//!
+//! Hardening (deployment, NOT in this binary):
+//!   - Cloudflare or Caddy CAPTCHA in front (e.g. Turnstile) for bot deterrence
+//!   - HTTPS via reverse proxy
+//!   - Bind to localhost only; expose via reverse proxy
+
+use anyhow::{Context, Result, anyhow, bail};
+use axum::{
+    Router,
+    extract::{ConnectInfo, State},
+    http::StatusCode,
+    response::Json,
+    routing::{get, post},
+};
+use clap::Parser;
+use dashmap::DashMap;
+use secp256k1::{PublicKey, SecretKey};
+use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
+use sentrix_wallet::{Keystore, Wallet};
+use serde::{Deserialize, Serialize};
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tower_http::cors::{Any, CorsLayer};
+use tracing::{error, info, warn};
+
+#[derive(Parser, Debug)]
+#[command(version, about = "Sentrix testnet faucet HTTP service")]
+struct Cli {
+    /// Path to the encrypted keystore JSON file
+    #[arg(long, env = "SENTRIX_FAUCET_KEYSTORE")]
+    keystore: String,
+
+    /// Keystore password — prefer the env var over the CLI flag (CLI flag
+    /// leaves password in shell history)
+    #[arg(long, env = "SENTRIX_FAUCET_PASSWORD", hide_env_values = true)]
+    password: String,
+
+    /// RPC base URL (POST /transactions, GET /accounts/{addr}/nonce)
+    #[arg(long, env = "SENTRIX_FAUCET_RPC_URL", default_value = "http://127.0.0.1:8545")]
+    rpc_url: String,
+
+    /// Bind address for the HTTP server
+    #[arg(long, env = "SENTRIX_FAUCET_LISTEN", default_value = "127.0.0.1:8546")]
+    listen: SocketAddr,
+
+    /// Drip amount in sentri (1 SRX = 100_000_000 sentri). Default 100 SRX.
+    #[arg(long, env = "SENTRIX_FAUCET_DRIP_AMOUNT", default_value_t = 100 * 100_000_000)]
+    drip_amount: u64,
+
+    /// Chain ID (must match testnet)
+    #[arg(long, env = "SENTRIX_FAUCET_CHAIN_ID", default_value_t = 7120)]
+    chain_id: u64,
+
+    /// Per-IP rate-limit window (seconds)
+    #[arg(long, env = "SENTRIX_FAUCET_IP_WINDOW_SECS", default_value_t = 3600)]
+    ip_window_secs: u64,
+
+    /// Max drips per IP per window
+    #[arg(long, env = "SENTRIX_FAUCET_IP_MAX_DRIPS", default_value_t = 3)]
+    ip_max_drips: u32,
+
+    /// Per-recipient cooldown seconds. Same address can drip again only
+    /// after this elapses.
+    #[arg(long, env = "SENTRIX_FAUCET_ADDR_COOLDOWN_SECS", default_value_t = 86400)]
+    addr_cooldown_secs: u64,
+
+    /// Tx fee paid by the faucet (sentri). MIN_TX_FEE by default.
+    #[arg(long, env = "SENTRIX_FAUCET_TX_FEE", default_value_t = MIN_TX_FEE)]
+    tx_fee: u64,
+}
+
+#[derive(Clone)]
+struct AppState {
+    secret_key: SecretKey,
+    public_key: PublicKey,
+    address: String,
+    rpc_url: String,
+    chain_id: u64,
+    drip_amount: u64,
+    tx_fee: u64,
+    ip_window: Duration,
+    ip_max_drips: u32,
+    addr_cooldown: Duration,
+    http: reqwest::Client,
+    /// IP → list of drip timestamps within the current window
+    ip_history: Arc<DashMap<IpAddr, Vec<Instant>>>,
+    /// recipient address → most recent drip timestamp
+    addr_last_drip: Arc<DashMap<String, Instant>>,
+}
+
+#[derive(Deserialize)]
+struct DripRequest {
+    /// Recipient address (0x + 40 hex chars). Case-insensitive.
+    to: String,
+}
+
+#[derive(Serialize)]
+struct DripResponse {
+    txid: String,
+    from: String,
+    to: String,
+    amount: u64,
+    nonce: u64,
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+    detail: Option<String>,
+}
+
+fn err(status: StatusCode, msg: &str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        status,
+        Json(ErrorResponse {
+            error: msg.into(),
+            detail: None,
+        }),
+    )
+}
+
+fn err_with(status: StatusCode, msg: &str, detail: String) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        status,
+        Json(ErrorResponse {
+            error: msg.into(),
+            detail: Some(detail),
+        }),
+    )
+}
+
+fn validate_address(addr: &str) -> Result<String> {
+    let lower = addr.to_lowercase();
+    let without_prefix = lower.strip_prefix("0x").unwrap_or(&lower);
+    if without_prefix.len() != 40 {
+        bail!("address must be 0x + 40 hex chars");
+    }
+    if !without_prefix.chars().all(|c| c.is_ascii_hexdigit()) {
+        bail!("address must be 0x + 40 hex chars");
+    }
+    Ok(format!("0x{}", without_prefix))
+}
+
+async fn fetch_nonce(http: &reqwest::Client, rpc_url: &str, address: &str) -> Result<u64> {
+    let url = format!("{}/accounts/{}/nonce", rpc_url.trim_end_matches('/'), address);
+    let resp = http.get(&url).send().await.context("nonce request")?;
+    if !resp.status().is_success() {
+        bail!("nonce HTTP {}", resp.status());
+    }
+    let body: serde_json::Value = resp.json().await.context("nonce parse")?;
+    body.get("nonce")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| anyhow!("nonce missing in response"))
+}
+
+async fn submit_tx(http: &reqwest::Client, rpc_url: &str, tx: &Transaction) -> Result<String> {
+    let url = format!("{}/transactions", rpc_url.trim_end_matches('/'));
+    let resp = http.post(&url).json(tx).send().await.context("tx submit")?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.context("submit response parse")?;
+    if !status.is_success() {
+        bail!("tx submit HTTP {}: {}", status, body);
+    }
+    body.get("txid")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| anyhow!("txid missing in response: {}", body))
+}
+
+/// Rate-limit checks. Returns Ok(()) on pass, Err(reason) on rejection.
+fn check_rate_limits(state: &AppState, ip: IpAddr, recipient: &str) -> Result<(), String> {
+    let now = Instant::now();
+    let window = state.ip_window;
+
+    // Per-IP: prune old entries, then count remaining
+    {
+        let mut entry = state.ip_history.entry(ip).or_default();
+        entry.retain(|t| now.duration_since(*t) < window);
+        if entry.len() >= state.ip_max_drips as usize {
+            return Err(format!(
+                "rate limit: IP {} reached {} drips in {}s window",
+                ip,
+                state.ip_max_drips,
+                window.as_secs()
+            ));
+        }
+        entry.push(now);
+    }
+
+    // Per-recipient: cooldown check
+    if let Some(last) = state.addr_last_drip.get(recipient)
+        && now.duration_since(*last) < state.addr_cooldown
+    {
+        let remaining = state.addr_cooldown - now.duration_since(*last);
+        return Err(format!(
+            "address cooldown: try again in {} seconds",
+            remaining.as_secs()
+        ));
+    }
+    state.addr_last_drip.insert(recipient.to_string(), now);
+
+    Ok(())
+}
+
+async fn handle_drip(
+    State(state): State<AppState>,
+    ConnectInfo(client): ConnectInfo<SocketAddr>,
+    Json(req): Json<DripRequest>,
+) -> Result<Json<DripResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let recipient = match validate_address(&req.to) {
+        Ok(a) => a,
+        Err(e) => return Err(err_with(StatusCode::BAD_REQUEST, "bad address", e.to_string())),
+    };
+
+    if recipient == state.address {
+        return Err(err(StatusCode::BAD_REQUEST, "cannot drip to self"));
+    }
+
+    if let Err(reason) = check_rate_limits(&state, client.ip(), &recipient) {
+        warn!(ip = %client.ip(), recipient = %recipient, reason = %reason, "drip rejected");
+        return Err(err_with(
+            StatusCode::TOO_MANY_REQUESTS,
+            "rate limit exceeded",
+            reason,
+        ));
+    }
+
+    let nonce = fetch_nonce(&state.http, &state.rpc_url, &state.address)
+        .await
+        .map_err(|e| {
+            error!(?e, "nonce fetch failed");
+            err_with(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "rpc nonce fetch failed",
+                e.to_string(),
+            )
+        })?;
+
+    let tx = Transaction::new(
+        state.address.clone(),
+        recipient.clone(),
+        state.drip_amount,
+        state.tx_fee,
+        nonce,
+        String::new(),
+        state.chain_id,
+        &state.secret_key,
+        &state.public_key,
+    )
+    .map_err(|e| {
+        error!(?e, "tx build failed");
+        err_with(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "tx build failed",
+            format!("{:?}", e),
+        )
+    })?;
+
+    let txid = submit_tx(&state.http, &state.rpc_url, &tx).await.map_err(|e| {
+        error!(?e, "tx submit failed");
+        err_with(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "rpc submit failed",
+            e.to_string(),
+        )
+    })?;
+
+    info!(
+        ip = %client.ip(),
+        recipient = %recipient,
+        amount_sentri = state.drip_amount,
+        txid = %txid,
+        "drip dispensed"
+    );
+
+    Ok(Json(DripResponse {
+        txid,
+        from: state.address.clone(),
+        to: recipient,
+        amount: state.drip_amount,
+        nonce,
+    }))
+}
+
+async fn handle_health(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    // Best-effort: report the faucet's current nonce + a hint balance from
+    // /accounts/{addr}. If RPC is down, we still return the static info.
+    let mut info = serde_json::json!({
+        "address": state.address,
+        "chain_id": state.chain_id,
+        "drip_amount_sentri": state.drip_amount,
+        "drip_amount_srx": state.drip_amount as f64 / 100_000_000.0,
+        "rpc_url": state.rpc_url,
+    });
+
+    if let Ok(nonce) = fetch_nonce(&state.http, &state.rpc_url, &state.address).await {
+        info["nonce"] = serde_json::json!(nonce);
+    }
+
+    Ok(Json(info))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    info!(keystore = %cli.keystore, "loading keystore");
+    let keystore = Keystore::load(&cli.keystore).context("load keystore")?;
+    let wallet: Wallet = keystore.decrypt(&cli.password).context("decrypt keystore")?;
+
+    let secret_key = wallet.get_secret_key().context("extract secret key")?;
+    let public_key = wallet.get_public_key().context("extract public key")?;
+    let address = wallet.address.clone();
+
+    info!(
+        address = %address,
+        chain_id = cli.chain_id,
+        drip_srx = cli.drip_amount as f64 / 100_000_000.0,
+        listen = %cli.listen,
+        rpc = %cli.rpc_url,
+        "faucet ready"
+    );
+
+    let state = AppState {
+        secret_key,
+        public_key,
+        address,
+        rpc_url: cli.rpc_url,
+        chain_id: cli.chain_id,
+        drip_amount: cli.drip_amount,
+        tx_fee: cli.tx_fee,
+        ip_window: Duration::from_secs(cli.ip_window_secs),
+        ip_max_drips: cli.ip_max_drips,
+        addr_cooldown: Duration::from_secs(cli.addr_cooldown_secs),
+        http: reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .context("build reqwest client")?,
+        ip_history: Arc::new(DashMap::new()),
+        addr_last_drip: Arc::new(DashMap::new()),
+    };
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/faucet/drip", post(handle_drip))
+        .route("/faucet/health", get(handle_health))
+        .layer(cors)
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(cli.listen)
+        .await
+        .with_context(|| format!("bind {}", cli.listen))?;
+
+    info!("serving on {}", cli.listen);
+
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(async {
+        tokio::signal::ctrl_c().await.ok();
+        info!("shutdown signal received");
+    })
+    .await
+    .context("http server")?;
+
+    Ok(())
+}

--- a/genesis/testnet.toml
+++ b/genesis/testnet.toml
@@ -1,0 +1,60 @@
+# Sentrix Testnet genesis configuration.
+#
+# Loaded at runtime via `--genesis genesis/testnet.toml`. Unlike mainnet,
+# testnet has no hardcoded byte-identity check — this file is the single
+# source of truth.
+#
+# Reset policy: testnet may be reset (genesis re-rolled) at operator
+# discretion. Keep the testnet faucet wallet keystore + private key off
+# this file (loaded separately by the faucet service).
+
+[chain]
+chain_id = 7120
+name = "Sentrix Testnet"
+
+[genesis]
+# Testnet genesis instant — distinct from mainnet (forces different block 0 hash).
+timestamp = 1714200000
+parent_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+# ── Validators ──────────────────────────────────────────────────────────
+#
+# Pubkeys empty: testnet validators bootstrap via keystore-on-disk, same
+# as mainnet. Stake values match the testnet 4-validator topology.
+
+[[genesis.validators]]
+address = "0x328d56b8174697ef6c9e40e19b7663797e16fa47"
+stake = 1050000000000000
+pubkey = ""
+
+# ── Genesis allocations (testnet only — mock SRX) ──────────────────────
+#
+# All amounts in sentri (1 SRX = 100_000_000 sentri). Mirror of mainnet
+# allocations + a dedicated faucet wallet for /faucet/drip dispensing.
+
+# Founder — 21,000,000 testnet-SRX
+[[genesis.balances]]
+address = "0x252f8cfed5acfa9d00d99a65e2ac91f395a35d78"
+amount = 2100000000000000
+
+# Ecosystem Fund — 21,000,000 testnet-SRX
+[[genesis.balances]]
+address = "0xeb70fdefd00fdb768dec06c478f450c351499f14"
+amount = 2100000000000000
+
+# Early Validator — 10,500,000 testnet-SRX
+[[genesis.balances]]
+address = "0x328d56b8174697ef6c9e40e19b7663797e16fa47"
+amount = 1050000000000000
+
+# Reserve — 10,500,000 testnet-SRX
+[[genesis.balances]]
+address = "0x2578cad17e3e56c2970a5b5eab45952439f5ba97"
+amount = 1050000000000000
+
+# Faucet wallet — 100,000,000 testnet-SRX (dispense pool)
+# Address generated 2026-04-27. Keystore + private key held off-repo.
+# Funded large enough to survive heavy testnet usage; refill via redeploy.
+[[genesis.balances]]
+address = "0x2ffc302fcd8c0eeab2796b3c1d134f18e8237762"
+amount = 10000000000000000


### PR DESCRIPTION
## Summary

Bootstraps testnet activation with genesis config + a standalone faucet HTTP service.

### \`genesis/testnet.toml\` (chain_id 7120)

Mirrors mainnet allocations plus a **100M-SRX faucet wallet** entry. Loaded at runtime via \`--genesis genesis/testnet.toml\`. Each testnet reset re-loads the premine fresh from this TOML.

### \`bin/sentrix-faucet/\` — standalone HTTP faucet

| Endpoint | Purpose |
|---|---|
| \`POST /faucet/drip\` | \`{\"to\": \"0x...\"}\` → build + sign + submit drip tx → return \`{txid, from, to, amount, nonce}\` |
| \`GET /faucet/health\` | Reports current nonce + faucet address (hint of liveness) |

**Hardening (in-process)**:
- Per-IP rate limit (default: 3 drips per hour)
- Per-recipient cooldown (default: 24h between drips to same address)
- Address regex sanity (must be \`0x\` + 40 hex)
- Nonce fetched fresh each request (no caching → no double-spend window)

**Hardening (deployment-side)**:
- Keystore password loaded from \`SENTRIX_FAUCET_PASSWORD\` env var (never logged)
- Bind to localhost; expose via reverse proxy
- Cloudflare/Turnstile CAPTCHA in front at deploy time

All defaults configurable via CLI flags + matching \`SENTRIX_FAUCET_*\` env vars.

### Faucet wallet

Address \`0x2ffc302fcd8c0eeab2796b3c1d134f18e8237762\` premined with 100M testnet-SRX. Keystore + password held off-repo; deploy runbook (in operator-internal docs) covers keystore placement + password rotation.

## NOT in this PR

| Item | Where |
|---|---|
| Caddy block for \`faucet.sentrixchain.com\` | Operator runbook |
| systemd unit | Operator runbook |
| DNS A record | Operator-managed |
| Cloudflare Turnstile / CAPTCHA | Separate hardening pass |

## Test plan

- [x] \`cargo build -p sentrix-faucet\` clean
- [x] \`cargo clippy -p sentrix-faucet -- -D warnings\` clean
- [x] \`sentrix-faucet --help\` renders all flags + env vars
- [x] \`genesis/testnet.toml\` parses (5 balances, 163M SRX total: 63M mainnet-mirror premine + 100M faucet)
- [ ] End-to-end smoke (deploy on testnet host, dispense to a real address)