### PR TITLE
feat(rpc): WebSocket subscriptions Phase 2 + 3 — logs + pendingTxs + sentrix_*

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -1292,13 +1292,22 @@ impl Blockchain {
         // Append block to chain
         self.chain.push(block);
 
-        // Notify WebSocket / SSE subscribers (newHeads) — non-blocking,
-        // infallible by trait contract. See sentrix-primitives::events.
+        // Notify WebSocket / SSE subscribers — non-blocking, infallible
+        // by trait contract. See sentrix-primitives::events.
         // The chain.last() is guaranteed Some here since we just pushed.
         if let Some(emitter) = &self.event_emitter
             && let Some(latest) = self.chain.last()
         {
+            // EVM-compat: eth_subscribe(newHeads)
             emitter.emit_new_head(latest);
+            // Sentrix-native: sentrix_subscribe(finalized)
+            // BFT supplies the justification — count signers if present.
+            let signers = latest
+                .justification
+                .as_ref()
+                .map(|j| j.precommits.len())
+                .unwrap_or(0);
+            emitter.emit_finalized(latest.index, &latest.hash, signers);
         }
 
         // Sliding window: evict oldest blocks beyond CHAIN_WINDOW_SIZE; evicted blocks stay in MDBX
@@ -1632,6 +1641,25 @@ impl Blockchain {
                         let key = log_key(block_height, tx_index, log_idx as u32);
                         let _ =
                             storage.put_bincode(sentrix_storage::tables::TABLE_LOGS, &key, &stored);
+
+                        // Notify WebSocket subscribers — eth_subscribe(logs).
+                        // Convert StoredLog to the trait-friendly LogData
+                        // shape (sentrix-primitives doesn't depend on
+                        // sentrix-evm so the trait can't take StoredLog
+                        // directly). Non-blocking, infallible.
+                        if let Some(emitter) = &self.event_emitter {
+                            let log_data = sentrix_primitives::events::LogData {
+                                block_height,
+                                block_hash: block_hash_hex.to_string(),
+                                tx_hash: tx.txid.clone(),
+                                tx_index,
+                                log_index: log_idx as u32,
+                                address: stored.address,
+                                topics: stored.topics.clone(),
+                                data: stored.data.clone(),
+                            };
+                            emitter.emit_log(&log_data);
+                        }
                     }
                 }
                 // Store contract RUNTIME code (not init code) if CREATE succeeded.

--- a/crates/sentrix-core/src/mempool.rs
+++ b/crates/sentrix-core/src/mempool.rs
@@ -154,7 +154,19 @@ impl Blockchain {
             Some(min_pos) => fee_pos.max(min_pos),
             None => fee_pos,
         };
+        // Capture txid BEFORE the move so we can emit the event after.
+        // The vec mutation borrows tx; emitting after the borrow ends
+        // keeps the lifetime simple.
+        let txid_for_event = tx.txid.clone();
         self.mempool.insert(pos, tx);
+
+        // Notify WebSocket subscribers — eth_subscribe(newPendingTransactions).
+        // Non-blocking, infallible by trait contract. Fires only on
+        // successful admission; rejections above already returned Err.
+        if let Some(emitter) = &self.event_emitter {
+            emitter.emit_pending_tx(&txid_for_event);
+        }
+
         Ok(())
     }
 

--- a/crates/sentrix-primitives/src/events.rs
+++ b/crates/sentrix-primitives/src/events.rs
@@ -18,6 +18,22 @@
 use crate::block::Block;
 use std::sync::Arc;
 
