### PR TITLE
docs: strip fabricated specifics — only ground-truth claims

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -18,8 +18,8 @@ Two main pools hold protocol-level capital:
 
 | Pool | Allocation | Purpose | Control mechanism |
 |---|---|---|---|
-| Strategic Reserve | 10,500,000 SRX | Airdrop campaign (5M), CEX listing fees (3M), DEX bootstrap liquidity (1.5M), emergency (1M) | SentrixSafe-governed (social custody bridge while Reserve EOA migrates into Safe-owned contract; planned Q3 2026) |
-| Ecosystem Fund | 21,000,000 SRX | Operational ops: faucet refill, marketing, bounties, dev grants | SentrixSafe-governed |
+| Strategic Reserve | 10,500,000 SRX | Airdrop campaign (5M), CEX listing fees (3M), DEX bootstrap liquidity (1.5M), emergency (1M) | EOA wallet, key held by Authority (same operator who controls SentrixSafe). Social custody — on-chain enforcement (Reserve owned by SentrixSafe contract) is acknowledged as a roadmap item without committed timeline. |
+| Ecosystem Fund | 21,000,000 SRX | Operational ops: faucet refill, marketing, bounties, dev grants | EOA wallet, key held by Authority. Same custody model as Strategic Reserve. |
 
 Sub-bucket targets are **policy-level commitments** (documented in this repo and on `sentrixchain.com/docs/tokenomics`). They are **not on-chain enforced** — they are auditable via on-chain transaction history.
 
@@ -105,8 +105,8 @@ For an upgrade to succeed without partition:
 
 There is **no on-chain governance vote** for protocol upgrades in the current model. This is a deliberate choice for the current bootstrap phase:
 - 4-validator network — voting would be performative
-- Operator-coordinated upgrades have been reliable to date (8+ forks shipped without partition incidents)
-- Future: once external validator onboarding scales beyond Foundation set, on-chain governance for upgrades is on the roadmap (no committed timeline yet)
+- 6 fork activations have shipped to date (see Past activations table below); 2 notable recovery incidents occurred (Voyager livelock 2026-04-25 — peer-mesh partition; cascade-jail 2026-04-28 — chain.db state divergence post deploy). Both resolved via halt-all + chain.db rsync from canonical state. No invalid block was ever accepted; no funds were lost.
+- Future: once external validator onboarding scales beyond Foundation set, on-chain governance for upgrades is a roadmap consideration (no committed timeline)
 
 ### Past activations
 
@@ -168,7 +168,7 @@ Mainnet incidents (validator jailing, livelock, chain.db divergence) are handled
 3. **Rsync** — broadcast canonical chain.db to other validators
 4. **Simul-start** — all validators start within a 1-2 second window
 
-This pattern is documented in operator runbooks. Recovery MTTR has been < 5 minutes for incidents experienced to date.
+This pattern is documented in operator runbooks. Recovery MTTR has improved over time as tooling matured: earlier incidents (Voyager livelock 2026-04-25, BFT cascade events) took 30+ minutes. Recent incidents (cascade-jail recovery 2026-04-28) recovered in approximately 3 minutes via halt-all + chain.db rsync. Trend is improving; fully-automated recovery tooling is a roadmap item.
 
 There is no governance vote for emergency response; the operator coordinates. Once the validator set decentralizes beyond the Foundation, this model will need a community-aware variant.
 
@@ -178,7 +178,7 @@ There is no governance vote for emergency response; the operator coordinates. On
 |---|---|
 | Q2 2026 | Foundation-operated 1-of-1 SentrixSafe, hardcoded fork gating, off-chain operator coordination |
 | Q3 2026 | SentrixSafe → 3-of-5 multisig migration; founder-vesting contract deploy (locks §2a on-chain) |
-| Q4 2026 | External validator onboarding (current 4 validators are Foundation-operated; goal: ≥10 active validators with independent operators) |
+| Q4 2026 | External validator onboarding begins (current 4 validators are Foundation-operated; expansion target + cadence to be set when operator readiness criteria are finalized) |
 | 2027+ | On-chain governance for protocol upgrades (proposal + voting framework, exact mechanism TBD) |
 | 2027+ | Decentralized treasury governance (DAO-style, replacing Foundation-coordinated multisig) |
 

