### PR TITLE
feat(consensus): NFT TokenOp data types (SRC-721 + SRC-1155, fork-gated, dormant)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -332,6 +332,20 @@ impl Blockchain {
                             ));
                         }
                     }
+                    op if op.is_nft_family() => {
+                        // SRC-721 + SRC-1155 dispatch is gated by
+                        // NFT_TOKENOP_HEIGHT fork. Pre-fork: reject. Wire
+                        // format stable from this PR; storage layer +
+                        // dispatch land in the follow-up PR.
+                        if !Self::is_nft_tokenop_height(self.height() + 1) {
+                            return Err(SentrixError::InvalidTransaction(
+                                "NFT TokenOp dispatch is gated by \
+                                 NFT_TOKENOP_HEIGHT fork (currently disabled)"
+                                    .into(),
+                            ));
+                        }
+                    }
+                    _ => unreachable!("TokenOp variant handled above"),
                 }
             }
 
@@ -611,6 +625,16 @@ impl Blockchain {
                             ));
                         }
                     }
+                    op if op.is_nft_family() => {
+                        if !Self::is_nft_tokenop_height(self.height() + 1) {
+                            return Err(SentrixError::InvalidTransaction(
+                                "NFT TokenOp dispatch is gated by \
+                                 NFT_TOKENOP_HEIGHT fork (currently disabled)"
+                                    .into(),
+                            ));
+                        }
+                    }
+                    _ => unreachable!("TokenOp variant handled above"),
                 }
             }
 
@@ -868,6 +892,30 @@ impl Blockchain {
                             amount,
                         )?;
                     }
+                    op if op.is_nft_family() => {
+                        // Pass-2 apply path: NFT TokenOp dispatch is
+                        // gated by NFT_TOKENOP_HEIGHT fork. Pre-fork:
+                        // reject (Pass-1 already rejected; this is
+                        // belt-and-suspenders). Storage layer handlers
+                        // land in the follow-up PR.
+                        if !Self::is_nft_tokenop_height(block.index) {
+                            return Err(SentrixError::InvalidTransaction(
+                                "NFT TokenOp dispatch is gated by \
+                                 NFT_TOKENOP_HEIGHT fork (currently disabled)"
+                                    .into(),
+                            ));
+                        }
+                        // Post-fork dispatch land in follow-up PR; for
+                        // now reject explicitly so accidentally enabling
+                        // the fork doesn't silently apply non-existent
+                        // handlers.
+                        return Err(SentrixError::InvalidTransaction(
+                            "NFT TokenOp dispatch handlers not yet wired \
+                             (Phase B follow-up PR)"
+                                .into(),
+                        ));
+                    }
+                    _ => unreachable!("TokenOp variant handled above"),
                 }
             }
 

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -114,6 +114,16 @@ const BFT_GATE_RELAX_HEIGHT_DEFAULT: u64 = u64::MAX;
 /// is incomplete). Wire-format stable per Phase A (PR #359).
 const JAIL_CONSENSUS_HEIGHT_DEFAULT: u64 = u64::MAX;
 
