### PR TITLE
docs: Strategic Reserve → StrategicReserveTimelock migration plan

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -18,7 +18,7 @@ Two main pools hold protocol-level capital:
 
 | Pool | Allocation | Purpose | Control mechanism |
 |---|---|---|---|
-| Strategic Reserve | 10,500,000 SRX | Airdrop campaign (5M), CEX listing fees (3M), DEX bootstrap liquidity (1.5M), emergency (1M) | EOA wallet, key held by Authority (same operator who controls SentrixSafe). Social custody — on-chain enforcement (Reserve owned by SentrixSafe contract) is acknowledged as a roadmap item without committed timeline. |
+| Strategic Reserve | 10,500,000 SRX | Airdrop campaign (5M), CEX listing fees (3M), DEX bootstrap liquidity (1.5M), emergency (1M) | EOA today, key held by Authority. **Migration to `StrategicReserveTimelock` contract is the active path** — contract code ready in [`sentrix-labs/canonical-contracts`](https://github.com/sentrix-labs/canonical-contracts/blob/main/contracts/StrategicReserveTimelock.sol) (24h timelock, SentrixSafe-controlled). Deploy + transfer is operator-decision when ready; no committed timeline. Until migrated: claim "SentrixSafe-governed" is social custody only. |
 | Ecosystem Fund | 21,000,000 SRX | Operational ops: faucet refill, marketing, bounties, dev grants | EOA wallet, key held by Authority. Same custody model as Strategic Reserve. |
 
 Sub-bucket targets are **policy-level commitments** (documented in this repo and on `sentrixchain.com/docs/tokenomics`). They are **not on-chain enforced** — they are auditable via on-chain transaction history.
@@ -171,6 +171,7 @@ There is no governance vote for emergency response; the operator coordinates. On
 | Q2 2026 | Foundation-operated 1-of-1 SentrixSafe, hardcoded fork gating, off-chain operator coordination |
 | Q3 2026 | Founder-vesting contract deploy (locks §2a on-chain) per tokenomics §9 |
 | Future (no committed timing) | SentrixSafe multi-sig expansion — when independent signers are recruited |
+| Future (no committed timing) | Strategic Reserve migration to `StrategicReserveTimelock` contract — code ready, operator-decision when ready (24h delay trade-off accepted) |
 | Future (no committed timing) | External validator onboarding — current 4 validators are Foundation-operated; criteria, cadence, and timing all TBD when operator-readiness framework is finalized |
 | Future (no committed timing) | On-chain governance for protocol upgrades — proposal + voting framework, mechanism TBD |
 | Future (no committed timing) | Decentralized treasury governance (DAO-style), replacing Foundation-coordinated multisig |

--- a/docs/security/MULTISIG.md
+++ b/docs/security/MULTISIG.md
@@ -84,8 +84,52 @@ The contract surface (1-of-1 today, expansion-ready) is the right signal to list
 
 The existing canonical contracts (WSRX, Multicall3, TokenFactory) have **no owner role** — they're immutable after deployment. Only SentrixSafe has owner-set governance. If future contracts gain owner roles (e.g., upgradeable proxies, pausable factories), `script/TransferOwnership.s.sol` will document the hand-off path.
 
+## Strategic Reserve migration plan (StrategicReserveTimelock)
+
+The Strategic Reserve (10.5M SRX, allocated for airdrop campaign + CEX listing fees + DEX bootstrap + emergency) currently sits in an EOA wallet (`0x2578cad17e3e...`). The Authority key holder controls direct spending — social custody, not on-chain enforcement.
+
+**Active migration path:** transfer Reserve into `StrategicReserveTimelock` — a thin wrapper over OpenZeppelin TimelockController v5.6.0, controlled by SentrixSafe with a hardcoded 24-hour delay.
+
+### Contract design
+
+- **Source:** [`canonical-contracts/contracts/StrategicReserveTimelock.sol`](https://github.com/sentrix-labs/canonical-contracts/blob/main/contracts/StrategicReserveTimelock.sol)
+- **Pattern:** OZ TimelockController (battle-tested in Compound governance, holds $billions across multiple deployments)
+- **Constructor (immutable post-deploy):**
+  - `minDelay = 86400` (24 hours)
+  - `proposers = [SentrixSafe]` — only SentrixSafe Authority can schedule spends
+  - `executors = [SentrixSafe]` — only SentrixSafe Authority can execute post-delay
+  - `cancellers = [SentrixSafe]` — can cancel pending operations during the window
+  - `admin = address(0)` — fully self-administered, role changes themselves go through the timelock
+
+### Spend flow (post-migration)
+
+1. **Schedule** — SentrixSafe calls `schedule(target, value, data, predecessor, salt, 86400)` → operation queued, visible on-chain
+2. **Wait 24h** — anyone can audit the pending operation via `getOperationState(id)` and (if SentrixSafe-authorized) cancel
+3. **Execute** — SentrixSafe calls `execute(...)` → operation runs
+
+### Cancel flow (operator safety)
+
+If an operator notices a wrong amount, wrong recipient, or proposed-under-coercion spend during the 24h window, SentrixSafe calls `cancel(id)` to abort the operation before damage.
+
+### Trade-off (why not migrated yet)
+
+- **Pro:** on-chain enforcement of "SentrixSafe-governed" claim becomes literally true; 24h cancel-window catches mistakes/coercion; future N-of-M expansion of SentrixSafe inherits all timelock protection
+- **Con:** every Reserve spend takes 24 hours to settle, vs instant in EOA model
+- **Mitigation:** day-to-day operational spending (faucet refill, marketing, bounties, dev grants) stays in Ecosystem Fund EOA (separate wallet, fast access). Reserve is only used for big planned events (CEX listings, DEX bootstrap, airdrop pre-fund, emergency) where 24h notice is practical.
+
+### Migration sequence (one-time, when operator decides)
+
+1. Deploy `StrategicReserveTimelock` contract on chain (mainnet first or testnet drill first — operator's call)
+2. Verify on Sourcify (`verify.sentrixchain.com`)
+3. Reserve EOA → transfer 10.5M SRX to deployed contract address
+4. Retire Reserve EOA private key (zero out, never reuse)
+5. Update governance/tokenomics docs to point Reserve at contract address
+
+**No timeline committed.** Migration is opt-in operator decision when ready.
+
 ## See also
 
 - [`canonical-contracts/docs/ADDRESSES.md`](https://github.com/sentrix-labs/canonical-contracts/blob/main/docs/ADDRESSES.md) — deployed addresses + ownership migration tx hashes
-- [`canonical-contracts/contracts/SentrixSafe.sol`](https://github.com/sentrix-labs/canonical-contracts/blob/main/contracts/SentrixSafe.sol) — contract source
+- [`canonical-contracts/contracts/SentrixSafe.sol`](https://github.com/sentrix-labs/canonical-contracts/blob/main/contracts/SentrixSafe.sol) — multisig contract source
+- [`canonical-contracts/contracts/StrategicReserveTimelock.sol`](https://github.com/sentrix-labs/canonical-contracts/blob/main/contracts/StrategicReserveTimelock.sol) — timelock contract source (Reserve migration target)
 - [Tokenomics > Governance](../tokenomics/OVERVIEW#8-governance) — broader governance roadmap


### PR DESCRIPTION
## Summary
Decision (2026-04-29): Strategic Reserve will migrate from EOA to \`StrategicReserveTimelock\` contract (canonical-contracts PR #12). Updates governance + multisig docs to reflect the plan.

### Changes
- **GOVERNANCE.md** — Reserve row now references migration path; roadmap table adds the migration as Future entry
- **MULTISIG.md** — adds new section explaining the contract design, spend flow, cancel flow, trade-off (24h delay), and migration sequence

### Honesty
No timeline committed. Migration is operator-decision when ready. Eco Fund stays EOA by design (operational speed); only Reserve migrates (strategic + planned events).

## Test plan
- [x] Docusaurus build clean
- [x] Live verified at docs.sentrixchain.com/security/MULTISIG