### PR TITLE
fix(rpc): pending-aware nonce (v2.1.57)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/mempool.rs
+++ b/crates/sentrix-core/src/mempool.rs
@@ -170,7 +170,11 @@ impl Blockchain {
         Ok(())
     }
 
-    fn mempool_pending_count(&self, address: &str) -> u64 {
+    /// Count of pending mempool txs from `address`. Public so the RPC layer
+    /// can surface `eth_getTransactionCount(addr, "pending")` correctly —
+    /// without it, faucets and dapps that need the next-usable nonce keep
+    /// signing with stale values and pile up un-includable txs.
+    pub fn mempool_pending_count(&self, address: &str) -> u64 {
         self.mempool
             .iter()
             .filter(|tx| tx.from_address == address)

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -44,8 +44,20 @@ pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) 
                 Ok(a) => a,
                 Err(e) => return Err((-32602, e.into())),
             };
+            // Standard EVM semantics for the second arg: `latest` returns
+            // the finalized account nonce; `pending` adds count of mempool
+            // entries from this account so the caller can sign the
+            // next-usable nonce. Without this distinction, faucets +
+            // dapps that fetched the nonce, signed, and submitted in
+            // quick succession would all sign the same nonce — chain
+            // accepted only the first, the rest piled up rejected
+            // mid-block. Live discovery 2026-05-02.
+            let block_tag = params[1].as_str().unwrap_or("latest");
             let bc = state.read().await;
-            let nonce = bc.accounts.get_nonce(&address);
+            let mut nonce = bc.accounts.get_nonce(&address);
+            if block_tag == "pending" {
+                nonce = nonce.saturating_add(bc.mempool_pending_count(&address));
+            }
             Ok(json!(to_hex(nonce)))
         }
         "eth_getBlockByNumber" => eth_get_block_by_number(params, state).await,

--- a/crates/sentrix-rpc/src/routes/accounts.rs
+++ b/crates/sentrix-rpc/src/routes/accounts.rs
@@ -37,8 +37,26 @@ pub(super) async fn get_nonce(
 ) -> Json<serde_json::Value> {
     let address = address.to_lowercase();
     let bc = state.read().await;
-    let nonce = bc.accounts.get_nonce(&address);
-    Json(serde_json::json!({ "address": address, "nonce": nonce }))
+    // Return the *pending-aware* nonce — finalized account nonce plus the
+    // number of in-mempool txs from this account. Callers who fetch this
+    // and immediately sign expect it to be the next-usable value; the
+    // pure finalized nonce caused a class of bugs where same-IP back-to-
+    // back claims (faucet, automated dapps) all signed the same nonce,
+    // chain accepted the first and rejected every later one with
+    // "Invalid nonce: expected N+1, got N". Live discovery 2026-05-02.
+    //
+    // `nonce_finalized` is exposed alongside so callers that genuinely
+    // want the finalized value (e.g. block explorers showing tx count)
+    // still have it without an extra round-trip.
+    let nonce_finalized = bc.accounts.get_nonce(&address);
+    let pending = bc.mempool_pending_count(&address);
+    let nonce = nonce_finalized.saturating_add(pending);
+    Json(serde_json::json!({
+        "address": address,
+        "nonce": nonce,
+        "nonce_finalized": nonce_finalized,
+        "pending": pending,
+    }))
 }
 
 pub(super) async fn get_wallet_info(

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.56"
+version = "2.1.57"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

eth_getTransactionCount now respects the `latest` / `pending` block tag
distinction; /accounts/X/nonce REST returns pending-aware by default
(plus exposes finalized + pending counts alongside).

## Why

Live discovery 2026-05-02: faucet calls `/accounts/X/nonce` before
signing each drip. Concurrent claims for distinct recipients all read
the same finalized nonce, signed it, and the chain accepted only the
first — every later one bounced with `Invalid nonce: expected N+1,
got N` and the mempool filled with un-includable txs.

Same root cause means standard wagmi/viem clients can't queue
back-to-back txs via `eth_getTransactionCount(addr, 'pending')`
because we were returning the finalized value for both block tags.

## Test plan

- [x] cargo test -p sentrix-rpc --lib (26/26 pass)
- [x] cargo test -p sentrix-core --lib (209/209 pass)
- [ ] Post-deploy: faucet claims for two distinct addresses in
      <1s back-to-back both succeed
- [ ] Post-deploy: eth_getTransactionCount(addr, 'pending') returns
      finalized + pending count