--- a/docs/i18n/ROADMAP_INDONESIA.md
+++ b/docs/i18n/ROADMAP_INDONESIA.md
@@ -65,7 +65,7 @@ Roadmap di bawah ini fokus ke milestone yang relevan untuk pasar Indonesia. Untu
 | Mainnet Sentrix Chain stabil | ✅ Selesai 25 April 2026 | 4 validator aktif, EVM live, V4 reward distribution aktif |
 | Submit ke Chainlist.org | ✅ PR diajukan (`ethereum-lists/chains#8266`) | Menunggu maintainer review |
 | Submit ke CoinGecko + CoinMarketCap | ⏳ Aplikasi sedang disusun | Target launch listing Q2 |
-| Audit eksternal — engagement firma audit | ⏳ Q2 target | 6–8 minggu audit + remediation window |
+| Audit eksternal | ⏳ Pertimbangan ke depan, bergantung budget + scope. Saat ini ongoing internal review (cargo audit + slither + mythril CI per PR + manual review). Tidak ada commitment timeline spesifik. |
 | Verifikasi kontrak self-host (Sourcify-equivalent) | ⏳ Q2 target | Untuk dApp builder dapat verify bytecode ↔ source |
 | Faucet testnet SRX (10M tSRX per claim) | ✅ Live | https://faucet.sentrixchain.com (testnet) |
 | Block explorer | ✅ Live | https://scan.sentrixchain.com |

--- a/docs/i18n/ROADMAP_INDONESIA.md
+++ b/docs/i18n/ROADMAP_INDONESIA.md
@@ -83,27 +83,24 @@ Roadmap di bawah ini fokus ke milestone yang relevan untuk pasar Indonesia. Untu
 | **Founder vesting contract deploy** | Lock 21M SRX founder allocation on-chain (saat ini social commitment, akan jadi enforced contract) |
 | **Bahasa Indonesia content expansion** | Translasi docs utama (validator guide, smart contract tutorial, faucet, claim airdrop) |
 
-### Q4 2026 (Oktober – Desember) — Real Economy Integration
+### Q4 2026 (Oktober – Desember) — Ekspansi Ekosistem
 
 | Milestone | Catatan |
 |---|---|
-| **Airdrop Phase 3 — Activity Rewards** (800.000 SRX) | Reward untuk active mainnet wallets, snapshot mainnet |
-| **Airdrop Phase 4 — Validator Delegators** (700.000 SRX) | Pro-rata ke delegator pada active validator set |
-| **External validator onboarding** | Saat ini 4 validator semua Foundation-operated. Target: ≥10 validator dengan operator independen |
-| **Indodax + 1 CEX Indonesia tambahan listing** | Tier-1 Indonesia CEX coverage |
-| **First RWA pilot integration** | Aset dunia nyata pertama on-chain (kategori belum diumumkan; akan di-publish saat partnership signed) |
-| **Native event/log system + GraphQL indexer** | Infrastruktur dApp-level — analytics, NFT marketplace listings, dApp discovery |
-| **Komunitas builder Indonesia — bootcamp + grants** | Program dev edukasi + grant pool dari Ecosystem Fund |
+| **Airdrop Phase 3 — Activity Rewards** (800.000 SRX) | Reward untuk active mainnet wallets, snapshot mainnet (per tokenomics §6) |
+| **Airdrop Phase 4 — Validator Delegators** (700.000 SRX) | Pro-rata ke delegator pada active validator set (per tokenomics §6) |
+| **External validator onboarding mulai** | Saat ini 4 validator semua Foundation-operated. Onboarding criteria + cadence akan dipublish saat ready. Target jumlah validator belum di-commit. |
+| **Indonesian CEX listing engagement berlanjut** | Tokocrypto / Pintu / Indodax — per status engagement-nya |
 
-### 2027+ — Skala & Decentralisasi
+### 2027+ — Decentralisasi Bertahap
 
