### PR TITLE
docs(changelog): correct version label — Phase A→D was v2.1.45 not v2.1.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,32 +9,37 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-> Empty placeholder — next release will land on this branch.
-
----
-
-## [2.1.46] — 2026-04-28 — eth_call → revm wiring + AddSelfStake activation + version bump
-
-> **Mainnet activation of `StakingOp::AddSelfStake`** + first cut of routing `eth_call` through real revm execution against live chain state. vps3 unjailed via real-SRX self-bond (no phantom-mint). 4-of-4 validators active. Workspace version bumped 2.1.44 → 2.1.46 across root + every internal crate.
+> Tonight's post-v2.1.46 work. Will land in v2.1.47 once tagged.
 
 ### Added / Fixed
 
 - **`crates/sentrix-rpc/src/jsonrpc/eth.rs`** (#389) — `eth_call` and `eth_estimateGas` now route through revm execution against the live chain state via `SentrixEvmDb::from_account_db(&bc.accounts)` (was `InMemoryDB` which only pre-loaded contract code, leaving every storage slot zero). Address normalization added so EIP-55 checksummed addresses resolve correctly against the lowercase `AccountDB` keys.
-- **`StakingOp::AddSelfStake`** — fork activated at `ADD_SELF_STAKE_HEIGHT=731245` on mainnet. Validators can bond real SRX into their own `self_stake` without the phantom-mint that pre-PR-#384 `force-unjail` produced. Recovery path for slashed validators with `self_stake < MIN_SELF_STAKE`.
-- **`reset-trie` CLI flag** (#384) — operator-side recovery printout for the force-unjail one-way trap.
-- **Operator-host scrub round** (#386, #387) — additional internal-tooling-reference scrub on operator-host paths.
+- **`crates/sentrix-rpc/src/jsonrpc/eth.rs`** (#391) — cap eth_call dry-run gas at `TX_GAS_LIMIT_CAP` (16,777,216, EIP-7825) instead of `BLOCK_GAS_LIMIT` (30M). revm with SpecId ≥ Osaka rejects gas_limit > cap with `TxGasLimitGreaterThanCap` even for read-only dry-runs; pre-fix every eth_call returned `0x` empty. Live-discovered after #389 deploy.
+
+### Documentation
+
+- **`genesis/mainnet.toml`** (#390) — clarifying comment block explains the v2 → v3 founder admin transfer history (block 444070, 2026-04-24). Comment-only; genesis hash regression test continues to pass.
+- **`README.md`** + **`CHANGELOG.md`** + **`docs/operations/NETWORKS.md`** (#392) — bump v2.1.44 references to v2.1.46 across public docs after the mainnet redeploy.
+
+---
+
+## [2.1.46] — 2026-04-28 — AddSelfStake activation + reset-trie CLI flag + workspace version bump
+
+> **Mainnet activation of `StakingOp::AddSelfStake`** for non-phantom validator self-bond. vps3 unjailed via real-SRX self-bond. 4-of-4 validators active. Workspace version bumped 2.1.44 → 2.1.46 across root + every internal crate.
+
+### Added / Fixed
+
+- **`StakingOp::AddSelfStake`** (#385) — supply-invariant validator self-bond. Validators can bond real SRX into their own `self_stake` without the phantom-mint that pre-PR-#384 `force-unjail` produced. Fork-gated at `ADD_SELF_STAKE_HEIGHT=731245` on mainnet. Recovery path for slashed validators with `self_stake < MIN_SELF_STAKE`.
+- **`reset-trie` CLI flag** (#384) — unblock force-unjail recovery on non-genesis chains. Operator-side recovery printout for the force-unjail one-way trap.
+- **Operator-host references scrub** (#386, #387) — IP-allowlist references in tools, source comments, audit docs replaced with generic `RPC_BASE_URL` env var pattern. Final grep across tracked files returns zero matches for the prior internal-host shorthand.
 
 ### Internal
 
 - **Workspace `Cargo.toml`** (#388) — bumped `version = "2.1.44" → "2.1.46"` across root + every internal crate + bin (uniform). `tools/*` keep their independent `0.1.0`.
 
-### Known follow-ups
-
-- **PR #389 partial** — wired `eth_call` through revm but mainnet probe found dry-run gas cap mismatch with EIP-7825; follow-up PR #391 caps at `TX_GAS_LIMIT_CAP` (16,777,216) instead of `BLOCK_GAS_LIMIT` (30M) so the per-tx cap revm enforces in `SpecId >= Osaka` doesn't reject every dry-run.
-
 ---
 
-## [2.1.42] — 2026-04-27 (later) — Phase A→D consensus-jail full stack + testnet bootstrap
+## [2.1.45] — 2026-04-27 (later) — Phase A→D consensus-jail full stack + testnet bootstrap
 
 > **The asymmetric-application bug class is now fixed at the protocol level.** Phase A (data types) shipped earlier this day in #359; this batch ships Phase B (helpers + fork gate), Phase C (dispatch verification), and Phase D (proposer emission + Pass-1/Pass-2 wiring + 4-validator determinism harness). Default behavior is unchanged: `JAIL_CONSENSUS_HEIGHT=u64::MAX` on default builds means the entire dispatch path is unreachable until an operator opts in.
 >


### PR DESCRIPTION
## Summary

Fixes a labeling bug from PR #392's CHANGELOG refresh: Phase A→D consensus-jail + testnet bootstrap content was promoted to a fictional \`[2.1.42]\` section, but those PRs (#368-#377) actually shipped in **v2.1.45** by git tag history.

- Rename \`[2.1.42]\` → \`[2.1.45]\` (matches the actual tag at commit \`3ee0316a\`).
- \`[2.1.46]\` scoped to its real content (AddSelfStake + reset-trie + scrub + version bump).
- \`[Unreleased]\` now lists the eth_call wiring (#389/#391) + genesis comment (#390) + doc refresh (#392) — these landed AFTER v2.1.46's tag and will ship in v2.1.47.

## Test plan

- [x] \`grep '## \\[' CHANGELOG.md\` returns sections in semver order.
- [x] No stray \`[2.1.42]\` references remain.
- [x] Doc-only change.