### PR TITLE
docs: note Blockscout sidecar (blockscout.sentrixchain.com) alongside scan

### DIFF
--- a/docs/operations/METAMASK.md
+++ b/docs/operations/METAMASK.md
@@ -29,6 +29,8 @@ Sentrix is fully MetaMask-compatible on both networks. Mainnet (chain ID 7119) a
 
 Mainnet supports `eth_sendRawTransaction` and Solidity contract deployment since the 2026-04-25 Voyager activation. Use mainnet for production deployments and testnet for development.
 
+> **Two parallel block explorers.** The custom `scan.sentrixchain.com` is the primary UX (covers Sentrix's native TokenOp / StakingOp events + validator pages + label system). For EVM-standard tooling — ERC-20 token holders, smart-contract source verification, EIP-3091 URLs — use `blockscout.sentrixchain.com`. Either URL works in MetaMask's "Block Explorer URL" field; pick the one matching the feature you'll use most. Listing platforms (CoinGecko / CoinMarketCap) and wallets that expect Blockscout-style endpoints should use the Blockscout URL.
+
 ## Get Test SRX
 
 Faucet: https://faucet.sentrixchain.com (or use a funded testnet wallet directly).

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -6,7 +6,8 @@
 |-|-|
 | Chain ID | 7119 (0x1bcf) |
 | RPC | https://rpc.sentrixchain.com |
-| Explorer | https://scan.sentrixchain.com |
+| Explorer (custom) | https://scan.sentrixchain.com — native TokenOps + StakingOps + validator UX |
+| Explorer (Blockscout) | https://blockscout.sentrixchain.com — EVM-standard UX (ERC-20 transfers, source verification) |
 | P2P port | 30303 |
 | API port | 8545 |
 | Block time | 1s |
@@ -60,6 +61,13 @@ Add network manually:
 | Chain ID | 7119 | 7120 |
 | Symbol | SRX | SRX |
 | Explorer | https://scan.sentrixchain.com | https://scan.sentrixchain.com (toggle Testnet) |
+
+> Sentrix runs **two parallel explorers**. `scan.sentrixchain.com` (custom) is the
+> primary UX for native protocol features — TokenOp / StakingOp events, validator
+> pages, label system. `blockscout.sentrixchain.com` (Blockscout v8) is the
+> EVM-standard sidecar for ERC-20 holders, contract source verification, and
+> EIP-3091-style URLs that wallets and listing sites expect. Either URL works in
+> the explorer field; pick by the feature you need.
 
 ### ethers.js
 


### PR DESCRIPTION
Adds a dual-explorer note to NETWORKS.md and METAMASK.md so listing platforms / wallet add-network instructions can pick the right URL.

Custom scan stays the primary explorer (handles native TokenOps + StakingOps + validator UX). Blockscout sidecar adds EVM-standard UX (ERC-20 holders, contract source verification, EIP-3091 URLs) that listing platforms expect.

No code changes.