-| Milestone | Catatan |
-|---|---|
-| **Airdrop Phase 5 — Retroactive Builders** (1.500.000 SRX) | Committee-reviewed: dApp deployers, audit contributors, ecosystem PRs |
-| **Tier-2 CEX international** | Gate.io, MEXC, KuCoin tier (post DEX TVL > $1M) |
-| **On-chain governance untuk protocol upgrade** | Saat ini upgrade dilakukan via koordinasi operator. Q4 2027+ target: voting-based governance |
-| **Decentralized treasury (DAO-style)** | Replace Foundation-coordinated multisig dengan governance token-based decision making |
-| **Tier-3 CEX (Binance, Coinbase) — realistik post-traction** | Setelah TVL meaningful + daily active address sustainable + regulator clarity |
+Roadmap setelah 2026 belum di-commit ke timeline spesifik. Direction signals:
+
+- **Airdrop Phase 5 — Retroactive Builders** (1.500.000 SRX) — committee-reviewed (per tokenomics §6, target Q4 2026 / Q1 2027)
+- **Tier-2 CEX international** (Gate.io, MEXC, KuCoin tier per tokenomics §7) — gated by DEX TVL milestone
+- **Tier-3 CEX** (Binance, Coinbase) — realistik post-traction (TVL meaningful + daily active addresses sustainable + regulator clarity)
+- **On-chain governance untuk protocol upgrade** — saat ini upgrade via koordinasi operator. Future move to voting-based governance is on roadmap once external validator set is mature; specific year not committed.
+- **Decentralized treasury (DAO-style)** — eventual replacement untuk Foundation-coordinated multisig. Sequenced after on-chain governance framework live.
 
 ---
 
@@ -128,8 +125,8 @@ Roadmap di bawah ini fokus ke milestone yang relevan untuk pasar Indonesia. Untu
 
 ### Untuk validator
 
-1. **Saat ini:** Foundation-operated 4 validator. External onboarding mulai Q4 2026.
-2. **Persyaratan teknis (akan dipublish):** minimum self-stake, hardware spec, uptime SLA, networking tier
+1. **Saat ini:** Foundation-operated 4 validator. External onboarding direction-signaled untuk Q4 2026 (criteria + cadence akan dipublish saat ready).
+2. **Persyaratan teknis:** akan dipublish saat onboarding window dibuka (minimum self-stake, hardware spec, uptime SLA, networking tier)
 3. **Reward economics:** V4 distribution — block reward + tx fee revenue, pro-rata berdasarkan stake
 
 ### Untuk content creator / educator
@@ -156,15 +153,12 @@ Roadmap di bawah ini fokus ke milestone yang relevan untuk pasar Indonesia. Untu
 
 Dokumen ini adalah **dokumen pertama** dalam program i18n Sentrix. Goal: membuat informasi tentang Sentrix Chain dapat diakses dalam Bahasa Indonesia, bukan hanya Inggris.
 
-**Roadmap translasi (urut prioritas):**
+**Status program i18n:**
 
-1. ✅ ROADMAP_INDONESIA.md (file ini — strategi & roadmap)
-2. ⏳ Faucet user guide
-3. ⏳ Validator setup guide
-4. ⏳ Smart contract developer quickstart
-5. ⏳ Tokenomics overview
-6. ⏳ Governance & multisig
-7. ⏳ Airdrop claim guide
+1. ✅ ROADMAP_INDONESIA.md (file ini — strategi & roadmap dalam Bahasa Indonesia)
+2. ⏳ Translasi tambahan (developer guide, validator guide, dll) belum di-commit ke prioritas spesifik. Direction: setelah content English stabil dan demand komunitas terlihat.
+
+Translasi yang dibutuhkan akan ditentukan berdasarkan demand komunitas — bukan via lump-translate semua docs sekaligus.
 
 **Kontribusi translasi:** translator dari komunitas Indonesia sangat dibutuhkan. PR dapat di-submit ke `sentrix-labs/sentrix` dengan path `docs/i18n/<filename>.md`. Style guide: pertahankan istilah teknis Inggris (smart contract, validator, mempool), translate konsep umum (governance → tata kelola, airdrop → airdrop [tetap], dll). Tidak terlalu kaku — Bahasa Indonesia conversational lebih baik daripada Bahasa Indonesia kaku translasi mesin.
 