+/// Minimal log payload — passed across the trait boundary so
+/// `sentrix-primitives` doesn't need to depend on `sentrix-evm`.
+/// The concrete bus converts `StoredLog` (in sentrix-evm) into this
+/// shape at the emit site.
+#[derive(Debug, Clone)]
+pub struct LogData {
+    pub block_height: u64,
+    pub block_hash: String,
+    pub tx_hash: String,
+    pub tx_index: u32,
+    pub log_index: u32,
+    pub address: [u8; 20],
+    pub topics: Vec<[u8; 32]>,
+    pub data: Vec<u8>,
+}
+
 /// Trait implemented by the WebSocket / SSE event-bus to receive
 /// notifications from consensus on chain events. Held as
 /// `Option<Arc<dyn EventEmitter>>` on `Blockchain`; default `None`
@@ -28,12 +44,40 @@ use std::sync::Arc;
 /// participate in that derive. Send + Sync because the bus is
 /// shared across async tasks. tokio::sync::broadcast::Sender
 /// already satisfies all three.
+///
+/// All emit_* methods MUST be non-blocking + infallible. Block
+/// production must NEVER depend on subscriber liveness — a failed
+/// broadcast (no receivers) is silently dropped.
+///
+/// All methods except `emit_new_head` have empty default impls so
+/// implementors can ship channels incrementally without breaking
+/// older callers. Phase 1 (newHeads) shipped 2026-04-28; Phase 2
+/// (logs + pending_tx) + Phase 3 (sentrix_*) follow.
 pub trait EventEmitter: Send + Sync + std::fmt::Debug {
     /// Called after every successfully-applied block (post chain.push).
-    /// Subscribers to `newHeads` get a notification with the block
-    /// header. The full block is passed for flexibility — the bus
-    /// decides which fields to project into the event payload.
+    /// Subscribers to `eth_subscribe(newHeads)` get a notification
+    /// with the block header.
     fn emit_new_head(&self, block: &Block);
+
+    /// Called once per EVM log emitted within a block. Subscribers
+    /// to `eth_subscribe(logs)` filter by address + topics and
+    /// forward matching logs.
+    fn emit_log(&self, _log: &LogData) {}
+
+    /// Called when a tx is admitted to the mempool. Subscribers to
+    /// `eth_subscribe(newPendingTransactions)` get the txid string.
+    /// Note: this fires on admission only, NOT on rejection.
+    fn emit_pending_tx(&self, _txid: &str) {}
+
+    /// Sentrix-native: called after every BFT-finalized block.
+    /// Equivalent to `emit_new_head` on the protocol-native side
+    /// but exposes finalization-specific fields (justification
+    /// signer count) that aren't in the EVM-compat header.
+    fn emit_finalized(&self, _height: u64, _hash: &str, _justification_signers: usize) {}
+
+    /// Sentrix-native: called at epoch boundary when the validator
+    /// set rotates. Subscribers see the new active set.
+    fn emit_validator_set(&self, _epoch: u64, _validators: &[String]) {}
 }
 
 /// No-op emitter used as the default — useful for tests and any

--- a/crates/sentrix-primitives/src/lib.rs
+++ b/crates/sentrix-primitives/src/lib.rs
@@ -20,7 +20,7 @@ pub use account::{Account, AccountDB, EMPTY_CODE_HASH, EMPTY_STORAGE_ROOT, SENTR
 pub use address::derive_address;
 pub use block::Block;
 pub use error::{SentrixError, SentrixResult};
-pub use events::{EventEmitter, NoopEmitter, SharedEmitter};
+pub use events::{EventEmitter, LogData, NoopEmitter, SharedEmitter};
 pub use justification::{BlockJustification, SignedPrecommit, supermajority_threshold};
 pub use merkle::{merkle_root, sha256_hex};
 pub use transaction::Transaction;

--- a/crates/sentrix-rpc/src/events.rs
+++ b/crates/sentrix-rpc/src/events.rs
@@ -14,7 +14,7 @@
 //! events behind is no longer "real-time" anyway.
 
 use sentrix_primitives::block::Block;
-use sentrix_primitives::events::EventEmitter;
+use sentrix_primitives::events::{EventEmitter, LogData};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
@@ -88,13 +88,93 @@ impl NewHeadEvent {
     }
 }
 
