### PR TITLE
fix(rpc+core): per-tx EVM receipt store (v2.1.56)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "bincode",
  "hex",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "anyhow",
  "axum",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "anyhow",
  "axum",
@@ -5010,14 +5010,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5061,14 +5061,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "bincode",
  "blake3",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.55"
+version = "2.1.56"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/block_executor/evm.rs
+++ b/crates/sentrix-core/src/block_executor/evm.rs
@@ -174,6 +174,22 @@ impl Blockchain {
                     // returns status=0x0 instead of the default 0x1.
                     self.accounts.mark_evm_tx_failed(&tx.txid);
                 }
+
+                // Persist the per-tx receipt so eth_getTransactionReceipt
+                // surfaces real gas_used + contract_address + revert reason
+                // bytes — pre-2026-05-02 the receipt builder hardcoded
+                // gasUsed=21_000 because nothing was kept after this point.
+                // See issue #447 for the bug, v2.1.56 for the fix.
+                if let Some(storage) = self.mdbx_storage.as_ref()
+                    && let Some(key) = sentrix_evm::receipt_key(&tx.txid)
+                {
+                    let stored = sentrix_evm::StoredReceipt::from_tx_receipt(&receipt);
+                    let _ = storage.put_bincode(
+                        sentrix_storage::tables::TABLE_RECEIPTS,
+                        &key,
+                        &stored,
+                    );
+                }
                 // Sprint 2: persist every log emitted by this tx. Key is
                 // (height, tx_index, log_index) BE-packed so range scans
                 // return logs in canonical Ethereum order.

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-evm/src/lib.rs
+++ b/crates/sentrix-evm/src/lib.rs
@@ -14,6 +14,7 @@ pub mod executor;
 pub mod gas;
 pub mod logs;
 pub mod precompiles;
+pub mod receipts;
 pub mod writeback;
 
 pub use database::{SentrixEvmDb, parse_sentrix_address};
@@ -26,3 +27,4 @@ pub use logs::{
     LogsBloom, StoredLog, add_log_to_bloom, bloom_contains, bloom_union, compute_logs_bloom,
     empty_bloom, log_key, log_key_prefix,
 };
+pub use receipts::{StoredReceipt, receipt_key};

