### PR TITLE
fix(grpc): pass --experimental_allow_proto3_optional to protoc on CI runners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5138,6 +5138,7 @@ version = "2.1.68"
 dependencies = [
  "async-stream",
  "prost",
+ "prost-build",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -26,3 +26,4 @@ async-stream = "0.3"
 
 [build-dependencies]
 tonic-build = "0.12"
+prost-build = "0.13"

--- a/crates/sentrix-grpc/build.rs
+++ b/crates/sentrix-grpc/build.rs
@@ -4,9 +4,18 @@
 // src/lib.rs. Re-run cargo build whenever proto/sentrix.proto changes.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 2026-05-05: Ubuntu 22.04's apt-installed protoc (3.12.x) treats
+    // proto3 `optional` fields as experimental and rejects without the
+    // explicit flag. Modern protoc (≥ 3.15) accepts them by default.
+    // Pass the flag so CI runners with the older apt package don't
+    // exit 101 on the `optional BlockHeight at_height = 2` field in
+    // GetBalanceRequest.
+    let mut config = prost_build::Config::new();
+    config.protoc_arg("--experimental_allow_proto3_optional");
+
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
-        .compile_protos(&["proto/sentrix.proto"], &["proto"])?;
+        .compile_protos_with_config(config, &["proto/sentrix.proto"], &["proto"])?;
     Ok(())
 }


### PR DESCRIPTION
Follow-up to #464. Ubuntu 22.04 protoc 3.12 needs explicit flag for proto3 optional fields. Local builds unaffected (newer protoc).