+/// Filterable EVM log event emitted on `eth_subscribe(logs)`. Mirrors
+/// Ethereum's standard `eth_subscription` log payload — address,
+/// topics, data, plus block + tx context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogEvent {
+    pub address: String, // 0x + 40 hex
+    pub topics: Vec<String>, // 0x + 64 hex each
+    pub data: String, // 0x + hex
+    #[serde(rename = "blockNumber")]
+    pub block_number: String, // hex u64
+    #[serde(rename = "blockHash")]
+    pub block_hash: String,
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: String,
+    #[serde(rename = "transactionIndex")]
+    pub transaction_index: String, // hex u32
+    #[serde(rename = "logIndex")]
+    pub log_index: String, // hex u32
+    pub removed: bool,
+}
+
+impl LogEvent {
+    pub fn from_log_data(log: &LogData) -> Self {
+        let with_0x = |s: &str| {
+            if s.starts_with("0x") {
+                s.to_string()
+            } else {
+                format!("0x{}", s)
+            }
+        };
+        Self {
+            address: format!("0x{}", hex::encode(log.address)),
+            topics: log
+                .topics
+                .iter()
+                .map(|t| format!("0x{}", hex::encode(t)))
+                .collect(),
+            data: format!("0x{}", hex::encode(&log.data)),
+            block_number: format!("0x{:x}", log.block_height),
+            block_hash: with_0x(&log.block_hash),
+            transaction_hash: with_0x(&log.tx_hash),
+            transaction_index: format!("0x{:x}", log.tx_index),
+            log_index: format!("0x{:x}", log.log_index),
+            removed: false,
+        }
+    }
+}
+
+/// Pending-transaction event emitted on `eth_subscribe(newPendingTransactions)`.
+/// Standard Ethereum payload is just the txid string; we keep that exact
+/// shape so dApp tooling consumes without special-casing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingTxEvent {
+    pub txid: String,
+}
+
+/// Sentrix-native: emitted on `sentrix_subscribe(finalized)`. Reports
+/// BFT finalization with justification signer count. Distinct from
+/// `newHeads` because Sentrix has instant BFT finality — every new
+/// block is finalized at the same moment it's produced.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FinalizedEvent {
+    pub height: u64,
+    pub hash: String,
+    #[serde(rename = "justificationSigners")]
+    pub justification_signers: usize,
+}
+
+/// Sentrix-native: emitted on `sentrix_subscribe(validatorSet)`.
+/// Fires at epoch boundary when the validator set rotates.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidatorSetEvent {
+    pub epoch: u64,
+    pub validators: Vec<String>,
+}
+
 /// Concrete event bus. Held as `Arc<EventBus>` and shared between
-/// the consensus path (which calls `emit_new_head`) and the
-/// WebSocket subscription handlers (which call `new_heads.subscribe()`
+/// the consensus path (which calls `emit_*` methods) and the
+/// WebSocket subscription handlers (which call `<channel>.subscribe()`
 /// to obtain a Receiver).
 #[derive(Debug, Clone)]
 pub struct EventBus {
     pub new_heads: broadcast::Sender<NewHeadEvent>,
+    pub logs: broadcast::Sender<LogEvent>,
+    pub pending_txs: broadcast::Sender<PendingTxEvent>,
+    pub finalized: broadcast::Sender<FinalizedEvent>,
+    pub validator_set: broadcast::Sender<ValidatorSetEvent>,
 }
 
 impl EventBus {
@@ -108,6 +188,10 @@ impl EventBus {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             new_heads: broadcast::channel(capacity).0,
+            logs: broadcast::channel(capacity).0,
+            pending_txs: broadcast::channel(capacity).0,
+            finalized: broadcast::channel(capacity).0,
+            validator_set: broadcast::channel(capacity).0,
         }
     }
 }