+/// Activation height for SRC-721 + SRC-1155 native NFT/multi-token TokenOp
+/// variants. Pre-fork: dispatch rejects (`is_nft_family()` returning true).
+/// Post-fork: full handlers run (storage layer + REST).
+///
+/// CONSENSUS CHANGE — every validator must set the same value; mismatch
+/// produces a fork. Operator activates with halt-all + simultaneous-start
+/// after testnet bake.
+/// u64::MAX = disabled (safe default; wire format stable from this PR).
+const NFT_TOKENOP_HEIGHT_DEFAULT: u64 = u64::MAX;
+
 /// Read Voyager fork height from env, default u64::MAX (mainnet safe).
 /// Testnet sets VOYAGER_FORK_HEIGHT=<height> in systemd service.
 pub fn get_voyager_fork_height() -> u64 {
@@ -173,6 +183,16 @@ pub fn get_jail_consensus_height() -> u64 {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(JAIL_CONSENSUS_HEIGHT_DEFAULT)
+}
+
+/// Read NFT TokenOp fork height from env, default `u64::MAX` (disabled).
+/// Post-fork: SRC-721 + SRC-1155 dispatch active. Operators activate via
+/// halt-all + simultaneous-start with `NFT_TOKENOP_HEIGHT=<height>`.
+pub fn get_nft_tokenop_height() -> u64 {
+    std::env::var("NFT_TOKENOP_HEIGHT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(NFT_TOKENOP_HEIGHT_DEFAULT)
 }
 
 /// Read chain_id from SENTRIX_CHAIN_ID env var, fallback to 7119.
@@ -748,6 +768,15 @@ impl Blockchain {
     /// jail as on-chain state mutation. Pre-fork: legacy local check_liveness.
     pub fn is_jail_consensus_height(height: u64) -> bool {
         let fork = get_jail_consensus_height();
+        fork != u64::MAX && height >= fork
+    }
+
+    /// Is the given height at or after the NFT TokenOp fork?
+    /// Post-fork: SRC-721 + SRC-1155 TokenOp variants dispatch.
+    /// Pre-fork: dispatch rejects (wire format stable, storage layer
+    /// + REST handlers gated until activation).
+    pub fn is_nft_tokenop_height(height: u64) -> bool {
+        let fork = get_nft_tokenop_height();
         fork != u64::MAX && height >= fork
     }
 

--- a/crates/sentrix-primitives/src/transaction.rs
+++ b/crates/sentrix-primitives/src/transaction.rs
@@ -28,9 +28,22 @@ pub const TOKEN_OP_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
 pub const PROTOCOL_TREASURY: &str = "0x0000000000000000000000000000000000000002";
 
 // ── Token operation types (encoded in Transaction.data field) ──
+//
+// Wire format: JSON-encoded `{"op":"<variant_name_snake_case>", ...fields}`.
+// Variants split into 3 family groups:
+//   1. Fungible (SRC-20-equivalent): Deploy, Transfer, Burn, Mint, Approve
+//   2. NFT (SRC-721-equivalent): Deploy/Mint/Transfer/Burn/Approve/SetApprovalForAll
+//      — gated by NFT_TOKENOP_HEIGHT fork. Pre-fork: dispatch rejects.
+//   3. Multi-token (SRC-1155-equivalent): DeployMulti/Mint/Transfer/Burn/BatchMint/BatchTransfer
+//      — same fork gate.
+//
+// EVM ERC-20/721/1155 deployed via `eth_sendRawTransaction` is a parallel
+// path; the two stacks DO NOT share contract addresses (native contract
+// addresses are derived from tx.txid; EVM addresses follow CREATE/CREATE2).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum TokenOp {
+    // ── SRC-20 (fungible) ────────────────────────────────────
     // max_supply=0 means unlimited; #[serde(default)] for backward compatibility with older transactions
     Deploy {
         name: String,
@@ -59,6 +72,132 @@ pub enum TokenOp {
         spender: String,
         amount: u64,
     },
+
+    // ── SRC-721 (NFT) ────────────────────────────────────────
+    // Gated by NFT_TOKENOP_HEIGHT fork. Pre-fork: dispatch rejects.
+    /// Deploy a SRC-721 NFT collection. `max_supply=0` means unlimited.
+    /// `base_uri` is the metadata-URI prefix; per-token URI is
+    /// `{base_uri}{token_id}`. Mint operations may override by passing
+    /// `metadata_uri` explicitly.
+    DeployNft {
+        name: String,
+        symbol: String,
+        base_uri: String,
+        max_supply: u64,
+    },
+    /// Mint a single SRC-721 NFT. Owner-only (deployer of the NFT contract).
+    /// `metadata_uri` overrides the contract's base_uri convention if non-empty.
+    MintNft {
+        contract: String,
+        to: String,
+        token_id: u64,
+        #[serde(default)]
+        metadata_uri: String,
+    },
+    /// Transfer a SRC-721 NFT. Sender (`tx.from_address`) must be the
+    /// current owner OR an approved operator.
+    TransferNft {
+        contract: String,
+        from: String,
+        to: String,
+        token_id: u64,
+    },
+    /// Burn a SRC-721 NFT. Sender must be the current owner.
+    BurnNft {
+        contract: String,
+        token_id: u64,
+    },
+    /// Approve a single token for transfer by `spender`. Approval cleared
+    /// on next successful transfer.
+    ApproveNft {
+        contract: String,
+        spender: String,
+        token_id: u64,
+    },
+    /// Approve / revoke an operator for all tokens owned by `tx.from_address`
+    /// in this contract. Mirrors ERC-721's `setApprovalForAll`.
+    SetApprovalForAll {
+        contract: String,
+        operator: String,
+        approved: bool,
+    },
+
+    // ── SRC-1155 (multi-token) ───────────────────────────────
+    // Gated by NFT_TOKENOP_HEIGHT fork (same gate as SRC-721).
+    /// Deploy a SRC-1155 multi-token contract. `base_uri` is the prefix for
+    /// per-token URIs (`{base_uri}{token_id}`).
+    DeployMulti {
+        name: String,
+        symbol: String,
+        base_uri: String,
+    },
+    /// Mint `amount` units of `token_id` to `to`. Owner-only.
+    /// `data` is opaque metadata passed through to receivers (matches ERC-1155).
+    MintMulti {
+        contract: String,
+        to: String,
+        token_id: u64,
+        amount: u64,
+        #[serde(default)]
+        data: String,
+    },
+    /// Transfer `amount` units of `token_id`. Sender must be `from` OR an
+    /// approved operator (via `SetApprovalForAll`).
+    TransferMulti {
+        contract: String,
+        from: String,
+        to: String,
+        token_id: u64,
+        amount: u64,
+    },
+    /// Burn `amount` units of `token_id` held by `from`. Sender must be
+    /// `from` OR an approved operator.
+    BurnMulti {
+        contract: String,
+        from: String,
+        token_id: u64,
+        amount: u64,
+    },
+    /// Batch-mint multiple `token_id` quantities. Lengths of `ids` and
+    /// `amounts` must match. Owner-only.
+    BatchMintMulti {
+        contract: String,
+        to: String,
+        ids: Vec<u64>,
+        amounts: Vec<u64>,
+    },
+    /// Batch-transfer multiple `token_id` quantities. Lengths of `ids` and
+    /// `amounts` must match. Sender must be `from` OR an approved operator.
+    BatchTransferMulti {
+        contract: String,
+        from: String,
+        to: String,
+        ids: Vec<u64>,
+        amounts: Vec<u64>,
+    },
+}
+
+impl TokenOp {
+    /// Returns true if this variant requires the `NFT_TOKENOP_HEIGHT`
+    /// fork to be active (SRC-721 + SRC-1155 family). Pre-fork dispatch
+    /// must reject these variants. Used by Pass-1 validation.
+    pub fn is_nft_family(&self) -> bool {
+        matches!(
+            self,
+            TokenOp::DeployNft { .. }
+                | TokenOp::MintNft { .. }
+                | TokenOp::TransferNft { .. }
+                | TokenOp::BurnNft { .. }
+                | TokenOp::ApproveNft { .. }
+                | TokenOp::SetApprovalForAll { .. }
+                | TokenOp::DeployMulti { .. }
+                | TokenOp::MintMulti { .. }
+                | TokenOp::TransferMulti { .. }
+                | TokenOp::BurnMulti { .. }
+                | TokenOp::BatchMintMulti { .. }
+                | TokenOp::BatchTransferMulti { .. }
+        )
+    }
 }
 
 // ── Staking operation types (Voyager Phase 2a) ──────────────
@@ -809,5 +948,105 @@ mod tests {
         };
         let b = a.clone();
         assert_eq!(a, b, "JailEvidence must implement PartialEq for testing");
+    }
+
+    // ── SRC-721 / SRC-1155 TokenOp wire-format tests ──────────────
+
+    #[test]
+    fn test_nft_deploy_round_trip() {
+        let op = TokenOp::DeployNft {
+            name: "Test NFT".into(),
+            symbol: "TNFT".into(),
+            base_uri: "ipfs://Qm/".into(),
+            max_supply: 10_000,
+        };
+        let encoded = op.encode().expect("encode");
+        assert!(encoded.contains("\"op\":\"deploy_nft\""));
+        let decoded = TokenOp::decode(&encoded).expect("decode");
+        assert!(matches!(decoded, TokenOp::DeployNft { .. }));
+    }
+
+    #[test]
+    fn test_nft_mint_round_trip() {
+        let op = TokenOp::MintNft {
+            contract: "0xnft1".into(),
+            to: "0xrecipient".into(),
+            token_id: 42,
+            metadata_uri: "ipfs://Qm/42.json".into(),
+        };
+        let encoded = op.encode().expect("encode");
+        assert!(encoded.contains("\"op\":\"mint_nft\""));
+        let decoded = TokenOp::decode(&encoded).expect("decode");
+        assert!(matches!(decoded, TokenOp::MintNft { token_id: 42, .. }));
+    }
+
+    #[test]
+    fn test_set_approval_for_all_round_trip() {
+        let op = TokenOp::SetApprovalForAll {
+            contract: "0xnft1".into(),
+            operator: "0xop".into(),
+            approved: true,
+        };
+        let encoded = op.encode().expect("encode");
+        assert!(encoded.contains("\"op\":\"set_approval_for_all\""));
+        let decoded = TokenOp::decode(&encoded).expect("decode");
+        assert!(matches!(decoded, TokenOp::SetApprovalForAll { approved: true, .. }));
+    }
+
+    #[test]
+    fn test_multi_batch_mint_round_trip() {
+        let op = TokenOp::BatchMintMulti {
+            contract: "0xmt1".into(),
+            to: "0xrecipient".into(),
+            ids: vec![1, 2, 3],
+            amounts: vec![10, 20, 30],
+        };
+        let encoded = op.encode().expect("encode");
+        assert!(encoded.contains("\"op\":\"batch_mint_multi\""));
+        let decoded = TokenOp::decode(&encoded).expect("decode");
+        assert!(matches!(decoded, TokenOp::BatchMintMulti { .. }));
+    }
+
+    #[test]
+    fn test_is_nft_family_predicate() {
+        // SRC-20 fungible variants → NOT NFT family
+        assert!(!TokenOp::Deploy {
+            name: "x".into(), symbol: "X".into(), decimals: 8, supply: 0, max_supply: 0
+        }.is_nft_family());
+        assert!(!TokenOp::Transfer {
+            contract: "c".into(), to: "t".into(), amount: 1
+        }.is_nft_family());
+
+        // SRC-721 variants → NFT family
+        assert!(TokenOp::DeployNft {
+            name: "n".into(), symbol: "N".into(), base_uri: "u".into(), max_supply: 0
+        }.is_nft_family());
+        assert!(TokenOp::MintNft {
+            contract: "c".into(), to: "t".into(), token_id: 1, metadata_uri: String::new()
+        }.is_nft_family());
+        assert!(TokenOp::SetApprovalForAll {
+            contract: "c".into(), operator: "o".into(), approved: false
+        }.is_nft_family());
+
+        // SRC-1155 variants → NFT family
+        assert!(TokenOp::DeployMulti {
+            name: "n".into(), symbol: "N".into(), base_uri: "u".into()
+        }.is_nft_family());
+        assert!(TokenOp::BatchTransferMulti {
+            contract: "c".into(), from: "f".into(), to: "t".into(),
+            ids: vec![1], amounts: vec![1]
+        }.is_nft_family());
+    }
+
+    #[test]
+    fn test_nft_op_decodes_via_token_op_enum() {
+        // Proves wire format is stable: a JSON-encoded NFT op decodes
+        // through TokenOp::decode without requiring a separate enum.
+        let json = r#"{"op":"transfer_nft","contract":"0xc","from":"0xf","to":"0xt","token_id":7}"#;
+        let decoded = TokenOp::decode(json).expect("decode");
+        match decoded {
+            TokenOp::TransferNft { token_id, .. } => assert_eq!(token_id, 7),
+            _ => panic!("expected TransferNft variant"),
+        }
     }
 }


### PR DESCRIPTION
Adds 12 new TokenOp variants for native NFT (SRC-721) + multi-token (SRC-1155). Wire format stable. All dispatch gated by `NFT_TOKENOP_HEIGHT` fork (default `u64::MAX`). Storage + REST land in follow-up PR.

## Variants

**SRC-721 (6):** DeployNft, MintNft, TransferNft, BurnNft, ApproveNft, SetApprovalForAll

**SRC-1155 (6):** DeployMulti, MintMulti, TransferMulti, BurnMulti, BatchMintMulti, BatchTransferMulti

## Tests

53 primitives (was 47, +6 new) + 205 core, clippy clean.

## Activation

Operator halt-all + simultaneous-start with `NFT_TOKENOP_HEIGHT=<height>` on all validators after testnet bake.