### PR TITLE
feat(grpc): sentrix-grpc skeleton crate with Tonic v0.12 + service.proto v0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -735,6 +735,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,11 +827,38 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "base64",
  "bytes",
  "form_urlencoded",
@@ -820,7 +869,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -833,10 +882,30 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1802,7 +1871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1887,6 +1956,12 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fnv"
@@ -2399,6 +2474,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,7 +2503,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -3283,6 +3371,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -3386,6 +3480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "multistream-select"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,7 +3581,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3764,6 +3864,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4000,6 +4110,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.13.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4041,7 +4203,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4078,7 +4240,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4288,7 +4450,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -4639,7 +4801,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4843,7 +5005,7 @@ dependencies = [
  "alloy-rlp",
  "argon2",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "bincode",
  "blake3",
  "chrono",
@@ -4873,7 +5035,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "uuid",
@@ -4954,7 +5116,7 @@ name = "sentrix-faucet"
 version = "2.1.68"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.8.9",
  "clap",
  "dashmap",
  "hex",
@@ -4968,6 +5130,19 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "sentrix-grpc"
+version = "2.1.68"
+dependencies = [
+ "async-stream",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tracing",
 ]
 
 [[package]]
@@ -4993,7 +5168,7 @@ name = "sentrix-node"
 version = "2.1.68"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.8.9",
  "bincode",
  "clap",
  "hex",
@@ -5037,7 +5212,7 @@ dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "axum",
+ "axum 0.8.9",
  "chrono",
  "futures-util",
  "hex",
@@ -5054,7 +5229,7 @@ dependencies = [
  "sha3 0.11.0",
  "subtle",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
 ]
@@ -5384,7 +5559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5506,7 +5681,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5662,6 +5837,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5758,6 +5944,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5787,7 +6037,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "crates/sentrix-wire", "bin/sentrix", "bin/sentrix-faucet"]
+members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "crates/sentrix-wire", "crates/sentrix-grpc", "bin/sentrix", "bin/sentrix-faucet"]
 
 [package]
 name = "sentrix"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "sentrix-grpc"
+version = "2.1.68"
+edition = "2024"
+license = "BUSL-1.1"
+description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"
+
+# 2026-05-05 v0.1 skeleton — handlers in src/lib.rs return tonic::Status::unimplemented
+# until main.rs integration lands. Reference design doc:
+# founder-private/audits/2026-05-05-grpc-service-proto-draft.md.
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+tonic = { version = "0.12", features = ["transport"] }
+prost = "0.13"
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "sync"] }
+tokio-stream = "0.1"
+tracing = "0.1"
+async-stream = "0.3"
+
+# Forbid unsafe code in this crate. Tonic + prost generate code so we
+# rely on their respective safety reviews; our handwritten code path
+# stays unsafe-free.
+
+[build-dependencies]
+tonic-build = "0.12"

--- a/crates/sentrix-grpc/build.rs
+++ b/crates/sentrix-grpc/build.rs
@@ -1,0 +1,12 @@
+// build.rs — compile proto/sentrix.proto into Rust types via tonic-build.
+//
+// Generated module is included via `tonic::include_proto!("sentrix.v1")` in
+// src/lib.rs. Re-run cargo build whenever proto/sentrix.proto changes.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .compile_protos(&["proto/sentrix.proto"], &["proto"])?;
+    Ok(())
+}