@@ -124,6 +208,40 @@ impl EventEmitter for EventBus {
         // which is fine — we don't want consensus to depend on whether
         // a websocket client is connected. Drop the result.
         let _ = self.new_heads.send(NewHeadEvent::from_block(block));
+    }
+
+    fn emit_log(&self, log: &LogData) {
+        let _ = self.logs.send(LogEvent::from_log_data(log));
+    }
+
+    fn emit_pending_tx(&self, txid: &str) {
+        let _ = self.pending_txs.send(PendingTxEvent {
+            txid: if txid.starts_with("0x") {
+                txid.to_string()
+            } else {
+                format!("0x{}", txid)
+            },
+        });
+    }
+
+    fn emit_finalized(&self, height: u64, hash: &str, justification_signers: usize) {
+        let with_0x = if hash.starts_with("0x") {
+            hash.to_string()
+        } else {
+            format!("0x{}", hash)
+        };
+        let _ = self.finalized.send(FinalizedEvent {
+            height,
+            hash: with_0x,
+            justification_signers,
+        });
+    }
+
+    fn emit_validator_set(&self, epoch: u64, validators: &[String]) {
+        let _ = self.validator_set.send(ValidatorSetEvent {
+            epoch,
+            validators: validators.to_vec(),
+        });
     }
 }
 

--- a/crates/sentrix-rpc/src/routes/mod.rs
+++ b/crates/sentrix-rpc/src/routes/mod.rs
@@ -262,17 +262,20 @@ pub fn create_router_with_bus(
         .merge(write_router)
         // ── WebSocket subscriptions (eth_subscribe / eth_unsubscribe) ──
         // Mounted at /ws. The WS sub-router carries its own compound
-        // state (Blockchain handle + EventBus) so the subscription
-        // tasks can both query the chain (HTTP fall-through) and
-        // listen to event broadcasts. The bus is the SAME instance
-        // the consensus path emits to, so subscribers see real
-        // block events.
+        // state (Blockchain handle + EventBus + per-IP limiter) so
+        // subscription tasks can both query the chain (HTTP fall-
+        // through) and listen to event broadcasts. The bus is the
+        // SAME instance the consensus path emits to, so subscribers
+        // see real block events. The ip_limiter caps per-source
+        // concurrent WS connections (defense — guards against fd
+        // exhaustion from a single abusive client).
         .merge(
             Router::new()
                 .route("/ws", get(crate::ws::ws_handler))
                 .with_state(crate::ws::WsState {
                     state: state.clone(),
                     bus,
+                    ip_limiter: crate::ws::WsIpLimiter::default(),
                 }),
         )
         // Axum layer order: LAST `.layer()` call is OUTERMOST

--- a/crates/sentrix-rpc/src/ws/mod.rs
+++ b/crates/sentrix-rpc/src/ws/mod.rs
@@ -40,7 +40,9 @@
 //! emitted to the client and the task aborts itself; the client must
 //! reconnect to resubscribe.
 
-use crate::events::{EventBus, NewHeadEvent};
+use crate::events::{
+    EventBus, FinalizedEvent, LogEvent, NewHeadEvent, PendingTxEvent, ValidatorSetEvent,
+};
 use crate::jsonrpc::{JsonRpcRequest, JsonRpcResponse, dispatch_request};
 use crate::routes::SharedState;
 use axum::{
@@ -67,6 +69,67 @@ use tokio::sync::{Mutex, broadcast};
 /// repeated `eth_subscribe` calls. 100 is generous (a real dApp uses
 /// 1-5).
 pub const MAX_SUBS_PER_CONNECTION: usize = 100;
+
+/// Cap concurrent WebSocket connections per source IP — defense
+/// against a single client exhausting the validator's file descriptor
+/// pool. 10 is generous: a wallet typically opens 1, an explorer
+/// frontend 2-3, a power user with multiple browser tabs 5+. Exceed
+/// → 503 at the upgrade response.
+pub const MAX_CONNECTIONS_PER_IP: usize = 10;
+
+/// Per-IP connection counter — shared across all WS upgrades. Wraps a
+/// HashMap behind a `tokio::sync::Mutex` so the upgrade handler can
+/// atomically check + increment, and the connection-close path can
+/// decrement.
+#[derive(Clone, Default)]
+pub struct WsIpLimiter(pub Arc<Mutex<HashMap<std::net::IpAddr, usize>>>);
+
+impl WsIpLimiter {
+    /// Increment the counter for `ip`. Returns `Ok(guard)` on success;
+    /// `Err(())` if the IP is at the cap. The guard's Drop decrements.
+    pub async fn try_acquire(&self, ip: std::net::IpAddr) -> Result<WsIpGuard, ()> {
+        let mut map = self.0.lock().await;
+        let count = map.entry(ip).or_insert(0);
+        if *count >= MAX_CONNECTIONS_PER_IP {
+            return Err(());
+        }
+        *count += 1;
+        Ok(WsIpGuard {
+            inner: self.0.clone(),
+            ip,
+        })
+    }
+}
+
+/// RAII guard that decrements the per-IP WS connection counter when
+/// dropped. Owned by the per-connection async task; goes out of scope
+/// when the connection closes (normal or error path), guaranteeing
+/// the counter releases without an explicit unlock call.
+pub struct WsIpGuard {
+    inner: Arc<Mutex<HashMap<std::net::IpAddr, usize>>>,
+    ip: std::net::IpAddr,
+}
+
+impl Drop for WsIpGuard {
+    fn drop(&mut self) {
+        // tokio::Mutex blocks_in_place isn't available in arbitrary
+        // contexts; spawn the decrement on the runtime instead so Drop
+        // stays infallible. This races against new acquires for the
+        // same IP — acceptable because the worst case is a brief moment
+        // where the counter is one higher than reality, never wedged.
+        let inner = self.inner.clone();
+        let ip = self.ip;
+        tokio::spawn(async move {
+            let mut map = inner.lock().await;
+            if let Some(count) = map.get_mut(&ip) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    map.remove(&ip);
+                }
+            }
+        });
+    }
+}
 
 /// `eth_subscription` envelope that wraps every subscription event
 /// payload. Matches Ethereum's standard shape so existing dApp tooling