--- a/docs/security/AUDIT_SUMMARY.md
+++ b/docs/security/AUDIT_SUMMARY.md
@@ -23,19 +23,12 @@ For the full technical detail of any individual round, see [`SECURITY_AUDIT_V11.
 
 ## Audit history
 
-| Round | Date | Scope | Findings (C/H/M/L/Info) | Status |
-|---|---|---|---|---|
-| V1–V3 | Jan 2026 – Feb 2026 | Foundational consensus + storage layer | 0 / 4 / 8 / 12 / 6 | All resolved or accepted |
-| V4 | Feb 2026 | BFT signing + double-sign detection | 0 / 1 / 3 / 5 / 4 | All resolved |
-| V5 | Mar 2026 | EVM integration + revm wiring | 0 / 2 / 4 / 6 / 5 | All resolved |
-| V6 | Mar 2026 | Validator security + keystore handling | 0 / 1 / 2 / 4 / 3 | All resolved |
-| V7 | Mar 2026 | Networking layer + libp2p hardening | 0 / 0 / 3 / 5 / 4 | All resolved |
-| V8 | Apr 2026 | Tokenomics correctness + supply invariants | 0 / 1 / 2 / 3 / 5 | All resolved |
-| V9 | Apr 2026 | Slashing + jailing logic | 0 / 0 / 2 / 4 / 4 | All resolved |
-| V10 | Apr 2026 | Pre-mainnet sweep | 0 / 1 / 3 / 4 / 6 | All resolved |
-| V11 | 2026-04-25 | Code review (39 files, ~6,500 LoC) | 0 / 2 / 5 / 7 / 8 | High items resolved; medium/low tracked |
+- **Cumulative through round 10:** 94 findings raised, 78 fixed (per [`SECURITY_REPORT.md`](SECURITY_REPORT.md))
+- **Round V11 (2026-04-25):** 0 critical / 2 high / 5 medium / 7 low / 8 info-level findings (per [`SECURITY_AUDIT_V11.md`](SECURITY_AUDIT_V11.md))
+- **Total cumulative:** 116 findings, 78+ fixed (numbers from `SECURITY_REPORT.md` + V11)
+- **0 critical** findings outstanding across all rounds
 
-**Severity legend:** C = critical, H = high, M = medium, L = low, Info = positive finding (good practice noted).
+Per-round breakdown of V1–V10 is aggregated in `SECURITY_REPORT.md` rather than maintained as separate files. V11 is documented separately because it was a deep code review (39 files, ~6,500 LoC).
 
 ### V11 highlights (most recent)
 
@@ -79,14 +72,14 @@ Pentest scenarios run against live testnet + mainnet (controlled, with operator 
 
 | Scenario | Outcome |
 |---|---|
-| Double-sign attempt by malicious validator | ✅ Detected & evidence-bundled (slashing engine) |
-| Long-range attack via finalized state replay | ✅ Rejected (committed-root protection) |
-| RPC overload / DoS attempt | ✅ Per-IP rate limiter held; no node degradation |
-| WebSocket connection flood | ✅ Per-IP connection limiter (10/IP) blocked excess |
-| Mempool spam (low-fee tx flood) | ✅ Min-fee + admit-rate-limit cleared spam without dropping legitimate tx |
-| Storage layer corruption simulation | ✅ MDBX integrity checks caught corruption; recovery ran cleanly |
+| RPC Flood (1000 requests) | ✅ Per-IP rate limiter held; chain never stalled |
+| Malformed requests (32 cases: invalid JSON, SQLi, XSS, path traversal, etc.) | ✅ 31/32 — proper HTTP error codes; nginx caught one before node |
+| Double-spend (same-nonce tx pairs via REST + RPC) | ✅ Auth layer blocked unauthenticated tx submissions before validation |
+| TX spam (100 rapid + 5 duplicate-nonce) | ✅ All rejected at auth + rate-limit layer |
+| P2P connection flood (120 simultaneous TCP) | ✅ Zero impact on block production or API latency |
+| Oversized payloads (1KB → 2MB on RPC + TX endpoints) | ✅ Nginx drops large payloads before reaching node |
 
-**6/6 passed.** Methodology + per-scenario detail in [`PENTEST_RESULTS.md`](PENTEST_RESULTS.md).
+**6/6 passed.** Tested 2026-04-15 against live Foundation validator. Chain advanced from height 140,282 → 140,811 during the run with no missed blocks. Full methodology + raw test output in [`PENTEST_RESULTS.md`](PENTEST_RESULTS.md).
 
 ## Score breakdown
 
@@ -114,12 +107,13 @@ Areas for continued improvement (tracked in `docs/security/` + audit folder):
 
 **Status:** No third-party audit firm has reviewed Sentrix Chain code as of 2026-04-28.
 
-**Plan:** Engage one of the well-known smart-contract / consensus auditors (Trail of Bits, OpenZeppelin Spearbit, Quantstamp, or similar) in **Q2 2026** for:
-- Full Rust core audit (consensus + storage + RPC, ~50K LoC scope)
-- Solidity contracts audit (canonical-contracts repo, ~1.5K LoC)
-- Estimated audit + remediation window: **6–8 weeks**
+**Plan:** Engage a tier-1 smart-contract / consensus audit firm in Q2 2026 (per tokenomics roadmap §9). Specific firm selection and audit timeline will be announced when engagement is signed.
 
-Budget allocated from Strategic Reserve (see [`docs/tokenomics/OVERVIEW.md`](../tokenomics/OVERVIEW.md)). External audit completion is a Tier-1 prerequisite for major CEX listings.
+**Scope (target):**
+- Rust core (consensus + storage + RPC layers)
+- Solidity contracts (canonical-contracts repo)
+
+Budget allocated from Strategic Reserve (see [`docs/tokenomics/OVERVIEW.md`](../tokenomics/OVERVIEW.md)). External audit completion is a prerequisite for major CEX listings.
 
 In the interim, the chain runs continuous internal review:
 - `cargo audit` + `gitleaks` on every PR

--- a/docs/security/AUDIT_SUMMARY.md
+++ b/docs/security/AUDIT_SUMMARY.md
@@ -19,7 +19,7 @@ For the full technical detail of any individual round, see [`SECURITY_AUDIT_V11.
 - **0 critical** findings outstanding
 - **0 fund-loss vulnerabilities** identified across all rounds
 - **6/6 pentest scenarios** passed on live network
-- **All audits** conducted by internal Sentrix Labs / SentrisCloud security team — no external audit firm engaged yet (planned Q2 2026, see [Pending external audit](#pending-external-audit))
+- **All audits** conducted by internal Sentrix Labs / SentrisCloud security team — no external audit firm engaged yet (see [External audit posture](#external-audit-posture))
 
 ## Audit history
 
@@ -103,23 +103,17 @@ Areas for continued improvement (tracked in `docs/security/` + audit folder):
 - BFT skip-round corner cases (Phase 2 RCA findings — implementation in progress)
 - External validator onboarding hardening (ongoing as set decentralizes)
 
-## Pending external audit
+## External audit posture
 
-**Status:** No third-party audit firm has reviewed Sentrix Chain code as of 2026-04-28.
+No third-party audit firm has reviewed Sentrix Chain code as of 2026-04-28. External audit is something we'd pursue when budget + scope align — no committed timeline.
 
-**Plan:** Engage a tier-1 smart-contract / consensus audit firm in Q2 2026 (per tokenomics roadmap §9). Specific firm selection and audit timeline will be announced when engagement is signed.
-
-**Scope (target):**
-- Rust core (consensus + storage + RPC layers)
-- Solidity contracts (canonical-contracts repo)
-
-Budget allocated from Strategic Reserve (see [`docs/tokenomics/OVERVIEW.md`](../tokenomics/OVERVIEW.md)). External audit completion is a prerequisite for major CEX listings.
-
-In the interim, the chain runs continuous internal review:
+The chain runs continuous internal review:
 - `cargo audit` + `gitleaks` on every PR
 - `slither` + `mythril` on Solidity contracts (CI gate)
 - Manual code review by Sentrix Labs / SentrisCloud security team for every PR
 - Public bug bounty: see [SECURITY.md](https://github.com/sentrix-labs/sentrix/blob/main/SECURITY.md) (safe-harbor policy in effect)
+
+Listing platforms or external auditors performing diligence: contact `security@sentriscloud.com` for code-walkthrough or audit-prep discussion.
 
 ## How to report
 

--- a/docs/tokenomics/AIRDROP_MECHANICS.md
+++ b/docs/tokenomics/AIRDROP_MECHANICS.md
@@ -32,41 +32,42 @@ Non-goals:
 
 Each phase has its own snapshot, eligibility filter, and Merkle distribution. Phases run sequentially — completion of one does not gate the next, but earlier phases inform later snapshot designs (e.g., Phase 1 testnet activity may filter Phase 3 mainnet snapshots).
 
-## Phase 1 — Testnet Heroes (detailed mechanics)
+## Phase 1 — Testnet Heroes (design direction)
 
-This is the imminent phase. Detailed mechanics for later phases will be added as their snapshot dates approach.
+Phase 1 is in design phase. Specific parameters (tx-count threshold, wallet-age threshold, snapshot height, claim window length, per-wallet distribution amount) will be locked and announced together at Phase 1 launch — they are deliberately not pre-committed here so that the design can adapt to actual testnet activity patterns observed pre-launch.
 
-### Eligibility filter
+### Eligibility direction
 
-A wallet on testnet 7120 is eligible if **all** of the following hold at the snapshot height:
+A wallet on testnet 7120 will be eligible if it shows evidence of **real participation** — not just faucet farming. Direction signals:
 
-1. **Cumulative tx count ≥ 50** — meaningful interaction, not faucet-claim-only
-2. **Wallet age ≥ 30 days** before snapshot — filters mass wallet generation in the days preceding announcement
-3. **At least one of the following "real activity" signals:**
-   - Deployed at least one smart contract on testnet
-   - Completed at least one DEX swap (once DEX is live on testnet)
-   - Operated as a registered validator on testnet for ≥ 7 days
-   - Verified via partner platform (Galxe / Zealy / Sentrix-quest portal — TBD)
+- Some minimum cumulative transaction count (threshold TBD at launch)
+- Some minimum wallet age before the snapshot (threshold TBD at launch)
+- At least one "real activity" signal — examples being considered:
+   - Smart contract deployed on testnet
+   - DEX swap (post DEX launch on testnet)
+   - Operating as registered testnet validator
+   - Verified completion via partner quest platform
 
-The "real activity" requirement is the primary sybil filter. Faucet-only farming (claim 10M tSRX, sit, claim airdrop) does not qualify.
+The "real activity" requirement is the primary sybil filter. Faucet-only farming will not qualify.
 
 ### Snapshot height
 
-Target: chain 7120 height **400,000** (estimated 2 weeks after public Phase 1 announcement). Exact height locked at announcement; activity after the snapshot does not count.
+Locked + announced at Phase 1 launch. Activity after the snapshot does not count.
 
-### Distribution
+### Distribution direction
 
-- **Flat allocation per eligible wallet** — all eligible wallets receive equal share. If 500 wallets qualify, each receives 2,000 SRX.
-- **No tiering** — Phase 1 is a community-trust signal (equal treatment for "passed the filter"). Tiering arrives in Phase 5 (Retroactive Builders) where merit genuinely differs.
-- **Mainnet SRX, not testnet tSRX** — recipients claim mainnet 7119 token, even though eligibility is determined on testnet 7120. Reason: mainnet token is the only one with real economic value.
-- **Claim window: 90 days** from contract deploy. Unclaimed SRX returns to Strategic Reserve (does not burn) — preserves the supply curve in `docs/tokenomics/OVERVIEW.md`.
+- **Distribution recipient token: mainnet SRX, not testnet tSRX** — recipients claim mainnet 7119 token, even though eligibility is determined on testnet 7120. Reason: mainnet token is the only one with real economic value.
+- **Per-wallet amount + tiering rules:** locked at launch (informed by snapshot eligible-pool size).
+- **Claim window length:** locked at launch. Unclaimed SRX disposition (return to Strategic Reserve vs. roll into next phase vs. burn) will be specified at launch.
 
-### Distribution mechanism
+### Distribution mechanism (planned shape)
 
-- Off-chain: snapshot eligibility → Merkle tree of `(address, amount)` leaves → publish root + leaf list (open data, anyone can verify their inclusion)
+- Off-chain: snapshot eligibility → Merkle tree of `(address, amount)` leaves → publish root + leaf list (open data, anyone can verify inclusion)
 - On-chain: deploy `MerkleAirdrop` claim contract on mainnet 7119, pre-fund with 1,000,000 SRX from Strategic Reserve in a single transparent transaction
 - User flow: connect wallet → see eligibility → call `claim(proof, amount)` → receive SRX
-- Sweep flow: after 90-day window, owner calls `sweep()` → unclaimed balance returns to Strategic Reserve
+- Sweep flow at end of claim window → unclaimed disposition per Phase 1 launch terms
+
+The Merkle-claim contract has not been deployed yet. Design + audit precede deployment.
 
 ### Exclusion list (hard rule, no exceptions)
 
@@ -84,16 +85,16 @@ The following wallets are excluded from all airdrop phases regardless of activit
 
 Specific addresses for validators + faucets are listed in the canonical addresses doc inside `sentrix-labs/canonical-contracts`.
 
-### Sybil resistance summary
+### Sybil resistance direction
 
-The eligibility filter is structured to make sybil farming unattractive:
+The eligibility filter is being designed to make sybil farming unattractive vs. expected reward. Layered filters under consideration:
 
-- **30-day wallet age** filters mass-generated wallets in announcement window
-- **50-tx threshold** raises cost of mass farming
-- **Real activity signal** (contract deploy / DEX swap / validator op / verified quest) requires non-trivial action that's hard to script-farm at scale
-- **Flat distribution** removes the incentive to fragment farming across many wallets (1 farmed wallet = same as 1 organic wallet)
+- Wallet-age cutoff (filters wallets generated mass-style after announcement)
+- Cumulative transaction-count threshold (raises farming cost)
+- "Real activity" signal — contract deploy / DEX swap / validator operation / verified quest. This is the primary filter: it requires non-trivial action that is hard to script-farm at scale.
+- Distribution shape (flat vs. tiered) — chosen to minimize the marginal value of farming many wallets vs. one organic wallet
 
-The result is a smaller eligible pool (~500 wallets expected for Phase 1, may be lower) but each recipient receives a meaningful 2,000 SRX. We optimize for "every recipient earned this" over "we hit a high claim count."
+We optimize for "every recipient earned this" over hitting a high claim count. The eligible pool is expected to be smaller-and-meaningful, not large-and-diluted.
 
 ## Phases 2–5 — design notes
 
@@ -101,35 +102,19 @@ Detailed mechanics will be published before each phase launches. Direction signa
 
 ### Phase 2 — Quest Campaign (Q3 2026)
 
-Galxe / Zealy / equivalent task platform integration. Tasks designed around real protocol use:
-- "Wrap 100 SRX → unwrap → record txid" (WSRX integration)
-- "Deploy a SRC-20 token via TokenFactory" (TokenFactory integration)
-- "Add liquidity to SRX/USDC pool on Sentrix DEX" (post-DEX-launch)
-
-Allocation per quest tier; rewards in mainnet SRX. Same exclusion list as Phase 1.
+Quest-platform integration (Galxe, Zealy, or equivalent — final platform TBD). Quests designed around real protocol use (canonical contract interaction, DEX activity post-launch, etc.). Allocation per quest tier; rewards in mainnet SRX. Same exclusion list as Phase 1.
 
 ### Phase 3 — Activity Rewards (Q3 2026)
 
-Mainnet snapshot. Eligibility weighted by:
-- Tx velocity over a measurement window (e.g., last 90 days)
-- Balance retention (avoiding "claim and dump" pattern)
-- Diverse interactions (not just SRX transfers — count contract calls)
-
-Distribution may be tiered (proportional to score) rather than flat. Final mechanic locked at snapshot.
+Mainnet snapshot of active wallets. Eligibility likely to combine signals such as transaction velocity over a measurement window, balance retention, and diversity of interactions. Specific weights + thresholds locked at snapshot.
 
 ### Phase 4 — Validator Delegators (Q4 2026)
 
-Pro-rata distribution to delegators on active validators at snapshot height. Validator self-stake does not count (validators already earn V4 rewards). Targets distributed staking participation.
+Pro-rata distribution to delegators on active validators at snapshot height. Targets distributed staking participation. Specific eligibility rules (e.g., handling of validator self-stake) locked at snapshot.
 
 ### Phase 5 — Retroactive Builders (Q4 2026 / Q1 2027)
 
-Committee-reviewed allocation for:
-- dApp deployers who shipped real users (DEX, NFT marketplace, game, etc.)
-- External audit contributors (third-party audits with public reports)
-- Ecosystem PRs to canonical-contracts, sentrix repo, frontend monorepo
-- Educational content creators (verified, non-trivial)
-
-Tiered allocation. Committee composition: SentrixSafe authority + 2–3 community members (TBD post-multisig migration).
+Committee-reviewed allocation for ecosystem contributors — dApp deployers, audit contributors, ecosystem PR authors, educational content creators. Tiered allocation. Committee composition will be specified before review begins (post-SentrixSafe-3-of-5-migration).
 
 ## Auditability
 
@@ -155,14 +140,16 @@ The Merkle tree leaf list is published openly so anyone can:
 
 ## Roadmap
 
-| Date | Milestone |
+| Quarter | Milestone |
 |---|---|
-| Q2 2026 | Phase 1 announcement (post-Chainlist listing); snapshot height locked + announced |
+| Q2 2026 | Phase 1 announcement (post-Chainlist listing); snapshot height locked at announcement |
 | Q2 2026 | `MerkleAirdrop.sol` deploy + pre-fund (single tx from Strategic Reserve) |
-| Q2 2026 | Phase 1 claim window opens (90 days) |
-| Q3 2026 | Phase 1 sweep + Phase 2 / 3 launch |
-| Q4 2026 | Phase 4 launch (post-DEX activity meaningful) |
+| Q2 2026 | Phase 1 claim window opens |
+| Q3 2026 | Phase 2 + Phase 3 launch (per tokenomics §6) |
+| Q4 2026 | Phase 4 launch |
 | Q4 2026 / Q1 2027 | Phase 5 retroactive committee review |
+
+Quarter-level targets follow tokenomics §6. Specific dates within each quarter are not pre-committed.
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary
Recovery PR — the honesty-fix commit was authored on top of #405 but got cut off in the squash-merge race. Re-applying as a fresh PR against current main.

Self-audit found multiple fabricated specifics in PR #404 docs that were not backed by source-of-truth tokenomics or prior decisions. Fix: replace fabricated numbers/dates/names with honest TBD-style language matching the underlying public commitment level.

### GOVERNANCE.md
- Drop unsubstantiated \"Q3 2026 Strategic Reserve EOA → contract migration\" claim
- Fix \"8+ forks shipped without partition incidents\" → 6 forks, 2 notable recovery incidents (Voyager livelock 2026-04-25, cascade-jail 2026-04-28)
- Fix \"Recovery MTTR < 5 minutes\" → realistic narrative (earlier 30+ min, recent ~3 min via halt-all + rsync)
- Drop \"≥10 active validators Q4 2026\" — no specific number committed

### AUDIT_SUMMARY.md
- Drop fabricated per-round V1-V11 table with invented dates+severity counts
- Drop fabricated auditor candidate list (Trail of Bits, Spearbit, Quantstamp, ConsenSys Diligence) — no firm has been approached
- Drop fabricated \"6-8 weeks\" timeline
- Replace pentest table with the actual 6 tests from PENTEST_RESULTS.md

### AIRDROP_MECHANICS.md
- Drop fabricated specific thresholds (≥50 tx, ≥30 days, 90-day window, snapshot 400000, ~500 wallet pool, flat 2000 SRX)
- Drop fabricated Phase 2-5 specific examples
- Drop fabricated unclaimed-disposition decision

### ROADMAP_INDONESIA.md
- Drop fabricated Q4 2026 milestones not in tokenomics
- Drop fabricated 2027+ specific years
- Drop fabricated Bahasa translation roadmap items

Principle: only commit to numbers + dates that are in the public tokenomics source-of-truth, on-chain state, or prior session logs. Otherwise defer to TBD or describe direction without a deadline.

## Test plan
- [x] Docusaurus build clean (verified, deployed to docs.sentrixchain.com)
- [x] No fabricated specifics remaining