### PR TITLE
fix(core): block proposer skips stale-nonce mempool txs (v2.1.58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,75 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.1.56] — 2026-05-02 — Per-tx EVM receipt persistence
+
+> `eth_getTransactionReceipt` was returning a synthetic minimal receipt because the EVM dispatch path didn't persist the per-tx outcome — gas used was always the block-aggregate, `contractAddress` was always null even on `CREATE`, and revert reasons were dropped. Indexers + block explorers had to re-execute every tx via `eth_call` to reconstruct what really happened. This release writes a real receipt row per tx alongside the block commit, and the RPC now reads from it.
+
+### Fixed
+
+- **`crates/sentrix-core` + `sentrix-rpc`** — persist per-tx EVM receipts at apply-time and surface them through `eth_getTransactionReceipt`. Real `gasUsed`, real `contractAddress` for `CREATE`, real `status`, real `logs[]` per-tx (not block-aggregate). Receipts ride the same MDBX write batch as the block, so a half-applied block can't leave a receipt orphan.
+
+---
+
+## [2.1.55] — 2026-05-02 — eth_estimateGas EIP-150 buffer
+
+### Fixed
+
+- **`crates/sentrix-rpc`** — `eth_estimateGas` was returning the raw used-gas figure from the dry-run, which then failed under EIP-150's 63/64 rule when the wallet submitted at exactly that limit. Add the standard 1.1× safety multiplier + ceiling cap at the block gas limit. Wallets that probed via `estimateGas` then sent at the returned value now mine first try.
+
+---
+
+## [2.1.54] — 2026-05-02 — Dry-run value-threading + revert reason surfacing
+
+### Fixed
+
+- **`crates/sentrix-rpc` + `sentrix-evm`** — `eth_call` and `eth_estimateGas` weren't threading `value` through to the dry-run `TxEnv`, so balance-conditional reverts (`require(msg.value > 0)` etc.) returned success for value-bearing simulations. Same shape as the v2.1.49 mainnet bug, but on the read path. Now: dry-run TxEnv carries `value` end-to-end; revert reasons + halt reasons (`OutOfGas`, `Revert(...)`, `OpcodeNotFound`) surface in the RPC response instead of bare "execution reverted".
+
+---
+
+## [2.1.51] — 2026-05-02 — MDBX explicit map size + growth step
+
+> Validators were hitting `MDBX_MAP_FULL` crash-loops on disk pressure earlier in the week even when free disk was available — MDBX's default geometry was too small for our chain.db trajectory + didn't auto-grow aggressively enough.
+
+### Fixed
+
+- **`crates/sentrix-storage`** — explicit `max_size` + `growth_step` on MDBX env open, sized for the projected chain growth + headroom. Closes the class of "MDBX_MAP_FULL with free disk" failures (the disk-full-from-forensic-backups class is operator-side; see `feedback_check_before_ops_execute` ops memory).
+
+### Internal
+
+- **All workspace + per-crate Cargo.toml** — bumped `version = "2.1.48" → "2.1.50"` to catch up the per-crate manifests that were left behind during the v2.1.49 emergency cut.
+
+---
+
+## [2.1.50] — 2026-05-02 — EVM value-transfer fork gate
+
+> v2.1.49 fixed the EVM value-transfer drop (`TxEnv` was missing `.value(...)`, all value-bearing txs silently zero-credited). But v2.1.49 applied the fix unconditionally, which would have re-executed every pre-fix block with the corrected semantics — i.e. every value-bearing tx between the EVM activation height and the v2.1.49 deploy height would have credited differently on replay → state-root divergence vs the canonical chain. This release puts the value-threading behind a fork gate so historical replay reproduces the historical (broken) execution exactly, and only post-fork blocks get the fix.
+
+### Fixed
+
+- **`crates/sentrix-evm` + `sentrix-core::block_executor`** — wrap the v2.1.49 `TxEnv::builder().value(tx_value)` change in a fork-height check. Fork height set forward of the deploy block so all four mainnet validators cross simultaneously after the binary swap. Pre-fork: `TxEnv.value = U256::ZERO` (matches v2.1.x ≤ 48 historical execution). Post-fork: `TxEnv.value = envelope.value()`.
+
+### Documentation
+
+- **Public copy audit** — overclaim sweep across landing + docs + whitepaper. Removes any phrasing that fabricates audit counts, partner names, or future dates. Tone re-anchored to the "real chain real blocks real code" line.
+
+---
+
+## [2.1.49] — 2026-05-01 — EVM value-transfer drop FIXED
+
+> All value-bearing EVM txs since the EVM activation height (mainnet h=579060) were silently dropping their value at the boundary between the native fee debit and the revm execute call. `cast send --value Nether <addr>` and `WSRX.deposit{value:Nether}()` reported `status=1` but the recipient never saw the wei. Both WSRX contracts had `totalSupply == 0` since deploy. Audit doc: `audits/2026-05-01-evm-value-transfer-bug.md`.
+
+### Fixed
+
+- **`crates/sentrix-core::block_executor::execute_evm_tx_in_block`** — was building `revm::TxEnv` from the decoded RLP envelope but never setting `.value(...)`. Default `U256::ZERO` made revm execute every value-bearing tx with `tx.value = 0`. The native fee debit happened in Pass-1 (`charge_fee_only`) but the value-of-tx never reached revm. PR #439, ~12 lines: bring `alloy_consensus::Transaction` into scope, extract `envelope.value()`, pass to `TxEnv::builder().value(tx_value)`. 244 unit tests across `sentrix-core` (207) + `sentrix-evm` (37) still green; no regressions for `value=0` txs.
+- **Clippy**: collapse if-let-with-condition in the v2.1.48 BFT FinalizeBlock guard (PR #438). Cosmetic only.
+
+### Operational
+
+- **WSRX deployments stay broken** until users re-deposit post-fix. Pre-v2.1.50 the fix executed retroactively — see v2.1.50 for the fork-gate that scopes this to post-fork blocks only.
+
+---
+
 ## [2.1.48] — 2026-04-30 — BFT FinalizeBlock hash-mismatch guard (closes recurring chain.db divergence)
 
 > **Closes the recurring chain.db divergence bug** that produced the ~30-min mainnet halts at h=773012 (vps5, 2026-04-28), h=921604 + h=932488 (2026-04-29), and h=1014804 + h=1015365 (2026-04-30, twice in one day). The audit at `audits/2026-04-30-eager-write-investigation.md` traces the actual mechanism: BFT engine's `FinalizeBlock` action carried the supermajority `block_hash` for the round, but the validator-loop handler discarded it (`block_hash: _`) and `.take()`'d whatever was stashed in `proposed_block`. If the validator missed the actual round-N proposal but the cluster's round-N precommits crossed our local supermajority threshold, we'd write a stale stash (a previous round's block) attached to the current round's justification. Next height's `parent_hash` references the cluster-canonical hash; our local height's hash doesn't match; libp2p sync rejects forward blocks with `Invalid block: invalid previous hash`; BFT can't progress. Recovery required chain.db rsync from a canonical peer + halt-all + simul-start.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "bincode",
  "hex",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "anyhow",
  "axum",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "anyhow",
  "axum",
@@ -5010,14 +5010,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5061,14 +5061,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "bincode",
  "blake3",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.56"
+version = "2.1.58"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # Sentrix
 
-**Where real assets live.**
+**Open source, EVM-compatible L1 built in Rust.**
 
-Sentrix is the financial infrastructure for the real economy — starting with Indonesia. We bring real-world assets on-chain with Bitcoin's monetary discipline (fixed 315M supply, 4-year halving) and Ethereum's programmability (EVM-native, Solidity-ready) — built for Southeast Asia's 600 million people first, then the world.
+Real chain, real blocks, real code. 1-second blocks, BFT finality, MetaMask-compatible. Built in Indonesia, BUSL-1.1 licensed.
 
 [![Website](https://img.shields.io/badge/website-sentrixchain.com-8A5A11)](https://sentrixchain.com)
 [![CI/CD](https://github.com/sentrix-labs/sentrix/actions/workflows/ci.yml/badge.svg)](https://github.com/sentrix-labs/sentrix/actions)
 [![Release](https://img.shields.io/github/v/release/sentrix-labs/sentrix)](https://github.com/sentrix-labs/sentrix/releases/latest)
-[![Tests](https://img.shields.io/badge/tests-700%2B%20passing-brightgreen)](https://github.com/sentrix-labs/sentrix/actions)
 [![Rust](https://img.shields.io/badge/rust-stable-orange)](Cargo.toml)
 [![Chain ID](https://img.shields.io/badge/chain%20ID-7119-blue)](docs/operations/NETWORKS.md)
 [![License](https://img.shields.io/badge/license-BUSL--1.1-purple)](LICENSE)
-[![Whitepaper](https://img.shields.io/badge/whitepaper-v1.2.4-8A5A11)](https://github.com/sentrix-labs/whitepaper)
+[![Whitepaper](https://img.shields.io/badge/whitepaper-v1.3.0-8A5A11)](https://github.com/sentrix-labs/whitepaper)
 
 ---
 
 ## What is Sentrix?
 
-Sentrix (SRX) is a purpose-built Layer-1 blockchain with 1-second block times, instant finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and web3.js connect natively. The chain serves as a settlement and tokenization layer for real-world assets — designed to bring institutional-grade financial primitives on-chain with the monetary discipline of Bitcoin and the programmability of Ethereum.
+Sentrix (SRX) is a Layer-1 blockchain with 1-second block times, BFT finality, and Ethereum-compatible tooling. MetaMask, ethers.js, and viem/wagmi connect natively. Solidity contracts deploy via Foundry / Hardhat / Remix. Native staking + slashing live on mainnet. Sentrix is a generic L1 — what gets built on top is up to whoever ships first.
 
-- **v2.1.48** — BFT FinalizeBlock hash-mismatch guard (closes recurring chain.db divergence). Plus the v2.1.47 set: MDBX storage, 1s blocks, 5000 tx/block capacity, Voyager DPoS+BFT live on mainnet, EVM (revm 38) with `eth_call` wired to revm execution against real chain state, V4 reward distribution v2 active, **tokenomics v2 fork ACTIVE on mainnet since h=640800** (BTC-parity 4-year halving + 315M cap), `StakingOp::AddSelfStake` ACTIVE since h=731245, libp2p sync race-safe
-- **700+ tests**, clippy clean, 11 security audit rounds
-- **4 validators** across 4 nodes (Foundation, Treasury, Core, Beacon) on the maintainer fleet
+- **Latest**: `v2.1.56` — per-tx EVM receipt persistence so `eth_getTransactionReceipt` returns real `gasUsed` + `contractAddress` + revert reasons. See [CHANGELOG.md](CHANGELOG.md) for the v2.1.49 → v2.1.56 fix train (EVM value-transfer drop, MDBX geometry, dry-run plumbing).
+- **Consensus**: Voyager DPoS+BFT live on mainnet (4-of-4 validators), 1s blocks, 5000 tx/block capacity, V4 reward v2 + tokenomics v2 forks ACTIVE.
+- **Storage**: MDBX (memory-mapped B+ tree, same as Reth/Erigon). Binary Sparse Merkle Tree (BLAKE3 + SHA-256) for state, with proofs.
+- **EVM**: revm 38, `eth_call` wired to revm execution against real chain state, fork-gated value-threading (post v2.1.50).
+- **Tests**: 700+ unit tests across the workspace, clippy clean.
 
 ## Features
 
@@ -114,7 +115,7 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 | Phase | Status | Focus |
 |-------|--------|-------|
 | **Pioneer** | Completed (mainnet h=0…579058) | PoA round-robin, MDBX storage, 1s blocks, SRC-20 tokens — succeeded by Voyager 2026-04-25 |
-| **Voyager** | **Live on mainnet (v2.1.48)** | DPoS proposer rotation + BFT finality, EVM (revm 38) with `eth_call` against real chain state, `eth_sendRawTransaction`, L1 peer auto-discovery + connection-limits hardening, V4 reward distribution v2 (treasury escrow + ClaimRewards), runtime-aware Voyager dispatch, race-safe block sync, tokenomics v2 fork (315M cap + 4-year halving), `StakingOp::AddSelfStake` for non-phantom validator self-bond |
+| **Voyager** | **Live on mainnet (v2.1.56)** | DPoS proposer rotation + BFT finality, EVM (revm 38) with `eth_call` against real chain state + fork-gated value-threading, `eth_sendRawTransaction`, L1 peer auto-discovery + connection-limits hardening, V4 reward distribution v2 (treasury escrow + ClaimRewards), runtime-aware Voyager dispatch, race-safe block sync, tokenomics v2 fork (315M cap + 4-year halving), `StakingOp::AddSelfStake` for non-phantom validator self-bond, per-tx EVM receipt persistence |
 | **Frontier** | Phase F-1 scaffold landed; F-2…F-10 planned | Parallel transaction execution, sub-1s block time, mainnet hard fork |
 | **Odyssey** | Future | Cross-chain bridges, mature ecosystem, light clients |
 
@@ -132,7 +133,7 @@ bin/sentrix/              CLI binary (main.rs at bin/sentrix/src/main.rs)
 
 See [SECURITY.md](SECURITY.md) for vulnerability reporting.
 
-11 audit rounds completed (116 findings, 78+ fixed). Pentest 6/6 passed on live network.
+Internal review pass on every release; published audit reports live in [docs/security/](docs/security/). External audits not yet engaged — track real coverage there, no fabricated counts.
 
 ## Contributing
 

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/block_producer.rs
+++ b/crates/sentrix-core/src/block_producer.rs
@@ -71,7 +71,37 @@ impl Blockchain {
         // 21_000 so they still participate in the accumulator.
         let take = self.mempool.len().min(MAX_TX_PER_BLOCK - 1);
         let mut current_gas_used: u64 = 0;
+        // Track per-sender expected nonce as we walk the queue so a
+        // sender with multiple txs in flight contributes them in order
+        // (n, n+1, n+2…) without us needing to re-fetch from the
+        // accounts map each time. Starting value is the on-chain
+        // nonce; we bump it as we include each tx from that sender.
+        use std::collections::HashMap;
+        let mut next_nonce_per_sender: HashMap<String, u64> = HashMap::new();
         for tx in self.mempool.iter().take(take) {
+            // Skip stale-nonce txs at proposal time. A tx with nonce
+            // strictly less than the chain's expected nonce will fail
+            // pre-validate (`Invalid nonce: expected N, got M`) and
+            // sink the entire block — every validator rejects, BFT
+            // can't finalize, the chain stalls. Live discovery
+            // 2026-05-02: a single stuck nonce-5 tx (whose sender's
+            // account was already at nonce 7) repeatedly poisoned
+            // proposals until manual `mempool clear` recovery. Pull
+            // expected nonce on first sight, bump as we include
+            // subsequent txs from the same sender.
+            let expected_nonce = *next_nonce_per_sender
+                .entry(tx.from_address.clone())
+                .or_insert_with(|| self.accounts.get_nonce(&tx.from_address));
+            if tx.nonce < expected_nonce {
+                continue;
+            }
+            // Future-nonce gap (tx.nonce > expected) means a same-
+            // sender lower-nonce tx must come first; skip until the
+            // gap closes naturally on a later proposal.
+            if tx.nonce > expected_nonce {
+                continue;
+            }
+
             let tx_gas = if tx.is_evm_tx() {
                 tx.data
                     .split(':')
@@ -86,6 +116,10 @@ impl Blockchain {
                 break;
             }
             current_gas_used = current_gas_used.saturating_add(tx_gas);
+            // Bump per-sender expected nonce so the next tx from the
+            // same sender (already validated to be tx.nonce + 1 by
+            // mempool admission) lines up on inclusion.
+            next_nonce_per_sender.insert(tx.from_address.clone(), expected_nonce + 1);
             transactions.push(tx.clone());
         }
 

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.56"
+version = "2.1.58"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -83,8 +83,9 @@ Configures GitHub Pages serving from `gh-pages` branch.
 
 ## Brand
 
-- Tagline: **"Where real assets live."**
-- Primary positioning: locked-in 2026-04-26 (internal brand-positioning doc)
+- Tagline: **"Open source, EVM-compatible L1 built in Rust."**
+- Hero lead: "Real chain, real blocks, real code."
+- Indonesia mentioned only as factual origin — no "Indonesia first" framing, no RWA framing until signed partnerships.
 - Logo source: [github.com/sentrix-labs/brand-kit](https://github.com/sentrix-labs/brand-kit)
 
 ## Maintenance


### PR DESCRIPTION
Mainnet recovery from the 2026-05-02 stall. Proposer-side guard so a stale-nonce mempool tx can't poison every proposal. Tests: 209/209 pass.