@@ -103,28 +166,45 @@ fn wrap_subscription(sub_id: &str, result: Value) -> Value {
     })
 }
 
-/// Combined router state for the WebSocket route. Holds both the
-/// blockchain state (for HTTP fall-through dispatch) and the event bus
-/// (for streaming subscriptions).
+/// Combined router state for the WebSocket route. Holds the blockchain
+/// state (for HTTP fall-through dispatch), the event bus (for streaming
+/// subscriptions), and the per-IP connection limiter.
 #[derive(Clone)]
 pub struct WsState {
     pub state: SharedState,
     pub bus: Arc<EventBus>,
+    pub ip_limiter: WsIpLimiter,
 }
 
-/// Axum WebSocket upgrade handler. Routes new connections to
-/// `handle_socket` after the HTTP-to-WS upgrade dance.
+/// Axum WebSocket upgrade handler. Per-IP connection limit enforced
+/// BEFORE the upgrade response — over-limit clients see a 503 instead
+/// of an established socket they'd just have to close.
 pub async fn ws_handler(
     ws: WebSocketUpgrade,
+    axum::extract::ConnectInfo(addr): axum::extract::ConnectInfo<std::net::SocketAddr>,
     State(ws_state): State<WsState>,
-) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_socket(socket, ws_state))
+) -> axum::response::Response {
+    let ip = addr.ip();
+    let guard = match ws_state.ip_limiter.try_acquire(ip).await {
+        Ok(g) => g,
+        Err(()) => {
+            return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
+    ws.on_upgrade(move |socket| {
+        // Move the guard into the handle_socket future so its Drop
+        // fires when the connection ends. Without this, the counter
+        // would leak.
+        let _g = guard;
+        handle_socket(socket, ws_state, _g)
+    })
+    .into_response()
 }
 
 /// Per-connection main loop. Reads JSON-RPC requests from the client,
 /// routes subscriptions to spawn-based listener tasks, falls through
 /// non-subscribe methods to the same dispatcher used by HTTP RPC.
-async fn handle_socket(socket: WebSocket, ws_state: WsState) {
+async fn handle_socket(socket: WebSocket, ws_state: WsState, _ip_guard: WsIpGuard) {
     let (sender, mut receiver) = socket.split();
     // Wrap the sender in a Mutex so multiple subscription tasks can
     // serialize writes safely. Without this, two tasks calling send
@@ -235,17 +315,28 @@ async fn handle_subscribe(
             let rx = bus.new_heads.subscribe();
             spawn_new_heads_listener(rx, sender.clone(), sub_id.clone())
         }
-        "logs" | "newPendingTransactions" => {
-            send_error(
-                sender,
-                id,
-                -32601,
-                &format!(
-                    "channel '{channel}' not yet implemented (Phase 2 work; only 'newHeads' shipped in this PR)"
-                ),
-            )
-            .await;
-            return;
+        "logs" => {
+            // Optional second param is the filter object: { address, topics }.
+            // Same filter shape as eth_getLogs. We parse here once, the
+            // listener task applies per-event without re-parsing.
+            let filter = LogFilter::from_params(params.get(1));
+            let rx = bus.logs.subscribe();
+            spawn_logs_listener(rx, sender.clone(), sub_id.clone(), filter)
+        }
+        "newPendingTransactions" => {
+            let rx = bus.pending_txs.subscribe();
+            spawn_pending_txs_listener(rx, sender.clone(), sub_id.clone())
+        }
+        // Sentrix-native channels (sentrix_subscribe equivalent — exposed
+        // via the same eth_subscribe entry point so dApp tooling works
+        // without learning a new method name).
+        "sentrix_finalized" => {
+            let rx = bus.finalized.subscribe();
+            spawn_finalized_listener(rx, sender.clone(), sub_id.clone())
+        }
+        "sentrix_validatorSet" => {
+            let rx = bus.validator_set.subscribe();
+            spawn_validator_set_listener(rx, sender.clone(), sub_id.clone())
         }
         "syncing" => {
             // Sentrix doesn't have a long-lived "syncing" mode, but we
@@ -305,6 +396,102 @@ async fn handle_unsubscribe(
     .await;
 }
 
+/// Filter for `eth_subscribe(logs)` — mirrors the eth_getLogs filter
+/// shape (address: single or array, topics: positional array of
+/// single-hash-or-array). Empty filter means "all logs".
+#[derive(Debug, Clone, Default)]
+struct LogFilter {
+    /// Hex addresses lowercased without the 0x prefix. Empty = match any.
+    addresses: Vec<[u8; 20]>,
+    /// Per-position topic match. None = wildcard at that position.
+    /// `Some(vec![hash])` = match that single hash. `Some(vec![h1, h2])`
+    /// = match either. Position 0..3.
+    topics: Vec<Option<Vec<[u8; 32]>>>,
+}
+
+impl LogFilter {
+    fn from_params(filter_value: Option<&Value>) -> Self {
+        let Some(filter) = filter_value else {
+            return Self::default();
+        };
+        let addresses = match filter.get("address") {
+            Some(Value::String(s)) => parse_addr(s).into_iter().collect(),
+            Some(Value::Array(arr)) => arr
+                .iter()
+                .filter_map(|v| v.as_str())
+                .filter_map(parse_addr)
+                .collect(),
+            _ => vec![],
+        };
+        let topics = match filter.get("topics") {
+            Some(Value::Array(arr)) => arr
+                .iter()
+                .map(|slot| match slot {
+                    Value::Null => None,
+                    Value::String(s) => parse_topic(s).map(|h| vec![h]),
+                    Value::Array(set) => {
+                        let hashes: Vec<[u8; 32]> = set
+                            .iter()
+                            .filter_map(|v| v.as_str())
+                            .filter_map(parse_topic)
+                            .collect();
+                        if hashes.is_empty() { None } else { Some(hashes) }
+                    }
+                    _ => None,
+                })
+                .collect(),
+            _ => vec![],
+        };
+        Self { addresses, topics }
+    }
+
+    fn matches(&self, log: &LogEvent) -> bool {
+        if !self.addresses.is_empty() {
+            // log.address is "0x" + 40 hex; parse to bytes.
+            let log_addr = match parse_addr(&log.address) {
+                Some(a) => a,
+                None => return false,
+            };
+            if !self.addresses.iter().any(|a| a == &log_addr) {
+                return false;
+            }
+        }
+        for (i, slot) in self.topics.iter().enumerate() {
+            let Some(set) = slot else { continue };
+            let topic = match log.topics.get(i).and_then(|t| parse_topic(t)) {
+                Some(t) => t,
+                None => return false,
+            };
+            if !set.iter().any(|s| s == &topic) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+fn parse_addr(s: &str) -> Option<[u8; 20]> {
+    let s = s.trim_start_matches("0x").to_ascii_lowercase();
+    let bytes = hex::decode(&s).ok()?;
+    if bytes.len() != 20 {
+        return None;
+    }
+    let mut out = [0u8; 20];
+    out.copy_from_slice(&bytes);
+    Some(out)
+}
+
+fn parse_topic(s: &str) -> Option<[u8; 32]> {
+    let s = s.trim_start_matches("0x").to_ascii_lowercase();
+    let bytes = hex::decode(&s).ok()?;
+    if bytes.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Some(out)
+}
+
 /// Spawn the per-subscription listener for `newHeads`. Loops on the
 /// broadcast Receiver and forwards every event to the WS sender as
 /// an `eth_subscription` message. Exits on Lagged or Closed.
@@ -348,6 +535,126 @@ fn spawn_new_heads_listener(
                     // Bus dropped — server is shutting down.
                     break;
                 }
+            }
+        }
+    })
+}
+
+/// Phase 2: per-subscription listener for `eth_subscribe(logs)`. Applies the
+/// LogFilter per-event before forwarding so unsubscribed addresses /
+/// non-matching topics never reach the wire. Exits on Lagged or Closed
+/// with the same semantics as `spawn_new_heads_listener`.
+fn spawn_logs_listener(
+    mut rx: broadcast::Receiver<LogEvent>,
+    sender: Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    sub_id: String,
+    filter: LogFilter,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    if !filter.matches(&event) {
+                        continue;
+                    }
+                    let payload = wrap_subscription(&sub_id, json!(event));
+                    let mut s = sender.lock().await;
+                    if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    let payload = json!({
+                        "jsonrpc": "2.0",
+                        "method": "eth_subscription",
+                        "params": {
+                            "subscription": sub_id,
+                            "result": null,
+                            "error": format!("subscription lagged ({skipped} events skipped); reconnect to resume"),
+                        },
+                    });
+                    let mut s = sender.lock().await;
+                    let _ = s.send(Message::Text(payload.to_string().into())).await;
+                    break;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
+}
+
+/// Phase 2: per-subscription listener for `eth_subscribe(newPendingTransactions)`.
+/// Standard Ethereum payload is just the txid string; emits that exact
+/// shape so dApp tooling consumes without special-casing.
+fn spawn_pending_txs_listener(
+    mut rx: broadcast::Receiver<PendingTxEvent>,
+    sender: Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    sub_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    let payload = wrap_subscription(&sub_id, json!(event.txid));
+                    let mut s = sender.lock().await;
+                    if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    let payload = json!({
+                        "jsonrpc": "2.0",
+                        "method": "eth_subscription",
+                        "params": {
+                            "subscription": sub_id,
+                            "result": null,
+                            "error": format!("subscription lagged ({skipped} events skipped); reconnect to resume"),
+                        },
+                    });
+                    let mut s = sender.lock().await;
+                    let _ = s.send(Message::Text(payload.to_string().into())).await;
+                    break;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
+}
+
+/// Phase 3: Sentrix-native — `sentrix_finalized` listener.
+/// On Lagged or Closed, exits the task (client must reconnect to resume).
+fn spawn_finalized_listener(
+    mut rx: broadcast::Receiver<FinalizedEvent>,
+    sender: Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    sub_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Ok(event) = rx.recv().await {
+            let payload = wrap_subscription(&sub_id, json!(event));
+            let mut s = sender.lock().await;
+            if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+                break;
+            }
+        }
+    })
+}
+
+/// Phase 3: Sentrix-native — `sentrix_validatorSet` listener. Fires at
+/// epoch boundary when the active set rotates. Wire-up of emit_validator_set
+/// in the staking layer pending — the channel is ready; subscribers will
+/// start receiving once the staking epoch-advance path calls
+/// `emit_validator_set`.
+fn spawn_validator_set_listener(
+    mut rx: broadcast::Receiver<ValidatorSetEvent>,
+    sender: Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    sub_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Ok(event) = rx.recv().await {
+            let payload = wrap_subscription(&sub_id, json!(event));
+            let mut s = sender.lock().await;
+            if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+                break;
             }
         }
     })


