### PR TITLE
fix(rpc+evm): thread value through dry-run + surface revert/halt reasons (v2.1.52→v2.1.54)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "bincode",
  "hex",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "anyhow",
  "axum",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "anyhow",
  "axum",
@@ -5010,14 +5010,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5061,14 +5061,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "bincode",
  "blake3",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.51"
+version = "2.1.54"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-evm/src/executor.rs
+++ b/crates/sentrix-evm/src/executor.rs
@@ -162,8 +162,31 @@ where
                     output: revm::context::result::Output::Call(call_bytes),
                     ..
                 } => (None, call_bytes.to_vec()),
+                // Surface revert reason data — this is the 4-byte error
+                // selector + ABI-encoded args for `revert XError(...)` calls.
+                // Pre-fix this path returned an empty Vec, so eth_estimateGas
+                // saw "execution reverted" with no reason and dApps couldn't
+                // distinguish e.g. `ZeroValue()` from `Slippage()`. Wallets +
+                // wagmi rely on this data to display human revert reasons.
+                ExecutionResult::Revert { output: revert_bytes, .. } => {
+                    (None, revert_bytes.to_vec())
+                }
                 _ => (None, Vec::new()),
             };
+            // Distinguish Halt (OOG, InvalidOpcode, StackOverflow, etc) from
+            // Revert. Halt has no `output` bytes — it's the EVM engine refusing
+            // to execute, not a contract `revert ...()`. Pre-fix both paths
+            // surfaced as bare "execution reverted" which masked OOG bugs in
+            // payable contract calls. Returning a typed error here lets the
+            // RPC layer distinguish: revert reason flows through receipt.output,
+            // halt reason flows through this Err so eth_estimateGas surfaces
+            // it as a clearly-different message.
+            if let ExecutionResult::Halt { reason, .. } = &exec_result {
+                return Err(format!(
+                    "EVM halt ({:?}) — gas_used={}; not a contract revert",
+                    reason, exec_result.tx_gas_used()
+                ));
+            }
             let receipt = TxReceipt {
                 success: exec_result.is_success(),
                 gas_used: exec_result.tx_gas_used(),

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -579,10 +579,28 @@ async fn run_evm_dry_run(
         None => revm::primitives::TxKind::Create,
     };
 
+    // Thread `value` from the call object into TxEnv. Without it, every
+    // dry-run simulates with msg.value=0 regardless of what the dApp
+    // requested — payable functions that gate on `if (msg.value == 0)
+    // revert ZeroValue();` (CoinBlastCurve.buy, WSRX.deposit, etc) always
+    // revert during wagmi's pre-flight eth_estimateGas check, surfacing
+    // as "RPC Request failed" in the user's wallet UI. Block-apply path
+    // (block_executor::evm.rs) was fixed in v2.1.49; this dry-run path
+    // was never updated. Found 2026-05-02 via CBLAST buy() debugging
+    // post-EVM_VALUE_TRANSFER_HEIGHT activation.
+    let tx_value: alloy_primitives::U256 = call_obj
+        .get("value")
+        .and_then(|v| v.as_str())
+        .and_then(|s| alloy_primitives::U256::from_str_radix(
+            s.trim_start_matches("0x"), 16
+        ).ok())
+        .unwrap_or(alloy_primitives::U256::ZERO);
+
     let tx = revm::context::TxEnv::builder()
         .caller(from_addr)
         .kind(tx_kind)
         .data(alloy_primitives::Bytes::from(data_bytes))
+        .value(tx_value)
         .gas_limit(gas_limit)
         .gas_price(0)
         .nonce(bc.accounts.get_nonce(from_str))

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.51"
+version = "2.1.54"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Three closely-related fixes shipped to live mainnet during 2026-05-02 incident debugging. Source PR catching up to the live binary.

## v2.1.52 — eth_call/eth_estimateGas value plumbing

\`run_evm_dry_run\` built TxEnv without \`.value()\` — every payable simulation ran with \`msg.value=0\`. Functions gated on \`if (msg.value == 0) revert ZeroValue();\` (CoinBlastCurve.buy, WSRX.deposit, Router.addLiquiditySRX) always reverted in wagmi's pre-flight check, surfacing as "RPC Request failed" in user wallets.

## v2.1.53 — surface contract revert reason

\`execute_tx_inner\` matched only Success variants for output extraction; Revert went to the catch-all and lost the 4-byte error selector + ABI args. dApps couldn't distinguish ZeroValue / Slippage / InsufficientReserve — all looked like bare "execution reverted".

## v2.1.54 — surface Halt distinctly from Revert

OutOfGas, InvalidOpcode, OutOfFunds etc went through the same path as contract reverts, masking engine-level failures behind "execution reverted". Now surfaces as \"EVM halt (OutOfGas) — gas_used=...; not a contract revert\".

## Verified post-deploy (mainnet h≈1,215,666, binary sha 1eec5f78cb4555f1)

- \`buy(0)\` with 1 SRX value: estimate \`0x4d8c7\` = 318,151 ✅ (was: empty revert)
- \`buy(0)\` no value: \`0x7c946ed7\` = ZeroValue selector ✅
- \`sell(1000, 0)\`: \`0x28b35f21\` = InsufficientReserve ✅
- \`WSRX.deposit()\` with value: \`0xcab1\` = 51,889 ✅
- Chain stable 4-of-4 advancing through deploy

## Test plan

- [x] Live mainnet binary verifies all of the above selectors
- [ ] Post-merge: tag v2.1.54 + push tag for release-tag parity