### PR TITLE
fix(evm): skip native nonce bump for EVM txs (Option A)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -800,8 +800,21 @@ impl Blockchain {
             // would still bump PROTOCOL_TREASURY's nonce, polluting state.
             // Dispatch (staking_op match below) is the only state mutation.
             if !tx.is_system_tx() {
-                self.accounts
-                    .transfer(&tx.from_address, &tx.to_address, tx.amount, tx.fee)?;
+                if tx.is_evm_tx() {
+                    // EVM tx: revm owns nonce + value + recipient credit
+                    // when `execute_evm_tx_in_block` runs below. Native
+                    // pass must NOT bump nonce or transfer value — doing
+                    // so caused `NonceTooLow { tx, state }` in revm
+                    // because state.nonce was already bumped by the time
+                    // revm read it. See
+                    // `audits/evm-create-nonce-bug-2026-04-27.md`.
+                    // Only the fee is collected here (split 50/50
+                    // burn/validator like every other tx).
+                    self.accounts.charge_fee_only(&tx.from_address, tx.fee)?;
+                } else {
+                    self.accounts
+                        .transfer(&tx.from_address, &tx.to_address, tx.amount, tx.fee)?;
+                }
                 // P1: checked_add — 5000 tx × max fee is far below u64::MAX
                 // in practice, but the guard is cheap and prevents a silent
                 // wrap if MAX_TX_PER_BLOCK or MIN_TX_FEE are ever tuned
@@ -1467,7 +1480,16 @@ impl Blockchain {
             .data(alloy_primitives::Bytes::from(calldata))
             .gas_limit(gas_limit)
             .gas_price(INITIAL_BASE_FEE as u128)
-            .nonce(sender_nonce.saturating_sub(1))
+            // EVM CREATE/CALL nonce: revm checks `tx.nonce == state.nonce`
+            // and bumps state.nonce internally. Native pass no longer
+            // pre-bumps nonce for EVM txs (charge_fee_only above), so
+            // `sender_nonce` here equals what the EVM tx claimed in its
+            // RLP. Pre-fix this used `sender_nonce.saturating_sub(1)` to
+            // compensate for native double-bump; that was a band-aid that
+            // broke for fresh-wallet CREATE (nonce 0 saturating to 0,
+            // state already at 1 → NonceTooLow). See
+            // `audits/evm-create-nonce-bug-2026-04-27.md`.
+            .nonce(sender_nonce)
             .chain_id(Some(tx.chain_id))
             .build()
             .unwrap_or_default();

--- a/crates/sentrix-core/tests/phase_d_4validator_determinism.rs
+++ b/crates/sentrix-core/tests/phase_d_4validator_determinism.rs
@@ -76,9 +76,15 @@ fn setup_validator_chain() -> Blockchain {
     }
 
     // Pad to (boundary - 1) so the next block lands on epoch boundary.
+    // Block::new stamps the timestamp from SystemTime::now(); two
+    // setup_validator_chain() calls straddling a wall-clock-second
+    // boundary would otherwise produce divergent pad-block hashes →
+    // diverging_evidence_rejected fails with "invalid previous hash"
+    // before the evidence-divergence check it actually wants to assert.
+    // Pin timestamp + recompute hash so all instances start identical.
     let target_height = sentrix_staking::epoch::EPOCH_LENGTH - 2;
     let prev_hash = bc.latest_block().unwrap().hash.clone();
-    let pad = Block::new(
+    let mut pad = Block::new(
         target_height,
         prev_hash,
         vec![Transaction::new_coinbase(
@@ -89,6 +95,8 @@ fn setup_validator_chain() -> Blockchain {
         )],
         validator,
     );
+    pad.timestamp = 1_700_000_000;
+    pad.hash = pad.calculate_hash();
     bc.chain.push(pad);
 
     bc

--- a/crates/sentrix-primitives/src/account.rs
+++ b/crates/sentrix-primitives/src/account.rs
@@ -117,6 +117,32 @@ impl AccountDB {
         Ok(())
     }
 
+    /// Charge `fee` against `from` without transferring value, without
+    /// crediting any recipient, and **without bumping the nonce.** Used by
+    /// the EVM apply path: revm owns nonce + value + recipient credit, so
+    /// the native pass must only collect the fee. Using regular `transfer`
+    /// for EVM txs causes `NonceTooLow { tx, state }` in revm because
+    /// native bumped the nonce before revm read state — see
+    /// `audits/evm-create-nonce-bug-2026-04-27.md`.
+    pub fn charge_fee_only(&mut self, from: &str, fee: u64) -> SentrixResult<()> {
+        let from_balance = self.get_balance(from);
+        if from_balance < fee {
+            return Err(SentrixError::InsufficientBalance {
+                have: from_balance,
+                need: fee,
+            });
+        }
+        let sender = self.get_or_create(from);
+        sender.balance = sender
+            .balance
+            .checked_sub(fee)
+            .ok_or_else(|| SentrixError::Internal("balance underflow".to_string()))?;
+        // No nonce bump — revm increments for EVM txs.
+        let burn_amount = fee.div_ceil(2);
+        self.total_burned = self.total_burned.saturating_add(burn_amount);
+        Ok(())
+    }
+
     pub fn transfer(&mut self, from: &str, to: &str, amount: u64, fee: u64) -> SentrixResult<()> {
         let total = amount
             .checked_add(fee)
@@ -451,5 +477,49 @@ mod tests {
             let validator = fee - burn;
             assert_eq!(burn + validator, fee, "fee={fee} not fully distributed");
         }
+    }
+
+    // ── charge_fee_only — regression for EVM CREATE nonce-too-low bug ──
+
+    #[test]
+    fn test_charge_fee_only_deducts_fee_and_does_not_bump_nonce() {
+        let mut db = AccountDB::new();
+        db.credit("alice", 100_000).unwrap();
+        let pre_nonce = db.get_nonce("alice");
+
+        db.charge_fee_only("alice", 10_000).expect("charge should succeed");
+
+        assert_eq!(db.get_balance("alice"), 90_000, "fee should be deducted");
+        assert_eq!(
+            db.get_nonce("alice"),
+            pre_nonce,
+            "charge_fee_only must NOT bump nonce — revm owns nonce for EVM txs"
+        );
+        assert_eq!(db.total_burned, 5_000, "half of fee burned, ceil-div");
+    }
+
+    #[test]
+    fn test_charge_fee_only_rejects_insufficient_balance() {
+        let mut db = AccountDB::new();
+        db.credit("alice", 9_999).unwrap();
+        let result = db.charge_fee_only("alice", 10_000);
+        assert!(matches!(
+            result,
+            Err(SentrixError::InsufficientBalance { have: 9_999, need: 10_000 })
+        ));
+        assert_eq!(db.get_balance("alice"), 9_999, "balance unchanged on rejection");
+        assert_eq!(db.get_nonce("alice"), 0, "nonce unchanged on rejection");
+    }
+
+    #[test]
+    fn test_transfer_still_bumps_nonce() {
+        // Regression guard: charge_fee_only is for EVM only;
+        // transfer (native path) MUST still bump nonce.
+        let mut db = AccountDB::new();
+        db.credit("alice", 100_000).unwrap();
+        db.transfer("alice", "bob", 50_000, 10_000).unwrap();
+        assert_eq!(db.get_nonce("alice"), 1, "native transfer must bump nonce");
+        assert_eq!(db.get_balance("alice"), 40_000);
+        assert_eq!(db.get_balance("bob"), 50_000);
     }
 }


### PR DESCRIPTION
## What

Fix EVM CREATE \`NonceTooLow { tx: 0, state: 1 }\` rejection that blocks every \`eth_sendRawTransaction\` deploy from a fresh wallet (Foundry, Hardhat, ethers, viem all hit it).

## Root cause

\`apply_block_inner\` pass-2 called \`accounts.transfer(from, to, amount, fee)\` for **every** non-system tx, including EVM txs. \`transfer\` bumps \`from.nonce\`. \`execute_evm_tx_in_block\` then read \`state.from.nonce = 1\` and built \`TxEnv.nonce = sender_nonce.saturating_sub(1) = 0\`, but revm rejects because at execution time it sees \`state.nonce = 1 > tx.nonce = 0\`.

The \`saturating_sub(1)\` band-aid masked this for non-zero starting nonces but failed for fresh-wallet CREATE: \`0.saturating_sub(1) = 0\`, state was already \`1\` → reject.

Full RCA: operator runbook \`evm-create-nonce-bug-2026-04-27.md\`.

## Fix (Option A — founder-approved)

Split the pass-2 dispatch:

| tx kind | native pass-2 | EVM pass |
|---|---|---|
| native (transfer/TokenOp/StakingOp) | \`transfer()\` — bumps nonce, moves value | n/a |
| EVM | \`charge_fee_only()\` — fee + burn only | revm bumps nonce, moves value |

Removed the \`.saturating_sub(1)\` compensation at \`block_executor.rs:1483\` since native no longer pre-bumps for EVM txs.

## Tests

3 new unit tests in \`primitives/account.rs\`:
- \`charge_fee_only\` deducts fee + burns half, **does not bump nonce**
- \`charge_fee_only\` rejects insufficient balance, leaves state unchanged
- \`transfer\` still bumps nonce (regression guard for native path)

Suites:
- \`sentrix-primitives\`: 47 → 50 passing
- \`sentrix-core\`: 205 passing
- clippy --tests -D warnings clean

## Out of scope (next step)

End-to-end CREATE deploy bake on testnet — covered by the canonical-contracts deploy plan once this merges.

## Activation

Consensus-touching. Per operator runbook: halt-all + simultaneous-start on testnet first (bake), then mainnet. **Not** an env-gated fork — it's a bug fix, but the synchronized restart pattern still applies.

## Refusing self-merge

Flagging for founder review per consensus discipline. Do not merge without fresh-brain pass.