--- a/crates/sentrix-grpc/proto/sentrix.proto
+++ b/crates/sentrix-grpc/proto/sentrix.proto
@@ -1,0 +1,184 @@
+syntax = "proto3";
+
+// Sentrix gRPC service v0.1 — package sentrix.v1.
+//
+// Parallel transport to JSON-RPC at port 8545. Same backend, same state,
+// different wire format. Methods here mirror the most common JSON-RPC paths
+// plus add a server-streaming variant for events that JSON-RPC + WebSocket
+// can express but at a higher per-subscriber cost.
+//
+// Versioning: "sentrix.v1" is a hard contract. Breaking changes go to
+// "sentrix.v2" with v1 retained for ≥ 2 minor releases overlap.
+//
+// Status: v0.1 skeleton. Handlers in crates/sentrix-grpc/src/lib.rs return
+// tonic::Status::unimplemented until main.rs integration lands. Reference
+// design doc: founder-private/audits/2026-05-05-grpc-service-proto-draft.md.
+
+package sentrix.v1;
+
+// 20-byte EVM-compatible address. Mirror of sentrix-primitives::Address.
+// Wire = bytes (NOT hex string) for binary efficiency.
+message Address {
+  bytes value = 1;  // exactly 20 bytes
+}
+
+// 32-byte hash — block hash, tx hash, state root.
+message Hash {
+  bytes value = 1;  // exactly 32 bytes
+}
+
+// Native amount — sentri (10^-8 SRX). u64 wire to match Sentrix internal.
+message Amount {
+  uint64 sentri = 1;
+}
+
+// Block height — u64 starting at 0 (genesis).
+message BlockHeight {
+  uint64 value = 1;
+}
+
+// Mirror of sentrix-primitives::Transaction. Identical wire format to chain
+// MDBX serialisation (modulo prost-encoding). Field numbers match the
+// canonical struct order; do NOT renumber on changes.
+message Transaction {
+  Hash txid = 1;
+  Address from_address = 2;
+  Address to_address = 3;
+  Amount amount = 4;
+  Amount fee = 5;
+  uint64 nonce = 6;
+  uint64 timestamp = 7;
+  bytes signature = 8;       // 64-byte ed25519 OR 65-byte secp256k1
+  bytes payload = 9;         // contract calldata (EVM) or staking-op blob
+  uint32 chain_id = 10;
+  uint32 tx_type = 11;       // 0 = transfer, 1 = contract, 2 = staking-op
+}
+
+message Block {
+  uint64 index = 1;
+  Hash hash = 2;
+  Hash parent_hash = 3;
+  Hash state_root = 4;
+  uint64 timestamp = 5;
+  Address proposer = 6;
+  uint32 round = 7;
+  repeated Transaction transactions = 8;
+  // BFT justification carried from validator-side; included for audit.
+  // Empty for blocks at h<100_000 (pre state-root-fork).
+  bytes justification = 9;
+}
+
+message Account {
+  Address address = 1;
+  Amount balance = 2;
+  uint64 nonce = 3;
+  // For contract accounts: 32-byte storage root + non-empty code_hash.
+  Hash storage_root = 4;
+  Hash code_hash = 5;
+}
+
+// Server-streaming event types.
+message ChainEvent {
+  oneof event {
+    BlockFinalized block_finalized = 1;
+    PendingTx pending_tx = 2;
+    ValidatorSetChange validator_set_change = 3;
+    LogEmitted log = 4;
+    // Synthetic Lagged sentinel — emitted when the per-subscriber broadcast
+    // channel drops oldest events (slow consumer). Mirrors tokio broadcast
+    // RecvError::Lagged semantics. Consumer should resync state from RPC.
+    StreamLagged lagged = 5;
+  }
+  uint64 sequence = 100;     // monotonic across all events on this stream
+  uint64 timestamp = 101;    // server-wall-clock unix seconds
+}
+
+message BlockFinalized { Block block = 1; }
+message PendingTx { Transaction tx = 1; }
+
+message ValidatorSetChange {
+  uint32 epoch = 1;
+  repeated Address active = 2;
+  repeated Address jailed = 3;
+}
+
+message LogEmitted {
+  Address contract = 1;
+  repeated Hash topics = 2;       // 0..4 topics per EVM convention
+  bytes data = 3;
+  Hash tx_hash = 4;
+  uint64 block_height = 5;
+  uint32 log_index = 6;
+}
+
+message StreamLagged {
+  uint64 skipped_count = 1;       // events dropped since last delivery
+}
+
+// ────────────────────────────────────────────────────────────
+// Service definition
+// ────────────────────────────────────────────────────────────
+service Sentrix {
+  // Submit a signed transaction to the local mempool. Same semantics as
+  // JSON-RPC eth_sendRawTransaction for EVM txs, with native fields exposed
+  // for staking-ops and other native variants.
+  rpc BroadcastTx(BroadcastTxRequest) returns (BroadcastTxResponse);
+
+  // Fetch a block by height OR by hash. Returns NOT_FOUND if outside the
+  // local chain window (currently 1000 blocks; older blocks need indexer).
+  rpc GetBlock(GetBlockRequest) returns (Block);
+
+  // Fetch account balance + nonce. Mirrors eth_getBalance +
+  // eth_getTransactionCount in a single round-trip. Includes mempool-pending
+  // nonce so wallets build correct next-tx without an extra call (matches
+  // the pending-aware nonce behaviour from chain v2.1.57).
+  rpc GetBalance(GetBalanceRequest) returns (Account);
+
+  // Server-streaming chain events. Subscribe once, receive every event type
+  // until cancel or server restart. Replaces N separate eth_subscribe calls.
+  // Backpressure: server bounded channel per stream (capacity 4096 — same as
+  // event_tx in chain). On slow client, server drops OLDEST events and emits
+  // a StreamLagged sentinel. Client should resync state from RPC.
+  rpc StreamEvents(StreamEventsRequest) returns (stream ChainEvent);
+}
+
+message BroadcastTxRequest { Transaction tx = 1; }
+
+message BroadcastTxResponse {
+  Hash txid = 1;
+  uint64 mempool_position = 2;   // 0-indexed; FIFO ordering UX
+}
+
+message GetBlockRequest {
+  oneof selector {
+    BlockHeight height = 1;
+    Hash hash = 2;
+    bool latest = 3;             // selector == "latest" shorthand
+    bool finalized = 4;          // selector == "finalized" (BFT-finalized head)
+  }
+}
+
+message GetBalanceRequest {
+  Address address = 1;
+  // Snapshot height — read state as-of this block. Default = latest.
+  // Returns FAILED_PRECONDITION if outside chain window.
+  optional BlockHeight at_height = 2;
+}
+
+message StreamEventsRequest {
+  // Filter set — empty = subscribe to all event types. Backend filters
+  // server-side so the wire only carries matched events.
+  repeated EventFilter filters = 1;
+  // Resume from a sequence number (0 = current head). Backend keeps last
+  // 4096 events in a ring buffer — beyond that, sequence is not resumable
+  // and the server returns FAILED_PRECONDITION.
+  uint64 from_sequence = 2;
+}
+
+enum EventFilter {
+  EVENT_FILTER_UNSPECIFIED = 0;
+  EVENT_FILTER_BLOCK_FINALIZED = 1;
+  EVENT_FILTER_PENDING_TX = 2;
+  EVENT_FILTER_VALIDATOR_SET = 3;
+  EVENT_FILTER_LOG = 4;
+}

