### PR TITLE
ci: install protoc on runners for sentrix-grpc proto codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # 2026-05-05: sentrix-grpc crate's build.rs invokes tonic-build
+      # → prost-build → protoc to compile proto/sentrix.proto into Rust.
+      # GitHub-hosted ubuntu-22.04 runners don't have protobuf-compiler
+      # installed by default, so cargo build / clippy / check fail with
+      # `Could not find `protoc`` (exit 101) on the sentrix-grpc target.
+      - name: Install protoc (protobuf-compiler)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler
+
       - name: Cache cargo
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
Fixes CI exit 101 introduced by PR #463 (sentrix-grpc skeleton). protoc is required by tonic-build → prost-build for compiling `proto/sentrix.proto`; not pre-installed on ubuntu-22.04 runners by default.

Test plan:
- [ ] CI green on this PR
- [ ] CI green on next push to main after merge