### PR TITLE
ci: upload sentrix-faucet release binary as workflow artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,14 @@ jobs:
           path: target/release/sentrix
           retention-days: 1
 
+      - name: Upload faucet binary
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-artifact@v5
+        with:
+          name: sentrix-faucet-binary
+          path: target/release/sentrix-faucet
+          retention-days: 1
+
   # RustSec advisory scan. Runs in parallel with Test so a newly-published
   # advisory against any transitive dep surfaces in ≤ 1 CI run rather than
   # waiting for the next manual `cargo audit` sweep. Ignore list mirrors


### PR DESCRIPTION
## Summary

Mirror of the existing \`sentrix\` binary upload step. Faucet binary needed at deploy time on the testnet host (and any future net hosts); having it as a CI artifact removes the build-locally + scp friction.

Same gating as the existing sentrix binary upload: only on push to \`main\`, retention 1 day.

## Test plan

- [x] Workflow YAML lints (no syntax change beyond a single new step)
- [ ] Confirm artifact appears on next push to main (visual check)