### PR TITLE
chore: v2.1.49 — EVM value-transfer fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.48"
+version = "2.1.49"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.48"
+version = "2.1.49"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"


### PR DESCRIPTION
Bumps workspace version to v2.1.49.

Tracks PR #439 (EVM value-transfer drop fix) shipping as the v2.1.49 release. Tag `v2.1.49` is already pushed.