### PR TITLE
feat(consensus-jail): startup warning when JAIL_CONSENSUS_HEIGHT armed below u64::MAX

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1281,6 +1281,13 @@ async fn cmd_start(
     port: u16,
     peers_str: String,
 ) -> anyhow::Result<()> {
+    // Loud warning if any consensus-touching env var is armed in a known-
+    // dangerous state. Currently covers JAIL_CONSENSUS_HEIGHT (the
+    // LivenessTracker non-determinism halt class). Fires before the chain
+    // even loads so an operator catching it can ctrl-C and reconfigure
+    // without partially booting into a halt-bound state.
+    sentrix::core::blockchain::warn_if_jail_consensus_armed();
+
     let storage = Arc::new(Storage::open(&get_db_path())?);
     let bc = storage
         .load_blockchain()?

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -202,6 +202,43 @@ pub fn get_jail_consensus_height() -> u64 {
         .unwrap_or(JAIL_CONSENSUS_HEIGHT_DEFAULT)
 }
 
+/// Startup-time guardrail: if `JAIL_CONSENSUS_HEIGHT` is set to anything
+/// other than `u64::MAX`, log a loud warning explaining what's at stake.
+///
+/// Why this exists: the consensus-jail dispatch has a known LivenessTracker
+/// non-determinism bug that has halted mainnet twice (h=892799 on 2026-04-29,
+/// h=979199 on 2026-04-30). Each incident the recovery loop ends with
+/// "set JAIL_CONSENSUS_HEIGHT=u64::MAX in env" — but env files are easy to
+/// forget about and easy to revert by accident. This warning fires loudly
+/// at every startup so the operator can catch a misconfig BEFORE the next
+/// epoch boundary triggers the divergence.
+///
+/// Removing this warning is tied to landing the actual canonical-only
+/// LivenessTracker fix (see `audits/AUDIT_REPORT_2026_04_29.md` Phase 3).
+/// Until then, any value other than u64::MAX is operator risk.
+pub fn warn_if_jail_consensus_armed() {
+    let height = get_jail_consensus_height();
+    if height < u64::MAX {
+        tracing::warn!(
+            "⚠️  JAIL_CONSENSUS_HEIGHT={} (NOT u64::MAX) — consensus-jail \
+             dispatch ARMED. Known to halt mainnet via LivenessTracker \
+             non-determinism (incidents: h=892799 / 2026-04-29, h=979199 / \
+             2026-04-30). Set env to 18446744073709551615 unless you have \
+             explicitly verified the canonical-only LivenessTracker fix \
+             has shipped. See founder-private/AUDIT_REPORT_2026_04_29.md.",
+            height
+        );
+        // Eprintln backup so the warning is also visible without RUST_LOG
+        // wired to WARN — defensive against ops accidentally running with
+        // info-only logging.
+        eprintln!(
+            "⚠️  JAIL_CONSENSUS_HEIGHT={} — see warn log above. This is a \
+             KNOWN HALT CONDITION. Confirm intent before continuing.",
+            height
+        );
+    }
+}
+
 /// Read NFT TokenOp fork height from env, default `u64::MAX` (disabled).
 /// Post-fork: SRC-721 + SRC-1155 dispatch active. Operators activate via
 /// halt-all + simultaneous-start with `NFT_TOKENOP_HEIGHT=<height>`.


### PR DESCRIPTION
## Why

Consensus-jail dispatch has a known LivenessTracker non-determinism class. Halted mainnet twice (h=892799 / 2026-04-29, h=979199 / 2026-04-30). Each recovery ends with operator setting env back to `JAIL_CONSENSUS_HEIGHT=18446744073709551615`. Env files are easy to revert by accident — between the two incidents above, this is exactly what happened (env got reverted from u64::MAX to 950400 silently, bug fired again).

This PR adds a loud startup warning so the misconfig is caught BEFORE the next epoch boundary triggers JailEvidenceBundle local-recompute divergence.

## What

- `warn_if_jail_consensus_armed()` in `sentrix-core::blockchain` — fires both `tracing::warn!` and `eprintln!` (visible without `RUST_LOG=warn`) when env reads anything other than `u64::MAX`.
- Called at the very top of `cmd_start` in the binary, before chain.db loads. Operator catching the warning can ctrl-C and reconfigure cleanly without partial-boot state.

## What this is NOT

- This is **not** the canonical-only LivenessTracker fix. That's scheduled for a dedicated fresh-brain session — multi-week scope per the audit (`founder-private/AUDIT_REPORT_2026_04_29.md` Phase 3 / 3 candidate paths).
- Pure operator-side guardrail. Zero consensus-path code touched.

## Test plan

- [x] `cargo build --release -p sentrix-node` clean
- [x] `cargo test --release -p sentrix-core --lib` — 207 tests pass
- [ ] Deploy on next mainnet chain-restart window (binary diff is tiny — boot warn only)
- [ ] Verify startup log shows the warning when `JAIL_CONSENSUS_HEIGHT=950400` (smoke test)
- [ ] Verify no warning when `JAIL_CONSENSUS_HEIGHT=18446744073709551615` (current production)