### PR TITLE
chore: add .mailmap to consolidate author identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+# Consolidate the multiple identities Satya Kwok has used across the
+# repo's history. GitHub renders display names from .mailmap, so this
+# fixes how the contributor list shows up on the repo home page +
+# `git shortlog` without rewriting commit history.
+#
+# Canonical: noreply form of @satyakwok (current GH login).
+Satya Kwok <satyakwok@users.noreply.github.com> <satyakwik@gmail.com>
+Satya Kwok <satyakwok@users.noreply.github.com> <satyakwikp77@gmail.com>
+Satya Kwok <satyakwok@users.noreply.github.com> <satyakwik@users.noreply.github.com>
+Satya Kwok <satyakwok@users.noreply.github.com> <satyakwok@users.noreply.github.com>
+Satya Kwok <satyakwok@users.noreply.github.com> <119509589+satyakwok@users.noreply.github.com>


### PR DESCRIPTION
## Why
\`git log --format='%ae' | sort -u\` returns 5 distinct \"Satya Kwok\" emails (two personal-email leaks plus three noreply variants tied to two GitHub logins), so the contributor list on the repo home page shows the chain as if it had three authors.

## Fix
A \`.mailmap\` collapses all five variants to the canonical \`satyakwok@users.noreply.github.com\` (the noreply form of @satyakwok, the current login). GitHub honours \`.mailmap\` for the contributor list, and \`git shortlog\` / \`git log --use-mailmap\` honour it locally — no history rewrite, no force push.

After this lands:
\`\`\`
$ git log --all --use-mailmap --format='%aN <%aE>' | sort -u
Mᴏᴏɴ <mooncity.james@gmail.com>
Satya Kwok <satyakwok@users.noreply.github.com>
dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
\`\`\`