### PR TITLE
chore(release): v2.1.47 — eth_call → revm + EIP-7825 gas cap fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,27 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-> Tonight's post-v2.1.46 work. Will land in v2.1.47 once tagged.
+> Empty placeholder — next release will land on this branch.
+
+---
+
+## [2.1.47] — 2026-04-28 — eth_call → revm wiring + EIP-7825 gas cap fix + version bump
+
+> **Mainnet `eth_call` now actually executes against revm + live chain state.** Previously stubbed; canonical-contract reads (`WSRX.name()`, `Multicall3.getCurrentBlockTimestamp()`, etc) returned `0x` empty. Two PRs land the full fix: #389 wires the revm dispatch path, #391 caps the dry-run gas at the EIP-7825 limit so revm doesn't reject every call.
 
 ### Added / Fixed
 
 - **`crates/sentrix-rpc/src/jsonrpc/eth.rs`** (#389) — `eth_call` and `eth_estimateGas` now route through revm execution against the live chain state via `SentrixEvmDb::from_account_db(&bc.accounts)` (was `InMemoryDB` which only pre-loaded contract code, leaving every storage slot zero). Address normalization added so EIP-55 checksummed addresses resolve correctly against the lowercase `AccountDB` keys.
-- **`crates/sentrix-rpc/src/jsonrpc/eth.rs`** (#391) — cap eth_call dry-run gas at `TX_GAS_LIMIT_CAP` (16,777,216, EIP-7825) instead of `BLOCK_GAS_LIMIT` (30M). revm with SpecId ≥ Osaka rejects gas_limit > cap with `TxGasLimitGreaterThanCap` even for read-only dry-runs; pre-fix every eth_call returned `0x` empty. Live-discovered after #389 deploy.
+- **`crates/sentrix-rpc/src/jsonrpc/eth.rs` + `crates/sentrix-evm/src/gas.rs`** (#391) — add `TX_GAS_LIMIT_CAP = 16_777_216` constant (EIP-7825) and clamp eth_call dry-run gas at this value instead of `BLOCK_GAS_LIMIT` (30M). revm with SpecId ≥ Osaka rejects `gas_limit > cap` with `TxGasLimitGreaterThanCap` even for read-only dry-runs; pre-fix every eth_call returned `0x` empty. Live-discovered after #389 deploy when `cast call <WSRX> "name()(string)"` still returned the ABI-decode error.
 
 ### Documentation
 
 - **`genesis/mainnet.toml`** (#390) — clarifying comment block explains the v2 → v3 founder admin transfer history (block 444070, 2026-04-24). Comment-only; genesis hash regression test continues to pass.
-- **`README.md`** + **`CHANGELOG.md`** + **`docs/operations/NETWORKS.md`** (#392) — bump v2.1.44 references to v2.1.46 across public docs after the mainnet redeploy.
+- **`README.md`** + **`docs/operations/NETWORKS.md`** + **`CHANGELOG.md`** (#392, #394) — bump v2.1.44 references to v2.1.46 across public docs after the mainnet redeploy; correct stale `[2.1.42]` CHANGELOG label to `[2.1.45]` to match git tag history.
+
+### Internal
+
+- **Workspace `Cargo.toml`** — bumped `version = "2.1.46" → "2.1.47"` across root + every internal crate + bin (uniform). `tools/*` keep their independent `0.1.0`.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4894,7 +4894,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "bincode",
  "hex",
@@ -4903,7 +4903,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "anyhow",
  "axum",
@@ -4969,7 +4969,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "anyhow",
  "axum",
@@ -5007,14 +5007,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5057,14 +5057,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5074,7 +5074,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5089,7 +5089,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "bincode",
  "blake3",
@@ -5105,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.44"
+version = "2.1.47"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Workspace version bump 2.1.46 → 2.1.47. Promotes the [Unreleased] section to [2.1.47].

Release content (already-merged PRs):
- #389 — eth_call/estimateGas route through revm against live chain state
- #390 — genesis/mainnet.toml clarifying comment for v2→v3 founder transfer
- #391 — cap eth_call dry-run gas at TX_GAS_LIMIT_CAP (EIP-7825) — fixes #389
- #392 — README+CHANGELOG+NETWORKS bump v2.1.44 → v2.1.46
- #394 — CHANGELOG renames stale [2.1.42] label → [2.1.45]

## Test plan

- [x] cargo build --release -p sentrix-rpc — clean
- [x] All 17 Cargo.toml files bumped uniformly to 2.1.47
- [x] Live mainnet binary built from this tree confirmed working: cast call WSRX.name() returns "Wrapped SRX"