--- a/crates/sentrix-grpc/src/lib.rs
+++ b/crates/sentrix-grpc/src/lib.rs
@@ -1,0 +1,136 @@
+//! Sentrix gRPC supplement transport (Tonic).
+//!
+//! Parallel to the JSON-RPC `eth_*` interface served at port 8545 — same
+//! backend, same state, different wire format. JSON-RPC remains the
+//! ecosystem-facing contract for wallets and dApps; gRPC is for SentrisCloud
+//! internal monitoring and power-user clients that prefer binary protocols.
+//!
+//! ## Status (2026-05-05 v0.1)
+//!
+//! Skeleton crate. Service handlers return [`tonic::Status::unimplemented`]
+//! until `bin/sentrix/src/main.rs` is updated to spawn a Tonic server next
+//! to the existing axum HTTP server and pass it the shared `Blockchain`
+//! state. That integration step is fork-gate-free (read-only handlers use
+//! the same `Arc<RwLock<Blockchain>>` as the JSON-RPC handlers; the
+//! `BroadcastTx` handler calls into the same `add_to_mempool` path) but
+//! requires care to avoid touching the chain binary mid-marathon — see
+//! the design doc at `founder-private/audits/2026-05-05-grpc-service-proto-draft.md`
+//! for the sequenced rollout plan.
+//!
+//! ## Concurrency
+//!
+//! Handlers are `async`. The bridge to the validator's existing channels
+//! uses `tokio::sync::mpsc` and `tokio::sync::broadcast` (see the
+//! `StreamEvents` plan). No `std::sync::Mutex` or `std::sync::RwLock` —
+//! the chain workspace audit completed 2026-05-05 enforces this discipline
+//! across all production code, and this crate is `#![forbid(unsafe_code)]`
+//! at the root.
+
+#![forbid(unsafe_code)]
+
+/// Generated types and service stubs from `proto/sentrix.proto`.
+pub mod sentrix_proto {
+    tonic::include_proto!("sentrix.v1");
+}
+
+use sentrix_proto::sentrix_server::{Sentrix, SentrixServer};
+use sentrix_proto::*;
+use tonic::{Request, Response, Status};
+
+/// Service handler. v0.1 holds no state — every method returns
+/// `Status::unimplemented`. The next iteration (post-marathon, fresh-brain)
+/// will add a `state: Arc<RwLock<Blockchain>>` field plumbed from
+/// `bin/sentrix/src/main.rs`.
+#[derive(Default)]
+pub struct SentrixService {
+    // Future:
+    //   shared_state: Arc<tokio::sync::RwLock<sentrix_core::blockchain::Blockchain>>,
+    //   event_bus: Arc<sentrix_rpc::events::EventBus>,
+    //
+    // Why tokio::sync (not std::sync): handlers are async fn that .await on
+    // the lock. std::sync::RwLock would block the tokio worker thread —
+    // the same wedge class fixed in chain v2.1.65/67/68 by switching the
+    // BFT message channels to try_send. The discipline is now codebase-wide
+    // (see the comment at crates/sentrix-rpc/src/routes/mod.rs:49 and the
+    // audit memo at founder-private/audits/2026-05-05-sentrix-sdk-design.md).
+}
+
+#[tonic::async_trait]
+impl Sentrix for SentrixService {
+    async fn broadcast_tx(
+        &self,
+        _request: Request<BroadcastTxRequest>,
+    ) -> Result<Response<BroadcastTxResponse>, Status> {
+        Err(Status::unimplemented(
+            "BroadcastTx not yet wired to mempool — see design doc \
+             founder-private/audits/2026-05-05-grpc-service-proto-draft.md",
+        ))
+    }
+
+    async fn get_block(
+        &self,
+        _request: Request<GetBlockRequest>,
+    ) -> Result<Response<Block>, Status> {
+        Err(Status::unimplemented(
+            "GetBlock not yet wired to chain state",
+        ))
+    }
+
+    async fn get_balance(
+        &self,
+        _request: Request<GetBalanceRequest>,
+    ) -> Result<Response<Account>, Status> {
+        Err(Status::unimplemented(
+            "GetBalance not yet wired to chain state",
+        ))
+    }
+
+    /// Server-streaming type. v0.1 returns an empty pinned stream that
+    /// immediately yields `Status::unimplemented`. Real impl will be a
+    /// `tokio::sync::broadcast::Receiver<ChainEvent>` adapted via
+    /// `tokio_stream::wrappers::BroadcastStream`, mirroring the existing
+    /// JSON-RPC WebSocket pattern at `crates/sentrix-rpc/src/ws/mod.rs`
+    /// (which also handles `RecvError::Lagged` by emitting a synthetic
+    /// `StreamLagged` sentinel).
+    type StreamEventsStream =
+        std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<ChainEvent, Status>> + Send>>;
+
+    async fn stream_events(
+        &self,
+        _request: Request<StreamEventsRequest>,
+    ) -> Result<Response<Self::StreamEventsStream>, Status> {
+        Err(Status::unimplemented(
+            "StreamEvents not yet wired to event bus",
+        ))
+    }
+}
+
+/// Build a `SentrixServer` instance ready to be served on a tonic transport.
+///
+/// Caller is responsible for binding to a transport (typically
+/// `tonic::transport::Server::builder().add_service(server_factory()).serve(addr)`).
+/// This crate INTENTIONALLY does not auto-bind — the bind decision lives
+/// in `bin/sentrix/src/main.rs` so the operator can gate it behind
+/// `SENTRIX_GRPC_ENABLED=1` and choose the address per host.
+pub fn server_factory() -> SentrixServer<SentrixService> {
+    SentrixServer::new(SentrixService::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_factory_compiles() {
+        let _ = server_factory();
+    }
+
+    #[tokio::test]
+    async fn handlers_return_unimplemented() {
+        let svc = SentrixService::default();
+        let req = Request::new(GetBlockRequest { selector: None });
+        let res = svc.get_block(req).await;
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().code(), tonic::Code::Unimplemented);
+    }
+}


### PR DESCRIPTION
v0.1 skeleton (handlers return Status::unimplemented). Compiles release. Zero std::sync. forbid(unsafe_code).

Real impl lands in next-session integration per audits/2026-05-05-grpc-service-proto-draft.md sequence — Week 7+ track.

Test plan:
- [x] cargo build -p sentrix-grpc --release (42s, clean)
- [x] cargo test -p sentrix-grpc covers compile + unimplemented handlers
- [x] zero std::sync usage in src
- [ ] post-integration: live BroadcastTx test against testnet