### PR TITLE
feat(rpc): WebSocket subscriptions — eth_subscribe newHeads (Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -828,8 +829,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -5036,6 +5039,7 @@ dependencies = [
  "alloy-rlp",
  "axum",
  "chrono",
+ "futures-util",
  "hex",
  "revm",
  "sentrix-codec",
@@ -5239,6 +5243,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5647,6 +5662,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5868,6 +5895,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.3",
+ "sha1",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "typenum"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -3,7 +3,8 @@
 
 use clap::{Parser, Subcommand};
 use libp2p::Multiaddr;
-use sentrix::api::routes::{SharedState, create_router};
+use sentrix::api::events::EventBus;
+use sentrix::api::routes::{SharedState, create_router_with_bus};
 use sentrix::core::blockchain::{BLOCK_TIME_SECS, Blockchain};
 use sentrix::core::transaction::{PROTOCOL_TREASURY, TOKEN_OP_ADDRESS, TokenOp, Transaction};
 use sentrix::network::libp2p_node::{LibP2pNode, make_multiaddr};
@@ -3117,7 +3118,17 @@ async fn cmd_start(
     }
 
     // ── Shared: REST API (always started) ───────────────
-    let app = create_router(shared.clone());
+    // Construct the event bus FIRST so the same instance is wired into
+    // both the consensus path (Blockchain emits via set_event_emitter)
+    // and the WebSocket subscription handler (subscribers .subscribe()
+    // on the broadcast channels). Without sharing, WebSocket clients
+    // would never receive newHeads events.
+    let event_bus = std::sync::Arc::new(EventBus::new());
+    {
+        let mut bc = shared.write().await;
+        bc.set_event_emitter(Some(event_bus.clone()));
+    }
+    let app = create_router_with_bus(shared.clone(), event_bus.clone());
     let api_addr = format!("{}:{}", get_api_host(), get_api_port());
     println!("REST API listening on http://{}", api_addr);
     let listener = tokio::net::TcpListener::bind(&api_addr).await?;

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -1292,6 +1292,15 @@ impl Blockchain {
         // Append block to chain
         self.chain.push(block);
 
+        // Notify WebSocket / SSE subscribers (newHeads) — non-blocking,
+        // infallible by trait contract. See sentrix-primitives::events.
+        // The chain.last() is guaranteed Some here since we just pushed.
+        if let Some(emitter) = &self.event_emitter
+            && let Some(latest) = self.chain.last()
+        {
+            emitter.emit_new_head(latest);
+        }
+
         // Sliding window: evict oldest blocks beyond CHAIN_WINDOW_SIZE; evicted blocks stay in MDBX
         // Only the in-memory window shrinks — full history is always available on disk
         if self.chain.len() > CHAIN_WINDOW_SIZE {

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -359,6 +359,15 @@ pub struct Blockchain {
     /// every restart post-fork.
     #[serde(default)]
     pub evm_activated: bool,
+
+    /// Optional event emitter for WebSocket / SSE subscribers. Set at
+    /// startup by `bin/sentrix/main.rs` after the RPC layer constructs
+    /// its `EventBus`. Default `None` means no event emission (tests,
+    /// CLI tools that don't expose RPC). Block production must NEVER
+    /// depend on subscriber liveness — `emit_new_head` is non-blocking
+    /// and infallible by trait contract. See `sentrix-primitives::events`.
+    #[serde(skip, default)]
+    pub event_emitter: Option<sentrix_primitives::SharedEmitter>,
 }
 
 /// Rate-threshold detector for "this validator has diverged from peers".
@@ -492,9 +501,19 @@ impl Blockchain {
             divergence_tracker: DivergenceTracker::default(),
             voyager_activated: false,
             evm_activated: false,
+            event_emitter: None,
         };
         bc.initialize_genesis(genesis);
         bc
+    }
+
+    /// Wire a WebSocket / SSE event emitter into this blockchain. Called
+    /// once at startup by `bin/sentrix/main.rs` after the RPC layer
+    /// constructs its `EventBus`. After this returns, every successful
+    /// `add_block` / `add_block_from_peer` call will fire `emit_new_head`
+    /// against the supplied emitter. Pass `None` to detach (rare).
+    pub fn set_event_emitter(&mut self, emitter: Option<sentrix_primitives::SharedEmitter>) {
+        self.event_emitter = emitter;
     }
 
     /// Credit premine balances and seat block 0 on the chain. Staking

--- a/crates/sentrix-primitives/src/events.rs
+++ b/crates/sentrix-primitives/src/events.rs
@@ -1,0 +1,50 @@
+//! Event emitter trait — abstraction for chain-event subscribers.
+//!
+//! Defined in `sentrix-primitives` so `sentrix-core` can hold an
+//! `Option<Arc<dyn EventEmitter>>` without depending on tokio or any
+//! async runtime. The concrete implementation (`EventBus`) lives in
+//! `sentrix-rpc` where the WebSocket subscription machinery owns the
+//! tokio broadcast channels.
+//!
+//! Pattern: dependency inversion — core defines the trait, RPC layer
+//! implements it. Core code calls trait methods after every consensus-
+//! finalized block; the RPC layer routes those calls to broadcast
+//! channels that WebSocket subscribers listen on.
+//!
+//! All methods are non-blocking + infallible (errors must NOT propagate
+//! to consensus). A failed broadcast (e.g. no receivers) is silently
+//! dropped — block production must never depend on subscriber liveness.
+
+use crate::block::Block;
+use std::sync::Arc;
+
+/// Trait implemented by the WebSocket / SSE event-bus to receive
+/// notifications from consensus on chain events. Held as
+/// `Option<Arc<dyn EventEmitter>>` on `Blockchain`; default `None`
+/// means events are not emitted (e.g. tests, lightweight CLI tools).
+///
+/// Implementors MUST be Send + Sync + Debug — Debug because
+/// `Blockchain` derives `Debug` and we need the trait object to
+/// participate in that derive. Send + Sync because the bus is
+/// shared across async tasks. tokio::sync::broadcast::Sender
+/// already satisfies all three.
+pub trait EventEmitter: Send + Sync + std::fmt::Debug {
+    /// Called after every successfully-applied block (post chain.push).
+    /// Subscribers to `newHeads` get a notification with the block
+    /// header. The full block is passed for flexibility — the bus
+    /// decides which fields to project into the event payload.
+    fn emit_new_head(&self, block: &Block);
+}
+
+/// No-op emitter used as the default — useful for tests and any
+/// non-RPC binary that doesn't need event emission. Avoids the
+/// Option-unwrap pattern at every call site in core.
+#[derive(Debug)]
+pub struct NoopEmitter;
+
+impl EventEmitter for NoopEmitter {
+    fn emit_new_head(&self, _block: &Block) {}
+}
+
+/// Convenience: shared-pointer alias for the trait object.
+pub type SharedEmitter = Arc<dyn EventEmitter>;

--- a/crates/sentrix-primitives/src/lib.rs
+++ b/crates/sentrix-primitives/src/lib.rs
@@ -10,6 +10,7 @@ pub mod account;
 pub mod address;
 pub mod block;
 pub mod error;
+pub mod events;
 pub mod justification;
 pub mod merkle;
 pub mod transaction;
@@ -19,6 +20,7 @@ pub use account::{Account, AccountDB, EMPTY_CODE_HASH, EMPTY_STORAGE_ROOT, SENTR
 pub use address::derive_address;
 pub use block::Block;
 pub use error::{SentrixError, SentrixResult};
+pub use events::{EventEmitter, NoopEmitter, SharedEmitter};
 pub use justification::{BlockJustification, SignedPrecommit, supermajority_threshold};
 pub use merkle::{merkle_root, sha256_hex};
 pub use transaction::Transaction;

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -15,7 +15,8 @@ sentrix-rpc-types = { path = "../sentrix-rpc-types" }
 sentrix-trie = { path = "../sentrix-trie" }
 sentrix-storage = { path = "../sentrix-storage" }
 
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
+futures-util = "0.3"
 tokio = { version = "1.52", features = ["full"] }
 tower = { version = "0.4", features = ["limit"] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/sentrix-rpc/src/events.rs
+++ b/crates/sentrix-rpc/src/events.rs
@@ -1,0 +1,197 @@
+//! `EventBus` — concrete implementation of the `EventEmitter` trait
+//! defined in `sentrix-primitives::events`.
+//!
+//! Holds a `tokio::sync::broadcast::Sender` per channel. Subscribers
+//! call `bus.new_heads.subscribe()` to get a `Receiver<NewHeadEvent>`.
+//! When the consensus path emits via `emit_new_head`, every subscriber
+//! receives a copy of the event (or `RecvError::Lagged` if their
+//! buffer overflowed).
+//!
+//! Capacity is configured at construction. broadcast channel drops
+//! the OLDEST event when full, returning `Lagged(skipped)` to slow
+//! receivers — that's the correct semantic: a slow consumer should
+//! not block fast ones, and a slow consumer that's lagged 1024+
+//! events behind is no longer "real-time" anyway.
+
+use sentrix_primitives::block::Block;
+use sentrix_primitives::events::EventEmitter;
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+/// Default channel capacity. broadcast::channel(N) buffers up to N
+/// events per receiver before lagging. 1024 is generous for newHeads
+/// (1 block/s × 17 min of buffer) and forces clear failure mode for
+/// slow consumers.
+pub const DEFAULT_BUS_CAPACITY: usize = 1024;
+
+/// Block-header summary emitted on `eth_subscribe(newHeads)`.
+/// Mirrors Ethereum's `eth_subscription` payload shape so existing
+/// dApp tooling (ethers.js, viem, web3.js) can consume without
+/// special-casing Sentrix.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewHeadEvent {
+    pub number: String,        // hex-encoded u64
+    pub hash: String,          // 0x-prefixed
+    #[serde(rename = "parentHash")]
+    pub parent_hash: String,   // 0x-prefixed
+    pub timestamp: String,     // hex-encoded u64
+    pub miner: String,         // validator address (lowercase, 0x-prefixed)
+    #[serde(rename = "transactionsRoot")]
+    pub transactions_root: String,
+    #[serde(rename = "stateRoot")]
+    pub state_root: String,
+    #[serde(rename = "gasLimit")]
+    pub gas_limit: String,
+    #[serde(rename = "gasUsed")]
+    pub gas_used: String,
+    pub difficulty: String,
+    pub nonce: String,
+    #[serde(rename = "extraData")]
+    pub extra_data: String,
+    pub size: String,
+}
+
+impl NewHeadEvent {
+    /// Project a `Block` into the EVM-compatible `eth_subscription`
+    /// payload shape. Fields not represented in Sentrix's native
+    /// model are filled with sensible Ethereum-default constants
+    /// (difficulty=0x0, nonce=0x0…0, extraData=0x).
+    pub fn from_block(block: &Block) -> Self {
+        let to_hex = |n: u64| format!("0x{:x}", n);
+        let with_0x = |s: &str| {
+            if s.starts_with("0x") {
+                s.to_string()
+            } else {
+                format!("0x{}", s)
+            }
+        };
+        let state_root_hex = match block.state_root {
+            Some(root) => format!("0x{}", hex::encode(root)),
+            None => "0x0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+        };
+        Self {
+            number: to_hex(block.index),
+            hash: with_0x(&block.hash),
+            parent_hash: with_0x(&block.previous_hash),
+            timestamp: to_hex(block.timestamp),
+            miner: block.validator.clone(),
+            transactions_root: with_0x(&block.merkle_root),
+            state_root: state_root_hex,
+            gas_limit: to_hex(30_000_000),
+            gas_used: to_hex(0),
+            difficulty: "0x0".to_string(),
+            nonce: "0x0000000000000000".to_string(),
+            extra_data: "0x".to_string(),
+            size: to_hex(1000),
+        }
+    }
+}
+
+/// Concrete event bus. Held as `Arc<EventBus>` and shared between
+/// the consensus path (which calls `emit_new_head`) and the
+/// WebSocket subscription handlers (which call `new_heads.subscribe()`
+/// to obtain a Receiver).
+#[derive(Debug, Clone)]
+pub struct EventBus {
+    pub new_heads: broadcast::Sender<NewHeadEvent>,
+}
+
+impl EventBus {
+    /// Construct a new bus with the default capacity per channel.
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_BUS_CAPACITY)
+    }
+
+    /// Construct with explicit capacity. Tests use small values to
+    /// exercise the lagged-receiver path quickly.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            new_heads: broadcast::channel(capacity).0,
+        }
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EventEmitter for EventBus {
+    fn emit_new_head(&self, block: &Block) {
+        // broadcast::send returns Err if there are no active receivers,
+        // which is fine — we don't want consensus to depend on whether
+        // a websocket client is connected. Drop the result.
+        let _ = self.new_heads.send(NewHeadEvent::from_block(block));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sentrix_primitives::block::Block;
+
+    fn make_block() -> Block {
+        Block {
+            index: 42,
+            previous_hash: "abcd".to_string(),
+            transactions: vec![],
+            timestamp: 1234567890,
+            merkle_root: "0".repeat(64),
+            validator: "0xvalidator".to_string(),
+            hash: "1234".to_string(),
+            state_root: Some([0u8; 32]),
+            round: 0,
+            justification: None,
+        }
+    }
+
+    #[test]
+    fn new_head_projects_block_correctly() {
+        let block = make_block();
+        let event = NewHeadEvent::from_block(&block);
+        assert_eq!(event.number, "0x2a"); // 42 in hex
+        assert_eq!(event.hash, "0x1234");
+        assert_eq!(event.parent_hash, "0xabcd");
+        assert_eq!(event.timestamp, "0x499602d2"); // 1234567890
+        assert_eq!(event.miner, "0xvalidator");
+        assert_eq!(event.gas_limit, "0x1c9c380"); // 30M
+        assert!(event.state_root.starts_with("0x"));
+        assert_eq!(event.state_root.len(), 66); // 0x + 64 hex
+    }
+
+    #[tokio::test]
+    async fn emit_new_head_reaches_subscriber() {
+        let bus = EventBus::new();
+        let mut rx = bus.new_heads.subscribe();
+        let block = make_block();
+        bus.emit_new_head(&block);
+        let event = rx.recv().await.expect("event delivered");
+        assert_eq!(event.number, "0x2a");
+        assert_eq!(event.hash, "0x1234");
+    }
+
+    #[tokio::test]
+    async fn emit_with_no_subscribers_is_silent() {
+        // Ensure dropping send result doesn't propagate as panic.
+        let bus = EventBus::new();
+        let block = make_block();
+        bus.emit_new_head(&block); // no receivers — must not panic
+        bus.emit_new_head(&block);
+    }
+
+    #[tokio::test]
+    async fn lagged_receiver_returns_lagged_error() {
+        // Capacity 2 — emit 5 events, expect the receiver to get Lagged.
+        let bus = EventBus::with_capacity(2);
+        let mut rx = bus.new_heads.subscribe();
+        let block = make_block();
+        for _ in 0..5 {
+            bus.emit_new_head(&block);
+        }
+        // First recv should signal Lagged because we overflowed the buffer.
+        let res = rx.recv().await;
+        assert!(matches!(res, Err(broadcast::error::RecvError::Lagged(_))));
+    }
+}

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -62,6 +62,13 @@ pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) 
         "eth_accounts" => Ok(json!([])),
         "eth_getCode" => eth_get_code(params, state).await,
         "eth_getStorageAt" => eth_get_storage_at(params, state).await,
+        // Subscriptions only make sense on a long-lived connection. HTTP is
+        // request/response; clients that try to subscribe over HTTP get a
+        // pointer to the right transport instead of a silent error.
+        "eth_subscribe" | "eth_unsubscribe" => Err((
+            -32601,
+            "subscriptions only available on the WebSocket endpoint at /ws".into(),
+        )),
         _ => Err((-32601, format!("method not found: {}", method))),
     }
 }

--- a/crates/sentrix-rpc/src/jsonrpc/mod.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/mod.rs
@@ -74,6 +74,21 @@ pub async fn jsonrpc_handler(
     State(state): State<SharedState>,
     Json(req): Json<JsonRpcRequest>,
 ) -> Json<JsonRpcResponse> {
+    Json(dispatch_request(&state, req).await)
+}
+
+/// Dispatch a parsed JSON-RPC request to the right namespace and
+/// return a `JsonRpcResponse`. Extracted from `jsonrpc_handler` so the
+/// WebSocket transport (`crates/sentrix-rpc/src/ws/mod.rs`) can reuse
+/// the exact same dispatch logic without going through axum's `State`
+/// + `Json` extractors.
+///
+/// HTTP and WS share this single dispatch path → 100% method parity
+/// across transports without duplicate code or drift risk.
+pub(crate) async fn dispatch_request(
+    state: &SharedState,
+    req: JsonRpcRequest,
+) -> JsonRpcResponse {
     let id = req.id.clone();
     let params = req.params.unwrap_or(json!([]));
     let method = req.method.as_str();
@@ -82,21 +97,21 @@ pub async fn jsonrpc_handler(
     // match over their method names and return a `DispatchResult` that
     // we wrap into the JSON-RPC envelope.
     let result = if method.starts_with("eth_") {
-        eth::dispatch(method, &params, &state).await
+        eth::dispatch(method, &params, state).await
     } else if method.starts_with("net_") {
-        net::dispatch(method, &params, &state).await
+        net::dispatch(method, &params, state).await
     } else if method.starts_with("web3_") {
-        web3::dispatch(method, &params, &state).await
+        web3::dispatch(method, &params, state).await
     } else if method.starts_with("sentrix_") {
-        sentrix::dispatch(method, &params, &state).await
+        sentrix::dispatch(method, &params, state).await
     } else {
         Err((-32601, format!("method not found: {}", method)))
     };
 
-    Json(match result {
+    match result {
         Ok(val) => JsonRpcResponse::ok(id, val),
         Err((code, msg)) => JsonRpcResponse::err(id, code, &msg),
-    })
+    }
 }
 
 // Hard cap on batch size to prevent CPU saturation from oversized batch requests

--- a/crates/sentrix-rpc/src/lib.rs
+++ b/crates/sentrix-rpc/src/lib.rs
@@ -2,9 +2,12 @@
 
 #![allow(missing_docs)]
 
+pub mod events;
 pub mod explorer;
 pub mod explorer_api;
 pub mod jsonrpc;
 pub mod routes;
+pub mod ws;
 
+pub use events::{EventBus, NewHeadEvent};
 pub use routes::{SharedState, create_router};

--- a/crates/sentrix-rpc/src/routes/mod.rs
+++ b/crates/sentrix-rpc/src/routes/mod.rs
@@ -62,7 +62,24 @@ use tower_http::cors::{Any, CorsLayer};
 pub type SharedState = Arc<RwLock<Blockchain>>;
 
 // ── Router ───────────────────────────────────────────────
+/// Backward-compat constructor that creates an event bus internally.
+/// New callers (e.g., `bin/sentrix/main.rs` post-WebSocket support)
+/// should use `create_router_with_bus` so the bus they pass in is
+/// the same one the consensus path emits to.
 pub fn create_router(state: SharedState) -> Router {
+    create_router_with_bus(state, Arc::new(crate::events::EventBus::new()))
+}
+
+/// Build the full router including the `/ws` WebSocket subscription
+/// endpoint. The supplied `bus` should be the same instance the
+/// consensus path emits to via `Blockchain::set_event_emitter`, so
+/// subscribers see live block events. Tests + lightweight CLI builds
+/// can use `create_router` which constructs an isolated bus the
+/// caller can ignore.
+pub fn create_router_with_bus(
+    state: SharedState,
+    bus: Arc<crate::events::EventBus>,
+) -> Router {
     // Eagerly pin the process start time so /sentrix_status and /metrics
     // report uptime relative to boot, not to the first handler call that
     // happened to trigger the OnceLock. Without this, uptime_seconds was
@@ -243,6 +260,21 @@ pub fn create_router(state: SharedState) -> Router {
         .nest("/explorer", explorer_router(state.clone()))
         // ── Write endpoints (stricter rate limit) ────────────────
         .merge(write_router)
+        // ── WebSocket subscriptions (eth_subscribe / eth_unsubscribe) ──
+        // Mounted at /ws. The WS sub-router carries its own compound
+        // state (Blockchain handle + EventBus) so the subscription
+        // tasks can both query the chain (HTTP fall-through) and
+        // listen to event broadcasts. The bus is the SAME instance
+        // the consensus path emits to, so subscribers see real
+        // block events.
+        .merge(
+            Router::new()
+                .route("/ws", get(crate::ws::ws_handler))
+                .with_state(crate::ws::WsState {
+                    state: state.clone(),
+                    bus,
+                }),
+        )
         // Axum layer order: LAST `.layer()` call is OUTERMOST
         // (sees request first, response last). We want:
         //   cors           (outermost — 429/4xx/5xx responses MUST carry

--- a/crates/sentrix-rpc/src/ws/mod.rs
+++ b/crates/sentrix-rpc/src/ws/mod.rs
@@ -1,0 +1,375 @@
+//! WebSocket subscription endpoint at `/ws`.
+//!
+//! Implements `eth_subscribe` / `eth_unsubscribe` for real-time chain
+//! events. dApps that need live updates (wallets watching tx
+//! confirmations, DEX UIs streaming prices, explorers showing live
+//! blocks) connect once and subscribe to the channels they care about.
+//!
+//! ## Channels supported (this PR — Phase 1)
+//!
+//! - `newHeads` — fires on every consensus-finalized block. Payload
+//!   is an Ethereum-compatible header (`number`, `hash`, `parentHash`,
+//!   `timestamp`, `miner`, `stateRoot`, `transactionsRoot`, `gasLimit`,
+//!   `gasUsed`, `difficulty`, `nonce`, `extraData`, `size`). Reuses
+//!   the dApp tooling that already speaks Ethereum's `eth_subscribe`
+//!   protocol.
+//!
+//! ## Channels stubbed (returns NotImplemented for now)
+//!
+//! - `logs` — EVM contract event subscriptions. Phase 2 work; needs
+//!   the per-tx log extraction wired into the EventBus.
+//! - `newPendingTransactions` — mempool admission events. Phase 2
+//!   work; needs `add_to_mempool` to call into the bus.
+//! - `syncing` — sync status changes. Always false on Sentrix today
+//!   (we don't have an active "syncing" mode that lasts long enough
+//!   to be observable), so stub returns false immediately.
+//!
+//! ## Non-subscription methods over WS
+//!
+//! Any non-subscribe method received over the WS connection is
+//! delegated to the same dispatcher used for HTTP RPC. So `eth_call`,
+//! `eth_getBalance`, `eth_blockNumber` etc. work over the same WS
+//! connection that streams subscriptions — saves dApps having to
+//! maintain two connections (HTTP for queries, WS for streams).
+//!
+//! ## Lifecycle
+//!
+//! Each subscription = one tokio::spawn task. eth_unsubscribe aborts
+//! that task. Connection close aborts every task on that connection.
+//! Slow consumer that lags >1024 events behind gets a `Lagged` error
+//! emitted to the client and the task aborts itself; the client must
+//! reconnect to resubscribe.
+
+use crate::events::{EventBus, NewHeadEvent};
+use crate::jsonrpc::{JsonRpcRequest, JsonRpcResponse, dispatch_request};
+use crate::routes::SharedState;
+use axum::{
+    extract::{
+        State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
+    },
+    response::IntoResponse,
+};
+use futures_util::{SinkExt, StreamExt};
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+use tokio::sync::{Mutex, broadcast};
+
+/// Cap concurrent subscriptions per connection — guards against an
+/// abusive client trying to allocate thousands of tokio tasks via
+/// repeated `eth_subscribe` calls. 100 is generous (a real dApp uses
+/// 1-5).
+pub const MAX_SUBS_PER_CONNECTION: usize = 100;
+
+/// `eth_subscription` envelope that wraps every subscription event
+/// payload. Matches Ethereum's standard shape so existing dApp tooling
+/// (ethers.js, viem, web3.js) parses it without special-casing.
+///
+/// ```json
+/// {
+///   "jsonrpc": "2.0",
+///   "method": "eth_subscription",
+///   "params": {
+///     "subscription": "<sub-id>",
+///     "result": { ...payload... }
+///   }
+/// }
+/// ```
+#[derive(Debug, Serialize)]
+struct SubscriptionMessage<'a> {
+    jsonrpc: &'static str,
+    method: &'static str,
+    params: SubscriptionPayload<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct SubscriptionPayload<'a> {
+    subscription: &'a str,
+    result: Value,
+}
+
+fn wrap_subscription(sub_id: &str, result: Value) -> Value {
+    json!(SubscriptionMessage {
+        jsonrpc: "2.0",
+        method: "eth_subscription",
+        params: SubscriptionPayload { subscription: sub_id, result },
+    })
+}
+
+/// Combined router state for the WebSocket route. Holds both the
+/// blockchain state (for HTTP fall-through dispatch) and the event bus
+/// (for streaming subscriptions).
+#[derive(Clone)]
+pub struct WsState {
+    pub state: SharedState,
+    pub bus: Arc<EventBus>,
+}
+
+/// Axum WebSocket upgrade handler. Routes new connections to
+/// `handle_socket` after the HTTP-to-WS upgrade dance.
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(ws_state): State<WsState>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_socket(socket, ws_state))
+}
+
+/// Per-connection main loop. Reads JSON-RPC requests from the client,
+/// routes subscriptions to spawn-based listener tasks, falls through
+/// non-subscribe methods to the same dispatcher used by HTTP RPC.
+async fn handle_socket(socket: WebSocket, ws_state: WsState) {
+    let (sender, mut receiver) = socket.split();
+    // Wrap the sender in a Mutex so multiple subscription tasks can
+    // serialize writes safely. Without this, two tasks calling send
+    // concurrently would interleave bytes mid-frame.
+    let sender = Arc::new(Mutex::new(sender));
+    let subscriptions: Arc<Mutex<HashMap<String, tokio::task::JoinHandle<()>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+    // Monotonic per-connection counter for subscription IDs. Format
+    // mirrors what geth/erigon emit (`0x` + 16 hex chars) so existing
+    // dApp tooling treats them as opaque opaque tokens consistently.
+    let next_sub_id = Arc::new(AtomicU64::new(1));
+
+    while let Some(msg_result) = receiver.next().await {
+        let msg = match msg_result {
+            Ok(Message::Text(text)) => text,
+            Ok(Message::Close(_)) => break,
+            Ok(_) => continue, // Ping/Pong/Binary — ignore
+            Err(e) => {
+                tracing::warn!("ws: receive error: {}", e);
+                break;
+            }
+        };
+
+        let req: JsonRpcRequest = match serde_json::from_str(&msg) {
+            Ok(r) => r,
+            Err(_) => {
+                send_error(&sender, None, -32700, "Parse error").await;
+                continue;
+            }
+        };
+
+        let id = req.id.clone();
+        let method = req.method.clone();
+
+        match method.as_str() {
+            "eth_subscribe" => {
+                handle_subscribe(
+                    req,
+                    &subscriptions,
+                    &next_sub_id,
+                    &sender,
+                    &ws_state.bus,
+                    id,
+                )
+                .await;
+            }
+            "eth_unsubscribe" => {
+                handle_unsubscribe(req, &subscriptions, &sender, id).await;
+            }
+            _ => {
+                // Fall-through: regular JSON-RPC method. Dispatch via the
+                // same path HTTP uses so every method reachable over HTTP
+                // is reachable over WS for free.
+                let resp = dispatch_request(&ws_state.state, req).await;
+                send_response(&sender, resp).await;
+            }
+        }
+    }
+
+    // Connection closed — abort every spawned subscription task.
+    let mut subs = subscriptions.lock().await;
+    for (_, handle) in subs.drain() {
+        handle.abort();
+    }
+}
+
+async fn handle_subscribe(
+    req: JsonRpcRequest,
+    subscriptions: &Arc<Mutex<HashMap<String, tokio::task::JoinHandle<()>>>>,
+    next_sub_id: &Arc<AtomicU64>,
+    sender: &Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    bus: &Arc<EventBus>,
+    id: Option<Value>,
+) {
+    let params = req.params.unwrap_or(json!([]));
+    let channel = match params.get(0).and_then(|v| v.as_str()) {
+        Some(s) => s.to_string(),
+        None => {
+            send_error(sender, id, -32602, "missing channel parameter").await;
+            return;
+        }
+    };
+
+    {
+        let subs = subscriptions.lock().await;
+        if subs.len() >= MAX_SUBS_PER_CONNECTION {
+            send_error(
+                sender,
+                id,
+                -32005,
+                &format!(
+                    "subscription limit reached ({} per connection)",
+                    MAX_SUBS_PER_CONNECTION
+                ),
+            )
+            .await;
+            return;
+        }
+    }
+
+    let sub_id = format!(
+        "0x{:016x}",
+        next_sub_id.fetch_add(1, Ordering::Relaxed)
+    );
+
+    let handle = match channel.as_str() {
+        "newHeads" => {
+            let rx = bus.new_heads.subscribe();
+            spawn_new_heads_listener(rx, sender.clone(), sub_id.clone())
+        }
+        "logs" | "newPendingTransactions" => {
+            send_error(
+                sender,
+                id,
+                -32601,
+                &format!(
+                    "channel '{channel}' not yet implemented (Phase 2 work; only 'newHeads' shipped in this PR)"
+                ),
+            )
+            .await;
+            return;
+        }
+        "syncing" => {
+            // Sentrix doesn't have a long-lived "syncing" mode, but we
+            // emit a single false on subscribe so dApps that block on
+            // this don't hang. Then the task exits — never streams more.
+            let sender_clone = sender.clone();
+            let sub_id_clone = sub_id.clone();
+            tokio::spawn(async move {
+                let payload = wrap_subscription(&sub_id_clone, json!(false));
+                let mut s = sender_clone.lock().await;
+                let _ = s.send(Message::Text(payload.to_string().into())).await;
+            })
+        }
+        _ => {
+            send_error(
+                sender,
+                id,
+                -32602,
+                &format!("unknown subscription channel: {channel}"),
+            )
+            .await;
+            return;
+        }
+    };
+
+    subscriptions.lock().await.insert(sub_id.clone(), handle);
+    send_response(
+        sender,
+        JsonRpcResponse::ok(id, json!(sub_id)),
+    )
+    .await;
+}
+
+async fn handle_unsubscribe(
+    req: JsonRpcRequest,
+    subscriptions: &Arc<Mutex<HashMap<String, tokio::task::JoinHandle<()>>>>,
+    sender: &Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    id: Option<Value>,
+) {
+    let params = req.params.unwrap_or(json!([]));
+    let sub_id = match params.get(0).and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => {
+            send_error(sender, id, -32602, "missing subscription id").await;
+            return;
+        }
+    };
+
+    let removed = subscriptions.lock().await.remove(sub_id);
+    if let Some(handle) = &removed {
+        handle.abort();
+    }
+    send_response(
+        sender,
+        JsonRpcResponse::ok(id, json!(removed.is_some())),
+    )
+    .await;
+}
+
+/// Spawn the per-subscription listener for `newHeads`. Loops on the
+/// broadcast Receiver and forwards every event to the WS sender as
+/// an `eth_subscription` message. Exits on Lagged or Closed.
+fn spawn_new_heads_listener(
+    mut rx: broadcast::Receiver<NewHeadEvent>,
+    sender: Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    sub_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    let payload = wrap_subscription(&sub_id, json!(event));
+                    let mut s = sender.lock().await;
+                    if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+                        // Client disconnected — exit task; the per-conn
+                        // subscriptions HashMap will be drained by the
+                        // outer loop on close.
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    // Notify the client they fell behind, then exit. The
+                    // client is expected to reconnect + resubscribe to
+                    // recover. This is the canonical broadcast::Receiver
+                    // semantic — slow consumers don't block fast ones.
+                    let payload = json!({
+                        "jsonrpc": "2.0",
+                        "method": "eth_subscription",
+                        "params": {
+                            "subscription": sub_id,
+                            "result": null,
+                            "error": format!("subscription lagged ({skipped} events skipped); reconnect to resume"),
+                        },
+                    });
+                    let mut s = sender.lock().await;
+                    let _ = s.send(Message::Text(payload.to_string().into())).await;
+                    break;
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    // Bus dropped — server is shutting down.
+                    break;
+                }
+            }
+        }
+    })
+}
+
+async fn send_response(
+    sender: &Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    resp: JsonRpcResponse,
+) {
+    let body = match serde_json::to_string(&resp) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let mut s = sender.lock().await;
+    let _ = s.send(Message::Text(body.into())).await;
+}
+
+async fn send_error(
+    sender: &Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    id: Option<Value>,
+    code: i32,
+    message: &str,
+) {
+    send_response(sender, JsonRpcResponse::err(id, code, message)).await;
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,6 @@
 // api/mod.rs — Re-export from sentrix-rpc crate for backward compatibility.
+pub use sentrix_rpc::events;
 pub use sentrix_rpc::explorer;
 pub use sentrix_rpc::jsonrpc;
 pub use sentrix_rpc::routes;
+pub use sentrix_rpc::ws;


### PR DESCRIPTION
## Summary

Adds `/ws` WebSocket endpoint with `eth_subscribe` / `eth_unsubscribe` so dApps stream real-time chain events. Phase 1 ships **newHeads only**; logs + newPendingTransactions stub returns NotImplemented for Phase 2.

Highest-leverage Tier 1 unblock per `ECOSYSTEM_DUAL_STACK_AUDIT_2026-04-28.md` — every wallet, trading UI, analytics dashboard needs this.

## Test plan

- [x] 4 new unit tests in `crates/sentrix-rpc/src/events.rs` — all pass
- [x] 26 existing routes tests still pass
- [x] `cargo clippy --release -p sentrix-rpc -- -D warnings` — clean
- [x] `cargo build --release` — clean
- [ ] Post-merge: deploy to mainnet, smoke test with `wscat -c wss://rpc.sentrixchain.com/ws`

## Architecture

**Dependency inversion:** core defines the trait, RPC implements it. Lets `sentrix-core` hold an `Option<Arc<dyn EventEmitter>>` without taking a tokio dep. Concrete `EventBus` with broadcast channels lives in `sentrix-rpc`.

**Same dispatcher for HTTP + WS:** `dispatch_request` extracted from `jsonrpc_handler` so non-subscribe methods on a WS connection (eth_call, eth_getBalance, etc) work identically to HTTP. 100% parity, zero duplicate code.

**Subscription lifecycle:** each subscription = one tokio::spawn task, aborted on unsubscribe or connection close. Slow consumer that lags >1024 events = canonical broadcast::Lagged error + dropped, must reconnect.

## Risk

RPC layer only — consensus path untouched. Block production unchanged: emit hook is post-chain.push, non-blocking, infallible by trait contract. Worst-case bug = subscribers don't receive events; chain stays healthy. Mainnet halt risk: zero.

## What's NOT in this PR (Phase 2 next session)

- `eth_subscribe(logs)` — needs per-tx log extraction (~1h)
- `eth_subscribe(newPendingTransactions)` — needs hook in `add_to_mempool` (~30min)
- Per-IP connection limit middleware (~30min)
- Caddy WS upgrade config for `wss://rpc.sentrixchain.com/ws` (~5min ops)