### PR DESCRIPTION
## Summary

Completes the \`eth_subscribe\` surface (Phase 1 was newHeads only in PR #398) and adds Sentrix-native channels. After this PR, builders can subscribe to:

- \`eth_subscribe(newHeads)\` — Phase 1 ✅
- \`eth_subscribe(logs)\` — filterable EVM contract events (address + topics)
- \`eth_subscribe(newPendingTransactions)\` — mempool admissions
- \`eth_subscribe(syncing)\` — stub (Sentrix has no syncing mode)
- \`eth_subscribe(sentrix_finalized)\` — BFT finalization with justification signer count
- \`eth_subscribe(sentrix_validatorSet)\` — epoch boundary changes (channel ready, staking emit_validator_set wire-up Phase 3 follow-up)

Plus per-IP connection limit (max 10 concurrent WS per source IP) — defense against fd exhaustion from a single abusive client.

## Test plan

- [x] \`cargo build --release\` — clean
- [x] \`cargo clippy --release -p sentrix-rpc -- -D warnings\` — clean
- [x] \`cargo test --release -p sentrix-rpc\` — 26/26 pass (incl 4 events tests)
- [ ] Post-merge: \`fast-deploy mainnet\` then smoke test:
  - WSRX log subscription with topic filter
  - newPendingTransactions on mempool admission
  - sentrix_finalized on every block

## Architecture

EventEmitter trait extended with 4 new emit methods, all defaulting to no-op so older implementors compile unchanged. Hook sites:

- \`block_executor.rs:1295\` — \`emit_finalized\` alongside \`emit_new_head\` after \`chain.push\`
- \`block_executor.rs:1623\` (per-log loop) — \`emit_log\` inside existing log-persist loop, in lockstep with \`storage.put_bincode(TABLE_LOGS)\`
- \`mempool.rs:158\` — \`emit_pending_tx\` on successful admission only

LogData struct in sentrix-primitives keeps the trait crate free of sentrix-evm dependency. Concrete \`EventBus\` in sentrix-rpc converts to LogEvent (Ethereum-compat shape) at the broadcast site.

LogFilter parses eth_getLogs-compatible filter (address: single/array, topics: positional null/string/array) once at subscribe time. Per-event match in the listener task — unsubscribed traffic never crosses the wire.

## Risk

RPC-only. Same risk profile as PR #398 — consensus path untouched, all hooks post-state-mutation, non-blocking, infallible by trait contract. Worst-case: subscribers don't receive events; chain stays healthy. Mainnet halt risk: zero.