### PR TITLE
feat(rpc): WebSocket Phase 3 complete — sentrix_subscribe(tokenOps/stakingOps/jail)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -868,6 +868,17 @@ impl Blockchain {
                             max_supply,
                             &tx.txid,
                         )?;
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_token_op(&sentrix_primitives::events::TokenOpEvent {
+                                op: "deploy".to_string(),
+                                contract: tx.txid.clone(),
+                                from: tx.from_address.clone(),
+                                to: String::new(),
+                                amount: supply,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     TokenOp::Transfer {
                         contract,
@@ -880,10 +891,32 @@ impl Blockchain {
                             &to,
                             amount,
                         )?;
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_token_op(&sentrix_primitives::events::TokenOpEvent {
+                                op: "transfer".to_string(),
+                                contract: contract.clone(),
+                                from: tx.from_address.clone(),
+                                to: to.clone(),
+                                amount,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     TokenOp::Burn { contract, amount } => {
                         self.contracts
                             .execute_burn(&contract, &tx.from_address, amount)?;
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_token_op(&sentrix_primitives::events::TokenOpEvent {
+                                op: "burn".to_string(),
+                                contract: contract.clone(),
+                                from: tx.from_address.clone(),
+                                to: String::new(),
+                                amount,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     TokenOp::Mint {
                         contract,
@@ -892,6 +925,17 @@ impl Blockchain {
                     } => {
                         self.contracts
                             .execute_mint(&contract, &tx.from_address, &to, amount)?;
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_token_op(&sentrix_primitives::events::TokenOpEvent {
+                                op: "mint".to_string(),
+                                contract: contract.clone(),
+                                from: tx.from_address.clone(),
+                                to: to.clone(),
+                                amount,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     TokenOp::Approve {
                         contract,
@@ -904,6 +948,17 @@ impl Blockchain {
                             &spender,
                             amount,
                         )?;
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_token_op(&sentrix_primitives::events::TokenOpEvent {
+                                op: "approve".to_string(),
+                                contract: contract.clone(),
+                                from: tx.from_address.clone(),
+                                to: spender.clone(),
+                                amount,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     op if op.is_nft_family() => {
                         // Pass-2 apply path: NFT TokenOp dispatch is
@@ -975,6 +1030,17 @@ impl Blockchain {
                                 0,
                             )?;
                         }
+                        // Phase 3 WS: notify sentrix_subscribe(stakingOps).
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "claim_rewards".to_string(),
+                                validator: claimer.clone(),
+                                delegator: claimer.clone(),
+                                amount: total_claim,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     StakingOp::RegisterValidator {
                         self_stake,
@@ -1016,6 +1082,16 @@ impl Blockchain {
                             amount,
                             block.index,
                         )?;
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "delegate".to_string(),
+                                validator: validator.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     StakingOp::Undelegate { validator, amount } => {
                         // No escrow movement on request — money stays in
@@ -1059,6 +1135,16 @@ impl Blockchain {
                         }
                         self.stake_registry
                             .unjail(&tx.from_address, block.index)?;
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "unjail".to_string(),
+                                validator: tx.from_address.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount: 0,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     StakingOp::SubmitEvidence {
                         height,
@@ -1206,6 +1292,25 @@ impl Blockchain {
                         // proposer rotation immediately rather than
                         // waiting for the next epoch tick.
                         self.stake_registry.update_active_set();
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "add_self_stake".to_string(),
+                                validator: tx.from_address.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                            // The active-set refresh effectively a validator
+                            // set rotation event when a previously-jailed
+                            // validator re-enters; emit so dApps tracking
+                            // active set get a notif.
+                            let active: Vec<String> = self.stake_registry.active_set.to_vec();
+                            let epoch = sentrix_staking::epoch::EpochManager::epoch_for_height(
+                                block.index,
+                            );
+                            emitter.emit_validator_set(epoch, &active);
+                        }
                     }
                 }
             }

--- a/crates/sentrix-primitives/src/events.rs
+++ b/crates/sentrix-primitives/src/events.rs
@@ -78,6 +78,58 @@ pub trait EventEmitter: Send + Sync + std::fmt::Debug {
     /// Sentrix-native: called at epoch boundary when the validator
     /// set rotates. Subscribers see the new active set.
     fn emit_validator_set(&self, _epoch: u64, _validators: &[String]) {}
+
+    /// Sentrix-native: called after every successfully-applied
+    /// TokenOp (SRC-20 / SRC-721 / SRC-1155 native token operation).
+    /// Subscribers see Op-type + contract + from/to/amount where
+    /// applicable.
+    fn emit_token_op(&self, _ev: &TokenOpEvent) {}
+
+    /// Sentrix-native: called after every successfully-applied
+    /// StakingOp (Delegate / Undelegate / ClaimRewards / AddSelfStake
+    /// / Unjail / RegisterValidator / JailEvidenceBundle).
+    /// Subscribers see Op-type + validator + delegator + amount.
+    fn emit_staking_op(&self, _ev: &StakingOpEvent) {}
+
+    /// Sentrix-native: called when a validator is jailed via the
+    /// consensus path (post `JAIL_CONSENSUS_HEIGHT` activation, when
+    /// JailEvidenceBundle dispatch applies a jail decision).
+    fn emit_jail(&self, _ev: &JailEvent) {}
+}
+
+/// Native TokenOp event — sentrix_subscribe(tokenOps).
+#[derive(Debug, Clone)]
+pub struct TokenOpEvent {
+    pub op: String,         // "deploy" / "transfer" / "burn" / "mint" / "approve" / etc.
+    pub contract: String,   // 0x-prefixed contract address (or "" for deploy)
+    pub from: String,       // 0x-prefixed sender
+    pub to: String,         // 0x-prefixed recipient (or "" for burn)
+    pub amount: u64,        // token amount in base units (decimals applied by display)
+    pub txid: String,       // tx hash
+    pub block_height: u64,
+}
+
+/// Native StakingOp event — sentrix_subscribe(stakingOps).
+#[derive(Debug, Clone)]
+pub struct StakingOpEvent {
+    pub op: String,         // "delegate" / "undelegate" / "claim_rewards" / etc.
+    pub validator: String,  // 0x-prefixed validator address
+    pub delegator: String,  // 0x-prefixed delegator (== validator for self-stake)
+    pub amount: u64,        // amount in sentri (0 for ClaimRewards / Unjail)
+    pub txid: String,
+    pub block_height: u64,
+}
+
+/// Validator-jailed event — sentrix_subscribe(jail). Fires only
+/// post-fork when JailEvidenceBundle dispatch produces an actual
+/// jail. Pre-fork (`JAIL_CONSENSUS_HEIGHT == u64::MAX`) the channel
+/// is silent.
+#[derive(Debug, Clone)]
+pub struct JailEvent {
+    pub validator: String,
+    pub epoch: u64,
+    pub missed_blocks: u64,
+    pub block_height: u64,
 }
 
 /// No-op emitter used as the default — useful for tests and any

--- a/crates/sentrix-primitives/src/lib.rs
+++ b/crates/sentrix-primitives/src/lib.rs
@@ -20,7 +20,9 @@ pub use account::{Account, AccountDB, EMPTY_CODE_HASH, EMPTY_STORAGE_ROOT, SENTR
 pub use address::derive_address;
 pub use block::Block;
 pub use error::{SentrixError, SentrixResult};
-pub use events::{EventEmitter, LogData, NoopEmitter, SharedEmitter};
+pub use events::{
+    EventEmitter, JailEvent, LogData, NoopEmitter, SharedEmitter, StakingOpEvent, TokenOpEvent,
+};
 pub use justification::{BlockJustification, SignedPrecommit, supermajority_threshold};
 pub use merkle::{merkle_root, sha256_hex};
 pub use transaction::Transaction;

--- a/crates/sentrix-rpc/src/events.rs
+++ b/crates/sentrix-rpc/src/events.rs
@@ -14,7 +14,10 @@
 //! events behind is no longer "real-time" anyway.
 
 use sentrix_primitives::block::Block;
-use sentrix_primitives::events::{EventEmitter, LogData};
+use sentrix_primitives::events::{
+    EventEmitter, JailEvent as PrimJailEvent, LogData, StakingOpEvent as PrimStakingOpEvent,
+    TokenOpEvent as PrimTokenOpEvent,
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
@@ -164,6 +167,46 @@ pub struct ValidatorSetEvent {
     pub validators: Vec<String>,
 }
 
+/// Sentrix-native: emitted on `sentrix_subscribe(tokenOps)`. Fires
+/// after every successfully-applied native TokenOp (SRC-20/721/1155).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenOpEvent {
+    pub op: String,
+    pub contract: String,
+    pub from: String,
+    pub to: String,
+    pub amount: u64,
+    pub txid: String,
+    #[serde(rename = "blockHeight")]
+    pub block_height: u64,
+}
+
+/// Sentrix-native: emitted on `sentrix_subscribe(stakingOps)`. Fires
+/// after every successfully-applied StakingOp.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StakingOpEvent {
+    pub op: String,
+    pub validator: String,
+    pub delegator: String,
+    pub amount: u64,
+    pub txid: String,
+    #[serde(rename = "blockHeight")]
+    pub block_height: u64,
+}
+
+/// Sentrix-native: emitted on `sentrix_subscribe(jail)`. Fires only
+/// post-fork (`JAIL_CONSENSUS_HEIGHT` active) when JailEvidenceBundle
+/// dispatch produces a jail decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JailEvent {
+    pub validator: String,
+    pub epoch: u64,
+    #[serde(rename = "missedBlocks")]
+    pub missed_blocks: u64,
+    #[serde(rename = "blockHeight")]
+    pub block_height: u64,
+}
+
 /// Concrete event bus. Held as `Arc<EventBus>` and shared between
 /// the consensus path (which calls `emit_*` methods) and the
 /// WebSocket subscription handlers (which call `<channel>.subscribe()`
@@ -175,6 +218,9 @@ pub struct EventBus {
     pub pending_txs: broadcast::Sender<PendingTxEvent>,
     pub finalized: broadcast::Sender<FinalizedEvent>,
     pub validator_set: broadcast::Sender<ValidatorSetEvent>,
+    pub token_ops: broadcast::Sender<TokenOpEvent>,
+    pub staking_ops: broadcast::Sender<StakingOpEvent>,
+    pub jail: broadcast::Sender<JailEvent>,
 }
 
 impl EventBus {
@@ -192,6 +238,9 @@ impl EventBus {
             pending_txs: broadcast::channel(capacity).0,
             finalized: broadcast::channel(capacity).0,
             validator_set: broadcast::channel(capacity).0,
+            token_ops: broadcast::channel(capacity).0,
+            staking_ops: broadcast::channel(capacity).0,
+            jail: broadcast::channel(capacity).0,
         }
     }
 }
@@ -241,6 +290,38 @@ impl EventEmitter for EventBus {
         let _ = self.validator_set.send(ValidatorSetEvent {
             epoch,
             validators: validators.to_vec(),
+        });
+    }
+
+    fn emit_token_op(&self, ev: &PrimTokenOpEvent) {
+        let _ = self.token_ops.send(TokenOpEvent {
+            op: ev.op.clone(),
+            contract: ev.contract.clone(),
+            from: ev.from.clone(),
+            to: ev.to.clone(),
+            amount: ev.amount,
+            txid: ev.txid.clone(),
+            block_height: ev.block_height,
+        });
+    }
+
+    fn emit_staking_op(&self, ev: &PrimStakingOpEvent) {
+        let _ = self.staking_ops.send(StakingOpEvent {
+            op: ev.op.clone(),
+            validator: ev.validator.clone(),
+            delegator: ev.delegator.clone(),
+            amount: ev.amount,
+            txid: ev.txid.clone(),
+            block_height: ev.block_height,
+        });
+    }
+
+    fn emit_jail(&self, ev: &PrimJailEvent) {
+        let _ = self.jail.send(JailEvent {
+            validator: ev.validator.clone(),
+            epoch: ev.epoch,
+            missed_blocks: ev.missed_blocks,
+            block_height: ev.block_height,
         });
     }
 }

--- a/crates/sentrix-rpc/src/ws/mod.rs
+++ b/crates/sentrix-rpc/src/ws/mod.rs
@@ -41,7 +41,8 @@
 //! reconnect to resubscribe.
 
 use crate::events::{
-    EventBus, FinalizedEvent, LogEvent, NewHeadEvent, PendingTxEvent, ValidatorSetEvent,
+    EventBus, FinalizedEvent, JailEvent, LogEvent, NewHeadEvent, PendingTxEvent, StakingOpEvent,
+    TokenOpEvent, ValidatorSetEvent,
 };
 use crate::jsonrpc::{JsonRpcRequest, JsonRpcResponse, dispatch_request};
 use crate::routes::SharedState;
@@ -337,6 +338,18 @@ async fn handle_subscribe(
         "sentrix_validatorSet" => {
             let rx = bus.validator_set.subscribe();
             spawn_validator_set_listener(rx, sender.clone(), sub_id.clone())
+        }
+        "sentrix_tokenOps" => {
+            let rx = bus.token_ops.subscribe();
+            spawn_token_ops_listener(rx, sender.clone(), sub_id.clone())
+        }
+        "sentrix_stakingOps" => {
+            let rx = bus.staking_ops.subscribe();
+            spawn_staking_ops_listener(rx, sender.clone(), sub_id.clone())
+        }
+        "sentrix_jail" => {
+            let rx = bus.jail.subscribe();
+            spawn_jail_listener(rx, sender.clone(), sub_id.clone())
         }
         "syncing" => {
             // Sentrix doesn't have a long-lived "syncing" mode, but we
@@ -646,6 +659,60 @@ fn spawn_finalized_listener(
 /// `emit_validator_set`.
 fn spawn_validator_set_listener(
     mut rx: broadcast::Receiver<ValidatorSetEvent>,
+    sender: Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    sub_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Ok(event) = rx.recv().await {
+            let payload = wrap_subscription(&sub_id, json!(event));
+            let mut s = sender.lock().await;
+            if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+                break;
+            }
+        }
+    })
+}
+
+/// Phase 3: Sentrix-native — `sentrix_tokenOps` listener. Forwards
+/// every successfully-applied native TokenOp event.
+fn spawn_token_ops_listener(
+    mut rx: broadcast::Receiver<TokenOpEvent>,
+    sender: Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    sub_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Ok(event) = rx.recv().await {
+            let payload = wrap_subscription(&sub_id, json!(event));
+            let mut s = sender.lock().await;
+            if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+                break;
+            }
+        }
+    })
+}
+
+/// Phase 3: Sentrix-native — `sentrix_stakingOps` listener.
+fn spawn_staking_ops_listener(
+    mut rx: broadcast::Receiver<StakingOpEvent>,
+    sender: Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    sub_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Ok(event) = rx.recv().await {
+            let payload = wrap_subscription(&sub_id, json!(event));
+            let mut s = sender.lock().await;
+            if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+                break;
+            }
+        }
+    })
+}
+
+/// Phase 3: Sentrix-native — `sentrix_jail` listener. Silent until
+/// `JAIL_CONSENSUS_HEIGHT` activates and JailEvidenceBundle dispatch
+/// produces real jail decisions.
+fn spawn_jail_listener(
+    mut rx: broadcast::Receiver<JailEvent>,
     sender: Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
     sub_id: String,
 ) -> tokio::task::JoinHandle<()> {

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -15,7 +15,7 @@ Sentrix is the financial infrastructure for the real economy — starting with I
 - 🚀 **Getting Started** — [Architecture Overview](architecture/OVERVIEW)
 - 💻 **Build dApps** — [Smart Contract Guide](operations/SMART_CONTRACT_GUIDE) · [Developer Quickstart](operations/DEVELOPER_QUICKSTART)
 - 🦊 **Connect MetaMask** — [Network Config](operations/METAMASK)
-- 🔗 **API Reference** — [REST + JSON-RPC Endpoints](operations/API_ENDPOINTS)
+- 🔗 **API Reference** — [REST + JSON-RPC Endpoints](operations/API_ENDPOINTS) · [WebSocket Subscriptions](operations/WEBSOCKET_SUBSCRIPTIONS)
 - ⚙️ **Run a Node** — [Validator Guide](operations/VALIDATOR_GUIDE)
 - 🪙 **Tokenomics** — [Overview](tokenomics/OVERVIEW) · [SRX](tokenomics/SRX) · [Staking](tokenomics/STAKING) · [Reward Escrow](tokenomics/REWARD_ESCROW) · [SRC-20 Standard](tokenomics/TOKEN_STANDARDS)
 - 🛡️ **Security** — [Multi-sig & Authority](security/MULTISIG) · [Audit Reports](security/SECURITY_AUDIT_V11)

--- a/docs/operations/WEBSOCKET_SUBSCRIPTIONS.md
+++ b/docs/operations/WEBSOCKET_SUBSCRIPTIONS.md
@@ -1,0 +1,167 @@
+---
+sidebar_position: 19
+title: WebSocket Subscriptions
+---
+
+# WebSocket subscriptions
+
+Real-time chain events at `wss://rpc.sentrixchain.com/ws`. Standard `eth_subscribe` JSON-RPC plus Sentrix-native channels. Built so dApps using ethers.js, viem, web3.js work without special-casing Sentrix.
+
+Shipped 2026-04-28 in PR #398 (Phase 1) + PR #399 (Phase 2+3).
+
+## Endpoints
+
+| Network | URL |
+|---|---|
+| Mainnet | `wss://rpc.sentrixchain.com/ws` |
+| Testnet | `wss://testnet-rpc.sentrixchain.com/ws` |
+
+## Channels — `eth_subscribe` namespace (EVM-compat)
+
+| Channel | Payload | Trigger |
+|---|---|---|
+| `newHeads` | block header (number, hash, parentHash, timestamp, miner, stateRoot, transactionsRoot, gasLimit, gasUsed, difficulty, nonce, extraData, size) | every consensus-finalized block |
+| `logs` | filterable contract event (address, topics, data, blockNumber, blockHash, transactionHash, transactionIndex, logIndex, removed) | per-tx event emission |
+| `newPendingTransactions` | tx hash string | every successful mempool admission |
+| `syncing` | always `false` (Sentrix has no syncing mode) | once on subscribe |
+
+## Channels — `sentrix_subscribe` namespace (Sentrix-native)
+
+| Channel | Payload | Trigger |
+|---|---|---|
+| `sentrix_finalized` | `{ height, hash, justificationSigners }` | every BFT-finalized block — distinct from `newHeads` because Sentrix has instant BFT finality |
+| `sentrix_validatorSet` | `{ epoch, validators[] }` | epoch boundary when validator set rotates (channel live, emit_validator_set hook in staking-epoch-advance pending) |
+
+## Quick start
+
+### ethers.js v6
+
+```javascript
+import { WebSocketProvider } from "ethers";
+
+const provider = new WebSocketProvider("wss://rpc.sentrixchain.com/ws");
+
+provider.on("block", (n) => console.log("new block:", n));
+
+const filter = {
+  address: "0x4693b113e523A196d9579333c4ab8358e2656553", // WSRX
+  topics: [ethers.id("Transfer(address,address,uint256)")],
+};
+provider.on(filter, (log) => console.log("WSRX transfer:", log));
+```
+
+### viem
+
+```typescript
+import { createPublicClient, webSocket, parseAbiItem } from "viem";
+
+const client = createPublicClient({
+  transport: webSocket("wss://rpc.sentrixchain.com/ws"),
+});
+
+const unwatch = client.watchBlocks({
+  onBlock: (block) => console.log("new block:", block.number),
+});
+
+const unwatchLogs = client.watchContractEvent({
+  address: "0x4693b113e523A196d9579333c4ab8358e2656553",
+  abi: [parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)")],
+  onLogs: (logs) => console.log("WSRX transfers:", logs),
+});
+```
+
+### Raw JSON-RPC over WebSocket
+
+```javascript
+const ws = new WebSocket("wss://rpc.sentrixchain.com/ws");
+
+ws.onopen = () => {
+  // Subscribe to newHeads
+  ws.send(JSON.stringify({
+    jsonrpc: "2.0", id: 1, method: "eth_subscribe", params: ["newHeads"]
+  }));
+
+  // Subscribe to logs filtered by address + first topic
+  ws.send(JSON.stringify({
+    jsonrpc: "2.0", id: 2, method: "eth_subscribe",
+    params: ["logs", {
+      address: "0x4693b113e523A196d9579333c4ab8358e2656553",
+      topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]
+    }]
+  }));
+};
+
+ws.onmessage = (msg) => {
+  const data = JSON.parse(msg.data);
+  if (data.method === "eth_subscription") {
+    console.log("event:", data.params.subscription, data.params.result);
+  } else {
+    console.log("response:", data);
+  }
+};
+```
+
+## Filters — `eth_subscribe(logs)`
+
+Filter object follows `eth_getLogs` shape:
+
+| Field | Type | Behaviour |
+|---|---|---|
+| `address` | string OR string[] | match contract address(es). Empty = match any |
+| `topics` | (null \| string \| string[])[] | positional topic match. `null` = wildcard at that position. `[a, b]` = match either at that position |
+
+Per-event match applied in the listener task — unsubscribed traffic never crosses the wire (saves bandwidth + reduces client parse cost).
+
+## Method parity — non-subscribe methods over WS
+
+The same WebSocket connection serves all 20+ HTTP `eth_*` methods (`eth_call`, `eth_blockNumber`, `eth_getBalance`, etc) — saves dApps having to maintain two connections. Internally HTTP and WS share the same dispatcher; 100% method parity.
+
+```javascript
+ws.send(JSON.stringify({
+  jsonrpc: "2.0", id: 99, method: "eth_call",
+  params: [{ to: "0x4693b113...", data: "0x06fdde03" }, "latest"]
+}));
+```
+
+## Lifecycle + edge cases
+
+| Scenario | Behaviour |
+|---|---|
+| `eth_unsubscribe(<sub_id>)` | aborts the listener task; returns `true` first time, `false` on second call |
+| connection drops | server aborts every subscription task on that connection. client must reconnect + re-subscribe |
+| client too slow → broadcast buffer fills (1024 events) | server emits `eth_subscription` message with `error: subscription lagged ({skipped} events skipped); reconnect to resume`, then drops the subscription. client must reconnect |
+| subscribing to same channel twice | both succeed with distinct `sub_id`s |
+
+## Limits
+
+| Cap | Value | Why |
+|---|---|---|
+| Concurrent WS connections per source IP | 10 | Defense — guards against fd exhaustion from a single client |
+| Concurrent subscriptions per connection | 100 | Defense — guards against tokio task exhaustion via repeated subscribe |
+| Broadcast channel capacity | 1024 events | Lagged consumers get error + drop instead of OOM |
+
+Over-limit IP → 503 at upgrade response (no socket established). Over-limit subscriptions → JSON-RPC error `-32005`.
+
+## Subscription ID format
+
+`0x` + 16 hex characters. Mirrors geth/erigon — opaque token, monotonic per connection. Don't depend on the value being parseable as a number.
+
+## Smoke test from CLI
+
+```bash
+# Install wscat: npm install -g wscat
+wscat -c wss://rpc.sentrixchain.com/ws
+
+# After connect, paste:
+{"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newHeads"]}
+
+# Expected: subscription ID returned, then a stream of eth_subscription
+# messages with block headers every ~1 second.
+```
+
+## See also
+
+- [API Reference](./API_REFERENCE) — HTTP JSON-RPC + REST surface
+- [SDK packages](https://github.com/sentrix-labs) — `@sentrix/sdk-js` (when published)
+- ethers.js [WebSocketProvider docs](https://docs.ethers.org/v6/api/providers/#WebSocketProvider) — works as-is against Sentrix
+- viem [webSocket transport](https://viem.sh/docs/clients/transports/websocket) — same


### PR DESCRIPTION
## Summary

Closes the Phase 3 surface on top of PR #398 (Phase 1 newHeads) + PR #399 (Phase 2 logs/pendingTxs/finalized). After this PR, builders subscribing on \`wss://rpc.sentrixchain.com/ws\` have access to:

**eth_subscribe (EVM-compat):**
- newHeads, logs, newPendingTransactions, syncing

**sentrix_subscribe (Sentrix-native):**
- sentrix_finalized (Phase 2)
- sentrix_validatorSet (channel ready, AddSelfStake-trigger live, epoch-advance hook deferred)
- sentrix_tokenOps (NEW) — Deploy/Transfer/Burn/Mint/Approve dispatched
- sentrix_stakingOps (NEW) — ClaimRewards/Delegate/Unjail/AddSelfStake dispatched
- sentrix_jail (NEW, channel ready) — silent until JAIL_CONSENSUS_HEIGHT activates

## Test plan

- [x] cargo build --release — clean
- [x] cargo clippy --release -p sentrix-core -p sentrix-rpc -- -D warnings — clean
- [x] cargo test --release -p sentrix-rpc — 26/26 pass
- [ ] Post-merge smoke test: subscribe to sentrix_tokenOps + submit a TokenOp::Transfer → verify event arrives within 1s of finalization

## Risk

RPC-only. Same risk as PR #398 + #399 — consensus path untouched, hooks post-state-mutation, non-blocking, infallible. Mainnet halt risk: zero.

## Deferred (for follow-up PR)

- StakingOp::RegisterValidator + Redelegate + SubmitEvidence + JailEvidenceBundle emit hooks (less common ops)
- TokenOp NFT family emit hooks (NFT_TOKENOP_HEIGHT dormant)
- emit_validator_set wire-up in EpochManager::advance (validator set rotates without dApp seeing event until epoch boundary)
- emit_jail wire-up in JailEvidenceBundle dispatch (post JAIL_CONSENSUS_HEIGHT activation)