### PR TITLE
fix(rpc): eth_estimateGas EIP-150 buffer (v2.1.55)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "bincode",
  "hex",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "anyhow",
  "axum",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "anyhow",
  "axum",
@@ -5010,14 +5010,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5061,14 +5061,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "bincode",
  "blake3",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.54"
+version = "2.1.55"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -506,7 +506,21 @@ async fn eth_estimate_gas(params: &Value, state: &SharedState) -> DispatchResult
                 };
                 return Err((-32000, reason));
             }
-            Ok(json!(to_hex(receipt.gas_used)))
+            // EIP-150 buffer: revm's dry-run uses gas_limit=TX_GAS_LIMIT_CAP (16M),
+            // so sub-calls always get plenty of forwarded gas (63/64 rule). When the
+            // wallet then submits the tx at gas_limit=receipt.gas_used, every sub-call
+            // gets MUCH less forwarded gas — typically ~5000 short of what cold-account
+            // value-transfer CALLs need. CoinBlastCurve.buy() reproduced this exactly:
+            // dry-run returned 319_355, real apply with the same limit OOG'd inside
+            // _safeSendSRX(feeRecipient, fee).call{value:fee}("") and reverted with
+            // TransferFailed(). Geth applies a 1.30× multiplier; we use 1.25× +
+            // 30_000 floor — generous enough to cover cold-access overhead in any
+            // reasonable contract while not waste-billing simple transfers.
+            let buffered = receipt
+                .gas_used
+                .saturating_add(receipt.gas_used / 4)
+                .max(receipt.gas_used.saturating_add(30_000));
+            Ok(json!(to_hex(buffered)))
         }
         Err((code, msg)) => Err((code, msg)),
     }

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.54"
+version = "2.1.55"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

- Apply 1.25x + 30k floor buffer to eth_estimateGas return value
- Bump all 17 per-crate Cargo.toml 2.1.54 → 2.1.55

## Why

Real-world failure: a CoinBlastCurve.buy() tx reverted on mainnet (block 1217742) despite eth_estimateGas reporting success. Cause: dry-run runs at TX_GAS_LIMIT_CAP (16M) so sub-calls never starve, but the returned gas_used becomes the wallet's submitted gas_limit. At that limit, EIP-150's 63/64 forwarding leaves inner CALLs short of cold-account + value-transfer overhead. \`_safeSendSRX(feeRecipient, fee).call{value:fee}("")\` OOGs internally → returns ok=false → parent reverts with TransferFailed().

Empirical threshold: gas=319_355 (estimateGas result) → revert; gas=325_000 → success. Buffer of ~6k needed; 1.25x gives plenty of margin without overcharging.

Geth uses 1.30x. We use 1.25x + 30k floor.

## Test plan

- [x] cargo test -p sentrix-rpc --lib (26/26 pass)
- [x] cargo check -p sentrix-rpc (clean)
- [ ] Post-deploy: re-submit a value-bearing contract call with default wallet gas — confirm success