### PR TITLE
fix(evm): fork-gate value-transfer plumbing — closes mainnet halt regression in v2.1.49 (v2.1.50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.49"
+version = "2.1.50"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.49"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/crates/sentrix-core/src/block_executor/evm.rs
+++ b/crates/sentrix-core/src/block_executor/evm.rs
@@ -46,15 +46,22 @@ impl Blockchain {
         };
         let _sender = envelope.recover_signer().ok();
 
-        // Pull native-value out of the envelope. Pre-fix this was dropped on
-        // the floor — TxEnv defaulted to U256::ZERO so revm never moved any
-        // SRX between EOAs even when the user signed a `value > 0` tx.
-        // Symptom: `WSRX.deposit{value: 1ether}()` and pure `cast send
-        // --value Nether <addr>` both reported status=1 + recipient balance
-        // unchanged. Native fee debit happens in the Pass-1 path
-        // (`charge_fee_only`) so we only need value-of-tx here, not fee.
-        // See `audits/2026-05-01-evm-value-transfer-bug.md`.
-        let tx_value: alloy_primitives::U256 = envelope.value();
+        // Pull native-value out of the envelope, but gate it. Flat-shipping
+        // the `.value()` plumbing in v2.1.49 produced 3 same-day mainnet
+        // halts on 2026-05-01 (2v2 split-brain at h≈1180k / 1191k / 1192k) —
+        // the apply path produces validator-specific state divergence on
+        // any value-bearing EVM tx. Until the RCA lands and a regression
+        // test pins the invariant, default `u64::MAX` keeps Pass-2 running
+        // with `TxEnv.value = ZERO` (v2.1.48-equivalent behaviour: value-
+        // bearing EVM txs no-op their transfer, native fee still debits via
+        // Pass-1 `charge_fee_only`). See
+        // `audits/2026-05-01-evm-value-transfer-divergence.md`.
+        let tx_value: alloy_primitives::U256 =
+            if Blockchain::is_evm_value_transfer_height(block_height) {
+                envelope.value()
+            } else {
+                alloy_primitives::U256::ZERO
+            };
 
         // Build EVM tx
         use alloy_primitives::{B256, U256};

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -141,6 +141,27 @@ const NFT_TOKENOP_HEIGHT_DEFAULT: u64 = u64::MAX;
 /// u64::MAX = disabled (safe default; wire format stable from this PR).
 const ADD_SELF_STAKE_HEIGHT_DEFAULT: u64 = u64::MAX;
 
+/// EVM value-transfer activation height. Pre-fork: Pass-2 EVM apply path
+/// runs every tx with `TxEnv.value = U256::ZERO` regardless of envelope
+/// value (matches v2.1.48 behaviour — value-bearing EVM txs no-op the
+/// transfer but native fee still debits via Pass-1 `charge_fee_only`).
+/// Post-fork: revm sees the real envelope value and moves SRX between
+/// EOAs / forwards into payable contract calls.
+///
+/// Why gated: shipped flat in v2.1.49, recurred the eager-write divergence
+/// pattern that v2.1.48's FinalizeBlock guard was meant to close. Three
+/// 2v2 split-brain halts on 2026-05-01 (h≈1180k / 1191k / 1192k) all
+/// followed the same shape — vps1+vps5 finalize one hash, vps2+vps3 the
+/// other. Faction split was deterministic across recoveries, suggesting
+/// the value-transfer apply path produces validator-specific divergence
+/// (likely revm/wei-sentri rounding interaction or block-context
+/// non-determinism — RCA pending in `audits/2026-05-01-evm-value-transfer-divergence.md`).
+///
+/// Until that RCA lands, default disabled mirrors v2.1.48 behaviour.
+/// Operator activates with halt-all + simul-start after the bug is
+/// understood + a regression test pins the invariant.
+const EVM_VALUE_TRANSFER_HEIGHT_DEFAULT: u64 = u64::MAX;
+
 /// Read Voyager fork height from env, default u64::MAX (mainnet safe).
 /// Testnet sets VOYAGER_FORK_HEIGHT=<height> in systemd service.
 pub fn get_voyager_fork_height() -> u64 {
@@ -258,6 +279,17 @@ pub fn get_add_self_stake_height() -> u64 {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(ADD_SELF_STAKE_HEIGHT_DEFAULT)
+}
+
+/// Read EVM value-transfer fork height from env, default `u64::MAX`
+/// (disabled — matches v2.1.48 EVM behaviour). Post-fork: Pass-2 EVM
+/// apply path threads envelope value into `TxEnv.value` so revm performs
+/// real SRX transfers between EOAs and into payable contract calls.
+pub fn get_evm_value_transfer_height() -> u64 {
+    std::env::var("EVM_VALUE_TRANSFER_HEIGHT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(EVM_VALUE_TRANSFER_HEIGHT_DEFAULT)
 }
 
 /// Read chain_id from SENTRIX_CHAIN_ID env var, fallback to 7119.
@@ -871,6 +903,16 @@ impl Blockchain {
     /// the activation PR; gate keeps it dormant until operator rollout).
     pub fn is_add_self_stake_height(height: u64) -> bool {
         let fork = get_add_self_stake_height();
+        fork != u64::MAX && height >= fork
+    }
+
+    /// EVM value-transfer fork-gate. Pre-fork: Pass-2 EVM apply runs every
+    /// tx with `TxEnv.value = U256::ZERO` (v2.1.48 behaviour, divergence-free).
+    /// Post-fork: envelope value flows into revm — value-bearing EVM txs
+    /// move SRX between accounts. See `EVM_VALUE_TRANSFER_HEIGHT_DEFAULT`
+    /// for the regression context this gate manages.
+    pub fn is_evm_value_transfer_height(height: u64) -> bool {
+        let fork = get_evm_value_transfer_height();
         fork != u64::MAX && height >= fork
     }
 
@@ -3169,6 +3211,39 @@ mod tests {
         assert!(!Blockchain::is_bft_gate_relax_height(u64::MAX - 1));
         // Default-disabled gate = pre-fork behavior.
         assert_eq!(Blockchain::min_active_for_bft(1_000_000, 4), 4);
+    }
+
+    /// EVM value-transfer gate: u64::MAX default = pre-fix v2.1.48 EVM
+    /// behaviour (TxEnv.value forced to ZERO). Pins the regression that
+    /// caused 3 mainnet halts on 2026-05-01 — flat-shipping the
+    /// envelope-value plumbing in v2.1.49 produced 2v2 split-brain
+    /// divergence on every value-bearing EVM tx. Default disabled keeps
+    /// chain stable until the divergence RCA lands. Operator activates
+    /// post-RCA via halt-all + simul-start with `EVM_VALUE_TRANSFER_HEIGHT`.
+    #[test]
+    fn test_evm_value_transfer_disabled_by_default() {
+        let _guard = env_test_lock();
+        unsafe {
+            std::env::remove_var("EVM_VALUE_TRANSFER_HEIGHT");
+        }
+        assert!(!Blockchain::is_evm_value_transfer_height(0));
+        assert!(!Blockchain::is_evm_value_transfer_height(u64::MAX - 1));
+    }
+
+    /// EVM value-transfer gate: when set, activates exactly at the
+    /// configured height and stays active for all subsequent heights.
+    #[test]
+    fn test_evm_value_transfer_activation_boundary() {
+        let _guard = env_test_lock();
+        unsafe {
+            std::env::set_var("EVM_VALUE_TRANSFER_HEIGHT", "1500000");
+        }
+        assert!(!Blockchain::is_evm_value_transfer_height(1_499_999));
+        assert!(Blockchain::is_evm_value_transfer_height(1_500_000));
+        assert!(Blockchain::is_evm_value_transfer_height(1_500_001));
+        unsafe {
+            std::env::remove_var("EVM_VALUE_TRANSFER_HEIGHT");
+        }
     }
 
     /// Phase D: build_jail_evidence_system_tx returns None pre-fork


### PR DESCRIPTION
## Summary

P0 regression fix. v2.1.49 (PR #439) flat-shipped `envelope.value()` into the Pass-2 EVM apply TxEnv. This produced **3 same-day mainnet halts on 2026-05-01** — every halt a deterministic 2v2 split-brain (vps1+vps5 vs vps2+vps3), recurring within ~24 min of each restart.

Recovery procedure (halt-all + chain.db rsync from canonical + simul-start) restored liveness three times today but the bug repro'd every cycle until vps1's disk was also tight enough to mask the symptom under MAP_FULL.

This PR adds a fork-gate over the value plumbing. Default `u64::MAX` keeps Pass-2 running with `TxEnv.value = ZERO` (v2.1.48-equivalent behaviour). Activation deferred until a proper RCA on the apply-path divergence lands.

## Why fork-gate, not revert

Reverts the *behavior* without reverting the *code*. The plumbing stays in tree so the fix can be re-activated cleanly via env var once the underlying divergence is understood. Mirrors how every other consensus-touching change in this codebase ships (`VOYAGER_FORK_HEIGHT`, `TOKENOMICS_V2_HEIGHT`, `JAIL_CONSENSUS_HEIGHT`, `ADD_SELF_STAKE_HEIGHT`, etc).

## Changes

- `crates/sentrix-core/src/blockchain.rs`
  - `EVM_VALUE_TRANSFER_HEIGHT_DEFAULT: u64 = u64::MAX`
  - `get_evm_value_transfer_height()` env reader (`EVM_VALUE_TRANSFER_HEIGHT`)
  - `Blockchain::is_evm_value_transfer_height(h)` runtime check
  - 2 regression tests: default-disabled, activation-boundary
- `crates/sentrix-core/src/block_executor/evm.rs`
  - `tx_value` gated on `is_evm_value_transfer_height(block_height)`
- `Cargo.toml` workspace version 2.1.49 → 2.1.50

## Tradeoff

Until operator sets `EVM_VALUE_TRANSFER_HEIGHT` env var, EVM value-bearing operations (`cast send --value`, `WSRX.deposit{value:...}`, `Router.addLiquiditySRX{value:...}`) no-op their transfer. Native fee still debits via Pass-1 `charge_fee_only`. **Same broken-but-stable state as v2.1.48.** Builders cannot move SRX through the EVM — but the chain stays alive.

## Test plan

- [x] `cargo test -p sentrix-core --lib test_evm_value_transfer` — 2 new tests pass
- [x] `cargo test -p sentrix-core --lib` — 209 tests pass (no regressions)
- [x] `cargo clippy -p sentrix-core --tests -- -D warnings` clean
- [ ] **Fresh-brain review required before merge** (consensus discipline — no self-merge)
- [ ] Post-merge: tag v2.1.50, Docker-build via rust:1.95-bullseye, halt-all + simul-start across all 4 mainnet validators
- [ ] Watch first ~30 min for non-recurrence
- [ ] Operator activation procedure (after RCA closes) documented in audit