### PR TITLE
rpc: emit standard EVM block fields + IP-whitelist rate limiter

### DIFF
--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -95,22 +95,7 @@ async fn eth_get_block_by_number(params: &Value, state: &SharedState) -> Dispatc
     // in-memory sliding window are served from MDBX, not silently
     // returned as null.
     match bc.get_block_any(index) {
-        Some(block) => Ok(json!({
-            "number": to_hex(block.index),
-            "hash": format!("0x{}", block.hash),
-            "parentHash": format!("0x{}", block.previous_hash),
-            "timestamp": to_hex(block.timestamp),
-            "miner": block.validator,
-            "transactions": block.transactions.iter().map(|tx| format!("0x{}", tx.txid)).collect::<Vec<_>>(),
-            "transactionsRoot": format!("0x{}", block.merkle_root),
-            "gasLimit": to_hex(30_000_000),
-            "gasUsed": to_hex(0),
-            "difficulty": "0x0",
-            "totalDifficulty": "0x0",
-            "size": to_hex(1000),
-            "extraData": "0x",
-            "nonce": "0x0000000000000000",
-        })),
+        Some(block) => Ok(build_block_json(&block)),
         None => Ok(json!(null)),
     }
 }
@@ -123,19 +108,51 @@ async fn eth_get_block_by_hash(params: &Value, state: &SharedState) -> DispatchR
         .to_string();
     let bc = state.read().await;
     match bc.get_block_by_hash(&hash) {
-        Some(block) => Ok(json!({
-            "number": to_hex(block.index),
-            "hash": format!("0x{}", block.hash),
-            "parentHash": format!("0x{}", block.previous_hash),
-            "timestamp": to_hex(block.timestamp),
-            "miner": block.validator,
-            "transactions": block.transactions.iter().map(|tx| format!("0x{}", tx.txid)).collect::<Vec<_>>(),
-            "transactionsRoot": format!("0x{}", block.merkle_root),
-            "gasLimit": to_hex(30_000_000),
-            "gasUsed": to_hex(0),
-        })),
+        Some(block) => Ok(build_block_json(&block)),
         None => Ok(json!(null)),
     }
+}
+
+// Standard EVM block fields beyond what Sentrix natively tracks. Off-the-shelf
+// EVM tooling (Blockscout indexer, etc.) pattern-matches these — missing keys
+// trigger FunctionClauseError on parse. Sentrix has no PoW/uncles, so most are
+// constants; `stateRoot` surfaces the real on-chain commitment when available.
+const ZERO_HASH_HEX: &str = "0x0000000000000000000000000000000000000000000000000000000000000000";
+// Keccak256 of empty RLP list — the canonical "no uncles" sentinel every EVM
+// chain emits.
+const EMPTY_SHA3_UNCLES: &str =
+    "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";
+// Empty 256-byte logs bloom (2 hex chars per byte → 512 zeros after 0x).
+const EMPTY_LOGS_BLOOM: &str = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+fn build_block_json(block: &sentrix_primitives::Block) -> Value {
+    let state_root = match block.state_root {
+        Some(bytes) => format!("0x{}", hex::encode(bytes)),
+        None => ZERO_HASH_HEX.to_string(),
+    };
+    json!({
+        "number": to_hex(block.index),
+        "hash": format!("0x{}", block.hash),
+        "parentHash": format!("0x{}", block.previous_hash),
+        "timestamp": to_hex(block.timestamp),
+        "miner": block.validator,
+        "transactions": block.transactions.iter().map(|tx| format!("0x{}", tx.txid)).collect::<Vec<_>>(),
+        "transactionsRoot": format!("0x{}", block.merkle_root),
+        "stateRoot": state_root,
+        "receiptsRoot": ZERO_HASH_HEX,
+        "logsBloom": EMPTY_LOGS_BLOOM,
+        "sha3Uncles": EMPTY_SHA3_UNCLES,
+        "mixHash": ZERO_HASH_HEX,
+        "uncles": [],
+        "gasLimit": to_hex(30_000_000),
+        "gasUsed": to_hex(0),
+        "difficulty": "0x0",
+        "totalDifficulty": "0x0",
+        "size": to_hex(1000),
+        "extraData": "0x",
+        "nonce": "0x0000000000000000",
+        "baseFeePerGas": to_hex(sentrix_evm::gas::INITIAL_BASE_FEE),
+    })
 }
 
 async fn eth_get_transaction_by_hash(params: &Value, state: &SharedState) -> DispatchResult {

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -108,7 +108,7 @@ async fn eth_get_block_by_hash(params: &Value, state: &SharedState) -> DispatchR
         .to_string();
     let bc = state.read().await;
     match bc.get_block_by_hash(&hash) {
-        Some(block) => Ok(build_block_json(&block)),
+        Some(block) => Ok(build_block_json(block)),
         None => Ok(json!(null)),
     }
 }

--- a/crates/sentrix-rpc/src/routes/ratelimit.rs
+++ b/crates/sentrix-rpc/src/routes/ratelimit.rs
@@ -49,6 +49,20 @@ pub(super) fn write_rate_limit_max() -> u32 {
         .unwrap_or(10)
 }
 
