### PR TITLE
fix(rpc): cap eth_call gas at TX_GAS_LIMIT_CAP (EIP-7825), not BLOCK_GAS_LIMIT

### DIFF
--- a/crates/sentrix-evm/src/gas.rs
+++ b/crates/sentrix-evm/src/gas.rs
@@ -13,6 +13,13 @@ pub const GAS_TARGET: u64 = 15_000_000;
 /// Maximum gas per block
 pub const BLOCK_GAS_LIMIT: u64 = 30_000_000;
 
+/// Per-transaction gas limit cap (EIP-7825, active in revm SpecId >= Osaka).
+/// 2^24 = 16_777_216. revm rejects any TxEnv whose `gas_limit` exceeds this
+/// with `TxGasLimitGreaterThanCap` even for read-only `eth_call` dry-runs,
+/// so the RPC layer must clamp `eth_call`/`eth_estimateGas` gas to this cap
+/// rather than `BLOCK_GAS_LIMIT`. View calls fit inside this comfortably.
+pub const TX_GAS_LIMIT_CAP: u64 = 16_777_216;
+
 /// Denominator for base fee change (max 12.5% per block)
 pub const BASE_FEE_CHANGE_DENOMINATOR: u64 = 8;
 

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -445,15 +445,24 @@ async fn run_evm_dry_run(
         .unwrap_or("0x")
         .trim_start_matches("0x");
     let data_bytes = hex::decode(data_hex).unwrap_or_default();
-    // P1: cap at BLOCK_GAS_LIMIT. Without the cap a client can request
-    // `u64::MAX` gas and force the EVM to run until it naturally OOGs,
-    // which at current INITIAL_BASE_FEE is a free long-running compute
-    // request against the validator — asymmetric DoS.
+    // P1: cap at TX_GAS_LIMIT_CAP (EIP-7825, 16_777_216). Without the cap
+    // a client can request `u64::MAX` gas and force the EVM to run until
+    // it naturally OOGs, which at current INITIAL_BASE_FEE is a free
+    // long-running compute request against the validator — asymmetric DoS.
+    //
+    // Cap MUST be `TX_GAS_LIMIT_CAP`, not `BLOCK_GAS_LIMIT`. revm with
+    // SpecId >= Osaka rejects `gas_limit > TX_GAS_LIMIT_CAP` (= 2^24)
+    // with `TxGasLimitGreaterThanCap` even for read-only dry-runs, so
+    // defaulting to `BLOCK_GAS_LIMIT` (30M) caused every `eth_call` and
+    // every `eth_estimateGas` to fail. Live-discovered 2026-04-28 after
+    // PR #389 deploy when `cast call WSRX.name()` returned `0x` for every
+    // canonical contract. View calls fit inside 16M comfortably (most
+    // use < 100K gas).
     let gas_limit = call_obj["gas"]
         .as_str()
         .and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
-        .unwrap_or(sentrix_evm::gas::BLOCK_GAS_LIMIT)
-        .min(sentrix_evm::gas::BLOCK_GAS_LIMIT);
+        .unwrap_or(sentrix_evm::gas::TX_GAS_LIMIT_CAP)
+        .min(sentrix_evm::gas::TX_GAS_LIMIT_CAP);
 
     let bc = state.read().await;
     use sentrix_evm::database::parse_sentrix_address;


### PR DESCRIPTION
## Summary

PR #389 wired \`eth_call\` through to revm execution but every call still returned \`0x\` empty on the deployed v2.1.46 binary. Live debug via \`eth_estimateGas\` (which surfaces the same error loudly) revealed:

\`\`\`
TxGasLimitGreaterThanCap { gas_limit: 30000000, cap: 16777216 }
\`\`\`

revm with \`SpecId >= Osaka\` enforces EIP-7825's per-transaction gas cap (2^24 = 16,777,216) on every \`TxEnv\` it executes — including read-only \`eth_call\` dry-runs. Sentrix's dry-run defaulted \`gas_limit\` to \`BLOCK_GAS_LIMIT\` (30M) and clamped at the same value, which always exceeded the per-tx cap → every call rejected pre-execution → empty \`0x\` returned via the EVM-execution-failed catch in the \`eth_call\` handler.

## Fix

- Add \`TX_GAS_LIMIT_CAP = 16_777_216\` to \`sentrix-evm::gas\`.
- Default \`eth_call\` / \`eth_estimateGas\` \`gas_limit\` to \`TX_GAS_LIMIT_CAP\` and clamp at the same. View calls use << 100K gas, so 16M is plenty.

## Test plan

- [x] \`cargo build --release -p sentrix-rpc -p sentrix-evm\` — clean
- [ ] After merge + deploy: \`cast call <WSRX> \"name()(string)\" --rpc-url https://rpc.sentrixchain.com\` should return \`\"Wrapped SRX\"\` (currently returns ABI-decode error because \`0x\` empty)
- [ ] \`cast call <Multicall3> \"getCurrentBlockTimestamp()(uint256)\"\` should return non-zero

## Risk

RPC-only change. No consensus path touched. Read-only \`eth_call\` does not affect block production or state. Cap value (16,777,216) is the EIP-7825 standard, identical to revm's internal default for \`SpecId::OSAKA\` and later.