### PR TITLE
feat(rpc): WebSocket Phase 3 — wire all remaining emit hooks

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -2202,6 +2202,13 @@ async fn cmd_start(
                                                                 total_rewards: 0,
                                                                 total_blocks_produced: 0,
                                                             };
+                                                            // Phase 3 WS: notify sentrix_subscribe(validatorSet)
+                                                            // — full epoch-advance wire-up. Subscribers see
+                                                            // the new active set on every epoch boundary,
+                                                            // not just AddSelfStake re-entry.
+                                                            if let Some(emitter) = &bc.event_emitter {
+                                                                emitter.emit_validator_set(next_num, &active_set);
+                                                            }
                                                             tracing::info!("Epoch {} started — {} validators, {} staked",
                                                                 next_num, active_set.len(), total_staked);
 
@@ -2605,6 +2612,14 @@ async fn cmd_start(
                                                         total_rewards: 0,
                                                         total_blocks_produced: 0,
                                                     };
+                                                    // Phase 3 WS: notify sentrix_subscribe(validatorSet) —
+                                                    // libp2p-applied path mirror of the validator-finalize
+                                                    // emit above. Both call sites must emit so subscribers
+                                                    // see the rotation regardless of which path applied
+                                                    // the boundary block.
+                                                    if let Some(emitter) = &bc.event_emitter {
+                                                        emitter.emit_validator_set(next_num, &active_set);
+                                                    }
                                                     tracing::info!("Epoch {} started — {} validators, {} staked",
                                                         next_num, active_set.len(), total_staked);
 

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -1068,6 +1068,16 @@ impl Blockchain {
                             format!("Community:{}", &tx.from_address[..10]),
                             public_key,
                         );
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "register_validator".to_string(),
+                                validator: tx.from_address.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount: self_stake,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     StakingOp::Delegate { validator, amount } => {
                         if tx.amount != amount {
@@ -1108,6 +1118,16 @@ impl Blockchain {
                             amount,
                             block.index,
                         )?;
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "undelegate".to_string(),
+                                validator: validator.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     StakingOp::Redelegate {
                         from_validator,
@@ -1126,6 +1146,16 @@ impl Blockchain {
                             amount,
                             block.index,
                         )?;
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: format!("redelegate:{}->{}", from_validator, to_validator),
+                                validator: to_validator.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     StakingOp::Unjail => {
                         if tx.amount != 0 {
@@ -1176,6 +1206,16 @@ impl Blockchain {
                         // has no reporter field in SubmitEvidence (the
                         // submitter IS the offender in this naive shape).
                         // Follow-up: separate submitter + offender fields.
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "submit_evidence".to_string(),
+                                validator: tx.from_address.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount: 0,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
+                        }
                     }
                     StakingOp::JailEvidenceBundle {
                         epoch: claimed_epoch,
@@ -1235,7 +1275,8 @@ impl Blockchain {
                         // Verified — apply jail to each cited validator.
                         // jail() updates stake_registry (consensus state mutation).
                         let current_height = self.height();
-                        for ev in claimed_evidence {
+                        let evidence_count = claimed_evidence.len() as u64;
+                        for ev in &claimed_evidence {
                             if let Err(e) = self.stake_registry.jail(
                                 &ev.validator,
                                 sentrix_staking::slashing::DOWNTIME_JAIL_BLOCKS,
@@ -1253,6 +1294,34 @@ impl Blockchain {
                             // Reset liveness tracker for this validator (matches
                             // legacy check_liveness behavior).
                             self.slashing.liveness.reset(&ev.validator);
+
+                            // Phase 3 WS: notify sentrix_subscribe(jail) per
+                            // jailed validator. Fires only when JAIL_CONSENSUS
+                            // dispatch actually applies a jail (post-fork only;
+                            // the gate at line 1192 ensures pre-fork rejects
+                            // before reaching here).
+                            if let Some(emitter) = &self.event_emitter {
+                                emitter.emit_jail(&sentrix_primitives::events::JailEvent {
+                                    validator: ev.validator.clone(),
+                                    epoch: claimed_epoch,
+                                    missed_blocks: ev.missed_count,
+                                    block_height: block.index,
+                                });
+                            }
+                        }
+                        // One staking_op event for the bundle as a whole, so
+                        // a dApp watching sentrix_stakingOps sees the
+                        // JailEvidenceBundle dispatch even if it doesn't
+                        // separately subscribe to sentrix_jail.
+                        if let Some(emitter) = &self.event_emitter {
+                            emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
+                                op: "jail_evidence_bundle".to_string(),
+                                validator: tx.from_address.clone(),
+                                delegator: tx.from_address.clone(),
+                                amount: evidence_count,
+                                txid: tx.txid.clone(),
+                                block_height: block.index,
+                            });
                         }
                     }
                     StakingOp::AddSelfStake { amount } => {

--- a/docs/operations/WEBSOCKET_SUBSCRIPTIONS.md
+++ b/docs/operations/WEBSOCKET_SUBSCRIPTIONS.md
@@ -30,7 +30,10 @@ Shipped 2026-04-28 in PR #398 (Phase 1) + PR #399 (Phase 2+3).
 | Channel | Payload | Trigger |
 |---|---|---|
 | `sentrix_finalized` | `{ height, hash, justificationSigners }` | every BFT-finalized block — distinct from `newHeads` because Sentrix has instant BFT finality |
-| `sentrix_validatorSet` | `{ epoch, validators[] }` | epoch boundary when validator set rotates (channel live, emit_validator_set hook in staking-epoch-advance pending) |
+| `sentrix_validatorSet` | `{ epoch, validators[] }` | every epoch-advance (active set rotation) |
+| `sentrix_tokenOps` | `{ op, contract, from, to, amount, txid, blockHeight }` | every native TokenOp dispatched (Deploy, Transfer, Burn, Mint, Approve) |
+| `sentrix_stakingOps` | `{ op, validator, delegator, amount, txid, blockHeight }` | every StakingOp dispatched (RegisterValidator, Delegate, Redelegate, Undelegate, ClaimRewards, Unjail, AddSelfStake, SubmitEvidence, JailEvidenceBundle) |
+| `sentrix_jail` | `{ validator, epoch, missedBlocks, blockHeight }` | per-validator inside a JailEvidenceBundle dispatch (post-JAIL_CONSENSUS_HEIGHT) |
 
 ## Quick start
 


### PR DESCRIPTION
## Summary
- Completes the long-tail emit_* hooks deferred from PR #400 — every `sentrix_subscribe` channel now fires from every relevant dispatch path.
- StakingOp arms wired: `RegisterValidator`, `Redelegate`, `Undelegate`, `SubmitEvidence`, `JailEvidenceBundle` (per-validator `emit_jail` + bundle-level `emit_staking_op`).
- `emit_validator_set` wired at both epoch-advance call sites in node main (validator-finalize path + libp2p-applied path).
- All emits sit AFTER state mutation so `Err` returns don't fire spurious events.
- Docs (`docs/operations/WEBSOCKET_SUBSCRIPTIONS.md`) updated to drop the "pending" notes.

## Test plan
- [x] cargo build --release — green
- [x] clippy -D warnings — clean
- [x] cargo test --release -p sentrix-rpc — 26/26 passing
- [ ] Smoke-test all 9 WS channels post-deploy on testnet (newHeads, logs, newPendingTransactions, syncing, sentrix_finalized, sentrix_validatorSet, sentrix_tokenOps, sentrix_stakingOps, sentrix_jail)