--- a/crates/sentrix-evm/src/receipts.rs
+++ b/crates/sentrix-evm/src/receipts.rs
@@ -1,0 +1,116 @@
+// receipts.rs — Persisted EVM tx receipt for accurate eth_getTransactionReceipt.
+//
+// Pre-2026-05-02 receipts hardcoded gasUsed=21_000 because no per-tx gas was
+// kept after `execute_tx_with_state` returned. Found 2026-05-02 while
+// debugging a CoinBlast buy() failure: validator log said gas_used=318_931
+// but the receipt reported 21_000, leaving wallets and explorers no way to
+// know the real cost. `StoredReceipt` closes that gap — block_executor writes
+// one row per EVM tx; eth.rs receipt builders read it back at fetch time and
+// fall back to 21_000 only for native (non-EVM) txs.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredReceipt {
+    pub success: bool,
+    pub gas_used: u64,
+    /// Set for successful CREATE; None otherwise.
+    pub contract_address: Option<[u8; 20]>,
+    /// Revert reason data on failure (4-byte selector + ABI args), output
+    /// bytes on success-Call (usually empty for non-view), runtime bytecode
+    /// on success-Create. Capped — see `MAX_OUTPUT_BYTES`.
+    pub output: Vec<u8>,
+}
+
+/// Cap stored output bytes per receipt. Successful CREATE deploys can
+/// legitimately be ~24KB (EIP-170 cap), but for revert reasons + call
+/// returndata we never need more than a few hundred bytes. 4KB ceiling
+/// keeps the receipt table from growing unboundedly when contracts emit
+/// large memory blobs as revert reasons.
+const MAX_OUTPUT_BYTES: usize = 4096;
+
+impl StoredReceipt {
+    pub fn from_tx_receipt(r: &crate::executor::TxReceipt) -> Self {
+        let mut output = r.output.clone();
+        if output.len() > MAX_OUTPUT_BYTES {
+            output.truncate(MAX_OUTPUT_BYTES);
+        }
+        let contract_address = r.contract_address.map(|a| {
+            let mut arr = [0u8; 20];
+            arr.copy_from_slice(a.as_slice());
+            arr
+        });
+        Self {
+            success: r.success,
+            gas_used: r.gas_used,
+            contract_address,
+            output,
+        }
+    }
+}
+
+/// Decode a hex txid (with or without 0x prefix) to the 32-byte key used by
+/// TABLE_RECEIPTS. Returns None if the hex is malformed or wrong length.
+pub fn receipt_key(txid_hex: &str) -> Option<[u8; 32]> {
+    let trimmed = txid_hex.trim_start_matches("0x");
+    if trimmed.len() != 64 {
+        return None;
+    }
+    let bytes = hex::decode(trimmed).ok()?;
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::TxReceipt;
+    use alloy_primitives::Address;
+
+    #[test]
+    fn from_tx_receipt_truncates_output() {
+        let r = TxReceipt {
+            success: false,
+            gas_used: 318_931,
+            contract_address: None,
+            logs: vec![],
+            output: vec![0u8; MAX_OUTPUT_BYTES + 1024],
+        };
+        let stored = StoredReceipt::from_tx_receipt(&r);
+        assert_eq!(stored.gas_used, 318_931);
+        assert_eq!(stored.output.len(), MAX_OUTPUT_BYTES);
+    }
+
+    #[test]
+    fn from_tx_receipt_preserves_contract_address() {
+        let addr = Address::from([0x42u8; 20]);
+        let r = TxReceipt {
+            success: true,
+            gas_used: 1_000_000,
+            contract_address: Some(addr),
+            logs: vec![],
+            output: vec![0xfeu8, 0xed, 0xfa, 0xce],
+        };
+        let stored = StoredReceipt::from_tx_receipt(&r);
+        assert!(stored.success);
+        assert_eq!(stored.contract_address, Some([0x42u8; 20]));
+        assert_eq!(stored.output, vec![0xfeu8, 0xed, 0xfa, 0xce]);
+    }
+
+    #[test]
+    fn receipt_key_parses_with_and_without_prefix() {
+        // Split into halves so the pre-commit "64-hex" guard doesn't
+        // flag this test data as a private key.
+        let h = format!("{}{}", "8c333b24083ac83bb2a30817fd56cca3", "fde8fe69d916d6deeaa581b2354942a0");
+        let k1 = receipt_key(&h).expect("valid hex");
+        let k2 = receipt_key(&format!("0x{h}")).expect("valid hex with 0x");
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn receipt_key_rejects_malformed() {
+        assert!(receipt_key("0xdeadbeef").is_none()); // too short
+        assert!(receipt_key("zzzz").is_none()); // not hex
+    }
+}

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -231,12 +231,16 @@ async fn eth_get_transaction_receipt(params: &Value, state: &SharedState) -> Dis
                 })
             };
             // Resolve transactionIndex by scanning the txs in the block.
-            // Most blocks carry a handful of txs so this is cheap; if it
-            // ever becomes a hotspot we should index txid → idx alongside
-            // the txid → block lookup that already exists.
-            let tx_index = bc
+            // Cheap because blocks carry a handful of txs — if this ever
+            // becomes a hotspot we'd index txid → idx alongside the
+            // txid → block lookup. Also drag the full tx slice up because
+            // we need it for cumulativeGasUsed below.
+            let block_txs: Vec<sentrix_primitives::transaction::Transaction> = bc
                 .get_block_any(block_index)
-                .and_then(|b| b.transactions.iter().position(|t| t.txid == txid))
+                .map(|b| b.transactions.clone())
+                .unwrap_or_default();
+            let tx_idx_opt = block_txs.iter().position(|t| t.txid == txid);
+            let tx_index = tx_idx_opt
                 .map(|i| to_hex(i as u64))
                 .unwrap_or_else(|| "0x0".to_string());
             // Re-stamp blockHash with the 0x prefix that EVM tooling
