### PR TITLE
chore(tools): scrub wg1 IPs from RPC-base-url examples in 4 helper binaries

### DIFF
--- a/tools/bench-tps/src/main.rs
+++ b/tools/bench-tps/src/main.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 #[derive(Parser, Debug)]
 #[command(about = "Sentrix TPS + pentest bench")]
 struct Args {
-    /// Node RPC base URL (e.g. http://10.20.0.4:9545)
+    /// Node RPC base URL (e.g. http://localhost:9545)
     #[arg(long, default_value = "http://localhost:9545")]
     rpc: String,
 

--- a/tools/claim-rewards/src/main.rs
+++ b/tools/claim-rewards/src/main.rs
@@ -8,7 +8,7 @@
 //
 // Usage:
 //   echo "<64-hex-privkey>" | claim-rewards \
-//     --rpc       http://10.20.0.2:8545 \
+//     --rpc       http://localhost:8545 \
 //     --chain-id  7119
 //   # add --dry-run to build + sign without POSTing
 //
@@ -34,7 +34,7 @@ use std::time::Duration;
 
 #[derive(Parser)]
 struct Args {
-    /// RPC base URL (e.g. http://10.20.0.2:8545)
+    /// RPC base URL (e.g. http://localhost:8545)
     #[arg(long)]
     rpc: String,
 

--- a/tools/drain-once/src/main.rs
+++ b/tools/drain-once/src/main.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 #[derive(Parser)]
 struct Args {
-    /// RPC base URL (e.g. http://10.20.0.2:8545)
+    /// RPC base URL (e.g. http://localhost:8545)
     #[arg(long)]
     rpc: String,
 

--- a/tools/transfer-amount/src/main.rs
+++ b/tools/transfer-amount/src/main.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 #[derive(Parser)]
 struct Args {
-    /// RPC base URL (e.g. http://10.20.0.2:8545)
+    /// RPC base URL (e.g. http://localhost:8545)
     #[arg(long)]
     rpc: String,
 


### PR DESCRIPTION
## What

Doc comments + \`clap\` arg help in \`tools/{claim-rewards,bench-tps,drain-once,transfer-amount}/\` used the operator's wg1 mainnet IPs as \`e.g.\` placeholders. Per the no-VPS-identifiers-in-public memory rule, these leak fleet topology into the public sentrix repo.

## Fix

Replace each wg1-IP placeholder with \`http://localhost:8545\` (or \`:9545\` for the testnet bench tool) — generic, no infrastructure leak. Runtime semantics unchanged: every tool still reads \`--rpc <url>\` from the operator at invocation time.

## Diff

| Tool | Replacement |
|---|---|
| \`tools/claim-rewards/src/main.rs\` (×2) | wg1 IP → \`http://localhost:8545\` |
| \`tools/drain-once/src/main.rs\` | wg1 IP → \`http://localhost:8545\` |
| \`tools/transfer-amount/src/main.rs\` | wg1 IP → \`http://localhost:8545\` |
| \`tools/bench-tps/src/main.rs\` | wg1 IP → \`http://localhost:9545\` |

## Companion

The same scrub for \`tools/add-self-stake/\` landed in PR #385 (the AddSelfStake feature PR); this PR covers the four pre-existing tools that had been carrying the IPs since they were authored.

The \`rca_*\` test-harness rename + comment scrub lands in PR #387.

## Verification

After scrub, the tools tree contains zero wg1-style RFC1918 leaks (sweep via tracked-files grep, see PR #387 for the full audit pattern).

No code change, comment + help-string only. No test impact.