### PR TITLE
fix(node): bft_tx try_send + BFT_TX_DROPPED counter — close last unbounded await in BFT msg path (v2.1.68)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "bincode",
  "hex",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "anyhow",
  "axum",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "anyhow",
  "axum",
@@ -5010,14 +5010,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5061,14 +5061,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "bincode",
  "blake3",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.67"
+version = "2.1.68"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1383,6 +1383,59 @@ async fn cmd_start(
     let (bft_tx, bft_rx) =
         tokio::sync::mpsc::channel::<sentrix::core::bft_messages::BftMessage>(4096);
 
+    // 2026-05-05 v2.1.68: cumulative count of BFT messages dropped because
+    // bft_tx was full when the event-handler tokio task tried to forward
+    // an inbound BFT message (Propose/Prevote/Precommit/RoundStatus) to
+    // the validator main loop. Pre-v2.1.68 the event handler used
+    // `bft_tx.send().await` which BLOCKED until the validator loop drained
+    // bft_rx — that pattern wedged the event handler whenever the validator
+    // main loop fell behind. The wedged event handler then backed up
+    // event_tx (4096 cap) which in turn backed up the swarm task. This was
+    // the LAST remaining unbounded-block point in the BFT message path
+    // (cmd_tx → swarm → event_tx → bft_tx → validator).
+    //
+    // v2.1.68 switches to `try_send` + drop-on-Full + this counter. Mirror
+    // of v2.1.65 (DROPPED_BFT_BROADCASTS for cmd_tx) and v2.1.67
+    // (EVENT_TX_DROPPED for event_tx). Trade-off accepted: lossy inbound
+    // BFT delivery under burst load, in exchange for never wedging the
+    // event-handler task. Operator playbook: if this counter increments
+    // during a halt, the validator main loop has fallen behind —
+    // investigate consumer-side back-pressure (slow MDBX writes /
+    // contended write locks / RPC handler block).
+    static BFT_TX_DROPPED: std::sync::atomic::AtomicU64 =
+        std::sync::atomic::AtomicU64::new(0);
+
+    fn try_send_bft(
+        bft_tx: &tokio::sync::mpsc::Sender<sentrix::core::bft_messages::BftMessage>,
+        msg: sentrix::core::bft_messages::BftMessage,
+        variant: &'static str,
+    ) {
+        let max = bft_tx.max_capacity();
+        match bft_tx.try_send(msg) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                let total = BFT_TX_DROPPED
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                tracing::error!(
+                    target: "bft_tx_drop",
+                    "bft_tx FULL ({}/{}) — DROPPED inbound {} (total drops since \
+                     boot: {}). Validator main loop not draining bft_rx fast enough; \
+                     BFT message lost — investigate consumer-side back-pressure \
+                     (slow MDBX writes / contended write lock).",
+                    max, max, variant, total,
+                );
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                tracing::error!(
+                    target: "bft_tx_drop",
+                    "bft_tx CLOSED — DROPPED inbound {} (validator main loop gone; \
+                     process should be restarting)",
+                    variant,
+                );
+            }
+        }
+    }
+
     // BFT engine watchdog — heartbeat counter incremented at the top of
     // every validator-loop iteration; a separate task panics + aborts
     // the process if the counter stays stale for STALL_THRESHOLD seconds.
@@ -3491,15 +3544,11 @@ async fn cmd_start(
                         &p.proposer[..p.proposer.len().min(12)],
                         &p.block_hash[..p.block_hash.len().min(16)]
                     );
-                    if let Err(e) = bft_tx_clone
-                        .send(sentrix::core::bft_messages::BftMessage::Propose(p))
-                        .await
-                    {
-                        tracing::error!(
-                            "C-07: BFT proposal forward failed (validator loop gone): {}",
-                            e
-                        );
-                    }
+                    try_send_bft(
+                        &bft_tx_clone,
+                        sentrix::core::bft_messages::BftMessage::Propose(p),
+                        "BftProposal",
+                    );
                 }
                 NodeEvent::BftPrevote(v) => {
                     let hash_tag = match &v.block_hash {
@@ -3513,15 +3562,11 @@ async fn cmd_start(
                         &v.validator[..v.validator.len().min(12)],
                         hash_tag
                     );
-                    if let Err(e) = bft_tx_clone
-                        .send(sentrix::core::bft_messages::BftMessage::Prevote(v))
-                        .await
-                    {
-                        tracing::error!(
-                            "C-07: BFT prevote forward failed (validator loop gone): {}",
-                            e
-                        );
-                    }
+                    try_send_bft(
+                        &bft_tx_clone,
+                        sentrix::core::bft_messages::BftMessage::Prevote(v),
+                        "BftPrevote",
+                    );
                 }
                 NodeEvent::BftPrecommit(c) => {
                     let hash_tag = match &c.block_hash {
@@ -3535,15 +3580,11 @@ async fn cmd_start(
                         &c.validator[..c.validator.len().min(12)],
                         hash_tag
                     );
-                    if let Err(e) = bft_tx_clone
-                        .send(sentrix::core::bft_messages::BftMessage::Precommit(c))
-                        .await
-                    {
-                        tracing::error!(
-                            "C-07: BFT precommit forward failed (validator loop gone): {}",
-                            e
-                        );
-                    }
+                    try_send_bft(
+                        &bft_tx_clone,
+                        sentrix::core::bft_messages::BftMessage::Precommit(c),
+                        "BftPrecommit",
+                    );
                 }
                 NodeEvent::BftRoundStatus(s) => {
                     tracing::debug!(
@@ -3552,15 +3593,11 @@ async fn cmd_start(
                         s.round,
                         &s.validator[..s.validator.len().min(12)]
                     );
-                    if let Err(e) = bft_tx_clone
-                        .send(sentrix::core::bft_messages::BftMessage::RoundStatus(s))
-                        .await
-                    {
-                        tracing::debug!(
-                            "C-07: BFT round-status forward failed (validator loop gone): {}",
-                            e
-                        );
-                    }
+                    try_send_bft(
+                        &bft_tx_clone,
+                        sentrix::core::bft_messages::BftMessage::RoundStatus(s),
+                        "BftRoundStatus",
+                    );
                 }
             }
         }

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.67"
+version = "2.1.68"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Mirror of v2.1.65 (cmd_tx) and v2.1.67 (event_tx). Closes the last unbounded blocking-await in the inbound BFT message path.

After v2.1.68: 3 drop counters across 3 channel layers — any future halt is definitively traceable.

Test plan:
- [x] cargo check clean
- [ ] post-deploy: sustained 30+ min advance with all 3 counters at 0
- [ ] confirm no regression vs v2.1.67's 25-min run