### PR TITLE
feat(grpc): tonic-web browser support (v2.1.70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,27 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Roadmap
 
 - **Native Rust SDK (`sentrix-sdk`, planned, no fixed ETA)** — high-level client crate for Rust developers building against Sentrix. Sub-crates: `sentrix-sdk` (umbrella), `-types` (struct parity with chain via shared `sentrix-primitives` dep — no drift possible at compile time), `-rpc` (JSON-RPC HTTP/WS client with mandatory 5-second timeouts and automatic retries), `-signer` (Argon2id keystore reuse), `-preflight` (client-side `revm` simulation for gas estimation + dry-run before submission), and a `sentrix-cli` binary for DevEx. All SDK modules `#![forbid(unsafe_code)]`. Will publish to crates.io.
-- **Native gRPC supplement transport (planned, no fixed ETA)** — high-bandwidth binary-protocol channel for high-throughput data streaming and power-user clients. Service surface: `BroadcastTx`, `GetBlock`, `GetBalance`, server-streaming `StreamEvents` with backpressure-aware lagging semantics. Designed as parallel to (not replacement of) the existing JSON-RPC `eth_*` interface — wallets and dApps continue using JSON-RPC at port 8545 unchanged. Default disabled (opt-in via `SENTRIX_GRPC_ENABLED=1`) so existing operators don't auto-expose a new port. Reference contract: `package sentrix.v1`.
 
 ### Internal
 
 - Audit pass 2026-05-05 confirmed clean: no `std::sync::Mutex` / `RwLock` held across an `.await` point in workspace production code. The codebase already enforces this discipline (explicit comment at `crates/sentrix-rpc/src/routes/mod.rs:49`); audit verified zero violations.
 - WebSocket broadcaster (`crates/sentrix-rpc/src/ws/`) already uses `tokio::sync::broadcast` with `RecvError::Lagged` handling — slow consumers drop the oldest frames per-subscriber without affecting the broadcaster or other subscribers. No code change needed for the "slow consumer" hardening pattern.
+
+## [2.1.70] — 2026-05-04 — gRPC-Web layer (browsers can talk to the side-car directly)
+
+Wraps the side-car gRPC service with `tonic_web::GrpcWebLayer` and enables HTTP/1.1 fallback (`accept_http1(true)`). Same port (default `:50051`) now serves both pure gRPC (HTTP/2 + `application/grpc`, used by Tonic / grpcio / grpc-go / grpcurl) and gRPC-Web (HTTP/1.1 or HTTP/2 + `application/grpc-web`, used by browsers via `@grpc/grpc-web` or `@protobuf-ts/grpcweb-transport`). The layer dispatches by content-type — pure gRPC clients see no behavioural change.
+
+Edge proxy CORS expanded on `grpc.sentrixchain.com` and `grpc-testnet.sentrixchain.com` to expose the gRPC-specific trailers (`Grpc-Status`, `Grpc-Message`, `Grpc-Encoding`, `Grpc-Accept-Encoding`) and accept the gRPC-Web request headers (`X-Grpc-Web`, `X-User-Agent`, `Grpc-Timeout`). Preflight `OPTIONS` returns 204 in <1 ms at the edge (no upstream hop).
+
+Default-OFF env-var gate from v2.1.69 retained — hosts without `SENTRIX_GRPC_ENABLED=1` see zero behavioural change. Public docs updated at `docs/operations/GRPC.md` with quickstart for TypeScript / Rust / Python / Go and a CORS reference.
+
+## [2.1.69] — 2026-05-04 — side-car Tonic gRPC server (read-only GetBlock + GetBalance)
+
+First implementation of the gRPC supplement transport from the [Unreleased] roadmap. New `sentrix-grpc` crate ships the proto schema (`package sentrix.v1`) and a server skeleton; integrated into the chain binary as a side-car spawned from `bin/sentrix/src/main.rs` when `SENTRIX_GRPC_ENABLED=1`. Bound to `SENTRIX_GRPC_ADDR` (default `0.0.0.0:50051`).
+
+Service surface in v0.2: `GetBlock` (by height, by hash, or `latest` / `finalized` selector — returns `NOT_FOUND` outside the local chain window) and `GetBalance` (balance + pending-aware nonce in one round-trip). `BroadcastTx` and `StreamEvents` return `tonic::Status::unimplemented` until v0.3 (proto Transaction ↔ chain Transaction marshalling needs careful field-by-field decoding; deferred for a regression-test pairing with the JSON-RPC path).
+
+Side-car spawn pattern: a wedged gRPC handler can stall its own task without affecting the validator main loop or the existing axum HTTP server. Read paths share the same `Arc<RwLock<Blockchain>>` as the JSON-RPC stack — same lock-contention profile as adding another axum handler, brief read-locks held for the minimum span. `#![forbid(unsafe_code)]` in the new crate; `tokio::sync::RwLock` only.
 
 ## [2.1.68] — 2026-05-05 — bft_tx try_send + BFT_TX_DROPPED counter (close last unbounded await in BFT msg path)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4451,7 +4451,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower 0.5.3",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5036,7 +5036,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
- "tower-http",
+ "tower-http 0.6.8",
  "tracing",
  "uuid",
  "zeroize",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "bincode",
  "hex",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5127,14 +5127,14 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tower-http",
+ "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5185,6 +5185,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tonic",
+ "tonic-web",
  "tracing",
  "tracing-subscriber 0.3.23",
  "zeroize",
@@ -5192,14 +5193,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5213,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5237,20 +5238,20 @@ dependencies = [
  "subtle",
  "tokio",
  "tower 0.5.3",
- "tower-http",
+ "tower-http 0.6.8",
  "tracing",
 ]
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5260,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5275,7 +5276,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "bincode",
  "blake3",
@@ -5291,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5310,7 +5311,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.69"
+version = "2.1.70"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5995,6 +5996,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-web"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5299dd20801ad736dccb4a5ea0da7376e59cd98f213bf1c3d478cf53f4834b58"
+dependencies = [
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project",
+ "tokio-stream",
+ "tonic",
+ "tower-http 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6029,6 +6050,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"
@@ -48,6 +48,12 @@ sentrix-wire = { path = "../../crates/sentrix-wire" }
 # spawn block.
 sentrix-grpc = { path = "../../crates/sentrix-grpc" }
 tonic = { version = "0.12", features = ["transport"] }
+# v2.1.70: gRPC-Web codec layer so browsers (Next.js / React with @grpc/grpc-web
+# or @protobuf-ts/grpcweb-transport) can hit the side-car without a separate
+# proxy. Same port as pure gRPC; tonic-web detects content-type at request
+# time and dispatches the right codec. CORS stays at the Caddy edge so the
+# headers stay in one place (matches rpc.sentrixchain.com pattern).
+tonic-web = "0.12"
 # V2 M-15 helper uses the SecretKey type from secp256k1 in its signature.
 # The wallet crate returns the same type from `get_secret_key`, but bin/
 # doesn't transitively re-export it, so we depend on the workspace version

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -3680,7 +3680,13 @@ async fn cmd_start(
                 );
                 tokio::spawn(async move {
                     let server = sentrix_grpc::server_factory(grpc_state);
+                    // v2.1.70: accept_http1(true) + GrpcWebLayer so browsers
+                    // can hit the same port. Pure gRPC clients (HTTP/2 +
+                    // application/grpc) still work — the layer dispatches by
+                    // content-type. CORS handled at Caddy edge, not here.
                     if let Err(e) = tonic::transport::Server::builder()
+                        .accept_http1(true)
+                        .layer(tonic_web::GrpcWebLayer::new())
                         .add_service(server)
                         .serve(grpc_addr)
                         .await

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.69"
+version = "2.1.70"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."

--- a/docs/operations/API_ENDPOINTS.md
+++ b/docs/operations/API_ENDPOINTS.md
@@ -6,6 +6,8 @@ Base URLs:
 - **Mainnet:** `https://rpc.sentrixchain.com` (chain_id 7119, **Voyager DPoS+BFT** since 2026-04-25)
 - **Testnet:** `https://testnet-rpc.sentrixchain.com` (chain_id 7120, **Voyager DPoS+BFT** since 2026-04-23)
 
+> Looking for binary RPC? See [**gRPC API**](./GRPC.md) for the Tonic-based transport at `grpc.sentrixchain.com:443` (mainnet) and `grpc-testnet.sentrixchain.com:443` (testnet) — same backend, Protocol Buffers schema, gRPC-Web friendly.
+
 Rate limits (per IP): **60 req/min global**, **10 req/min write endpoints** (POST to `/transactions`, `/tokens/deploy|transfer|burn`, `/rpc`).
 
 Auth: most endpoints are public. Handlers tagged with `_auth: ApiKey` check the `X-API-Key` header against `SENTRIX_API_KEY` env var on the validator (16-char min, constant-time compare). If the env var isn't set, auth is skipped.

--- a/docs/operations/GRPC.md
+++ b/docs/operations/GRPC.md
@@ -1,0 +1,323 @@
+---
+sidebar_position: 4
+title: gRPC API
+---
+
+# Sentrix Chain — gRPC API
+
+Sentrix Chain ships a Tonic-based gRPC interface as a parallel transport to the JSON-RPC `eth_*` endpoints. Same backend, same state, different wire format.
+
+**When to use gRPC instead of JSON-RPC:**
+- Binary protocol — smaller payloads, faster decode than JSON
+- Strongly-typed schema via Protocol Buffers — no runtime parsing surprises
+- HTTP/2 multiplexing — many in-flight calls over one connection
+- Native server-streaming (when `StreamEvents` lands in v0.3)
+
+**When JSON-RPC is still the right call:**
+- MetaMask, ethers.js, hardhat, viem — all speak `eth_*` over JSON-RPC. Don't switch your dApp away from a working transport.
+- Quick `curl` exploration without code generation
+- Web pages that just need `eth_blockNumber` once on load
+
+---
+
+## Endpoints
+
+| Network | Endpoint | chain_id |
+|---|---|---|
+| Mainnet | `grpc.sentrixchain.com:443` | 7119 |
+| Testnet | `grpc-testnet.sentrixchain.com:443` | 7120 |
+
+Both endpoints terminate TLS at the edge proxy and forward to the validator side-car over a private hop. Cloudflare proxy is enabled with the gRPC protocol toggle on, so HTTP/2 + `te: trailers` traverses the edge transparently.
+
+Browser clients can hit the same hostnames over **gRPC-Web** (HTTP/1.1 or HTTP/2 with `application/grpc-web` content-type). Edge CORS is permissive (`Access-Control-Allow-Origin: *`) and exposes the `grpc-status` / `grpc-message` trailers so client libraries can read errors correctly.
+
+---
+
+## Schema
+
+Canonical `.proto` lives in the repository at:
+
+> `crates/sentrix-grpc/proto/sentrix.proto`
+
+Service: **`sentrix.v1.Sentrix`** (note: `Sentrix`, not `SentrixService` or `BlockchainService`).
+
+To generate clients, fetch the file directly from `main` and feed it to your codegen toolchain (`protoc`, `tonic-build`, `grpc-tools`, etc).
+
+```bash
+curl -O https://raw.githubusercontent.com/sentrix-labs/sentrix/main/crates/sentrix-grpc/proto/sentrix.proto
+```
+
+Reflection is **not** enabled on the side-car. `grpcurl` clients must be invoked with `-import-path` + `-proto`; `grpcurl list` will fail.
+
+---
+
+## Methods (v0.2)
+
+### `GetBlock(GetBlockRequest) → Block`
+
+Fetch a block by height, by hash, or via the `latest` / `finalized` selector. Returns `NOT_FOUND` if the block is outside the validator's in-memory chain window (currently 1000 blocks; older blocks need an indexer).
+
+**Request:**
+
+```protobuf
+message GetBlockRequest {
+  oneof selector {
+    BlockHeight height = 1;   // { value: <uint64> }
+    Hash hash = 2;             // { value: <32 bytes> }
+    bool latest = 3;
+    bool finalized = 4;
+  }
+}
+```
+
+**Response (`Block`):**
+
+```protobuf
+message Block {
+  uint64 index = 1;
+  Hash hash = 2;
+  Hash parent_hash = 3;
+  Hash state_root = 4;
+  uint64 timestamp = 5;
+  Address proposer = 6;
+  uint32 round = 7;
+  repeated Transaction transactions = 8;  // empty in v0.2
+  bytes justification = 9;                 // bincoded BFT justification
+}
+```
+
+> **v0.2 limitation:** `transactions` is returned empty. Full marshalling lands in v0.3 alongside `BroadcastTx`. To fetch transactions today, use the JSON-RPC `eth_getBlockByNumber` endpoint.
+
+### `GetBalance(GetBalanceRequest) → Account`
+
+Single round-trip for `eth_getBalance` + `eth_getTransactionCount`. Includes mempool-pending nonce (matches the chain's pending-aware nonce behaviour).
+
+**Request:**
+
+```protobuf
+message GetBalanceRequest {
+  Address address = 1;                       // { value: <20 bytes> }
+  optional BlockHeight at_height = 2;       // historical reads — see limitation
+}
+```
+
+**Response (`Account`):**
+
+```protobuf
+message Account {
+  Address address = 1;
+  Amount balance = 2;     // { sentri: <uint64> }
+  uint64 nonce = 3;
+  Hash storage_root = 4;  // not populated in v0.2
+  Hash code_hash = 5;     // not populated in v0.2
+}
+```
+
+> **v0.2 limitation:** `at_height` historical reads return `FAILED_PRECONDITION`. Snapshot-isolated reads need an MDBX-snapshot refactor; tracked for v0.3.
+
+### `BroadcastTx(BroadcastTxRequest) → BroadcastTxResponse`
+
+Submit a signed transaction to the local mempool. **Returns `UNIMPLEMENTED` in v0.2.** Use JSON-RPC `eth_sendRawTransaction` for now.
+
+### `StreamEvents(StreamEventsRequest) → stream ChainEvent`
+
+Server-streaming subscription replacing N separate `eth_subscribe` calls. **Returns `UNIMPLEMENTED` in v0.2.** Use the WebSocket `eth_subscribe` endpoint for now.
+
+---
+
+## Quickstart
+
+### `grpcurl` (CLI)
+
+```bash
+# fetch the proto
+curl -O https://raw.githubusercontent.com/sentrix-labs/sentrix/main/crates/sentrix-grpc/proto/sentrix.proto
+
+# latest block on mainnet
+grpcurl -import-path . -proto sentrix.proto \
+  -d '{"latest":true}' \
+  grpc.sentrixchain.com:443 sentrix.v1.Sentrix/GetBlock
+
+# specific height
+grpcurl -import-path . -proto sentrix.proto \
+  -d '{"height":{"value":1440000}}' \
+  grpc.sentrixchain.com:443 sentrix.v1.Sentrix/GetBlock
+
+# balance — Address.value is base64-encoded 20 bytes
+grpcurl -import-path . -proto sentrix.proto \
+  -d '{"address":{"value":"<base64-of-20-byte-address>"}}' \
+  grpc.sentrixchain.com:443 sentrix.v1.Sentrix/GetBalance
+```
+
+### Rust (Tonic)
+
+```toml
+# Cargo.toml
+[dependencies]
+tonic = "0.12"
+prost = "0.13"
+tokio = { version = "1", features = ["full"] }
+
+[build-dependencies]
+tonic-build = "0.12"
+```
+
+```rust
+// build.rs
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::compile_protos("proto/sentrix.proto")?;
+    Ok(())
+}
+
+// src/main.rs
+pub mod sentrix_proto { tonic::include_proto!("sentrix.v1"); }
+
+use sentrix_proto::sentrix_client::SentrixClient;
+use sentrix_proto::GetBlockRequest;
+use sentrix_proto::get_block_request::Selector;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = SentrixClient::connect("https://grpc.sentrixchain.com").await?;
+    let resp = client.get_block(GetBlockRequest {
+        selector: Some(Selector::Latest(true)),
+    }).await?;
+    println!("latest block index = {}", resp.into_inner().index);
+    Ok(())
+}
+```
+
+### TypeScript / Node (`@grpc/grpc-js`)
+
+```bash
+npm install @grpc/grpc-js @grpc/proto-loader
+```
+
+```typescript
+import { credentials, loadPackageDefinition } from "@grpc/grpc-js";
+import { loadSync } from "@grpc/proto-loader";
+
+const pkgDef = loadSync("./sentrix.proto", { keepCase: true, longs: String });
+const proto = loadPackageDefinition(pkgDef) as any;
+
+const client = new proto.sentrix.v1.Sentrix(
+  "grpc.sentrixchain.com:443",
+  credentials.createSsl(),
+);
+
+client.GetBlock({ latest: true }, (err: any, block: any) => {
+  if (err) return console.error(err);
+  console.log("latest block index =", block.index);
+});
+```
+
+### Browser / Next.js (`@grpc/grpc-web` or `@protobuf-ts/grpcweb-transport`)
+
+The gRPC-Web codec is enabled on the same host — browsers can call directly without a separate proxy.
+
+```bash
+npm install @protobuf-ts/grpcweb-transport @protobuf-ts/runtime-rpc
+# (plus your codegen pipeline of choice — e.g. ts-proto, protobuf-ts plugin for protoc)
+```
+
+```typescript
+import { GrpcWebFetchTransport } from "@protobuf-ts/grpcweb-transport";
+import { SentrixClient } from "./generated/sentrix.client";
+
+const transport = new GrpcWebFetchTransport({
+  baseUrl: "https://grpc.sentrixchain.com",
+});
+
+const client = new SentrixClient(transport);
+
+const { response } = await client.getBlock({ selector: { oneofKind: "latest", latest: true } });
+console.log("latest block index =", response.index);
+```
+
+### Python (`grpcio`)
+
+```bash
+pip install grpcio grpcio-tools
+python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. sentrix.proto
+```
+
+```python
+import grpc
+import sentrix_pb2 as pb
+import sentrix_pb2_grpc as svc
+
+channel = grpc.secure_channel("grpc.sentrixchain.com:443", grpc.ssl_channel_credentials())
+client = svc.SentrixStub(channel)
+
+resp = client.GetBlock(pb.GetBlockRequest(latest=True))
+print("latest block index =", resp.index)
+```
+
+### Go (`google.golang.org/grpc`)
+
+```bash
+go get google.golang.org/grpc google.golang.org/grpc/credentials
+protoc --go_out=. --go-grpc_out=. sentrix.proto
+```
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials"
+    pb "yourmodule/proto"
+)
+
+func main() {
+    creds := credentials.NewClientTLSFromCert(nil, "")
+    conn, err := grpc.Dial("grpc.sentrixchain.com:443", grpc.WithTransportCredentials(creds))
+    if err != nil { log.Fatal(err) }
+    defer conn.Close()
+
+    client := pb.NewSentrixClient(conn)
+    block, err := client.GetBlock(context.Background(), &pb.GetBlockRequest{
+        Selector: &pb.GetBlockRequest_Latest{Latest: true},
+    })
+    if err != nil { log.Fatal(err) }
+    log.Printf("latest block index = %d", block.Index)
+}
+```
+
+---
+
+## CORS (browser clients)
+
+The edge proxy adds the following headers on every gRPC-Web response:
+
+```
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, OPTIONS
+Access-Control-Allow-Headers: Content-Type, X-Grpc-Web, X-User-Agent, Grpc-Timeout
+Access-Control-Expose-Headers: Grpc-Status, Grpc-Message, Grpc-Encoding, Grpc-Accept-Encoding
+Access-Control-Max-Age: 86400
+```
+
+Preflight `OPTIONS` requests are answered with `204 No Content`. Standard gRPC-Web client libraries work without any custom configuration.
+
+---
+
+## Limitations
+
+- **Chain window:** Validators serve blocks within their last ~1000-block in-memory window. Older blocks need to come from an indexer (none operated by Sentrix Labs at this time — community indexers welcome).
+- **No reflection:** `grpcurl list` won't work. Use the `.proto` file.
+- **No history reads:** `at_height` on `GetBalance` returns `FAILED_PRECONDITION`.
+- **Read-only:** `BroadcastTx` and `StreamEvents` are stubs in v0.2; use JSON-RPC `eth_sendRawTransaction` and the WebSocket `eth_subscribe` endpoint until v0.3.
+- **Single validator per network:** The published endpoint forwards to a single validator side-car. If that validator restarts, expect a brief connection reset; clients should implement standard gRPC retry with exponential backoff.
+
+---
+
+## Roadmap
+
+- **v0.3** — full transaction marshalling (`BroadcastTx`), event-bus subscription (`StreamEvents`), MDBX snapshot reads (`at_height`).
+- **v0.4** — multi-validator load balancing on the edge, optional gRPC compression negotiation, server reflection toggle for tooling.
+
+Track progress at the canonical design doc in the repo: `crates/sentrix-grpc/proto/sentrix.proto` is updated as methods come online.


### PR DESCRIPTION
## Summary
- Add `tonic-web = 0.12` to `bin/sentrix`
- Wrap side-car with `tonic_web::GrpcWebLayer` + `accept_http1(true)` so browser clients (Next.js / React) can hit the same port via gRPC-Web
- Pure gRPC path (HTTP/2 + `application/grpc`) unchanged — layer dispatches by content-type
- Default-OFF env-var gate from v2.1.69 retained; hosts without `SENTRIX_GRPC_ENABLED=1` see zero behavioural change
- CORS stays at edge proxy (matches the existing pattern on `rpc.sentrixchain.com`)

## Test plan
- [x] `cargo check --release -p sentrix-node` passes locally with tonic 0.12.3 + tonic-web 0.12.3
- [ ] Build via Docker (rust:1.95-bullseye, glibc 2.31 baseline)
- [ ] Deploy to testnet val1; smoke-test pure gRPC path still returns blocks
- [ ] Curl with `application/grpc-web` headers returns gRPC-Web framed response
- [ ] Browser (or grpcurl-equivalent gRPC-Web client) reaches the chain end-to-end via edge proxy
- [ ] Deploy to one mainnet validator; verify chain advances + endpoint live