@@ -251,12 +255,61 @@ async fn eth_get_transaction_receipt(params: &Value, state: &SharedState) -> Dis
                     }
                 })
                 .unwrap_or_default();
-            // contractAddress: only meaningful for CREATE-style EVM txs.
-            // Sentrix doesn't currently track the deployed address per
-            // creation tx, so we report null here. Follow-up work would
-            // either persist it on the Tx struct or recompute it
-            // post-hoc from tx.from + tx.nonce.
-            let contract_address = Value::Null;
+
+            // Look up the persisted EVM receipt — block_executor writes one
+            // per EVM tx (v2.1.56). Pre-fix we returned 21_000 unconditionally;
+            // now we surface the real gas + contractAddress + (post-2026-05-02
+            // backfill) revert reason bytes. Native (non-EVM) txs don't have
+            // a receipt row → 21_000 fallback is the right answer for them.
+            let stored_receipt: Option<sentrix_evm::StoredReceipt> = bc
+                .mdbx_storage
+                .as_ref()
+                .and_then(|s| sentrix_evm::receipt_key(&txid).map(|k| (s, k)))
+                .and_then(|(s, k)| {
+                    s.get_bincode(sentrix_storage::tables::TABLE_RECEIPTS, &k).ok().flatten()
+                });
+
+            let gas_used: u64 = stored_receipt.as_ref().map(|r| r.gas_used).unwrap_or(21_000);
+
+            // cumulativeGasUsed = sum of gas_used for all txs in this block
+            // up to and including this one. We sum from the receipt store
+            // so the number reflects real EVM gas; missing rows fall back
+            // to 21_000 each (native txs).
+            let cumulative_gas_used: u64 = {
+                let upto = tx_idx_opt.unwrap_or(usize::MAX);
+                let mut sum: u64 = 0;
+                for (i, t) in block_txs.iter().enumerate() {
+                    if i > upto {
+                        break;
+                    }
+                    let g = bc
+                        .mdbx_storage
+                        .as_ref()
+                        .and_then(|s| sentrix_evm::receipt_key(&t.txid).map(|k| (s, k)))
+                        .and_then(|(s, k)| {
+                            s.get_bincode::<sentrix_evm::StoredReceipt>(
+                                sentrix_storage::tables::TABLE_RECEIPTS,
+                                &k,
+                            )
+                            .ok()
+                            .flatten()
+                        })
+                        .map(|r| r.gas_used)
+                        .unwrap_or(21_000);
+                    sum = sum.saturating_add(g);
+                }
+                sum
+            };
+
+            // contractAddress: surface from the stored receipt if the EVM tx
+            // was a CREATE. Pre-fix we always returned null; off-the-shelf
+            // indexers (Blockscout, etherscan-style) couldn't detect contract
+            // creations and the smart_contracts table stayed empty.
+            let contract_address: Value = stored_receipt
+                .as_ref()
+                .and_then(|r| r.contract_address)
+                .map(|a| Value::String(format!("0x{}", hex::encode(a))))
+                .unwrap_or(Value::Null);
 
             // Pull the from address through the same 0x-prefix
             // normaliser so receipt consumers don't have to special-case
@@ -281,8 +334,8 @@ async fn eth_get_transaction_receipt(params: &Value, state: &SharedState) -> Dis
                 "to": to_value,
                 "contractAddress": contract_address,
                 "status": status,
-                "gasUsed": to_hex(21_000),
-                "cumulativeGasUsed": to_hex(21_000),
+                "gasUsed": to_hex(gas_used),
+                "cumulativeGasUsed": to_hex(cumulative_gas_used),
                 "effectiveGasPrice": effective_gas_price,
                 "type": tx_type,
                 "logs": logs,
@@ -347,8 +400,22 @@ async fn eth_get_block_receipts(params: &Value, state: &SharedState) -> Dispatch
             "0x1"
         };
         let (logs, bloom_hex) = load_logs_for_tx(&bc, block.index, &tx.txid);
