### PR TITLE
docs: refresh README + CHANGELOG + NETWORKS for v2.1.46 mainnet deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,34 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased] — 2026-04-27 (later) — Phase A→D consensus-jail full stack + testnet bootstrap
+## [Unreleased]
+
+> Empty placeholder — next release will land on this branch.
+
+---
+
+## [2.1.46] — 2026-04-28 — eth_call → revm wiring + AddSelfStake activation + version bump
+
+> **Mainnet activation of `StakingOp::AddSelfStake`** + first cut of routing `eth_call` through real revm execution against live chain state. vps3 unjailed via real-SRX self-bond (no phantom-mint). 4-of-4 validators active. Workspace version bumped 2.1.44 → 2.1.46 across root + every internal crate.
+
+### Added / Fixed
+
+- **`crates/sentrix-rpc/src/jsonrpc/eth.rs`** (#389) — `eth_call` and `eth_estimateGas` now route through revm execution against the live chain state via `SentrixEvmDb::from_account_db(&bc.accounts)` (was `InMemoryDB` which only pre-loaded contract code, leaving every storage slot zero). Address normalization added so EIP-55 checksummed addresses resolve correctly against the lowercase `AccountDB` keys.
+- **`StakingOp::AddSelfStake`** — fork activated at `ADD_SELF_STAKE_HEIGHT=731245` on mainnet. Validators can bond real SRX into their own `self_stake` without the phantom-mint that pre-PR-#384 `force-unjail` produced. Recovery path for slashed validators with `self_stake < MIN_SELF_STAKE`.
+- **`reset-trie` CLI flag** (#384) — operator-side recovery printout for the force-unjail one-way trap.
+- **Operator-host scrub round** (#386, #387) — additional internal-tooling-reference scrub on operator-host paths.
+
+### Internal
+
+- **Workspace `Cargo.toml`** (#388) — bumped `version = "2.1.44" → "2.1.46"` across root + every internal crate + bin (uniform). `tools/*` keep their independent `0.1.0`.
+
+### Known follow-ups
+
+- **PR #389 partial** — wired `eth_call` through revm but mainnet probe found dry-run gas cap mismatch with EIP-7825; follow-up PR #391 caps at `TX_GAS_LIMIT_CAP` (16,777,216) instead of `BLOCK_GAS_LIMIT` (30M) so the per-tx cap revm enforces in `SpecId >= Osaka` doesn't reject every dry-run.
+
+---
+
+## [2.1.42] — 2026-04-27 (later) — Phase A→D consensus-jail full stack + testnet bootstrap
 
 > **The asymmetric-application bug class is now fixed at the protocol level.** Phase A (data types) shipped earlier this day in #359; this batch ships Phase B (helpers + fork gate), Phase C (dispatch verification), and Phase D (proposer emission + Pass-1/Pass-2 wiring + 4-validator determinism harness). Default behavior is unchanged: `JAIL_CONSENSUS_HEIGHT=u64::MAX` on default builds means the entire dispatch path is unreachable until an operator opts in.
 >

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sentrix is the financial infrastructure for the real economy — starting with I
 
 Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, instant finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and web3.js connect natively. The chain serves as a settlement and tokenization layer for real-world assets — designed to bring institutional-grade financial primitives on-chain with the monetary discipline of Bitcoin and the programmability of Ethereum.
 
-- **v2.1.44** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active, **tokenomics v2 fork ACTIVE on mainnet since h=640800** (BTC-parity 4-year halving + 315M cap), libp2p sync race-safe
+- **v2.1.46** — MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 37) active, V4 reward distribution v2 active, **tokenomics v2 fork ACTIVE on mainnet since h=640800** (BTC-parity 4-year halving + 315M cap), `StakingOp::AddSelfStake` ACTIVE since h=731245, libp2p sync race-safe
 - **551+ tests**, clippy clean, 11 security audit rounds
 - **4 validators** across 4 nodes (Foundation, Treasury, Core, Beacon) on the maintainer fleet
 
@@ -113,7 +113,7 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 | Phase | Status | Focus |
 |-------|--------|-------|
 | **Pioneer** | Completed (mainnet h=0…579058) | PoA round-robin, MDBX storage, 1s blocks, SRC-20 tokens — succeeded by Voyager 2026-04-25 |
-| **Voyager** | **Live on mainnet (v2.1.44)** | DPoS proposer rotation + BFT finality, EVM (revm 37), `eth_sendRawTransaction`, L1 peer auto-discovery + connection-limits hardening, V4 reward distribution v2 (treasury escrow + ClaimRewards), runtime-aware Voyager dispatch, race-safe block sync, tokenomics v2 fork (315M cap + 4-year halving) |
+| **Voyager** | **Live on mainnet (v2.1.46)** | DPoS proposer rotation + BFT finality, EVM (revm 37), `eth_sendRawTransaction`, L1 peer auto-discovery + connection-limits hardening, V4 reward distribution v2 (treasury escrow + ClaimRewards), runtime-aware Voyager dispatch, race-safe block sync, tokenomics v2 fork (315M cap + 4-year halving), `StakingOp::AddSelfStake` for non-phantom validator self-bond |
 | **Frontier** | Phase F-1 scaffold landed; F-2…F-10 planned | Parallel transaction execution, sub-1s block time, mainnet hard fork |
 | **Odyssey** | Future | Cross-chain bridges, mature ecosystem, light clients |
 

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -15,7 +15,7 @@
 | Consensus | **Voyager** (DPoS + BFT, `voyager_activated=true` since h=579047 / 2026-04-25) |
 | EVM | Active — `evm_activated=true` since the same height; MetaMask compatible |
 | Reward distribution | **V4 reward v2** active since h=590100 / 2026-04-25 — coinbase routes to `PROTOCOL_TREASURY` (0x0000…0002), validators + delegators claim via `ClaimRewards` staking op |
-| Binary | v2.1.44 |
+| Binary | v2.1.46 |
 
 ## Testnet
 


### PR DESCRIPTION
## Summary

Re-applies the v2.1.44 → v2.1.46 version bump across the public doc surfaces now that the binary is actually 2.1.46 on all four mainnet validators (deployed 2026-04-28 via fast-deploy).

- README: bump version in two places + add AddSelfStake notes.
- NETWORKS: mainnet binary v2.1.44 → v2.1.46.
- CHANGELOG: empty new \`[Unreleased]\` placeholder; promote previous \`[Unreleased]\` to \`[2.1.42] — 2026-04-27\`; add new \`[2.1.46] — 2026-04-28\` covering AddSelfStake activation, eth_call → revm wiring (#389), reset-trie CLI flag (#384), operator-host scrub (#386/#387), workspace version bump (#388). Discloses that PR #389 needs PR #391 follow-up to fully work.

## Test plan

- [x] All changes are documentation-only — no code, no config, no consensus impact.
- [x] CHANGELOG version sections match git-log reality on \`main\`.