### PR TITLE
chore: bump per-crate Cargo.toml versions 2.1.48 → 2.1.50

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "bincode",
  "hex",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "anyhow",
  "axum",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "anyhow",
  "axum",
@@ -5010,14 +5010,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5061,14 +5061,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "bincode",
  "blake3",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.48"
+version = "2.1.50"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.48"
+version = "2.1.50"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Catches the 16 per-crate Cargo.toml versions up to workspace 2.1.50. The workspace top-level version has been ahead since v2.1.49 + v2.1.50 bumps only touched workspace metadata — per-crate manifests stayed at 2.1.48.

## Why now

Closes the pre-existing CI failure on `tests/integration_sentrix_status::returns_all_expected_fields`. sentrix-rpc reports `env!("CARGO_PKG_VERSION")` (= '2.1.48' from its own manifest) on `/sentrix_status`, while the test compares against workspace `env!("CARGO_PKG_VERSION")` (= '2.1.50'). The mismatch was masking real test signal on every CI run since v2.1.49 — the v2.1.50 PR's CI failure prompted catching this up.

## Test plan
- [x] `cargo test --test integration_sentrix_status returns_all_expected_fields` passes locally on this branch
- Not consensus-touching: 16 Cargo.toml metadata changes only, no source code changes.