### PR TITLE
docs: Docusaurus pages for tonight's tokenomics + multisig + observability work

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -17,7 +17,9 @@ Sentrix is the financial infrastructure for the real economy — starting with I
 - 🦊 **Connect MetaMask** — [Network Config](operations/METAMASK)
 - 🔗 **API Reference** — [REST + JSON-RPC Endpoints](operations/API_ENDPOINTS)
 - ⚙️ **Run a Node** — [Validator Guide](operations/VALIDATOR_GUIDE)
-- 🪙 **Tokenomics** — [SRX](tokenomics/SRX) · [SRC-20 Standard](tokenomics/TOKEN_STANDARDS) · [Staking](tokenomics/STAKING)
+- 🪙 **Tokenomics** — [Overview](tokenomics/OVERVIEW) · [SRX](tokenomics/SRX) · [Staking](tokenomics/STAKING) · [Reward Escrow](tokenomics/REWARD_ESCROW) · [SRC-20 Standard](tokenomics/TOKEN_STANDARDS)
+- 🛡️ **Security** — [Multi-sig & Authority](security/MULTISIG) · [Audit Reports](security/SECURITY_AUDIT_V11)
+- 📡 **Operations** — [Mainnet Observability](operations/OBSERVABILITY) · [Validator Onboarding](operations/VALIDATOR_ONBOARDING)
 
 ## Network at a glance
 

