### PR TITLE
fix(storage): explicit MDBX max_size + growth_step (v2.1.51) — fixes 5 mainnet halts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "bincode",
  "hex",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "anyhow",
  "axum",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "anyhow",
  "axum",
@@ -5010,14 +5010,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5061,14 +5061,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "bincode",
  "blake3",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.50"
+version = "2.1.51"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-storage/src/mdbx.rs
+++ b/crates/sentrix-storage/src/mdbx.rs
@@ -4,9 +4,30 @@
 
 use crate::error::{StorageError, StorageResult};
 use crate::tables::ALL_TABLES;
-use libmdbx::{Database, DatabaseOptions, NoWriteMap, RW, TableFlags, Transaction, WriteFlags};
+use libmdbx::{
+    Database, DatabaseOptions, Mode, NoWriteMap, RW, ReadWriteOptions, TableFlags, Transaction,
+    WriteFlags,
+};
 use serde::{Serialize, de::DeserializeOwned};
 use std::path::Path;
+
+/// MDBX geometry — explicit upper bound + growth step. Default libmdbx
+/// geometry has a small upper_size and grows in tiny increments, which
+/// caused 5 mainnet halts on 2026-05-01 (h≈1.18M / 1.19M / 1.197M):
+/// once the file's geometric ceiling is hit, every trie write fails with
+/// `MDBX_MAP_FULL`. The validators that hit it can't persist new state,
+/// in-memory blockchain advances anyway, they propose blocks with stale
+/// state, peers reject → 2v2 split-brain → BFT halt. Independent write
+/// histories across the fleet (vps1+vps5 vs vps2+vps3) made the failure
+/// deterministically factional even on byte-identical post-rsync chain.db.
+///
+/// 64 GB upper bound covers ~20× current chain.db size at expected growth
+/// rate (3 GB / 1.2M blocks ≈ 2.5 µB / block × 5y projection at 1 block/s
+/// = ~400 GB worst case; conservative 64 GB ceiling for now, lift later
+/// if validators approach it). 256 MB growth step minimises fragmentation
+/// vs the libmdbx default tiny step.
+const MAX_DB_SIZE: isize = 64 * 1024 * 1024 * 1024;
+const GROWTH_STEP: isize = 256 * 1024 * 1024;
 
 /// Sentrix storage backed by libmdbx.
 ///
@@ -32,6 +53,11 @@ impl MdbxStorage {
             path,
             DatabaseOptions {
                 max_tables: Some(16),
+                mode: Mode::ReadWrite(ReadWriteOptions {
+                    max_size: Some(MAX_DB_SIZE),
+                    growth_step: Some(GROWTH_STEP),
+                    ..Default::default()
+                }),
                 ..Default::default()
             },
         )

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.50"
+version = "2.1.51"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

P0 fix shipped to mainnet 2026-05-02. Source PR catching up to the live binary.

The 5 mainnet halts on 2026-05-01 were NOT caused by the EVM value-transfer plumbing (v2.1.49 PR #439), as initially suspected. The actual root cause was MDBX's geometric \`upper_size\` ceiling on chain.db — once a validator's chain.db file crossed it, trie writes failed with \`MDBX_MAP_FULL\` while the in-memory blockchain advanced regardless. That validator proposed blocks built on unpersisted state, peers rejected → split-brain → halt.

## Evidence

\`SENTRIX_TRIE_TRACE=1\` capture on vps1+vps5 at the divergence height:

\`\`\`
[trie-trace] update_trie_for_block at h=1197002
[trie-trace] touched (sorted): 1 addresses
[trie-trace]   addr=0x4cad4793b25b6bb2c... balance=4085700035000 nonce=1
[trie-trace] root pre-update: 5e3797e4b305ee12...
WARN: BFT add_block failed: Internal error: trie update failed at block 1197002:
      Storage error: MDBX error: MDBX_MAP_FULL: Environment mapsize limit reached
\`\`\`

Same line on vps2+vps3 ends with \`commit at h=1197002 → root=5e3797e4b305ee12...\` (no MAP_FULL — different MDBX page-allocation history meant their files hadn't crossed the ceiling yet).

Faction split (Foundation+Beacon vs Treasury+Core) was deterministic across 5 halts, which matched the file-size ceiling pattern: vps1's chain.db had less geometric headroom than vps2's, so vps1 hit the wall first every time.

## Fix

\`\`\`rust
Mode::ReadWrite(ReadWriteOptions {
    max_size: Some(64 * 1024 * 1024 * 1024),  // 64 GB upper bound
    growth_step: Some(256 * 1024 * 1024),     // 256 MB growth step
    ..Default::default()
})
\`\`\`

64 GB covers ~20× current chain.db size (3 GB / 1.2M blocks). Existing files grow into the new ceiling on next write — no migration.

## Deployed already

Binary \`f0febb3ffffa4b0f97e534bc50dc7c11f91969462b6641e503ad268e4f594ceb\` shipped to all 4 mainnet validators 2026-05-02 ~03:00 CEST. **121 minutes uptime past previous halt cycles** with zero recurrence (chain h=1,201,302 → 1,210k+ continuous). This PR catches the source up to the live binary.

Workspace + 16 per-crate Cargo.toml versions bumped 2.1.50 → 2.1.51 in lockstep.

## Test plan

- [x] Live mainnet 121+ min uptime (was previously 24-50 min between halts)
- [x] Chain advancing 4-of-4 active continuously
- [ ] Post-merge: tag \`v2.1.51\` on main HEAD
- [ ] Tag pushed for release-tag parity with deployed binary