### PR TITLE
docs: refresh stale doc surfaces — genesis clarification + README + CHANGELOG

### DIFF
--- a/genesis/mainnet.toml
+++ b/genesis/mainnet.toml
@@ -42,6 +42,19 @@ pubkey = ""
 # the live chain.
 
 # Founder — 21,000,000 SRX
+#
+# HISTORICAL NOTE — DO NOT EDIT THIS ADDRESS:
+# This file lists the original Founder v2 address as the genesis seed. The
+# v2 wallet was compromised via session-context leak on 2026-04-23 and the
+# admin role + balance were transferred on-chain to Founder v3
+# (0x5b5b06688dcdbe532353ac610aaff41af825279d) on 2026-04-24 via tx
+# 0x07354cc4208d3fa52033aa84cca02ac02774fa913407573427cf0d037c2d4c2e
+# at block 444070.
+#
+# Genesis is immutable consensus history — modifying this address would
+# fork the chain and invalidate every existing block. The live admin
+# Founder v3 is the result of normal on-chain activity post-genesis,
+# fully verifiable on https://scan.sentrixchain.com.
 [[genesis.balances]]
 address = "0x252f8cfed5acfa9d00d99a65e2ac91f395a35d78"
 amount = 2100000000000000


### PR DESCRIPTION
## Summary

Doc-only audit pass to bring stale public surfaces up to date with current mainnet reality (v2.1.46, h≈760K, multisig migration FINAL, canonical contracts deployed).

- `genesis/mainnet.toml` — clarifying comment about Founder v2 → v3 admin transfer at block 444070 (the genesis listed address differs from the live admin wallet visible on the explorer; comment explains why).
- `README.md` — bump v2.1.44 → v2.1.46 in the release banner + Voyager Live row. Add `eth_call` execution + AddSelfStake activation to capability list.
- `CHANGELOG.md`:
  - Promote previous `[Unreleased]` (Phase A→D consensus-jail + testnet bootstrap) to `[2.1.42] — 2026-04-27 (later)`.
  - Add new `[2.1.46] — 2026-04-28` covering eth_call → revm wiring, AddSelfStake activation, reset-trie CLI flag, operator-host scrub round, workspace version bump.
  - Add new `[Unreleased] — 2026-04-28` covering documentation + multisig migration FINAL (governance only, no consensus changes).

## Test plan

- [x] `cargo test --lib -p sentrix-core genesis` — 11/11 pass, including:
  - `test_mainnet_genesis_block_hash_matches_hardcoded` ✓
  - `test_total_premine_matches_hardcoded` ✓
  - `test_mainnet_embedded_parses_and_validates` ✓
- [x] All changes are documentation-only — no code, no config, no consensus impact.
- [x] CHANGELOG version sections match git-log reality on `main`.

## Risk

Zero consensus risk. Comment-only TOML changes; markdown-only README/CHANGELOG. The genesis hash regression test would have failed if anything material changed.