### PR TITLE
chore(scrub): remove operator-host references from tracked source + audit

### DIFF
--- a/audits/libp2p-resilience-audit-2026-04-27.md
+++ b/audits/libp2p-resilience-audit-2026-04-27.md
@@ -28,7 +28,7 @@ This is **correct in theory** — only remove when all connections to that peer 
 ## Hypothesis: brief peer_count=0 during peer-stop event
 
 **What we observed (mainnet test, 2026-04-27 ~6:25 WIB):**
-- Stopped Beacon (vps5) at T=0
+- Stopped Beacon validator at T=0
 - Other 3 validators: peer_count expected 2 (Foundation+Treasury+Core seeing each other minus Beacon)
 - Logs showed nil-precommit for h=690613 across ~10 rounds (5 minutes)
 - Eventually chain stalled despite 3 online validators

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1160,10 +1160,10 @@ fn cmd_validator_force_unjail(
     // NOT update the state_trie. After 2026-04-25's verify-deep gate,
     // chain.db that's been touched by force-unjail without a trie
     // rebuild will fail the boot-time consistency check on subsequent
-    // peers — discovered live during the 2026-04-27 vps3 unjail
-    // attempt. The recovery is a cluster-wide trie rebuild from the
-    // post-edit AccountDB. Print the canonical procedure here so the
-    // operator doesn't have to remember it from the runbook.
+    // peers — discovered live during the 2026-04-27 unjail attempt.
+    // The recovery is a cluster-wide trie rebuild from the post-edit
+    // AccountDB. Print the canonical procedure here so the operator
+    // doesn't have to remember it from the runbook.
     println!();
     println!("NEXT STEPS — cluster-wide trie reconciliation:");
     println!();

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -412,7 +412,7 @@ impl Blockchain {
         // Offline replay bypass (SENTRIX_REPLAY_BYPASS_AUTHZ=1): skip the
         // round-robin slot check so genesis-to-tip replay can apply blocks
         // without reconstructing the full historical authority state. Used
-        // by the rca_vps3_env_repro::replay_and_compare diagnostic harness.
+        // by the rca_env_repro::replay_and_compare diagnostic harness.
         // Production validators MUST NOT set this (would let any address
         // produce blocks at any height — only safe when chain.db is offline
         // and we're rederiving state from authoritative block history).

--- a/crates/sentrix-core/tests/fork_determinism.rs
+++ b/crates/sentrix-core/tests/fork_determinism.rs
@@ -17,7 +17,7 @@
 //!
 //! What it does NOT prove: the actual stale-snapshot rsync reproducer. That
 //! requires a real source chain.db (large, off-repo) and is exercised by
-//! `rca_vps3_env_repro.rs` operator-driven harness. These tests are CI
+//! `rca_env_repro.rs` operator-driven harness. These tests are CI
 //! regression guards: any future change that breaks them is *guaranteed*
 //! to break #1e on the live network.
 
@@ -804,7 +804,7 @@ fn test_voyager_active_stale_snapshot_peer_sync() {
 /// `block_executor.rs` only fires for blocks at height ≥ 100,000. This
 /// test is `#[ignore]`'d because producing 100,000+ blocks in a unit
 /// test is impractical. Operator-driven manual verification via the
-/// `apply_canonical_block_to_forensic` harness in `rca_vps3_env_repro.rs`
+/// `apply_canonical_block_to_forensic` harness in `rca_env_repro.rs`
 /// is the recommended integration-level test:
 ///
 ///   1. With env unset: confirm forensic+507499 produces APPLY_RESULT=Err

--- a/crates/sentrix-core/tests/rca_env_repro.rs
+++ b/crates/sentrix-core/tests/rca_env_repro.rs
@@ -24,7 +24,7 @@
 //!    SENTRIX_ALLOW_UNENCRYPTED_DISK=true \
 //!    TEST_CHAIN_DB=/path/to/chain.db \
 //!    TEST_HEIGHT_FROM=1 TEST_HEIGHT_TO=1000 \
-//!    cargo test -p sentrix-core --test rca_vps3_env_repro \
+//!    cargo test -p sentrix-core --test rca_env_repro \
 //!      replay_and_compare -- --ignored --nocapture
 //!    ```
 //! 3. Compare the `CUMULATIVE_OK` / `MISMATCH …` output across hosts.
@@ -168,7 +168,7 @@ fn read_committed_trie_root() {
 ///      SENTRIX_ALLOW_UNENCRYPTED_DISK=true \
 ///      TEST_CHAIN_DB=/path/to/forensic/chain.db \
 ///      TEST_BLOCK_FILE=/path/to/canonical-block-N.json \
-///      cargo test -p sentrix-core --test rca_vps3_env_repro \
+///      cargo test -p sentrix-core --test rca_env_repro \
 ///        apply_canonical_block_to_forensic -- --ignored --nocapture
 ///      ```
 ///   4. Output reports:
@@ -584,7 +584,7 @@ fn replay_and_compare() {
 ///      TEST_STATE_DB=/path/to/state.db \
 ///      TEST_BLOCK_SOURCE_DB=/path/to/live-chain.db \
 ///      TEST_HEIGHT_FROM=388340 TEST_HEIGHT_TO=388400 \
-///      cargo test --release -p sentrix-core --test rca_vps3_env_repro \
+///      cargo test --release -p sentrix-core --test rca_env_repro \
 ///        snapshot_seed_env_repro -- --ignored --nocapture
 ///      ```
 ///   5. Diff the per-block MISMATCH / CUMULATIVE_OK lines across hosts.


### PR DESCRIPTION
## What

Final pass on the post-2026-04-27 operator-identifier scrub. Five tracked files still carried operator-host labels in comments / docs:

| File | Replacement |
|---|---|
| \`bin/sentrix/src/main.rs:1163\` | host-suffixed unjail-attempt note → generic \"the 2026-04-27 unjail attempt\" (introduced by #384, fixed forward) |
| \`audits/libp2p-resilience-audit-2026-04-27.md:31\` | host-suffixed Beacon-stopped event line → role-only \"Stopped Beacon validator\" |
| \`crates/sentrix-core/src/block_executor.rs:415\` | stale \`rca_<host>_env_repro::replay_and_compare\` → \`rca_env_repro::replay_and_compare\` |
| \`crates/sentrix-core/tests/fork_determinism.rs:20,807\` | same stale \`rca_<host>_env_repro.rs\` references → \`rca_env_repro.rs\` |
| \`crates/sentrix-core/tests/rca_env_repro.rs:27,171,587\` | stale \`cargo test --test rca_<host>_env_repro\` cmd snippets → \`--test rca_env_repro\` |

The \`rca_*\` rename targets were stale — the harness was renamed to \`rca_env_repro\` at some prior point but the call-site references weren't updated. Function path \`replay_and_compare\` verified to exist in the renamed file at line 382.

## Verification

\`\`\`
git ls-files | grep -vE '^\\.github/workflows/|^\\.githooks/' | xargs grep -niE 'host[0-9]|host-id-pattern'
→ empty after this PR
\`\`\`

Build + targeted test pass:
- \`cargo build -p sentrix-core\` — clean
- \`cargo test -p sentrix-core --tests fork_determinism\` — 5 ignored (expected, see test docstring), 0 failed

## Out of scope (tracked but deferred)

- \`.github/workflows/ci.yml\` — uses GitHub Secret names with operator-host labels for the (currently disabled, \`if: false\`) deploy job. Renaming requires GitHub-Secret-store rotation alongside workflow YAML edits — dedicated infra PR.
- \`.githooks/pre-commit\` — references an SSH-username literal as a scrub-target. Renaming would require renaming the SSH user on the actual host, out of scope here.

No code change, comments + doc strings + test-cmd snippets only. No runtime impact.

## Companion

Sibling scrub PRs:

- #385 (consensus): \`tools/add-self-stake/\` + \`StakingOp::AddSelfStake\`
- #386 (chore): scrub wg1 IPs from 4 pre-existing tools

This PR closes the source-side tracking. After merge, the only remaining operator-host refs in tracked files are intentional infra mappings in \`.github/\` and \`.githooks/\` per the deferral note above.