### PR TITLE
docs: honesty pass 2 — strip residual fabricated specifics

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -178,9 +178,9 @@ There is no governance vote for emergency response; the operator coordinates. On
 |---|---|
 | Q2 2026 | Foundation-operated 1-of-1 SentrixSafe, hardcoded fork gating, off-chain operator coordination |
 | Q3 2026 | SentrixSafe → 3-of-5 multisig migration; founder-vesting contract deploy (locks §2a on-chain) |
-| Q4 2026 | External validator onboarding begins (current 4 validators are Foundation-operated; expansion target + cadence to be set when operator readiness criteria are finalized) |
-| 2027+ | On-chain governance for protocol upgrades (proposal + voting framework, exact mechanism TBD) |
-| 2027+ | Decentralized treasury governance (DAO-style, replacing Foundation-coordinated multisig) |
+| Future (no committed timing) | External validator onboarding — current 4 validators are Foundation-operated; criteria, cadence, and timing all TBD when operator-readiness framework is finalized |
+| Future (no committed timing) | On-chain governance for protocol upgrades — proposal + voting framework, mechanism TBD |
+| Future (no committed timing) | Decentralized treasury governance (DAO-style), replacing Foundation-coordinated multisig |
 
 The trajectory is intentional: bootstrap with concentrated control for safety + speed, decentralize as community + tooling matures. No "instant DAO at launch" — that's a recipe for unmaintained governance.
 

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -6,7 +6,7 @@ This document describes how decisions are made on Sentrix Chain — who controls
 
 ## TL;DR
 
-- **Treasury control:** SentrixSafe multisig contracts (Gnosis Safe-style) deployed on both chains. Currently 1-of-1 (bootstrap), transitioning to 3-of-5 in Q3 2026.
+- **Treasury control:** SentrixSafe multisig contracts (Gnosis Safe-style) deployed on both chains. Currently 1-of-1 with the Authority key as sole owner. Multi-sig expansion (adding owners + raising threshold) is possible at any time via on-chain `addOwner()` + `changeThreshold()`, but no specific expansion timeline is committed.
 - **Protocol upgrades:** Hard forks gated by build-time constants + height triggers. Validators must adopt the upgraded binary; misalignment results in self-fork (no committee veto).
 - **Audit / change log:** every governance-relevant transaction (multisig spend, fork activation, premine outflow) is publicly visible on `scan.sentrixchain.com`.
 
