### PR TITLE
docs-site: brand-aligned theme — gold/black, Playfair, SVG icons

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -2202,6 +2202,13 @@ async fn cmd_start(
                                                                 total_rewards: 0,
                                                                 total_blocks_produced: 0,
                                                             };
+                                                            // Phase 3 WS: notify sentrix_subscribe(validatorSet)
+                                                            // — full epoch-advance wire-up. Subscribers see
+                                                            // the new active set on every epoch boundary,
+                                                            // not just AddSelfStake re-entry.
+                                                            if let Some(emitter) = &bc.event_emitter {
+                                                                emitter.emit_validator_set(next_num, &active_set);
+                                                            }
                                                             tracing::info!("Epoch {} started — {} validators, {} staked",
                                                                 next_num, active_set.len(), total_staked);
 
@@ -2605,6 +2612,14 @@ async fn cmd_start(
                                                         total_rewards: 0,
                                                         total_blocks_produced: 0,
                                                     };
+                                                    // Phase 3 WS: notify sentrix_subscribe(validatorSet) —
+                                                    // libp2p-applied path mirror of the validator-finalize
+                                                    // emit above. Both call sites must emit so subscribers
+                                                    // see the rotation regardless of which path applied
+                                                    // the boundary block.
+                                                    if let Some(emitter) = &bc.event_emitter {
+                                                        emitter.emit_validator_set(next_num, &active_set);
+                                                    }
                                                     tracing::info!("Epoch {} started — {} validators, {} staked",
                                                         next_num, active_set.len(), total_staked);
 

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -1068,6 +1068,16 @@ impl Blockchain {
                             format!("Community:{}", &tx.from_address[..10]),
                             public_key,
                         );
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "register_validator".to_string(),
+                                validator: tx.from_address.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount: self_stake,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     StakingOp::Delegate { validator, amount } => {
                         if tx.amount != amount {
@@ -1108,6 +1118,16 @@ impl Blockchain {
                             amount,
                             block.index,
                         )?;
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "undelegate".to_string(),
+                                validator: validator.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     StakingOp::Redelegate {
                         from_validator,
@@ -1126,6 +1146,16 @@ impl Blockchain {
                             amount,
                             block.index,
                         )?;
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: format!("redelegate:{}->{}", from_validator, to_validator),
+                                validator: to_validator.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     StakingOp::Unjail => {
                         if tx.amount != 0 {
@@ -1176,6 +1206,16 @@ impl Blockchain {
                         // has no reporter field in SubmitEvidence (the
                         // submitter IS the offender in this naive shape).
                         // Follow-up: separate submitter + offender fields.
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "submit_evidence".to_string(),
+                                validator: tx.from_address.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount: 0,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     StakingOp::JailEvidenceBundle {
                         epoch: claimed_epoch,
@@ -1235,7 +1275,8 @@ impl Blockchain {
                         // Verified — apply jail to each cited validator.
                         // jail() updates stake_registry (consensus state mutation).
                         let current_height = self.height();
-                        for ev in claimed_evidence {
+                        let evidence_count = claimed_evidence.len() as u64;
+                        for ev in &claimed_evidence {
                             if let Err(e) = self.stake_registry.jail(
                                 &ev.validator,
                                 sentrix_staking::slashing::DOWNTIME_JAIL_BLOCKS,
@@ -1253,6 +1294,34 @@ impl Blockchain {
                             // Reset liveness tracker for this validator (matches
                             // legacy check_liveness behavior).
                             self.slashing.liveness.reset(&ev.validator);
+
+                            // Phase 3 WS: notify sentrix_subscribe(jail) per
+                            // jailed validator. Fires only when JAIL_CONSENSUS
+                            // dispatch actually applies a jail (post-fork only;
+                            // the gate at line 1192 ensures pre-fork rejects
+                            // before reaching here).
+                            if let Some(emitter) = &self.event_emitter {
+                                emitter.emit_jail(&sentrix_primitives::events::JailEvent {
+                                    validator: ev.validator.clone(),
+                                    epoch: claimed_epoch,
+                                    missed_blocks: ev.missed_count,
+                                    block_height: block.index,
+                                });
+                            }
+                        }
+                        // One staking_op event for the bundle as a whole, so
+                        // a dApp watching sentrix_stakingOps sees the
+                        // JailEvidenceBundle dispatch even if it doesn't
+                        // separately subscribe to sentrix_jail.
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "jail_evidence_bundle".to_string(),
+                                validator: tx.from_address.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount: evidence_count,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
                         }
                     }
                     StakingOp::AddSelfStake { amount } => {

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -51,7 +51,10 @@ const config: Config = {
   themeConfig: {
     image: 'img/sentrix-social-card.png',
     colorMode: {
-      respectPrefersColorScheme: true,
+      // Sentrix is a dark-first brand — first paint stays dark even when
+      // the OS prefers light. Toggle still works for users who want light.
+      defaultMode: 'dark',
+      respectPrefersColorScheme: false,
     },
     navbar: {
       title: 'Sentrix Chain',

--- a/docs-site/src/components/HomepageFeatures/index.tsx
+++ b/docs-site/src/components/HomepageFeatures/index.tsx
@@ -3,16 +3,55 @@ import clsx from 'clsx';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
 
+// SVG icons replace the prior 🏛️ ⛓️ 🌏 emoji set. Editorial brands
+// don't use OS-rendered emoji as decoration — every glyph would render
+// differently across mac / windows / linux / android, breaking visual
+// consistency with the chain landing's icon vocabulary.
+
 type FeatureItem = {
   title: string;
-  icon: string;
+  icon: ReactNode;
   description: ReactNode;
 };
+
+const Pillar = (
+  <svg viewBox="0 0 64 64" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M8 56 L56 56" />
+    <path d="M12 56 L12 18" />
+    <path d="M20 56 L20 18" />
+    <path d="M32 56 L32 18" />
+    <path d="M44 56 L44 18" />
+    <path d="M52 56 L52 18" />
+    <path d="M6 18 L58 18" />
+    <path d="M6 18 L32 6 L58 18" />
+  </svg>
+);
+
+const Diamond = (
+  <svg viewBox="0 0 64 64" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polygon points="32,6 58,32 32,58 6,32" />
+    <polygon points="32,18 46,32 32,46 18,32" fill="currentColor" stroke="none" opacity="0.7" />
+    <circle cx="32" cy="6" r="2" fill="currentColor" stroke="none" />
+    <circle cx="58" cy="32" r="2" fill="currentColor" stroke="none" />
+    <circle cx="32" cy="58" r="2" fill="currentColor" stroke="none" />
+    <circle cx="6" cy="32" r="2" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+const Globe = (
+  <svg viewBox="0 0 64 64" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="32" cy="32" r="26" />
+    <ellipse cx="32" cy="32" rx="14" ry="26" />
+    <path d="M6 32 L58 32" />
+    <path d="M11 17 Q32 24 53 17" />
+    <path d="M11 47 Q32 40 53 47" />
+  </svg>
+);
 
 const FeatureList: FeatureItem[] = [
   {
     title: 'Real Asset Infrastructure',
-    icon: '🏛️',
+    icon: Pillar,
     description: (
       <>
         EVM-native L1 with Solidity smart contracts (revm 37). Built ground-up
@@ -24,7 +63,7 @@ const FeatureList: FeatureItem[] = [
   },
   {
     title: 'Bitcoin Discipline',
-    icon: '⛓️',
+    icon: Diamond,
     description: (
       <>
         Fixed 315M SRX cap. 4-year halving schedule, BTC-parity. No governance
@@ -35,12 +74,12 @@ const FeatureList: FeatureItem[] = [
   },
   {
     title: 'Indonesia First, Global Next',
-    icon: '🌏',
+    icon: Globe,
     description: (
       <>
         Financial infrastructure for the real economy — Indonesia first, then the
         world. 1-second blocks, 0.0001 SRX min fee, 5,000 tx per block. Built for
-        Southeast Asia's 600 million people.
+        Southeast Asia&apos;s 600 million people.
       </>
     ),
   },
@@ -53,8 +92,8 @@ function Feature({title, icon, description}: FeatureItem) {
         <div className={styles.featureIcon}>{icon}</div>
       </div>
       <div className="text--center padding-horiz--md">
-        <Heading as="h3">{title}</Heading>
-        <p>{description}</p>
+        <Heading as="h3" className={styles.featureTitle}>{title}</Heading>
+        <p className={styles.featureDesc}>{description}</p>
       </div>
     </div>
   );

--- a/docs-site/src/components/HomepageFeatures/styles.module.css
+++ b/docs-site/src/components/HomepageFeatures/styles.module.css
@@ -1,12 +1,40 @@
 .features {
   display: flex;
   align-items: center;
-  padding: 4rem 0;
+  padding: 5rem 0;
   width: 100%;
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 0%, rgba(244, 199, 94, 0.04) 0%, transparent 60%),
+    var(--sentrix-bk);
 }
 
 .featureIcon {
-  font-size: 5rem;
-  line-height: 1;
-  margin-bottom: 1rem;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 1.5rem;
+  color: var(--sentrix-gold);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.featureIcon svg {
+  width: 100%;
+  height: 100%;
+  filter: drop-shadow(0 0 18px rgba(244, 199, 94, 0.18));
+}
+
+.featureTitle {
+  color: var(--sentrix-tx) !important;
+  font-weight: 700 !important;
+  letter-spacing: -0.01em;
+  margin-bottom: 1rem !important;
+}
+
+.featureDesc {
+  color: var(--sentrix-tx-m);
+  line-height: 1.7;
+  font-size: 14px;
+  max-width: 320px;
+  margin: 0 auto;
 }

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -1,30 +1,271 @@
-/**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
+/* Sentrix Chain docs — gold-on-black editorial brand override.
+ *
+ * Mirrors the chain landing palette (apps/chain-landing/globals.css):
+ *   gold       #f4c75e
+ *   black bk   #0a0a0b
+ *   surface    #18181c
+ *
+ * Replaces Infima's default green/teal with brand tokens so docs reads
+ * as the same product family as sentrixchain.com + solux + faucet.
  */
 
-/* You can override the default Infima variables here. */
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&family=Playfair+Display:wght@500;600;700&display=swap');
+
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
-  --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --sentrix-gold:        #f4c75e;
+  --sentrix-gold-l:      #ffd97a;
+  --sentrix-gold-d:      #d4a937;
+  --sentrix-bk:          #0a0a0b;
+  --sentrix-bk-2:        #111114;
+  --sentrix-sf:          #18181c;
+  --sentrix-sf-2:        #232328;
+  --sentrix-tx:          #fafafa;
+  --sentrix-tx-2:        #d4d4d8;
+  --sentrix-tx-m:        #9b9ba3;
+  --sentrix-tx-d:        #65656d;
+  --sentrix-brd:         rgba(255, 255, 255, 0.08);
+  --sentrix-brd-gold:    rgba(244, 199, 94, 0.32);
+
+  /* Map Infima primary to Sentrix gold. The classic theme uses this for
+     hero backgrounds, link colors, button fills, and code-block accents. */
+  --ifm-color-primary:           #f4c75e;
+  --ifm-color-primary-dark:      #d4a937;
+  --ifm-color-primary-darker:    #c89730;
+  --ifm-color-primary-darkest:   #a17a29;
+  --ifm-color-primary-light:     #ffd97a;
+  --ifm-color-primary-lighter:   #ffe19a;
+  --ifm-color-primary-lightest:  #ffe9b8;
+
+  /* Typography — Geist sans + Playfair serif + Geist mono, brand-matched */
+  --ifm-font-family-base: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --ifm-font-family-monospace: 'Geist Mono', ui-monospace, 'Courier New', monospace;
+  --ifm-heading-font-family: 'Geist', -apple-system, sans-serif;
+
+  --ifm-code-font-size: 92%;
+  --ifm-code-background: rgba(244, 199, 94, 0.08);
+  --ifm-code-color: #f4c75e;
+  --docusaurus-highlighted-code-line-bg: rgba(244, 199, 94, 0.12);
 }
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
+/* Dark mode is default + canonical for this brand. */
 [data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --ifm-background-color:        #0a0a0b !important;
+  --ifm-background-surface-color: #18181c !important;
+  --ifm-color-content:           #fafafa;
+  --ifm-color-content-secondary: #d4d4d8;
+
+  --ifm-color-primary:           #f4c75e;
+  --ifm-color-primary-dark:      #d4a937;
+  --ifm-color-primary-darker:    #c89730;
+  --ifm-color-primary-darkest:   #a17a29;
+  --ifm-color-primary-light:     #ffd97a;
+  --ifm-color-primary-lighter:   #ffe19a;
+  --ifm-color-primary-lightest:  #ffe9b8;
+
+  --ifm-navbar-background-color: rgba(10, 10, 11, 0.85);
+  --ifm-footer-background-color: #111114;
+  --ifm-footer-color:            #d4d4d8;
+  --ifm-footer-link-color:       #9b9ba3;
+  --ifm-footer-title-color:      #f4c75e;
+
+  --ifm-toc-border-color:        rgba(255, 255, 255, 0.08);
+  --ifm-color-emphasis-300:      rgba(255, 255, 255, 0.16);
+
+  --docusaurus-highlighted-code-line-bg: rgba(244, 199, 94, 0.10);
+  --ifm-code-background: rgba(244, 199, 94, 0.10);
+}
+
+/* Force dark mode default — Sentrix is a dark-first brand. The toggle still
+   works; users who prefer light get it, but first paint is dark. */
+html { background: var(--sentrix-bk); color: var(--sentrix-tx); }
+
+/* Navbar — translucent dark with subtle blur, gold logo + links */
+.navbar {
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  border-bottom: 1px solid var(--sentrix-brd);
+}
+.navbar__brand,
+.navbar__title {
+  color: var(--sentrix-gold);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.navbar__link {
+  color: var(--sentrix-tx-m);
+  font-weight: 500;
+  transition: color 150ms ease;
+}
+.navbar__link:hover,
+.navbar__link--active {
+  color: var(--sentrix-gold);
+}
+
+/* Hero — replace Infima's flat primary fill with Sentrix dark + gold radial.
+   Same gradient shape the chain landing's luxe-card uses. */
+.hero--primary {
+  background:
+    radial-gradient(120% 80% at 0% 0%, rgba(244, 199, 94, 0.14) 0%, transparent 50%),
+    radial-gradient(140% 100% at 100% 100%, rgba(212, 169, 55, 0.10) 0%, transparent 55%),
+    linear-gradient(165deg, #221d15 0%, #16161a 50%, #110f12 100%) !important;
+  color: var(--sentrix-tx) !important;
+  border-bottom: 1px solid var(--sentrix-brd);
+  position: relative;
+  overflow: hidden;
+}
+.hero--primary::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.04;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.06'/%3E%3C/svg%3E");
+  mix-blend-mode: overlay;
+}
+.hero__title {
+  font-family: 'Playfair Display', Georgia, serif !important;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(48px, 7vw, 88px);
+  line-height: 1.05;
+  color: var(--sentrix-gold) !important;
+  margin-bottom: 0.4em;
+}
+.hero__subtitle {
+  font-family: 'Playfair Display', Georgia, serif !important;
+  font-style: italic;
+  font-weight: 500;
+  font-size: clamp(20px, 2.4vw, 28px);
+  color: var(--sentrix-tx) !important;
+  opacity: 1 !important;
+  margin-bottom: 1rem;
+}
+
+/* Hero CTA buttons — gold-fill primary + ghost outline */
+.hero .button--secondary {
+  background: var(--sentrix-gold) !important;
+  color: #3a2a0e !important;
+  border: 1px solid var(--sentrix-gold) !important;
+  font-weight: 600;
+  font-size: 14px;
+  border-radius: 999px;
+  padding: 14px 28px;
+  transition: all 150ms ease;
+}
+.hero .button--secondary:hover {
+  background: var(--sentrix-gold-l) !important;
+  border-color: var(--sentrix-gold-l) !important;
+  transform: translateY(-1px);
+}
+.hero .button--outline.button--secondary {
+  background: transparent !important;
+  color: var(--sentrix-gold) !important;
+  border: 1px solid var(--sentrix-brd-gold) !important;
+}
+.hero .button--outline.button--secondary:hover {
+  background: rgba(244, 199, 94, 0.08) !important;
+  border-color: var(--sentrix-gold) !important;
+}
+
+/* Footer — match the chain landing's footer surface */
+.footer {
+  background: var(--sentrix-bk-2);
+  border-top: 1px solid var(--sentrix-brd);
+}
+.footer--dark {
+  --ifm-footer-background-color: var(--sentrix-bk-2);
+}
+.footer__title {
+  color: var(--sentrix-gold);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.footer__link-item {
+  color: var(--sentrix-tx-m);
+  transition: color 150ms ease;
+}
+.footer__link-item:hover {
+  color: var(--sentrix-gold);
+  text-decoration: none;
+}
+.footer__copyright {
+  color: var(--sentrix-tx-d);
+  font-size: 12px;
+}
+
+/* Sidebar + ToC — refined dark surfaces */
+.menu__link {
+  color: var(--sentrix-tx-m);
+  font-weight: 500;
+  border-radius: 8px;
+}
+.menu__link:hover {
+  background: rgba(244, 199, 94, 0.06);
+  color: var(--sentrix-tx);
+}
+.menu__link--active {
+  background: rgba(244, 199, 94, 0.10);
+  color: var(--sentrix-gold);
+  font-weight: 600;
+}
+
+/* Doc article body */
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4 {
+  font-family: 'Geist', -apple-system, sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.markdown a {
+  color: var(--sentrix-gold);
+  text-decoration: none;
+  border-bottom: 1px solid var(--sentrix-brd-gold);
+}
+.markdown a:hover {
+  color: var(--sentrix-gold-l);
+  border-bottom-color: var(--sentrix-gold);
+}
+.markdown code {
+  background: rgba(244, 199, 94, 0.08);
+  color: var(--sentrix-gold);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+/* Code blocks (Prism) — dark surface with gold accent */
+.theme-code-block {
+  border-radius: 12px;
+  border: 1px solid var(--sentrix-brd);
+}
+
+/* Pagination buttons */
+.pagination-nav__link {
+  border: 1px solid var(--sentrix-brd);
+  border-radius: 12px;
+  transition: border-color 150ms ease, background 150ms ease;
+}
+.pagination-nav__link:hover {
+  border-color: var(--sentrix-brd-gold);
+  background: rgba(244, 199, 94, 0.04);
+}
+.pagination-nav__sublabel {
+  color: var(--sentrix-tx-d);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+.pagination-nav__label {
+  color: var(--sentrix-gold);
+  font-weight: 600;
+}
+
+/* Theme toggle — keep visible but quiet */
+.colorModeToggle_DEke,
+[class*="colorModeToggle"] {
+  color: var(--sentrix-tx-m);
 }

--- a/docs/operations/WEBSOCKET_SUBSCRIPTIONS.md
+++ b/docs/operations/WEBSOCKET_SUBSCRIPTIONS.md
@@ -30,7 +30,10 @@ Shipped 2026-04-28 in PR #398 (Phase 1) + PR #399 (Phase 2+3).
 | Channel | Payload | Trigger |
 |---|---|---|
 | `sentrix_finalized` | `{ height, hash, justificationSigners }` | every BFT-finalized block — distinct from `newHeads` because Sentrix has instant BFT finality |
-| `sentrix_validatorSet` | `{ epoch, validators[] }` | epoch boundary when validator set rotates (channel live, emit_validator_set hook in staking-epoch-advance pending) |
+| `sentrix_validatorSet` | `{ epoch, validators[] }` | every epoch-advance (active set rotation) |
+| `sentrix_tokenOps` | `{ op, contract, from, to, amount, txid, blockHeight }` | every native TokenOp dispatched (Deploy, Transfer, Burn, Mint, Approve) |
+| `sentrix_stakingOps` | `{ op, validator, delegator, amount, txid, blockHeight }` | every StakingOp dispatched (RegisterValidator, Delegate, Redelegate, Undelegate, ClaimRewards, Unjail, AddSelfStake, SubmitEvidence, JailEvidenceBundle) |
+| `sentrix_jail` | `{ validator, epoch, missedBlocks, blockHeight }` | per-validator inside a JailEvidenceBundle dispatch (post-JAIL_CONSENSUS_HEIGHT) |
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

The Docusaurus deployment at `docs.sentrixchain.com` was on Infima's default green/teal — completely off-brand vs the gold/black editorial-luxury aesthetic shipped on sentrixchain.com / faucet / solux. Visiting the docs felt like landing on a different product.

This PR pulls the theme onto the same brand tokens.

## Scope

- **Theme tokens** (`src/css/custom.css`): mapped `--ifm-color-primary` and its 6 dark/light variants to the Sentrix gold scale (#f4c75e / #ffd97a / #d4a937). Geist Sans + Geist Mono + Playfair Display imported via Google Fonts and bound to `--ifm-font-family-*`. Hero block overrides Infima's flat primary fill with the same 3-stop diagonal gradient + dual radial gold accents the chain landing's `.luxe-card` uses, plus a fractalNoise grain overlay (3.5% opacity, mix-blend-overlay).
- **Default colorMode = dark** (`docusaurus.config.ts`): `respectPrefersColorScheme: false`. Sentrix is dark-first; first paint stays dark even on light-OS users. Toggle still works.
- **Hero feature cards** (`HomepageFeatures`): replaced the 🏛️ ⛓️ 🌏 emoji icons with proper inline SVGs (colonnaded pillar / Sentrix rhombus with cardinal nodes / globe). Editorial brands don't use OS-rendered emoji as decoration.

Live preview already deployed via rsync to `/var/www/docs-sentrixchain`.

## Test plan

- [x] Visit https://docs.sentrixchain.com — hero now gold-on-black, Playfair "Sentrix Chain" + italic "Where real assets live."
- [x] Feature cards show SVG icons (no emoji)
- [ ] Theme toggle still works (gold accents adapt to light mode)
- [ ] Sidebar / ToC / pagination read in brand colors