--- a/docs/operations/OBSERVABILITY.md
+++ b/docs/operations/OBSERVABILITY.md
@@ -1,0 +1,151 @@
+---
+sidebar_position: 18
+title: Mainnet Observability
+---
+
+# Mainnet observability
+
+Three-tier monitoring stack on the build host that catches mainnet stalls + per-validator divergence + auto-recovers. Shipped 2026-04-28 after a 30-min h=773013 stall ran undetected because alerting was incomplete.
+
+## Stack overview
+
+| Tier | Component | Cadence | What it watches |
+|---|---|---|---|
+| 1 | **Watchdog daemon** (`scripts/watch-mainnet.sh`) | every 30s | Edge stall + per-validator height lag + RPC reachability |
+| 2 | **Prometheus + Alertmanager** | 15s scrape | 12 alert rules across chain + hosts + info |
+| 3 | **External uptime check** (UptimeRobot, recommended) | 5 min | HTTP keyword on `/sentrix_status` from outside the fleet |
+
+All three converge on the same Telegram bot (`@Sentrixnotif_bot` via Alertmanager Telegram receiver). Multi-source redundancy means failure of one path doesn't blind the operator.
+
+## Tier 1 — Watchdog daemon
+
+`scripts/watch-mainnet.sh` runs every 30 seconds via `sentrix-watchdog.timer` systemd unit. Three checks per tick:
+
+### Check 1: Edge stall
+
+Polls `https://rpc.sentrixchain.com/sentrix_status` for `latest_block_height`. If height doesn't advance in 2 minutes → WARN, in 5 minutes → CRITICAL with optional auto-recovery.
+
+### Check 2: Per-validator lag
+
+Probes each validator's `:8545` (or `:8549` for the Treasury validator on its non-default port) and compares against the cluster median. Any validator > 10 blocks behind → WARN. Catches the divergence pattern that caused the 2026-04-28 stall (one validator silently fell 1 block behind, BFT then couldn't recover for 30 min).
+
+### Check 3: RPC reachability
+
+Times out on per-validator probe → WARN. Catches the case where systemd reports a service "active" but the validator process is hung (RPC port not responding).
+
+### Alert routing
+
+Configured in `/etc/sentrix/watchdog.env`:
+
+```bash
+TELEGRAM_BOT_TOKEN=<from BotFather>
+TELEGRAM_CHAT_ID=<your operator chat>
+DISCORD_WEBHOOK_URL=                # optional, parallel route
+AUTO_RECOVERY=false                  # flip true after 1-2 weeks soak
+STALL_WARN_SEC=120
+STALL_CRITICAL_SEC=300
+LAG_WARN_BLOCKS=10
+```
+
+### Auto-recovery
+
+When `AUTO_RECOVERY=true`, watchdog runs `scripts/recover-mainnet.sh` automatically after 5 min of stall. Recovery sequence:
+
+1. Probe per-validator height; identify canonical (highest with ≥ 2 agreeing peers).
+2. If any lagger > 5 blocks behind canonical → halt, backup divergent chain.db (timestamped), tar-pipe canonical chain.db over.
+3. halt-all + simul-start in parallel across all 4 validators.
+4. Verify chain advances within 25s; exit code 2 if still stuck (operator escalation needed).
+
+Proven 2026-04-28: end-to-end recovery in **36 seconds** (vs the 30 min manual MTTR observed earlier same day). Forensic backups of divergent chain.db are preserved at `/opt/<service>/data/chain.db.divergent-h<H>-<timestamp>/`.
+
+## Tier 2 — Prometheus + Alertmanager
+
+[Prometheus](https://prometheus.io/) on the build host scrapes 10 targets every 15-30s:
+
+| Job | Targets | Purpose |
+|---|---|---|
+| `node_exporter` | All 5 VPS at `:9100` | OS metrics (CPU, RAM, disk, network) |
+| `sentrix-mainnet` | 4 mainnet validators at `:8545` (vps2: `:8549`) | Chain metrics (height, mempool, fees, validators) |
+| `prometheus` | self at `localhost:9090` | self-scrape |
+
+### Alert rules (12 total)
+
+**Chain (6):**
+
+- `ChainHeightStalled` (critical) — `delta(sentrix_block_height[2m]) == 0`, fires after 1m
+- `BlockTimeDegraded` (warning) — `sentrix_block_time_seconds > 8`, fires after 2m
+- `NoActiveValidators` (critical) — `sentrix_active_validators == 0`, fires after 30s
+- `PeerBlockSaveFailing` (critical) — `rate(sentrix_peer_block_save_fails_total[5m]) > 0`
+- **`ValidatorLagBehindCluster`** (warning) — per-validator height vs cluster max > 10, fires after 2m. Catches the divergence pattern that today's halt trained on.
+- **`ValidatorHeightSpread`** (critical) — cluster max - min > 20, fires after 2m. Catches split-brain even when no single vps is "the lagger".
+
+**Hosts (3):**
+
+- `TargetDown` (warning) — any scrape target unreachable for >3m
+- `DiskSpaceLow` (warning) — root mount < 15% free for >15m
+- `HighMemoryUsage` (warning) — RAM > 90% for >10m
+
+**Info (3):**
+
+- `ValidatorSetChanged` (info) — admin op fired (audit trail)
+- `MempoolHot` (info) — `sentrix_tx_pool_size > 100` for >2m
+- `BlockHeightMilestone` (info) — every 100K blocks
+
+### Telegram delivery
+
+Alertmanager (port 9093) routes alerts to Telegram via the `@Sentrixnotif_bot` receiver:
+
+```yaml
+receivers:
+  - name: telegram
+    telegram_configs:
+      - bot_token: <token>
+        chat_id: <operator_chat_id>
+        send_resolved: true
+        parse_mode: HTML
+```
+
+Severity tiers: `critical` = group_wait 5s, repeat every 10m. `warning` = group_wait 15s, repeat every 30m. `info` = group_wait 1m (batch), repeat 720h (fire-once).
+
+## Tier 3 — External uptime (UptimeRobot)
+
+Eliminates the "what if the build host itself dies" gap. Free tier covers 50 monitors at 5-min interval. Setup at [uptimerobot.com](https://uptimerobot.com):
+
+1. **Sign up** (free).
+2. **Monitor 1 — Mainnet RPC alive** — type `HTTP(s) — Keyword`, URL `https://rpc.sentrixchain.com/sentrix_status`, keyword `latest_block_height`.
+3. **Monitor 2 — Testnet RPC** — same with `testnet-rpc`.
+4. **Monitor 3-5** — explorer + faucet + docs (HTTP-only, 200 check).
+5. **Telegram integration** — Profile → Integrations → Add Telegram → use the same `@Sentrixnotif_bot`.
+
+## Manual operator commands
+
+```bash
+# Tail live ticks
+sudo journalctl -t sentrix-watchdog -f
+
+# Force a tick now (debug)
+sudo systemctl start sentrix-watchdog.service
+
+# Read current state
+cat /var/lib/sentrix-watchdog/state.json | jq
+
+# Trigger manual recovery (skip waiting for stall threshold)
+~/founder-private/scripts/recover-mainnet.sh
+
+# Disable temporarily (planned maintenance)
+sudo systemctl stop sentrix-watchdog.timer
+```
+
+## Known limitations
+
+- **Build-host SPOF for tiers 1-2** — both run on the build host. If that host dies, only Tier 3 (UptimeRobot) pages. Mitigation: ensure UptimeRobot is configured before relying on the stack.
+- **Heuristic canonical selection in `recover-mainnet.sh`** — picks "highest height with ≥ 2 agreeing peers". Edge case: 4-way split-brain (all 4 different heights) picks the highest. Adequate for the common 1-validator-lagging pattern but not for full consensus splits.
+- **No state_root cross-check at same height** — detects HEIGHT lag, not state divergence at matching heights. Same-height divergence would slip through. The `state-divergence-recovery` runbook covers that case manually.
+- **Auto-recovery may halt during legitimate slow blocks** — if real network conditions cause a 5-min slowdown without divergence, auto-recovery would unnecessarily halt-all. Soak with `AUTO_RECOVERY=false` long enough to trust the threshold before flipping on.
+
+## See also
+
+- [`runbooks/mainnet-watchdog.md`](https://github.com/satyakwok/sentrixfounder-private/blob/main/runbooks/mainnet-watchdog.md) — operator runbook (private)
+- [Monitoring](./MONITORING) — Prometheus + Grafana setup overview
+- [Emergency Rollback](./EMERGENCY_ROLLBACK) — when to restore from off-host backup
+- [Testnet Recovery](./TESTNET_RECOVERY) — testnet-only recovery patterns

--- a/docs/security/MULTISIG.md
+++ b/docs/security/MULTISIG.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 5
+title: Multi-sig & Authority Wallet
+---
+
+# SentrixSafe & authority wallet model
+
+How privileged actions on Sentrix Chain are governed: a minimal Gnosis Safe-derived multi-sig, currently 1-of-1 with a dedicated authority signer, transitioning to 3-of-5 in Q3 2026.
+
+## Architecture
+
+- **SentrixSafe contract** at `0x6272dC0C842F05542f9fF7B5443E93C0642a3b26` (mainnet 7119) and `0xc9D7a61D7C2F428F6A055916488041fD00532110` (testnet 7120). Source in [`canonical-contracts`](https://github.com/sentrix-labs/canonical-contracts/blob/main/contracts/SentrixSafe.sol).
+- **Authority signer** EOA `0xa25236925bc10954e0519731cc7ba97f4bb5714b` — pure-signing role, holds 0 SRX, sole owner of both Safes with threshold=1.
+- **Bootstrap deployer** EOA `0x5acb04058fc4dfa258f29ce318282377cac176fd` — deployed all four canonical contracts (WSRX, Multicall3, TokenFactory, SentrixSafe) on 2026-04-27. **Retired from Safe ownership 2026-04-28.**
+
+## Why decoupled signers
+
+Pre-2026-04-28, the single Founder wallet (Founder v3, `0x5b5b06688dcd...`, 21M SRX premine) was the natural Safe-owner candidate. Decoupling that role from the premine wallet to a dedicated authority EOA gives:
+
+1. **Clean role separation** — Founder v3 = pure premine holder (passive). Authority = pure signer (0 SRX). If either keystore leaks the blast radius is bounded.
+2. **Easier rotation** — rotating the signing key doesn't move 21M SRX around.
+3. **Audit trail clarity** — every Safe `execTransaction` is signed by the authority address; no confusion with founder personal-funds movements.
+
+## Migration history (2026-04-28)
+
+Both Safes started as 1-of-1 multisigs owned by the bootstrap deployer (set at construction time). Migration sequence:
+
+| Step | Chain | Action | Tx | Block |
+|---|---|---|---|---|
+| 1 | testnet 7120 | `addOwner(authority, threshold=1)` | `0xb70a83eb416e2323aa8cc422d72fc89bd9a6f6e4338ce2b6bc8560a711d0c70f` | 881639 |
+| 2 | mainnet 7119 | `addOwner(authority, threshold=1)` | `0xd17400c35f0716db7410384fd728ed3b02185bf861880aad7b44326ba7690b19` | 755821 |
+| 3 | testnet 7120 | `removeOwner(deployer, threshold=1)` | `0xb0c69e89252c4e00b920600b2211f3857c07da0aa7f5c6719cc3dc8c42b6d728` | 884599 |
+| 4 | mainnet 7119 | `removeOwner(deployer, threshold=1)` | `0x8e9ca8b4cbe0bac8332de225045b83059b3a05ea2748d58d61218c7598d1d6e0` | 757829 |
+
+Final state both chains: **1-of-1 with authority sole owner, threshold=1, nonce=2.**
+
+## Off-chain SafeTx construction
+
+Both `addOwner` and `removeOwner` were built fully off-chain because `eth_call` and `eth_getStorageAt` were stubbed pre-PR-#389. SafeTx hash computation:
+
+```
+TX_TYPEHASH      = keccak256("SafeTx(address to,uint256 value,bytes data,uint256 operation,uint256 nonce)")
+DOMAIN_SEPARATOR = keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, chainId, safe_addr))
+structHash       = keccak256(abi.encode(TX_TYPEHASH, to, value, keccak(data), operation, nonce))
+txHash           = keccak256(0x1901 || DOMAIN_SEPARATOR || structHash)
+signature        = cast wallet sign --no-hash <txHash> --private-key <signer>
+```
+
+Submitted via `cast send <safe> "execTransaction(address,uint256,bytes,uint256,bytes)" ...` from the deployer (which still had ~0.5 SRX for gas). Verified each tx receipt: `status=0x1`, two events fired (`AddedOwner(addr)` / `RemovedOwner(addr)` + `ExecutionSuccess(safeTxHash)`).
+
+## Verifying current state
+
+After PR #389 + #391 deployed in v2.1.47 (eth_call wired with EIP-7825 gas cap):
+
+```bash
+cast call 0x6272dC0C842F05542f9fF7B5443E93C0642a3b26 "getOwners()(address[])" \
+  --rpc-url https://rpc.sentrixchain.com
+# → [0xa25236925bc10954e0519731cc7ba97f4bb5714b]
+
+cast call 0x6272dC0C842F05542f9fF7B5443E93C0642a3b26 "getThreshold()(uint256)" \
+  --rpc-url https://rpc.sentrixchain.com
+# → 1
+```
+
+## Q3 2026: 3-of-5 migration plan
+
+Adds 4 additional signers to the Safe, then `changeThreshold(3)`. Target signer slate:
+
+| Slot | Role | Held by |
+|---|---|---|
+| 1 | Authority (current) | Sentrix Labs core team |
+| 2 | Founder backup | Cold-storage wallet, separate from Founder v3 premine |
+| 3 | Independent advisor 1 | TBD |
+| 4 | Independent advisor 2 | TBD |
+| 5 | Security council seat | TBD (audit firm or community-elected) |
+
+Sequenced as: `addOwner(slot2, threshold=1)` → `addOwner(slot3, threshold=1)` → `addOwner(slot4, threshold=1)` → `addOwner(slot5, threshold=1)` → `changeThreshold(3)`. All signed by current authority (1-of-1 still suffices throughout).
+
+## Key contract operations gated by Safe
+
+- **`SentrixSafe.addOwner(address, uint256)`** — add a new signer + new threshold.
+- **`SentrixSafe.removeOwner(address, uint256)`** — remove a signer + new threshold. Enforces `owners.length - 1 >= _threshold`.
+- **`SentrixSafe.changeThreshold(uint256)`** — change quorum without changing owner set.
+- **`SentrixSafe.execTransaction(...)`** — execute arbitrary (target, value, calldata) operations against any contract. Used for the addOwner/removeOwner self-calls + future governance txs.
+
+The existing canonical contracts (WSRX, Multicall3, TokenFactory) have **no owner role** — they're immutable after deployment. Only SentrixSafe has owner-set governance. If future contracts gain owner roles (e.g., upgradeable proxies, pausable factories), `script/TransferOwnership.s.sol` will document the hand-off path.
+
+## See also
+
+- [`canonical-contracts/docs/ADDRESSES.md`](https://github.com/sentrix-labs/canonical-contracts/blob/main/docs/ADDRESSES.md) — deployed addresses + ownership migration tx hashes
+- [`canonical-contracts/contracts/SentrixSafe.sol`](https://github.com/sentrix-labs/canonical-contracts/blob/main/contracts/SentrixSafe.sol) — contract source
+- [Tokenomics > Governance](../tokenomics/OVERVIEW#8-governance) — broader governance roadmap

--- a/docs/tokenomics/OVERVIEW.md
+++ b/docs/tokenomics/OVERVIEW.md
@@ -1,0 +1,147 @@
+---
+sidebar_position: 1
+title: Tokenomics Overview
+---
+
+# Tokenomics
+
+The full breakdown of SRX supply, distribution, halving schedule, vesting, and reward economics. For the visual version, see [`sentrixchain.com/docs/tokenomics`](https://sentrixchain.com/docs/tokenomics).
+
+## At a glance
+
+| Field | Value | Status |
+|---|---|---|
+| Hard cap | **315,000,000 SRX** | ✅ Enforced on-chain (3-layer guard) |
+| Premine | **63,000,000 SRX** (20%) | ✅ Genesis allocations, immutable |
+| Mining supply | **252,000,000 SRX** (80%) | ✅ Geometric series, 4-year halving |
+| Block reward (era 0) | **1 SRX/block** | ✅ Live |
+| Block time | **1 second** | `BLOCK_TIME_SECS = 1` |
+| Halving | every **126,000,000 blocks** (~4 years, BTC-parity) | Active since `TOKENOMICS_V2_HEIGHT=640800` |
+| Mining duration | ~108–112 years (asymptotic) | Halving 27 → reward = 0 |
+| Native fee burn | **50% burned, 50% to validator** | `account.rs::div_ceil(2)` |
+| Decimals | **8** (1 SRX = 100,000,000 sentri) | BTC-style, NOT 18 like ERC-20 |
+
+Live verification:
+
+```bash
+curl -s https://rpc.sentrixchain.com/chain/info | jq '{height, max_supply_srx, next_block_reward_srx, total_minted_srx, total_burned_srx}'
+```
+
+## 1. Hard cap: 315M SRX
+
+Enforced at three independent layers in `crates/sentrix-core/src/blockchain.rs`:
+
+1. **Constant** `MAX_SUPPLY_V2 = 315_000_000 × 100_000_000` sentri (line 31)
+2. **Reward clamp** `reward.min(remaining)` in `Blockchain::get_block_reward` (line 1110)
+3. **Mint counter** `total_minted = total_minted.saturating_add(coinbase_amount)` with cap re-check (`block_executor.rs:809`)
+
+The cap is technically asymptotic: integer truncation in the halving series leaves a residue of ~1.88 SRX never minted, so live `total_minted` saturates just below 315M.
+
+## 2. Premine: 63M SRX (20%)
+
+Four genesis wallets, set in [`genesis/mainnet.toml`](https://github.com/sentrix-labs/sentrix/blob/main/genesis/mainnet.toml) and immutable. Sub-allocation policies below are governance intent; each top-level address is publicly auditable on the [explorer](https://scan.sentrixchain.com).
+
+| Slot | Address | Amount | Policy |
+|---|---|---|---|
+| Founder | `0x5b5b06688dcdbe532353ac610aaff41af825279d` | 21,000,000 SRX | 12-mo cliff + 48-mo linear vesting (60 mo total) — social commitment, on-chain vesting contract pending Q3 2026 |
+| Ecosystem Fund | `0xeb70fdefd00fdb768dec06c478f450c351499f14` | 21,000,000 SRX | Multi-sig governed: Dev Grants 8M · Hackathon 3M · Marketing 5M · Faucet 1M · Reserve 4M |
+| Validator Incentive Pool | `0x328d56b8174697ef6c9e40e19b7663797e16fa47` | 10,500,000 SRX | Distributed over ~24 months post external-validator onboarding |
+| Strategic Reserve | `0x2578cad17e3e56c2970a5b5eab45952439f5ba97` | 10,500,000 SRX | Multi-sig governed: Airdrops 5M · CEX Listings 3M · DEX Liquidity 1.5M · Emergency 1M |
+
+> **Genesis note:** `genesis/mainnet.toml` lists the historical Founder v2 address as the seed (`0x252f8cfed5...`). The live admin Founder v3 (`0x5b5b06688dcd...`) inherited the balance via on-chain admin transfer at block 444070 (txid `0x07354cc4...`, 2026-04-24). Genesis is immutable; the live state on the explorer is correct.
+
+## 3. Halving schedule — BTC-parity
+
+Geometric halving series: each era is **126,000,000 blocks ≈ 4 years**. Initial reward 1 SRX/block.
+
+| Era | Block range (post-fork from h=640,800) | Approx years from launch | Reward (SRX/block) | Era mint (SRX) |
+|---|---|---|---|---|
+| 0 | 640,800 → 126,640,800 | 0 → ~4 | 1.0 | 126,000,000 |
+| 1 | 126,640,800 → 252,640,800 | ~4 → ~8 | 0.5 | 63,000,000 |
+| 2 | … | ~8 → ~12 | 0.25 | 31,500,000 |
+| 3 | … | ~12 → ~16 | 0.125 | 15,750,000 |
+| 4 | … | ~16 → ~20 | 0.0625 | 7,875,000 |
+| 5 | … | ~20 → ~24 | 0.03125 | 3,937,500 |
+| … | … | … | ÷2 each era | … |
+| 26 | … | ~108 | 1 sentri | 1.26 SRX |
+| 27+ | from ~year 108 | ~112+ | 0 (integer truncation) | 0 |
+
+**Geometric total:** `1 SRX × 126M × Σ(2⁻ᵏ) = 252M SRX`. Integer-truncation actual: ~252M − 1.88 SRX residue.
+
+Pre-fork (h \< 640,800) used 42M-block halving with a 210M cap. Fork was activated cleanly while still in v1 era 0 (cumulative halvings transition smoothly with no reward jump).
+
+## 4. Burn mechanism
+
+### Native flat-fee (current)
+
+- Min fee: **10,000 sentri = 0.0001 SRX** (`MIN_TX_FEE`, [`crates/sentrix-primitives/src/transaction.rs:9`](https://github.com/sentrix-labs/sentrix/blob/main/crates/sentrix-primitives/src/transaction.rs#L9))
+- Split: **50% burned, 50% to block validator** — `burn = fee.div_ceil(2)`, `validator = fee - burn`
+- Algebraic invariant: `burn + validator == fee` proved in `account.rs::test_validator_share_lossless`
+
+### Reward routing post-V4-fork
+
+Since `VOYAGER_REWARD_V2_HEIGHT=590100` (2026-04-25), block reward (1 SRX) routes to PROTOCOL_TREASURY escrow instead of directly to the proposer's balance. Validators + delegators drain via `StakingOp::ClaimRewards`. See [Reward Escrow](./REWARD_ESCROW) for the sentinel address explainer.
+
+Fee revenue (post split) still credits the validator immediately every block — only the 1 SRX block reward is escrowed.
+
+### Live (2026-04-28)
+
+Cumulative burned: `~15 SRX` at h≈780k. Burn rate scales with EVM dApp adoption.
+
+## 5. Vesting
+
+| Recipient | Amount | Schedule | On-chain enforcement |
+|---|---|---|---|
+| Founder | 21,000,000 | 12-mo cliff + 48-mo linear (60 mo total) | ❌ Pending — vesting contract Q3 2026 |
+| Ecosystem Fund | 21,000,000 | Multi-sig governance, transparent disbursement | ✅ SentrixSafe |
+| Validator Incentive | 10,500,000 | Distributed over 24 months post external-validator launch | ❌ Policy (governance-gated drips) |
+| Strategic Reserve | 10,500,000 | Multi-sig governance | ✅ SentrixSafe |
+
+All four wallets publicly auditable on the [explorer](https://scan.sentrixchain.com). Any unscheduled outflow is observable in real-time.
+
+## 6. Airdrop strategy — 5M SRX
+
+Phased rollout from the Strategic Reserve. Each phase has its own snapshot + criteria; distribution via Merkle-claim:
+
+| Phase | Allocation | Audience | Trigger |
+|---|---|---|---|
+| 1 — Testnet Heroes | 1,000,000 | Active testnet validators + power users | Q2 2026 |
+| 2 — Quest Campaign | 1,000,000 | Galxe/Zealy-style task completion | Q3 2026 |
+| 3 — Activity Rewards | 800,000 | Active mainnet wallets | Q3 2026 |
+| 4 — Validator Delegators | 700,000 | Pro-rata to delegators | Q4 2026 |
+| 5 — Retroactive Builders | 1,500,000 | dApp deployers, audit contributors, ecosystem PRs | Q4 2026 / Q1 2027 |
+
+## 7. Listing roadmap
+
+Target tiers, subject to maintainer approval (aggregators) or commercial agreement (CEXs).
+
+| Tier | When | Targets |
+|---|---|---|
+| 0 — Aggregators (free) | Q2-Q3 2026 | CoinGecko, CoinMarketCap, DefiLlama, Chainlist (PR #8266 live) |
+| 1 — Indonesian CEX | Q3-Q4 2026 | Tokocrypto, Pintu, Indodax |
+| 2 — International | Q4 2026 - Q1 2027 | Gate.io, MEXC, KuCoin |
+| 3 — Top tier | 2027+ | Binance, Coinbase (traction-gated) |
+
+Listing fee budget: 3M SRX from Strategic Reserve.
+
+## 8. Governance
+
+| Period | Setup | Authority signer(s) |
+|---|---|---|
+| **Today (2026-04-28)** | SentrixSafe 1-of-1 on both chains | Authority `0xa25236925bc10954e0519731cc7ba97f4bb5714b` |
+| **Q3 2026 target** | SentrixSafe 3-of-5 multi-sig | Authority + Founder backup + 2× independent advisors + 1× security council |
+
+Migration history (2026-04-28): `addOwner(authority)` testnet block 881639 + mainnet block 755821; `removeOwner(deployer)` testnet block 884599 + mainnet block 757829. Bootstrap deployer EOA retired from Safe ownership. Tx hashes in [canonical-contracts ADDRESSES.md](https://github.com/sentrix-labs/canonical-contracts/blob/main/docs/ADDRESSES.md).
+
+## 9. Transparency commitments
+
+- **Public tokenomics page:** [sentrixchain.com/docs/tokenomics](https://sentrixchain.com/docs/tokenomics)
+- **Real-time wallet labels** in the explorer (Founder, Ecosystem Fund, Reserve, Authority, Safes, Treasury sentinel)
+- **On-chain verifiable** — every claim above checks out via `cast call` / RPC against the live chain.
+
+## See also
+
+- [SRX](./SRX) — native coin units, supply, distribution
+- [Staking](./STAKING) — Voyager DPoS + reward distribution
+- [Token Standards](./TOKEN_STANDARDS) — SRC-20 native + ERC-20 via EVM
+- [Reward Escrow](./REWARD_ESCROW) — sentinel addresses + PROTOCOL_TREASURY explainer

--- a/docs/tokenomics/REWARD_ESCROW.md
+++ b/docs/tokenomics/REWARD_ESCROW.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 5
+title: Reward Escrow & Sentinel Addresses
+---
+
+# Reward escrow & protocol sentinels
+
+Three addresses on Sentrix Chain hold balances but have **no private key** — they're protocol-reserved sentinels, mutated only by consensus-level operations. If you spot them in the explorer's top accounts and wonder where the funds came from, this is the explainer.
+
+| Address | Role | Live mainnet balance (2026-04-28) |
+|---|---|---|
+| `0x0000000000000000000000000000000000000002` | **PROTOCOL_TREASURY** — V4 reward escrow | ~903K SRX |
+| `0x0000000000000000000000000000000000000000` | **TOKEN_OP_ADDRESS** — TokenOp routing marker + EVM CREATE marker | ~0 SRX |
+| `0x0000000000000000000000000000000000000100` | **STAKING_ADDRESS** — reserved (not currently used as `to`) | 0 SRX |
+
+## Protocol Treasury (`0x0000…0002`) — the most important one
+
+Active since the V4 reward-v2 fork at `VOYAGER_REWARD_V2_HEIGHT=590100` (2026-04-25). Pre-fork: every block's 1 SRX coinbase reward minted directly into the proposer's balance. Post-fork: coinbase mints into `PROTOCOL_TREASURY`. The stake registry tracks per-validator `pending_rewards` and per-delegator `delegator_rewards` as accumulators. Validators + delegators drain their share via `StakingOp::ClaimRewards`, which transfers from the treasury → claimer's balance.
+
+**Therefore:** `balance(PROTOCOL_TREASURY)` ≈ sum of unclaimed rewards owed by the protocol to participants. **NOT a foundation-controlled treasury.** No keystore can move funds out — only the consensus-level `ClaimRewards` dispatch (gated by stake registry accumulator entries) can mutate this balance.
+
+### Code paths
+
+- [`crates/sentrix-primitives/src/transaction.rs`](https://github.com/sentrix-labs/sentrix/blob/main/crates/sentrix-primitives/src/transaction.rs) — `pub const PROTOCOL_TREASURY = "0x0000…0002"`
+- [`crates/sentrix-core/src/block_executor.rs:789-793`](https://github.com/sentrix-labs/sentrix/blob/main/crates/sentrix-core/src/block_executor.rs#L789) — coinbase routing: `if Self::is_reward_v2_height(block.index) { coinbase_recipient = PROTOCOL_TREASURY }`
+- [`crates/sentrix-staking/src/staking.rs::distribute_reward`](https://github.com/sentrix-labs/sentrix/blob/main/crates/sentrix-staking/src/staking.rs) — multi-signer pro-rata accumulator update
+- `block_executor.rs::StakingOp::ClaimRewards` — drain path
+
+### Daily flow
+
+```
+Block produced
+  ↓
+Coinbase 1 SRX → 0x0000…0002 (PROTOCOL_TREASURY)
+  ↓
+StakeRegistry tracks per-validator pending_rewards + per-delegator delegator_rewards (accumulators)
+  ↓
+Validator/delegator submits StakingOp::ClaimRewards
+  ↓
+Transfer from 0x0000…0002 → claimer's balance (drains the accumulator)
+```
+
+86,400 blocks/day × 1 SRX = ~86,400 SRX/day minted into treasury. Drain rate = sum of all daily ClaimRewards. Steady-state: drains roughly match mints; balance reflects "lazy claimers" who haven't bothered to drain accumulators yet.
+
+## Token Op sentinel (`0x0000…0000`)
+
+Marker address used in two distinct cases:
+
+- **Native TokenOp routing** — `Transaction.to_address` of any `TokenOp::Deploy` / `Transfer` / `Burn` is set to this sentinel. The actual token-state mutation happens in the consensus dispatch logic (not as a regular balance transfer). Block executor recognizes the marker and routes to `ContractRegistry`.
+- **EVM CREATE marker** — when an EVM tx has `to_address = 0x0` (= sentinel), block executor knows it's a contract deployment and routes to revm's `TxKind::Create`.
+
+Balance under normal operation: 0 SRX. Token-burn ops have it as the destination but the burned supply is accounted in `total_burned`, not in this address's balance.
+
+## Staking sentinel (`0x0000…0100`)
+
+Reserved for staking-op routing convention. Not currently used as a tx `to` field — staking ops route via `PROTOCOL_TREASURY` in the V4 reward-v2 era. Reserved so dApps and tooling don't accidentally claim it as a regular EOA address.
+
+## Audit verification
+
+```bash
+# Live balance via eth_getBalance
+curl -s -X POST https://rpc.sentrixchain.com -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x0000000000000000000000000000000000000002","latest"],"id":1}'
+
+# Or via /accounts/top REST
+curl -s "https://rpc.sentrixchain.com/accounts/top?limit=10" | jq '.accounts[] | select(.address=="0x0000000000000000000000000000000000000002")'
+
+# In the explorer: https://scan.sentrixchain.com/address/0x0000000000000000000000000000000000000002
+```
+
+The explorer (`scan.sentrixchain.com`) labels these addresses as "Protocol Treasury (Reward Escrow)", "Sentrix Token Op (sentinel)", "Sentrix Staking (sentinel)" so they don't appear as unlabeled hex in the top-accounts view.
+
+## See also
+
+- [Tokenomics Overview](./OVERVIEW) — full SRX economic model
+- [Staking](./STAKING) — Voyager DPoS reward distribution
+- [Claim Rewards](../operations/CLAIM_REWARDS) — operator runbook for draining the escrow


### PR DESCRIPTION
## Summary

Closes the gap between tonight's chain-landing tokenomics page (visual/marketing) and docs.sentrixchain.com (developer/canonical reference). Four new pages:

- **`tokenomics/OVERVIEW.md`** — comprehensive technical tokenomics with code references + source links.
- **`tokenomics/REWARD_ESCROW.md`** — explains the three protocol-reserved sentinels (PROTOCOL_TREASURY, TOKEN_OP, STAKING). Triggered by user spotting 0x0000…0002 in explorer top accounts.
- **`security/MULTISIG.md`** — SentrixSafe + authority-wallet model + 2026-04-28 migration history + Q3 2026 3-of-5 plan.
- **`operations/OBSERVABILITY.md`** — three-tier monitoring stack shipped tonight (watchdog daemon + Prometheus/Alertmanager + UptimeRobot guide).

Also updates `intro.md` quick-links to surface Tokenomics + Security + Operations entries.

## Test plan

- [x] Docusaurus build clean (warnings only on deprecated config option, non-blocking).
- [x] Deployed to /var/www/docs-sentrixchain via scripts/deploy-docs.sh.
- [x] All 4 pages serving HTTP 200 with proper SSR titles:
  - https://docs.sentrixchain.com/tokenomics/OVERVIEW
  - https://docs.sentrixchain.com/tokenomics/REWARD_ESCROW
  - https://docs.sentrixchain.com/security/MULTISIG
  - https://docs.sentrixchain.com/operations/OBSERVABILITY

Doc-only.