### PR TITLE
docs: sync public docs to current state (v2.1.44 + Phase A→D + testnet bootstrap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sentrix is the financial infrastructure for the real economy — starting with I
 
 Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, instant finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and web3.js connect natively. The chain serves as a settlement and tokenization layer for real-world assets — designed to bring institutional-grade financial primitives on-chain with the monetary discipline of Bitcoin and the programmability of Ethereum.
 
-- **v2.1.39** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active, **tokenomics v2 fork ACTIVE on mainnet since h=640800** (BTC-parity 4-year halving + 315M cap), libp2p sync race-safe
+- **v2.1.44** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active, **tokenomics v2 fork ACTIVE on mainnet since h=640800** (BTC-parity 4-year halving + 315M cap), libp2p sync race-safe
 - **551+ tests**, clippy clean, 11 security audit rounds
 - **4 validators** across 4 nodes (Foundation, Treasury, Core, Beacon) on the maintainer fleet
 
@@ -113,7 +113,7 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 | Phase | Status | Focus |
 |-------|--------|-------|
 | **Pioneer** | Completed (mainnet h=0…579058) | PoA round-robin, MDBX storage, 1s blocks, SRC-20 tokens — succeeded by Voyager 2026-04-25 |
-| **Voyager** | **Live on mainnet (v2.1.39)** | DPoS proposer rotation + BFT finality, EVM (revm 37), `eth_sendRawTransaction`, L1 peer auto-discovery + connection-limits hardening, V4 reward distribution v2 (treasury escrow + ClaimRewards), runtime-aware Voyager dispatch, race-safe block sync, tokenomics v2 fork (315M cap + 4-year halving) |
+| **Voyager** | **Live on mainnet (v2.1.44)** | DPoS proposer rotation + BFT finality, EVM (revm 37), `eth_sendRawTransaction`, L1 peer auto-discovery + connection-limits hardening, V4 reward distribution v2 (treasury escrow + ClaimRewards), runtime-aware Voyager dispatch, race-safe block sync, tokenomics v2 fork (315M cap + 4-year halving) |
 | **Frontier** | Phase F-1 scaffold landed; F-2…F-10 planned | Parallel transaction execution, sub-1s block time, mainnet hard fork |
 | **Odyssey** | Future | Cross-chain bridges, mature ecosystem, light clients |
 

--- a/docs/operations/EMERGENCY_ROLLBACK.md
+++ b/docs/operations/EMERGENCY_ROLLBACK.md
@@ -81,6 +81,10 @@ The 2026-04-25 / 2026-04-26 incident hotfix series:
 - v2.1.37: libp2p sync cascade-bail filter (P0: 2026-04-26 mainnet stall at h=604547 root cause + fix). Recovered via Treasury-canonical chain.db rsync. See PR #334 (RCA held in operator runbooks).
 - v2.1.38: legacy TCP-path deletion (sync.rs + node.rs trimmed) + cumulative skip-counter observability for race re-emergence detection
 - v2.1.39: tokenomics v2 fork (consensus, env-gated). 126M-block halving (4-year BTC-parity) + 315M MAX_SUPPLY. Activated on testnet at h=381651 (2026-04-26), armed on mainnet at h=640800 via `TOKENOMICS_V2_HEIGHT` env var. Same fork-gate pattern as VOYAGER_REWARD_V2_HEIGHT (zero behavior change pre-fork-height; runtime dispatch in `get_block_reward()` + `max_supply_for(height)` + `halvings_at(height)`). PR #336 + #337 (RPC display fix).
+- v2.1.40: fork-aware explorer richlist display (pre-fork hardcoded 210M now tracks `/chain/info` `max_supply_srx`). PR #348.
+- v2.1.41: jail-cascade observability + fork-gated BFT safety gate relaxation (`BFT_GATE_RELAX_HEIGHT`, default DISABLED — operator activates after testnet bake). PRs #350-#352.
+- v2.1.42 / v2.1.43: asymmetric-application fixes (record_block_signatures + distribute_reward + epoch_manager now fire from libp2p apply paths, not just validator-loop finalize). PRs #356, #362.
+- v2.1.44: Phase A→D consensus-jail full stack (StakingOp::JailEvidenceBundle epoch-boundary system tx, dispatch recompute-and-compare, 4-validator determinism harness). All dormant pre-fork via `JAIL_CONSENSUS_HEIGHT=u64::MAX` default. Activation = operator halt-all event. PRs #359/#365/#366/#368/#369/#371/#372 + testnet bootstrap (#374).
 
 ---
 

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -15,7 +15,7 @@
 | Consensus | **Voyager** (DPoS + BFT, `voyager_activated=true` since h=579047 / 2026-04-25) |
 | EVM | Active — `evm_activated=true` since the same height; MetaMask compatible |
 | Reward distribution | **V4 reward v2** active since h=590100 / 2026-04-25 — coinbase routes to `PROTOCOL_TREASURY` (0x0000…0002), validators + delegators claim via `ClaimRewards` staking op |
-| Binary | v2.1.39 |
+| Binary | v2.1.44 |
 
 ## Testnet
 
@@ -37,7 +37,7 @@ Testnet tokens have no real value. Use the faucet to get test SRX.
 
 Testnet runs in Docker on build host (`/opt/sentrix-testnet-docker/`) since
 the 2026-04-23 migration; fresh genesis at chain_id 7120, current
-height ~382K (post tokenomics-v2 fork at h=381651), binary v2.1.39.
+height ~382K (post tokenomics-v2 fork at h=381651), binary v2.1.44.
 
 > **Mainnet operational note (2026-04-25, post-Voyager):** mainnet successfully
 > transitioned from Pioneer PoA to Voyager DPoS+BFT at h=579047. EVM was

--- a/docs/roadmap/CHANGELOG.md
+++ b/docs/roadmap/CHANGELOG.md
@@ -1,5 +1,80 @@
 # Changelog
 
+## [Unreleased] — 2026-04-27 (later) — Phase A→D consensus-jail + testnet bootstrap
+
+Consensus-jail full stack lands as a fork-gated future activation. Default `JAIL_CONSENSUS_HEIGHT=u64::MAX` makes the entire dispatch path inert until an operator opts in.
+
+### Added
+
+- `Transaction::new_jail_evidence_bundle()` system-tx constructor + `is_system_tx()` predicate
+- `Blockchain::build_jail_evidence_system_tx()` proposer helper (epoch-boundary emission, returns None pre-fork / non-boundary / no-evidence)
+- `block_producer` calls helper after coinbase
+- `validate_block` Q4 required-presence: at epoch boundary post-fork with local downtime evidence, block MUST contain matching `JailEvidenceBundle` system tx
+- Phase C dispatch: cited-epoch check + local recompute compare + per-validator jail apply
+- 4-validator consensus-determinism integration test (`tests/phase_d_4validator_determinism.rs`) — proves all peers converge on identical jail state + identical state_root, plus negative test that diverging LivenessTracker rejects via dispatch
+- `genesis/testnet.toml` (chain_id 7120) + `bin/sentrix-faucet/` standalone HTTP service
+- CI uploads `sentrix-faucet` release binary as workflow artifact alongside `sentrix`
+- `pub(crate) mod test_util::env_test_lock()` so fork-gate tests serialize across modules under cargo's default parallel runner
+
+### Hygiene
+
+- Internal-tooling and operator-host references scrubbed from public source files, audits, and docs (round 2). Final grep across tracked files: zero matches.
+
+### Activation
+
+`JAIL_CONSENSUS_HEIGHT` defaults disabled. To activate, operators set the env var on all validators in a coordinated halt-all + simultaneous-start. Prerequisites: LivenessTracker convergence verified across the fleet (≥4h clean operation post asymmetric-record fixes), then 24-48h testnet bake before mainnet.
+
+### PRs
+
+- #359 — Phase A data plumbing
+- #365 — Phase B helpers + fork gate
+- #366 — Phase C dispatch verification
+- #368 — Phase D Step 1+2 (system tx auth + helper)
+- #369 — Phase D Step 3+4 (proposer emit + Pass-1/Pass-2 skip)
+- #371 — Phase D Q4 + Step 5-lite (required-presence + e2e)
+- #372 — Phase D Step 5-full (4-validator determinism)
+- #373 — internal-references hygiene scrub round 2
+- #374 — testnet genesis + faucet binary
+- #375 — CI faucet artifact upload
+- #376 — public CHANGELOG sync
+
+---
+
+## [2.1.41] — 2026-04-27 — Jail-cascade observability + fork-gated BFT safety gate relaxation
+
+Liveness fix bundle for the jail-cascade pattern. Two mainnet stalls on 2026-04-26 (h=633599 evening, h=662399 night) traced to per-validator stake_registry divergence (one validator sees another as jailed, others see active). The P1 BFT safety gate then refused to participate (active < MIN_BFT_VALIDATORS=4), stalling the chain.
+
+### Added
+
+- DEBUG-level tracing snapshot of per-validator (signed_count, missed_count) every 1000 blocks (PR #350)
+- `BFT_GATE_RELAX_HEIGHT` env-gated activation, default `u64::MAX` (disabled)
+- `Blockchain::is_bft_gate_relax_height(h)` + `min_active_for_bft(h, total)` runtime-aware helpers (pre-fork: `MIN_BFT_VALIDATORS=4`; post-fork: `⌈2/3 × N⌉` supermajority)
+- P1 BFT safety gate uses runtime-aware `min_active_for_bft` lookup (PRs #351, #355)
+- Asymmetric-application fixes: `record_block_signatures`, `distribute_reward`, `epoch_manager.record_block` now fire from libp2p apply paths (was: only validator-loop finalize) (#356, #362)
+
+### Activation
+
+Operators must explicitly set `BFT_GATE_RELAX_HEIGHT=<height>` on each validator to activate the relaxation. Coordinated rollout required (testnet bake, then mainnet halt-all + simultaneous-start with env var).
+
+### PRs
+
+- #350 (observability + RCA + design)
+- #351 (P1 gate relaxation, with self-review fix for clamp bug)
+- #355 (Pass-2 L2 gate parity)
+- #356, #362 (asymmetric apply fixes)
+
+---
+
+## [2.1.40] — 2026-04-27 — Fork-aware explorer richlist display
+
+Polish release. Pre-fork the explorer richlist hardcoded "Total supply: 210000000 SRX" — a tokenomics-v2 chain post-fork should show 315M. v2.1.40 makes the explorer page read max supply via `/chain/info` (which already reports fork-aware values per #337), so the display tracks reality without further code changes.
+
+### PRs
+
+- #348 — fork-aware richlist display
+
+---
+
 ## [2.1.39] — 2026-04-26 — Tokenomics v2 fork (BTC-parity halving + 315M cap)
 
 Consensus fork. Re-targets emission curve: 4-year halving (126M blocks) + 315M cap. Closes v1 math gap (geometric asymptoted at 84M from mining; 147M effective max instead of nominal 210M).


### PR DESCRIPTION
## Summary

README, NETWORKS, EMERGENCY_ROLLBACK version log, and the roadmap CHANGELOG were all behind the latest binary line. This brings them current.

## Changes

| File | Change |
|---|---|
| \`README.md\` | latest section now reads v2.1.44 (was v2.1.39) |
| \`docs/operations/NETWORKS.md\` | mainnet binary entry v2.1.44 (was v2.1.39) |
| \`docs/operations/EMERGENCY_ROLLBACK.md\` | extend version log with v2.1.40 → v2.1.44 entries |
| \`docs/roadmap/CHANGELOG.md\` | prepend \`[Unreleased]\` entry covering Phase A→D + testnet bootstrap; insert missing \`[2.1.40]\` + \`[2.1.41]\` entries |

## Hygiene

No internal-tooling or operator-host references introduced. Final grep across tracked files: zero matches for prohibited internal terms.

## Test plan

- [x] No internal-references leak (grep clean)
- [x] Markdown lint OK