@@ -56,26 +56,18 @@ Why deploy multisig if effectively single-sig? Three reasons:
 
 Tx hashes available in [`canonical-contracts/docs/ADDRESSES.md`](https://github.com/sentrix-labs/canonical-contracts/blob/main/docs/ADDRESSES.md).
 
-### Q3 2026 target — 3-of-5
+### Multi-sig expansion (no committed timeline)
 
-Migration plan:
+The contract is shape-ready for N-of-M expansion. Adding owners + raising threshold is a same-day on-chain operation:
 
-| Owner | Role |
-|---|---|
-| Authority | Operational signer (existing) |
-| Founder backup | Recovery key (cold) |
-| Independent advisor #1 | External oversight |
-| Independent advisor #2 | External oversight |
-| Security council seat | Reserved for community-elected member |
+```
+addOwner(<new_signer_address>)   // repeat per signer
+changeThreshold(<new_threshold>) // raise threshold
+```
 
-Threshold increases from 1 → 3. Migration steps:
-1. `addOwner(founder_backup)`
-2. `addOwner(advisor_1)`
-3. `addOwner(advisor_2)`
-4. `addOwner(council)`
-5. `changeThreshold(3)`
+Expansion will happen when independent signers (advisors, security council members) are recruited and onboarded. No timeline is committed because committing to a specific quarter without recruited signers in pipeline would be performative — a 3-of-5 wallet with non-responsive co-signers is worse than a working 1-of-1.
 
-After migration, no spend can occur without 3 of 5 signers. The Authority alone cannot unilaterally move treasury funds.
+The 1-of-1 setup is honest about Sentrix's current operational stage. The signal we want to send to listing platforms and partners is: governance contract exists + ready to expand, not "we will definitely have 5 signers by date X."
 
 ## 2. Protocol upgrades (hard forks)
 
@@ -177,7 +169,8 @@ There is no governance vote for emergency response; the operator coordinates. On
 | Quarter | Milestone |
 |---|---|
 | Q2 2026 | Foundation-operated 1-of-1 SentrixSafe, hardcoded fork gating, off-chain operator coordination |
-| Q3 2026 | SentrixSafe → 3-of-5 multisig migration; founder-vesting contract deploy (locks §2a on-chain) |
+| Q3 2026 | Founder-vesting contract deploy (locks §2a on-chain) per tokenomics §9 |
+| Future (no committed timing) | SentrixSafe multi-sig expansion — when independent signers are recruited |
 | Future (no committed timing) | External validator onboarding — current 4 validators are Foundation-operated; criteria, cadence, and timing all TBD when operator-readiness framework is finalized |
 | Future (no committed timing) | On-chain governance for protocol upgrades — proposal + voting framework, mechanism TBD |
 | Future (no committed timing) | Decentralized treasury governance (DAO-style), replacing Foundation-coordinated multisig |

--- a/docs/i18n/ROADMAP_INDONESIA.md
+++ b/docs/i18n/ROADMAP_INDONESIA.md
@@ -80,8 +80,7 @@ Roadmap di bawah ini fokus ke milestone yang relevan untuk pasar Indonesia. Untu
 | **Airdrop Phase 2 — Quest Campaign** (1.000.000 SRX) | Galxe / Zealy-style integration, partnership platform Indonesia |
 | **DEX launch (canonical AMM)** | Uniswap V2-fork atau equivalen, bootstrap likuiditas dari Strategic Reserve (1.5M SRX) |
 | **Engagement Tokocrypto + Pintu** | Listing CEX Indonesia tier-1, Bappebti-licensed |
-| **SentrixSafe migrasi 1-of-1 → 3-of-5** | Governance multisig dengan 3 dari 5 signer (per tokenomics §8) |
-| **Founder vesting contract deploy** | Lock 21M SRX founder allocation on-chain (saat ini social commitment, akan jadi enforced contract) |
+| **Founder vesting contract deploy** | Lock 21M SRX founder allocation on-chain (per tokenomics §9) — saat ini social commitment, jadi enforced contract setelah deploy |
 
 ### Q4 2026 (Oktober – Desember) — Ekspansi Ekosistem
 
@@ -132,7 +131,7 @@ Roadmap setelah 2026 belum di-commit ke timeline spesifik. Direction signals:
 
 1. **Bahasa Indonesia gap:** kami butuh tutorial, video, threads, deep-dive Bahasa Indonesia tentang Sentrix
 2. **Phase 5 retroactive eligible:** content creator dengan output verified + non-trivial → committee review untuk grant alokasi
-3. **Strategic Reserve dukungan partnership:** untuk creator dengan reach signifikan, partnership formal possible (Q3+ post-multisig migration)
+3. **Strategic Reserve dukungan partnership:** untuk creator dengan reach signifikan, partnership formal possible (timing TBD per kapasitas operasional)
 
 ---
 

--- a/docs/i18n/ROADMAP_INDONESIA.md
+++ b/docs/i18n/ROADMAP_INDONESIA.md
@@ -67,6 +67,8 @@ Roadmap di bawah ini fokus ke milestone yang relevan untuk pasar Indonesia. Untu
 | Submit ke CoinGecko + CoinMarketCap | ⏳ Aplikasi sedang disusun | Target launch listing Q2 |
 | Audit eksternal | ⏳ Pertimbangan ke depan, bergantung budget + scope. Saat ini ongoing internal review (cargo audit + slither + mythril CI per PR + manual review). Tidak ada commitment timeline spesifik. |
 | Verifikasi kontrak self-host (Sourcify-equivalent) | ⏳ Q2 target | Untuk dApp builder dapat verify bytecode ↔ source |
+| SDK packaging (`@sentrix/sdk-js`, `sentrix-sdk-rs`) | ⏳ Q2 target (per tokenomics §9) | Untuk dApp developer integrate cepat |
+| Docs site polish | ⏳ Q2 target (per tokenomics §9) | Improve onboarding + i18n coverage |
 | Faucet testnet SRX (10M tSRX per claim) | ✅ Live | https://faucet.sentrixchain.com (testnet) |
 | Block explorer | ✅ Live | https://scan.sentrixchain.com |
 
@@ -78,10 +80,8 @@ Roadmap di bawah ini fokus ke milestone yang relevan untuk pasar Indonesia. Untu
 | **Airdrop Phase 2 — Quest Campaign** (1.000.000 SRX) | Galxe / Zealy-style integration, partnership platform Indonesia |
 | **DEX launch (canonical AMM)** | Uniswap V2-fork atau equivalen, bootstrap likuiditas dari Strategic Reserve (1.5M SRX) |
 | **Engagement Tokocrypto + Pintu** | Listing CEX Indonesia tier-1, Bappebti-licensed |
-| **SDK packaging** (`@sentrix/sdk-js`, `sentrix-sdk-rs`) | Untuk dApp developer Indonesia bisa integrate cepat |
-| **SentrixSafe migrasi 1-of-1 → 3-of-5** | Governance multisig dengan 3 dari 5 signer (founder, founder backup, 2 advisor independen, security council seat) |
+| **SentrixSafe migrasi 1-of-1 → 3-of-5** | Governance multisig dengan 3 dari 5 signer (per tokenomics §8) |
 | **Founder vesting contract deploy** | Lock 21M SRX founder allocation on-chain (saat ini social commitment, akan jadi enforced contract) |
-| **Bahasa Indonesia content expansion** | Translasi docs utama (validator guide, smart contract tutorial, faucet, claim airdrop) |
 
 ### Q4 2026 (Oktober – Desember) — Ekspansi Ekosistem
 
@@ -89,8 +89,7 @@ Roadmap di bawah ini fokus ke milestone yang relevan untuk pasar Indonesia. Untu
 |---|---|
 | **Airdrop Phase 3 — Activity Rewards** (800.000 SRX) | Reward untuk active mainnet wallets, snapshot mainnet (per tokenomics §6) |
 | **Airdrop Phase 4 — Validator Delegators** (700.000 SRX) | Pro-rata ke delegator pada active validator set (per tokenomics §6) |
-| **External validator onboarding mulai** | Saat ini 4 validator semua Foundation-operated. Onboarding criteria + cadence akan dipublish saat ready. Target jumlah validator belum di-commit. |
-| **Indonesian CEX listing engagement berlanjut** | Tokocrypto / Pintu / Indodax — per status engagement-nya |
+| **Indonesian CEX listing engagement berlanjut** | Tokocrypto / Pintu / Indodax — per status engagement masing-masing |
 
 ### 2027+ — Decentralisasi Bertahap
 
@@ -111,7 +110,7 @@ Roadmap setelah 2026 belum di-commit ke timeline spesifik. Direction signals:
 1. **Cobain testnet:** Klaim 10M tSRX di [https://faucet.sentrixchain.com](https://faucet.sentrixchain.com) (chain ID 7120 di Metamask)
 2. **Cek block explorer:** [https://scan.sentrixchain.com](https://scan.sentrixchain.com) — lihat transaksi, validator, kontrak
 3. **Follow channel resmi:** Telegram, Twitter/X (akun resmi akan dipublish menjelang Phase 1 airdrop)
-4. **Eligibility airdrop Phase 1** (Testnet Heroes): Lakukan minimum 50 tx di testnet, deploy minimum 1 kontrak, atau jadi validator testnet selama ≥7 hari sebelum snapshot height (target 400.000)
+4. **Eligibility airdrop Phase 1** (Testnet Heroes): Detail kriteria + threshold + snapshot height akan diumumkan saat Phase 1 launch. Direction: bukan sekadar klaim faucet, tapi real participation (deploy kontrak / aktivitas DEX / operasi validator testnet / completion via partner quest platform). Lihat [`AIRDROP_MECHANICS.md`](../tokenomics/AIRDROP_MECHANICS.md) untuk design direction terbaru.
 
 ### Untuk developer
 
@@ -125,7 +124,7 @@ Roadmap setelah 2026 belum di-commit ke timeline spesifik. Direction signals:
 
 ### Untuk validator
 
-1. **Saat ini:** Foundation-operated 4 validator. External onboarding direction-signaled untuk Q4 2026 (criteria + cadence akan dipublish saat ready).
+1. **Saat ini:** Foundation-operated 4 validator. External onboarding ada di roadmap; timing + criteria belum committed.
 2. **Persyaratan teknis:** akan dipublish saat onboarding window dibuka (minimum self-stake, hardware spec, uptime SLA, networking tier)
 3. **Reward economics:** V4 distribution — block reward + tx fee revenue, pro-rata berdasarkan stake
 

--- a/docs/operations/SMART_CONTRACT_GUIDE.md
+++ b/docs/operations/SMART_CONTRACT_GUIDE.md
@@ -143,7 +143,7 @@ For most dApp use cases, you don't need to deploy your own infrastructure contra
 - **WSRX** is required if you're building or integrating with DEX/lending — most protocols only accept ERC-20 tokens, not native SRX
 - **Multicall3** address matches the well-known `mds1/multicall` deployment on other chains (the JS libraries auto-detect it)
 - **TokenFactory** lets non-Solidity-experts deploy a token in one transaction, no copy-paste-deploy ritual needed
-- **SentrixSafe** is the same contract Sentrix's own treasury uses (1-of-1 today, 3-of-5 Q3 2026)
+- **SentrixSafe** is the same contract Sentrix's own treasury uses (currently 1-of-1, expansion-ready)
 
 For complete walkthrough — deploying via Hardhat / Foundry / wagmi / viem — see [`canonical-contracts/docs/INTEGRATION.md`](https://github.com/sentrix-labs/canonical-contracts/blob/main/docs/INTEGRATION.md).
 

--- a/docs/security/MULTISIG.md
+++ b/docs/security/MULTISIG.md
@@ -5,7 +5,7 @@ title: Multi-sig & Authority Wallet
 
 # SentrixSafe & authority wallet model
 
-How privileged actions on Sentrix Chain are governed: a minimal Gnosis Safe-derived multi-sig, currently 1-of-1 with a dedicated authority signer, transitioning to 3-of-5 in Q3 2026.
+How privileged actions on Sentrix Chain are governed: a minimal Gnosis Safe-derived multi-sig, currently 1-of-1 with a dedicated authority signer. The contract is shape-ready to expand to N-of-M when independent signers are recruited; no specific expansion timeline is committed.
 
 ## Architecture
 
@@ -62,19 +62,18 @@ cast call 0x6272dC0C842F05542f9fF7B5443E93C0642a3b26 "getThreshold()(uint256)" \
 # → 1
 ```
 
-## Q3 2026: 3-of-5 migration plan
+## Multi-sig expansion (no committed timeline)
 
-Adds 4 additional signers to the Safe, then `changeThreshold(3)`. Target signer slate:
+The contract is shape-ready for N-of-M expansion. Whenever independent signers are recruited and onboarded, the expansion is a same-day on-chain operation:
 
-| Slot | Role | Held by |
-|---|---|---|
-| 1 | Authority (current) | Sentrix Labs core team |
-| 2 | Founder backup | Cold-storage wallet, separate from Founder v3 premine |
-| 3 | Independent advisor 1 | TBD |
-| 4 | Independent advisor 2 | TBD |
-| 5 | Security council seat | TBD (audit firm or community-elected) |
+```
+addOwner(<new_signer>, threshold=1)   // repeat per signer; threshold stays 1 until last step
+changeThreshold(<new_threshold>)      // raise quorum once full signer set is in place
+```
 
-Sequenced as: `addOwner(slot2, threshold=1)` → `addOwner(slot3, threshold=1)` → `addOwner(slot4, threshold=1)` → `addOwner(slot5, threshold=1)` → `changeThreshold(3)`. All signed by current authority (1-of-1 still suffices throughout).
+No timeline is committed because committing to a specific quarter without recruited signers in pipeline would be performative — a multi-sig wallet with non-responsive co-signers is operationally worse than a working 1-of-1.
+
+The contract surface (1-of-1 today, expansion-ready) is the right signal to listing platforms and partners: governance contract exists + ready to expand, not "we will definitely have N signers by date X."
 
 ## Key contract operations gated by Safe
 

--- a/docs/tokenomics/AIRDROP_MECHANICS.md
+++ b/docs/tokenomics/AIRDROP_MECHANICS.md
@@ -114,7 +114,7 @@ Pro-rata distribution to delegators on active validators at snapshot height. Tar
 
 ### Phase 5 — Retroactive Builders (Q4 2026 / Q1 2027)
 
-Committee-reviewed allocation for ecosystem contributors — dApp deployers, audit contributors, ecosystem PR authors, educational content creators. Tiered allocation. Committee composition will be specified before review begins (post-SentrixSafe-3-of-5-migration).
+Committee-reviewed allocation for ecosystem contributors — dApp deployers, audit contributors, ecosystem PR authors, educational content creators. Tiered allocation. Committee composition will be specified before review begins.
 
 ## Auditability
 

--- a/docs/tokenomics/AIRDROP_MECHANICS.md
+++ b/docs/tokenomics/AIRDROP_MECHANICS.md
@@ -24,7 +24,7 @@ Non-goals:
 
 | Phase | Allocation | Audience | Trigger |
 |---|---|---|---|
-| **1 — Testnet Heroes** | 1,000,000 SRX | Validators + power-users on chain 7120 (cumulative tx count ≥ N pre-snapshot, wallet age ≥ 30 days) | Q2 2026, post-Chainlist listing |
+| **1 — Testnet Heroes** | 1,000,000 SRX | Validators + power-users on chain 7120 (cumulative tx count ≥ N pre-snapshot) | Q2 2026, post-Chainlist listing |
 | **2 — Quest Campaign** | 1,000,000 SRX | Galxe / Zealy-style task completers (faucet, swap, contract-deploy quests) | Q3 2026 |
 | **3 — Activity Rewards** | 800,000 SRX | Active mainnet wallets (tx velocity + balance retention metrics) | Q3 2026 |
 | **4 — Validator Delegators** | 700,000 SRX | Pro-rata to delegators on active validators (snapshot height TBD) | Q4 2026 |

--- a/docs/tokenomics/OVERVIEW.md
+++ b/docs/tokenomics/OVERVIEW.md
@@ -129,7 +129,7 @@ Listing fee budget: 3M SRX from Strategic Reserve.
 | Period | Setup | Authority signer(s) |
 |---|---|---|
 | **Today (2026-04-28)** | SentrixSafe 1-of-1 on both chains | Authority `0xa25236925bc10954e0519731cc7ba97f4bb5714b` |
-| **Q3 2026 target** | SentrixSafe 3-of-5 multi-sig | Authority + Founder backup + 2× independent advisors + 1× security council |
+| **Future (no committed timing)** | SentrixSafe N-of-M multi-sig — expansion to multiple signers when independent co-signers are recruited and onboarded | Authority + future co-signers |
 
 Migration history (2026-04-28): `addOwner(authority)` testnet block 881639 + mainnet block 755821; `removeOwner(deployer)` testnet block 884599 + mainnet block 757829. Bootstrap deployer EOA retired from Safe ownership. Tx hashes in [canonical-contracts ADDRESSES.md](https://github.com/sentrix-labs/canonical-contracts/blob/main/docs/ADDRESSES.md).
 


### PR DESCRIPTION
## Summary
Follow-up to PR #406. User re-asked \"yakin udah clear?\" — re-audit caught 4 more fabrications that pass-1 missed.

### GOVERNANCE.md
- \"Q4 2026 External validator onboarding begins\" → \"Future (no committed timing)\" (not in TOKENOMICS §9 Q4)
- 2027+ specific years for on-chain governance / DAO treasury → \"Future (no committed timing)\"

### AIRDROP_MECHANICS.md
- Phase 1 trigger row: dropped fabricated \"wallet age ≥ 30 days\" (only \"tx count ≥ N\" is in TOKENOMICS §6)

### ROADMAP_INDONESIA.md
- Pengguna eligibility: dropped fabricated 50 tx / 1 kontrak / ≥7 hari / height 400.000
- Validator section: dropped \"Q4 2026\" specific quarter for onboarding
- Q3 table: removed fabricated specific Bahasa translation doc list
- Q2 table: ADDED SDK + Docs site polish (TOKENOMICS §9 Q2; were incorrectly in Q3)
- Q4 table: removed \"External validator onboarding mulai\" (not in TOKENOMICS Q4)

Final state: every Q2/Q3/Q4 2026 commitment in public docs matches TOKENOMICS §6/§7/§8/§9 exactly.

## Test plan
- [x] Pass-2 grep audit returns zero fabricated specifics
- [ ] Docusaurus rebuild + deploy after merge