+/// Comma-separated list of IPs that bypass both rate limiters. Set via
+/// `SENTRIX_RATE_LIMIT_WHITELIST` env. Used so trusted infrastructure
+/// (block-explorer indexers, monitoring exporters, internal mesh peers)
+/// can drive the RPC at full speed without lifting the per-IP cap for
+/// the public internet. Reads the env var per request so operator
+/// changes take effect on next call without restart.
+fn rate_limit_whitelist_contains(ip: &str) -> bool {
+    let raw = match std::env::var("SENTRIX_RATE_LIMIT_WHITELIST") {
+        Ok(v) if !v.is_empty() => v,
+        _ => return false,
+    };
+    raw.split(',').any(|entry| entry.trim() == ip)
+}
+
 /// A7: distinct limiter newtypes so write + read counters do not alias
 /// each other. Both are registered as separate `Extension<T>` entries on
 /// requests.
@@ -128,6 +142,9 @@ pub(super) async fn ip_rate_limit_middleware(
     next: axum::middleware::Next,
 ) -> axum::response::Response {
     let ip = extract_client_ip(&request);
+    if rate_limit_whitelist_contains(&ip) {
+        return next.run(request).await;
+    }
     let allowed = if let Some(limiter) = request.extensions().get::<GlobalIpLimiter>().cloned() {
         check_rate_limit(
             limiter.0,
@@ -156,6 +173,9 @@ pub(super) async fn write_rate_limit_middleware(
     next: axum::middleware::Next,
 ) -> axum::response::Response {
     let ip = extract_client_ip(&request);
+    if rate_limit_whitelist_contains(&ip) {
+        return next.run(request).await;
+    }
     let allowed = if let Some(limiter) = request.extensions().get::<WriteIpLimiter>().cloned() {
         check_rate_limit(
             limiter.0,

--- a/docs/operations/METAMASK.md
+++ b/docs/operations/METAMASK.md
@@ -29,6 +29,8 @@ Sentrix is fully MetaMask-compatible on both networks. Mainnet (chain ID 7119) a
 
 Mainnet supports `eth_sendRawTransaction` and Solidity contract deployment since the 2026-04-25 Voyager activation. Use mainnet for production deployments and testnet for development.
 
+> **Two parallel block explorers.** The custom `scan.sentrixchain.com` is the primary UX (covers Sentrix's native TokenOp / StakingOp events + validator pages + label system). For EVM-standard tooling — ERC-20 token holders, smart-contract source verification, EIP-3091 URLs — use `blockscout.sentrixchain.com`. Either URL works in MetaMask's "Block Explorer URL" field; pick the one matching the feature you'll use most. Listing platforms (CoinGecko / CoinMarketCap) and wallets that expect Blockscout-style endpoints should use the Blockscout URL.
+
 ## Get Test SRX
 
 Faucet: https://faucet.sentrixchain.com (or use a funded testnet wallet directly).

--- a/docs/operations/NETWORKS.md
+++ b/docs/operations/NETWORKS.md
@@ -6,7 +6,8 @@
 |-|-|
 | Chain ID | 7119 (0x1bcf) |
 | RPC | https://rpc.sentrixchain.com |
-| Explorer | https://scan.sentrixchain.com |
+| Explorer (custom) | https://scan.sentrixchain.com — native TokenOps + StakingOps + validator UX |
+| Explorer (Blockscout) | https://blockscout.sentrixchain.com — EVM-standard UX (ERC-20 transfers, source verification) |
 | P2P port | 30303 |
 | API port | 8545 |
 | Block time | 1s |
@@ -60,6 +61,13 @@ Add network manually:
 | Chain ID | 7119 | 7120 |
 | Symbol | SRX | SRX |
 | Explorer | https://scan.sentrixchain.com | https://scan.sentrixchain.com (toggle Testnet) |
+
+> Sentrix runs **two parallel explorers**. `scan.sentrixchain.com` (custom) is the
+> primary UX for native protocol features — TokenOp / StakingOp events, validator
+> pages, label system. `blockscout.sentrixchain.com` (Blockscout v8) is the
+> EVM-standard sidecar for ERC-20 holders, contract source verification, and
+> EIP-3091-style URLs that wallets and listing sites expect. Either URL works in
+> the explorer field; pick by the feature you need.
 
 ### ethers.js
 


### PR DESCRIPTION
## Summary

Two RPC patches needed to unblock Blockscout (and any off-the-shelf EVM indexer) integrating against Sentrix:

### 1. Standard EVM block fields in eth_getBlock*

`eth_getBlockByNumber` / `eth_getBlockByHash` were missing five fields that Blockscout's `EthereumJSONRPC.Block.do_elixir_to_params/1` pattern-matches on:

- `mixHash` → constant `0x00...00` (Sentrix has no PoW)
- `sha3Uncles` → empty Merkle root constant
- `uncles` → empty array
- `stateRoot` → real on-chain commitment (post state-root fork height; falls back to zero-pad)
- `receiptsRoot` → zero-pad for now
- `logsBloom` → zero-pad for now
- `baseFeePerGas` → `sentrix_evm::gas::INITIAL_BASE_FEE`

Without these fields the indexer crash-loops on every block fetch (FunctionClauseError → BEAM exit).

Inline `json!` builder refactored into `build_block_json(&Block)` so both byNumber + byHash routes share one schema.

### 2. SENTRIX_RATE_LIMIT_WHITELIST

New env (comma-separated IPs / IPv6 addresses) carves trusted infrastructure (block-explorer indexers, monitoring exporters) out of both the global + write rate limiters without lifting per-IP caps for the public internet. Read per-request so operator changes apply on next call.

## Test plan

- [x] cargo check + cargo test (workspace clean)
- [x] Live verified on mainnet 7119 — patched binary running on all 4 validators, block fields confirmed in eth_getBlockByNumber response (h≈869K)
- [x] Whitelist verified — Blockscout indexer at `blockscout.sentrixchain.com` now indexing without rate-limit errors