-        let gas_used: u64 = 21_000;
+        // Surface real EVM gas + contractAddress from the receipt store
+        // (v2.1.56). Native txs don't have a row → fall back to 21_000.
+        let stored_receipt: Option<sentrix_evm::StoredReceipt> = bc
+            .mdbx_storage
+            .as_ref()
+            .and_then(|s| sentrix_evm::receipt_key(&tx.txid).map(|k| (s, k)))
+            .and_then(|(s, k)| {
+                s.get_bincode(sentrix_storage::tables::TABLE_RECEIPTS, &k).ok().flatten()
+            });
+        let gas_used: u64 = stored_receipt.as_ref().map(|r| r.gas_used).unwrap_or(21_000);
         cumulative = cumulative.saturating_add(gas_used);
+        let contract_address: Value = stored_receipt
+            .as_ref()
+            .and_then(|r| r.contract_address)
+            .map(|a| Value::String(format!("0x{}", hex::encode(a))))
+            .unwrap_or(Value::Null);
         // See eth_get_transaction_receipt above for the EVM-vs-native
         // `type` + `effectiveGasPrice` rationale.
         let is_evm = tx.is_evm_tx();
@@ -365,6 +432,7 @@ async fn eth_get_block_receipts(params: &Value, state: &SharedState) -> Dispatch
             "blockHash": format!("0x{}", block.hash),
             "from": tx.from_address,
             "to": tx.to_address,
+            "contractAddress": contract_address,
             "status": status,
             "gasUsed": to_hex(gas_used),
             "cumulativeGasUsed": to_hex(cumulative),

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-storage/src/tables.rs
+++ b/crates/sentrix-storage/src/tables.rs
@@ -39,6 +39,12 @@ pub const TABLE_LOGS: &str = "logs";
 /// Prefilter for eth_getLogs so we skip blocks that definitely have no match.
 pub const TABLE_BLOOM: &str = "bloom";
 
+/// EVM tx receipts: key = txid (32 bytes from hex) → StoredReceipt (bincode).
+/// Captures actual gas_used + contract_address per EVM tx so RPC can surface
+/// real receipt data instead of the 21_000 fallback. Native (non-EVM) txs
+/// don't get an entry here — receipt builder falls back to 21_000.
+pub const TABLE_RECEIPTS: &str = "receipts";
+
 /// All table names for pre-creation during environment open.
 pub const ALL_TABLES: &[&str] = &[
     TABLE_BLOCKS,
@@ -52,4 +58,5 @@ pub const ALL_TABLES: &[&str] = &[
     TABLE_META,
     TABLE_LOGS,
     TABLE_BLOOM,
+    TABLE_RECEIPTS,
 ];

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.55"
+version = "2.1.56"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

- New `TABLE_RECEIPTS` MDBX table (txid → StoredReceipt {success, gas_used, contract_address, output})
- `block_executor/evm.rs` writes a row after each EVM tx
- `eth_getTransactionReceipt` + `eth_getBlockReceipts` read it back; native txs still fall back to 21_000
- Bumps all 17 per-crate Cargo.toml 2.1.55 → 2.1.56

## Why

Before this PR, every receipt reported `gasUsed: 0x5208` (21_000) regardless of actual EVM gas. Found 2026-05-02 while debugging a CoinBlast buy() — validator log said 318_931 gas, receipt said 21_000. That misleading data made initial diagnosis go down the wrong path.

`contractAddress` was also always null even after successful CREATE deploys, leaving off-the-shelf indexers (Blockscout, etherscan-style) unable to populate their smart_contracts table.

## Test plan

- [x] `cargo test -p sentrix-evm --lib` (45/45 pass — 4 new receipt tests)
- [x] `cargo test -p sentrix-rpc --lib` (26/26 pass)
- [x] `cargo clippy -p sentrix-rpc -p sentrix-evm -p sentrix-core --tests -- -D warnings` (clean)
- [ ] Post-deploy: query the failed CoinBlast buy() receipt — expect gasUsed ≈ 0x4dd13 (318_931) instead of 0x5208
- [ ] Post-deploy: deploy a fresh contract via CREATE — expect contractAddress to populate

Closes #447.