### PR TITLE
fix(network): event_tx try_send + DROPPED counter — close swarm-task wedge (v2.1.67)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "bincode",
  "hex",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "anyhow",
  "axum",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "anyhow",
  "axum",
@@ -5010,14 +5010,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5061,14 +5061,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "bincode",
  "blake3",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.66"
+version = "2.1.67"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -19,6 +19,28 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// the 2026-04-26 mainnet stall (h=604547).
 static SYNC_SKIPPED_TOTAL: AtomicU64 = AtomicU64::new(0);
 
+/// 2026-05-05 v2.1.67: cumulative count of NodeEvents dropped because
+/// `event_tx` was full when the swarm task tried to forward an inbound
+/// BFT message (Proposal / Prevote / Precommit / RoundStatus) to the
+/// event-handling task. Pre-v2.1.67 the swarm task used
+/// `event_tx.send(...).await` which BLOCKED until the consumer drained
+/// — that pattern wedged the entire swarm task whenever the validator
+/// main loop fell behind, producing the silent-halt class observed
+/// at h=1,400,218 (2026-05-05 afternoon) where vps5's prevote was
+/// never broadcast despite the BFT engine producing the BroadcastPrevote
+/// action and `DROPPED_BFT_BROADCASTS` (cmd_tx counter) staying at 0.
+///
+/// v2.1.67 switches to `try_send` + drop-on-Full + this counter.
+/// Mirrors the v2.1.65 cmd_tx pattern. Trade-off accepted: lossy
+/// inbound BFT delivery under burst load, in exchange for never
+/// wedging the swarm task. Halts caused by lost messages will now
+/// be OBSERVABLE via `rate(EVENT_TX_DROPPED) > 0` instead of invisible.
+/// Operator playbook: if this counter starts incrementing during a
+/// halt, the validator main loop has fallen behind — investigate
+/// consumer-side back-pressure (slow MDBX writes, contended write
+/// locks, RPC handler blocking).
+pub static EVENT_TX_DROPPED: AtomicU64 = AtomicU64::new(0);
+
 /// 2026-05-05 v2.1.66: swarm-task progress counter. Incremented on
 /// every iteration of the run_swarm select! loop. Read by a separate
 /// watchdog tokio task — if the counter stays still for ≥30 s, the
@@ -1202,6 +1224,67 @@ async fn on_rr_event(
     }
 }
 
+// 2026-05-05 v2.1.67: non-blocking event_tx forward used by the inbound
+// BFT message handlers. Pre-v2.1.67 used `event_tx.send(...).await` which
+// blocked the swarm task whenever the downstream consumer (the event
+// handler tokio task at main.rs:3407) fell behind on draining. That wedge
+// pattern produced silent halts: the swarm task couldn't deliver inbound
+// BFT messages to the BFT engine AND couldn't process outbound broadcast
+// commands either, so vps5 looked silent on the wire while local engine
+// state believed it was operating. The h=1,400,218 halt on 2026-05-05
+// matched this pattern (DROPPED_BFT_BROADCASTS=0 ruled out cmd_tx; no
+// libp2p outbound failures ruled out request_response per-peer wedge;
+// only the swarm-task internal stall fit).
+//
+// Trade-off: lossy inbound BFT message delivery under burst load — better
+// than wedging the swarm task. Halts caused by drops are at least
+// observable now via `rate(EVENT_TX_DROPPED) > 0` (use Telegram alerter
+// or /metrics scrape).
+fn try_send_event(
+    event_tx: &mpsc::Sender<NodeEvent>,
+    event: NodeEvent,
+    variant: &'static str,
+) {
+    let depth_pre = event_tx.max_capacity() - event_tx.capacity();
+    let max = event_tx.max_capacity();
+    let start = std::time::Instant::now();
+    match event_tx.try_send(event) {
+        Ok(()) => {
+            let elapsed = start.elapsed();
+            // try_send is microseconds in steady state; >100ms means the
+            // tracing subsystem itself is slow (file I/O, log rotation).
+            // Worth knowing — log it but don't take action.
+            if elapsed.as_millis() > 100 {
+                tracing::warn!(
+                    target: "event_tx_lat",
+                    "event_tx try_send {} took {}ms — surrounding logging or \
+                     allocator suspect (depth was {}/{})",
+                    variant, elapsed.as_millis(), depth_pre, max,
+                );
+            }
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+            let total = EVENT_TX_DROPPED.fetch_add(1, Ordering::Relaxed) + 1;
+            tracing::error!(
+                target: "event_tx_drop",
+                "event_tx FULL ({}/{}) — DROPPED inbound {} (total drops since \
+                 boot: {}). Validator-loop consumer not draining fast enough; \
+                 BFT message lost — investigate consumer-side back-pressure \
+                 (slow MDBX writes / contended write lock / RPC handler block).",
+                max, max, variant, total,
+            );
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+            tracing::error!(
+                target: "event_tx_drop",
+                "event_tx CLOSED — DROPPED inbound {} (event-handler task is \
+                 gone; process should be restarting)",
+                variant,
+            );
+        }
+    }
+}
+
 // ── Inbound request handler ──────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
@@ -1452,7 +1535,7 @@ async fn on_inbound_request(
                 );
                 return;
             }
-            let _ = event_tx.send(NodeEvent::BftProposal(*proposal)).await;
+            try_send_event(event_tx, NodeEvent::BftProposal(*proposal), "BftProposal");
         }
 
         // ── BFT Prevote ─────────────────────────────────
@@ -1475,7 +1558,7 @@ async fn on_inbound_request(
                 );
                 return;
             }
-            let _ = event_tx.send(NodeEvent::BftPrevote(prevote)).await;
+            try_send_event(event_tx, NodeEvent::BftPrevote(prevote), "BftPrevote");
         }
 
         // ── BFT Precommit ───────────────────────────────
@@ -1498,7 +1581,7 @@ async fn on_inbound_request(
                 );
                 return;
             }
-            let _ = event_tx.send(NodeEvent::BftPrecommit(precommit)).await;
+            try_send_event(event_tx, NodeEvent::BftPrecommit(precommit), "BftPrecommit");
         }
 
         // ── BFT RoundStatus ────────────────────────────
@@ -1521,7 +1604,7 @@ async fn on_inbound_request(
                 );
                 return;
             }
-            let _ = event_tx.send(NodeEvent::BftRoundStatus(status)).await;
+            try_send_event(event_tx, NodeEvent::BftRoundStatus(status), "BftRoundStatus");
         }
     }
 }

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.66"
+version = "2.1.67"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Closes the silent-halt class at h=1,400,218 by switching swarm-task event_tx forward from blocking .send().await to non-blocking try_send + drop counter + breadcrumb logs.

See commit message for full RCA + trade-off analysis. Mirrors v2.1.65 cmd_tx pattern.

Test plan:
- [x] cargo check clean
- [ ] post-deploy: `grep event_tx_drop` in journalctl — should be 0 in steady state, non-zero during halt = root-cause confirmation
- [ ] sustained 15-min advance without halt cycle