### PR TITLE
feat(node): bump BFT message-channel buffers + channel-depth watchdog metric (v2.1.61)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "bincode",
  "hex",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "anyhow",
  "axum",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "anyhow",
  "axum",
@@ -5010,14 +5010,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5061,14 +5061,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "bincode",
  "blake3",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.60"
+version = "2.1.61"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1295,7 +1295,17 @@ async fn cmd_start(
 
     let shared: SharedState = Arc::new(RwLock::new(bc));
 
-    let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<NodeEvent>(256);
+    // Capacity 4096 (was 256). Each NodeEvent is at most a few hundred
+    // bytes (BftPrevote/BftPrecommit are tiny, NewBlock is the largest)
+    // so the worst-case memory footprint is on the order of MB, far
+    // cheaper than the cost of a BFT-message backpressure stall. A 4-
+    // validator cluster issuing prevote+precommit per block at 1 block/s
+    // tops out at ~12 messages/s here; 256 slots covered ~20s of stall,
+    // 4096 covers ~5 min — long enough to ride out any reasonable
+    // validator-loop pause without losing the await-based send semantics
+    // that BFT requires (dropped votes destabilise consensus more than
+    // backpressure does).
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<NodeEvent>(4096);
 
     // ── P2P: libp2p TCP + Noise + Yamux ─────────────────
     println!("P2P transport: libp2p (Noise encrypted)");
@@ -1363,8 +1373,15 @@ async fn cmd_start(
     let shutdown_flag = Arc::new(AtomicBool::new(false));
 
     // BFT event channel — forwards P2P BFT votes from event handler to validator loop
+    // Same 4096 capacity rationale as event_tx above. This is the
+    // event-handler → validator-loop hop; when validator pauses (e.g.
+    // long write lock during epoch boundary processing), incoming BFT
+    // messages buffer here. 256 slots was tight enough that a slow
+    // finalize would stall the event handler trying to forward;
+    // 4096 gives enough margin that the validator's heartbeat watchdog
+    // catches a truly stuck loop before this channel saturates.
     let (bft_tx, bft_rx) =
-        tokio::sync::mpsc::channel::<sentrix::core::bft_messages::BftMessage>(256);
+        tokio::sync::mpsc::channel::<sentrix::core::bft_messages::BftMessage>(4096);
 
     // BFT engine watchdog — heartbeat counter incremented at the top of
     // every validator-loop iteration; a separate task panics + aborts
@@ -1389,13 +1406,27 @@ async fn cmd_start(
     if validator.is_some() {
         let heartbeat = validator_heartbeat.clone();
         let shutdown = shutdown_flag.clone();
+        // Capture sender handles so the watchdog can also surface channel
+        // depth — `Sender::capacity()` returns free slots, max - free =
+        // depth. If a backpressure stall is what's wedging the validator
+        // loop, this gives us the smoking gun without waiting for the
+        // 60s abort threshold.
+        let event_tx_for_watchdog = event_tx.clone();
+        let bft_tx_for_watchdog = bft_tx.clone();
         tokio::spawn(async move {
             use tokio::time::{Duration, sleep};
             const STALL_THRESHOLD: Duration = Duration::from_secs(60);
             const WARN_THRESHOLD: Duration = Duration::from_secs(20);
             const TICK: Duration = Duration::from_secs(5);
+            // Channel-depth observability: log every CHANNEL_GAUGE_TICK
+            // even on a healthy chain so we have a baseline to diff
+            // against when something goes wrong. Pressure threshold is
+            // 25% — well below saturation but distinct from idle noise.
+            const CHANNEL_GAUGE_TICK: Duration = Duration::from_secs(30);
+            const CHANNEL_PRESSURE_PCT: usize = 25;
             let mut last_seen = heartbeat.load(Ordering::Acquire);
             let mut last_changed = tokio::time::Instant::now();
+            let mut last_gauge = tokio::time::Instant::now();
             loop {
                 sleep(TICK).await;
                 if shutdown.load(Ordering::Acquire) {
@@ -1405,27 +1436,58 @@ async fn cmd_start(
                 if current != last_seen {
                     last_seen = current;
                     last_changed = tokio::time::Instant::now();
-                    continue;
+                } else {
+                    let stale = last_changed.elapsed();
+                    if stale >= STALL_THRESHOLD {
+                        let event_depth = event_tx_for_watchdog.max_capacity()
+                            - event_tx_for_watchdog.capacity();
+                        let bft_depth = bft_tx_for_watchdog.max_capacity()
+                            - bft_tx_for_watchdog.capacity();
+                        tracing::error!(
+                            target: "validator_watchdog",
+                            "FATAL: validator loop heartbeat stale for {}s (counter={}, \
+                             event_tx_depth={}/{}, bft_tx_depth={}/{}) \
+                             — BFT engine wedged. Aborting so systemd restarts cleanly.",
+                            stale.as_secs(), current,
+                            event_depth, event_tx_for_watchdog.max_capacity(),
+                            bft_depth, bft_tx_for_watchdog.max_capacity(),
+                        );
+                        std::process::abort();
+                    } else if stale >= WARN_THRESHOLD {
+                        tracing::warn!(
+                            target: "validator_watchdog",
+                            "validator loop heartbeat stale for {}s (counter={}) — \
+                             abort threshold {}s",
+                            stale.as_secs(), current, STALL_THRESHOLD.as_secs(),
+                        );
+                    }
                 }
-                let stale = last_changed.elapsed();
-                if stale >= STALL_THRESHOLD {
-                    tracing::error!(
-                        target: "validator_watchdog",
-                        "FATAL: validator loop heartbeat stale for {}s (counter={}) \
-                         — BFT engine wedged. Aborting so systemd restarts cleanly.",
-                        stale.as_secs(),
-                        current,
-                    );
-                    std::process::abort();
-                } else if stale >= WARN_THRESHOLD {
-                    tracing::warn!(
-                        target: "validator_watchdog",
-                        "validator loop heartbeat stale for {}s (counter={}) — \
-                         abort threshold {}s",
-                        stale.as_secs(),
-                        current,
-                        STALL_THRESHOLD.as_secs(),
-                    );
+
+                // Channel-depth gauge — independent of heartbeat staleness so
+                // we see backpressure forming even when the loop is still
+                // making progress (just slower than the producer).
+                if last_gauge.elapsed() >= CHANNEL_GAUGE_TICK {
+                    last_gauge = tokio::time::Instant::now();
+                    let event_max = event_tx_for_watchdog.max_capacity();
+                    let bft_max = bft_tx_for_watchdog.max_capacity();
+                    let event_depth = event_max - event_tx_for_watchdog.capacity();
+                    let bft_depth = bft_max - bft_tx_for_watchdog.capacity();
+                    let event_pct = event_depth * 100 / event_max.max(1);
+                    let bft_pct = bft_depth * 100 / bft_max.max(1);
+                    if event_pct >= CHANNEL_PRESSURE_PCT || bft_pct >= CHANNEL_PRESSURE_PCT {
+                        tracing::warn!(
+                            target: "channel_depth",
+                            "backpressure: event_tx={}% ({}/{}) bft_tx={}% ({}/{})",
+                            event_pct, event_depth, event_max,
+                            bft_pct, bft_depth, bft_max,
+                        );
+                    } else {
+                        tracing::debug!(
+                            target: "channel_depth",
+                            "event_tx={}/{} bft_tx={}/{}",
+                            event_depth, event_max, bft_depth, bft_max,
+                        );
+                    }
                 }
             }
         });

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.60"
+version = "2.1.61"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Margin + observability follow-up to v2.1.60. Two adjustments from the deep-audit punch-list.

### Channel capacity 256 → 4096

\`event_tx\` (libp2p → event-handler) and \`bft_tx\` (event-handler → validator) buffers raised to 4096. The 256 ceiling covered ~20s of validator-loop pause at 12 BFT msgs/s; longer pauses started backpressure-cascading into libp2p (the worst case the deep audit flagged). 4096 covers ~5 min — past the 60s validator-watchdog abort threshold, so the heartbeat catches a real stall before the channel ever saturates.

Memory cost: ~MB. Cheap insurance.

### Channel-depth watchdog metric

The watchdog now also gauges channel depth on a 30s tick:
- WARN target \`channel_depth\` when either channel ≥ 25% full
- DEBUG when below
- On FATAL abort, dumps depth alongside heartbeat counter

If backpressure ever IS the cause of a future stall, the gauge surfaces it without waiting for an outage.

## What's NOT shipped

- Cosmetic refactor to shorten FinalizeBlock write-lock hold (audit punch-list #1) — lock-hold is sync-only with no nested awaits, not a deadlock surface, just a long-ish CPU window. Consensus-touching cosmetic churn with no actual bug to fix; ships separately if at all.
- \`try_send\` + drop on bft_tx (punch-list #2) — drop semantics riskier than the backpressure they're meant to prevent (losing prevotes/precommits destabilises BFT more than a momentary stall does). Capacity bump above is the safer way to widen the same window.

## Test plan

- [x] All 209 sentrix-core tests pass.
- [x] Deployed to mainnet 2026-05-04 via fast-deploy halt-all+simul-start.
- [x] Chain advanced post-restart (h=1,354,571 → 1,354,581 = +10 blocks).
- [x] All 4 validators on v2.1.61.