### PR TITLE
fix(network): swarm-task watchdog — abort on libp2p select!-loop stall (v2.1.66)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "bincode",
  "hex",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "anyhow",
  "axum",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "anyhow",
  "axum",
@@ -5010,14 +5010,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5061,14 +5061,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "bincode",
  "blake3",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.65"
+version = "2.1.66"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -19,6 +19,26 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// the 2026-04-26 mainnet stall (h=604547).
 static SYNC_SKIPPED_TOTAL: AtomicU64 = AtomicU64::new(0);
 
+/// 2026-05-05 v2.1.66: swarm-task progress counter. Incremented on
+/// every iteration of the run_swarm select! loop. Read by a separate
+/// watchdog tokio task — if the counter stays still for ≥30 s, the
+/// swarm task is wedged (most likely on `event_tx.send().await` if
+/// the validator-loop consumer is stuck, or on internal libp2p
+/// state-machine deadlock) and we trigger `std::process::abort()` so
+/// systemd `Restart=always` cycles cleanly without MDBX corruption.
+///
+/// Same pattern as the v2.1.60 heartbeat watchdog and v2.1.62 chain-
+/// height watchdog. Closes the silent-thread-death class observed at
+/// h=1392113 (2026-05-05 morning) and h=1398998 (2026-05-05 afternoon)
+/// where vps1's libp2p went unresponsive while the validator main
+/// loop kept ticking — peers' BFT prevote/precommit/proposal/round-
+/// status all timed out outbound to vps1 (`outbound failure to
+/// 12D3KooWSZ...JJE: Timeout while waiting for a response`) and the
+/// cluster lost a voter without any local signal that vps1 should
+/// restart. With this watchdog vps1 will self-abort + cycle back via
+/// systemd before the cluster crosses the quorum threshold.
+pub static SWARM_TICK: AtomicU64 = AtomicU64::new(0);
+
 /// 2026-05-05 v2.1.65: cumulative count of broadcasts dropped because
 /// the swarm cmd_tx channel was full (try_send → TrySendError::Full).
 /// This is the silent-thread-death root cause from h=1392113 on
@@ -514,6 +534,50 @@ async fn run_swarm(
     // Periodic Kademlia bootstrap: every 60s, random walk to discover new peers.
     let mut kad_interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
 
+    // 2026-05-05 v2.1.66: spawn the swarm-task watchdog. It reads
+    // SWARM_TICK every 5 s; if the counter stays still for ≥30 s past
+    // the startup grace, the swarm select! loop has wedged and we
+    // abort. sync_interval (30 s) and kad_interval (60 s) ticks alone
+    // keep SWARM_TICK incrementing during quiet periods so we don't
+    // false-positive on a chain with no traffic.
+    tokio::spawn(async move {
+        use tokio::time::{Duration, sleep, Instant as TokioInstant};
+        const STALL_THRESHOLD: Duration = Duration::from_secs(30);
+        const STARTUP_GRACE: Duration = Duration::from_secs(60);
+        const TICK: Duration = Duration::from_secs(5);
+
+        let started = TokioInstant::now();
+        let mut last_seen = SWARM_TICK.load(Ordering::Acquire);
+        let mut last_changed = TokioInstant::now();
+        loop {
+            sleep(TICK).await;
+            // Honour startup grace — peer mesh + identify handshakes +
+            // initial gossipsub mesh formation can take >30 s on cold
+            // start. Reset the baseline during this window.
+            if started.elapsed() < STARTUP_GRACE {
+                last_seen = SWARM_TICK.load(Ordering::Acquire);
+                last_changed = TokioInstant::now();
+                continue;
+            }
+            let current = SWARM_TICK.load(Ordering::Acquire);
+            if current != last_seen {
+                last_seen = current;
+                last_changed = TokioInstant::now();
+            } else if last_changed.elapsed() >= STALL_THRESHOLD {
+                tracing::error!(
+                    target: "swarm_watchdog",
+                    "FATAL: libp2p swarm task stalled — no select!-loop progress \
+                     for {}s (counter={}). Aborting cleanly so systemd restarts \
+                     (closes silent-thread-death class at h=1392113 / h=1398998 \
+                     where libp2p went unresponsive while validator main loop \
+                     kept ticking).",
+                    last_changed.elapsed().as_secs(), current,
+                );
+                std::process::abort();
+            }
+        }
+    });
+
     loop {
         tokio::select! {
             // ── Commands from the LibP2pNode handle ──────
@@ -700,6 +764,15 @@ async fn run_swarm(
                 let _ = swarm.behaviour_mut().kademlia.bootstrap();
             }
         }
+
+        // 2026-05-05 v2.1.66: signal swarm-task progress to watchdog.
+        // After every select! branch fires (cmd / event / sync_interval
+        // / kad_interval), bump the counter. If the loop wedges in any
+        // .await inside a branch (event_tx.send back-pressure being the
+        // most likely real cause), the counter stops advancing and the
+        // watchdog spawned at the top of run_swarm will fire SIGABRT
+        // after STALL_THRESHOLD seconds.
+        SWARM_TICK.fetch_add(1, Ordering::Release);
     }
 
     Ok(())

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.65"
+version = "2.1.66"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Closes silent-thread-death class observed at h=1392113 + h=1398998 on 2026-05-05 where libp2p went unresponsive while validator main loop kept ticking. Conservative self-healing wrapper — does not diagnose the underlying libp2p wedge but ensures wedged validators self-abort + cycle via systemd before quorum is lost.

See commit message for full RCA + implementation notes.

Test plan:
- [x] cargo check -p sentrix-node --release (clean)
- [ ] cluster behaviour under load (mainnet rolling deploy after Docker build)