### PR TITLE
feat(grpc): StreamEvents v0.3 push (v2.1.71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Audit pass 2026-05-05 confirmed clean: no `std::sync::Mutex` / `RwLock` held across an `.await` point in workspace production code. The codebase already enforces this discipline (explicit comment at `crates/sentrix-rpc/src/routes/mod.rs:49`); audit verified zero violations.
 - WebSocket broadcaster (`crates/sentrix-rpc/src/ws/`) already uses `tokio::sync::broadcast` with `RecvError::Lagged` handling — slow consumers drop the oldest frames per-subscriber without affecting the broadcaster or other subscribers. No code change needed for the "slow consumer" hardening pattern.
 
+## [2.1.71] — 2026-05-04 — StreamEvents v0.3 (push BlockFinalized via broadcast)
+
+Wires the side-car gRPC service into `sentrix-rpc::events::EventBus` — the existing tokio `broadcast::Sender` bus that powers the WebSocket `eth_subscribe` handlers. The `StreamEvents` method now subscribes to `new_heads` on request and yields `ChainEvent::BlockFinalized` for each block as it lands. Single source of truth for event ordering: a gRPC stream subscriber and a WS subscriber see the same sequence at the broadcast::Sender boundary, no duplicate event-emit code path.
+
+Backpressure: `RecvError::Lagged` forwards as `ChainEvent::Lagged` with the broadcast's skipped_count — slow consumer can resync state via `GetBlock` instead of silently missing events. Mirrors the WS handler's Lagged semantics (1024-event capacity, drop-oldest).
+
+Filter / from_sequence / additional event variants (PendingTx, ValidatorSetChange, LogEmitted) deferred to v0.4 — same pattern, just additional `broadcast::Sender` subscriptions multiplexed onto this stream. Current impl always subscribes to all BlockFinalized from "now".
+
+Default-OFF env-var gate retained from v2.1.69. Hosts without `SENTRIX_GRPC_ENABLED=1` see zero behavioural change. Indexer in the `sentriscloud/indexer` repo can swap from `watchTipGrpc` polling to `streamBlocks` push for sub-100ms tip detection (push latency = broadcast hop, not 200ms poll interval).
+
 ## [2.1.70] — 2026-05-04 — gRPC-Web layer (browsers can talk to the side-car directly)
 
 Wraps the side-car gRPC service with `tonic_web::GrpcWebLayer` and enables HTTP/1.1 fallback (`accept_http1(true)`). Same port (default `:50051`) now serves both pure gRPC (HTTP/2 + `application/grpc`, used by Tonic / grpcio / grpc-go / grpcurl) and gRPC-Web (HTTP/1.1 or HTTP/2 + `application/grpc-web`, used by browsers via `@grpc/grpc-web` or `@protobuf-ts/grpcweb-transport`). The layer dispatches by content-type — pure gRPC clients see no behavioural change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "bincode",
  "hex",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5143,6 +5143,7 @@ dependencies = [
  "prost-build",
  "sentrix-core",
  "sentrix-primitives",
+ "sentrix-rpc",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5152,7 +5153,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5170,7 +5171,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5193,14 +5194,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5214,7 +5215,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5244,14 +5245,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5261,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5276,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "bincode",
  "blake3",
@@ -5292,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5311,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.70"
+version = "2.1.71"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -3670,6 +3670,7 @@ async fn cmd_start(
         .unwrap_or(false)
     {
         let grpc_state = shared.clone();
+        let grpc_event_bus = event_bus.clone();
         let grpc_addr_str = std::env::var("SENTRIX_GRPC_ADDR")
             .unwrap_or_else(|_| "0.0.0.0:50051".to_string());
         match grpc_addr_str.parse::<std::net::SocketAddr>() {
@@ -3679,7 +3680,7 @@ async fn cmd_start(
                     grpc_addr
                 );
                 tokio::spawn(async move {
-                    let server = sentrix_grpc::server_factory(grpc_state);
+                    let server = sentrix_grpc::server_factory(grpc_state, grpc_event_bus);
                     // v2.1.70: accept_http1(true) + GrpcWebLayer so browsers
                     // can hit the same port. Pure gRPC clients (HTTP/2 +
                     // application/grpc) still work — the layer dispatches by

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"
@@ -21,6 +21,11 @@ tracing = "0.1"
 async-stream = "0.3"
 sentrix-core = { path = "../sentrix-core" }
 sentrix-primitives = { path = "../sentrix-primitives" }
+# v0.3: server-streaming StreamEvents subscribes to sentrix-rpc::events::EventBus
+# (the existing tokio broadcast bus that powers the WebSocket eth_subscribe path).
+# Same bus, same Lagged semantics — gRPC-Web and JSON-RPC WS see the same event
+# ordering at the broadcast::Sender boundary.
+sentrix-rpc = { path = "../sentrix-rpc" }
 hex = "0.4"
 bincode = "1.3"
 

--- a/crates/sentrix-grpc/src/lib.rs
+++ b/crates/sentrix-grpc/src/lib.rs
@@ -50,6 +50,7 @@ use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
 use sentrix_core::blockchain::Blockchain;
+use sentrix_rpc::events::{EventBus, NewHeadEvent};
 
 /// Shared state handle — identical type to the one passed to the JSON-RPC
 /// router (`crates/sentrix-rpc/src/routes/mod.rs::SharedState`). Same Arc;
@@ -60,21 +61,30 @@ pub type SharedState = Arc<RwLock<Blockchain>>;
 /// stack. Read paths use a brief read-lock; the BroadcastTx path (when
 /// implemented) will use the same brief write-lock pattern as
 /// `routes::transactions::send_transaction`.
+///
+/// v0.3 also holds an `Arc<EventBus>` so `stream_events` can subscribe to
+/// the same broadcast channels powering the WebSocket `eth_subscribe` handlers.
+/// Single source-of-truth for event ordering — a gRPC stream subscriber and
+/// a WS subscriber see the same sequence at the broadcast::Sender boundary.
 pub struct SentrixServiceImpl {
     state: SharedState,
+    event_bus: Arc<EventBus>,
 }
 
 impl SentrixServiceImpl {
-    pub fn new(state: SharedState) -> Self {
-        Self { state }
+    pub fn new(state: SharedState, event_bus: Arc<EventBus>) -> Self {
+        Self { state, event_bus }
     }
 }
 
 /// Convenience constructor returning a tonic-ready `SentrixServer`.
 /// Caller is responsible for binding to a transport — see the gated
 /// spawn block in `bin/sentrix/src/main.rs`.
-pub fn server_factory(state: SharedState) -> SentrixServer<SentrixServiceImpl> {
-    SentrixServer::new(SentrixServiceImpl::new(state))
+pub fn server_factory(
+    state: SharedState,
+    event_bus: Arc<EventBus>,
+) -> SentrixServer<SentrixServiceImpl> {
+    SentrixServer::new(SentrixServiceImpl::new(state, event_bus))
 }
 
 // ── Helpers: chain-string-hex ↔ proto-bytes ──────────────────────────────
@@ -126,6 +136,34 @@ fn parse_hex_prefixed(s: &str, expect_bytes: usize) -> Option<Vec<u8>> {
         return None;
     }
     hex::decode(trimmed).ok()
+}
+
+/// Parse a `0x`-prefixed hex u64 (e.g. `"0x2a"` → 42). NewHeadEvent encodes
+/// numeric fields this way for ethers.js / viem compatibility.
+fn parse_hex_u64(s: &str) -> Option<u64> {
+    let trimmed = s.strip_prefix("0x").unwrap_or(s);
+    u64::from_str_radix(trimmed, 16).ok()
+}
+
+/// Marshal a `NewHeadEvent` (hex-string-encoded EVM-shaped header) into a
+/// proto `Block`. Used by the StreamEvents subscriber path. transactions
+/// stays empty in v0.3 — same as GetBlock — clients refetch full bodies via
+/// JSON-RPC `eth_getBlockByNumber` until v0.4 plumbs proto Transaction.
+fn newhead_to_proto_block(ev: &NewHeadEvent) -> Block {
+    Block {
+        index: parse_hex_u64(&ev.number).unwrap_or(0),
+        hash: chain_hash_to_proto(&ev.hash),
+        parent_hash: chain_hash_to_proto(&ev.parent_hash),
+        state_root: chain_hash_to_proto(&ev.state_root),
+        timestamp: parse_hex_u64(&ev.timestamp).unwrap_or(0),
+        proposer: chain_addr_to_proto(&ev.miner),
+        // NewHeadEvent doesn't carry the BFT round — that's an internal
+        // consensus detail not exposed in the EVM-compatible header shape.
+        // Streaming consumers that need round info can refetch via GetBlock.
+        round: 0,
+        transactions: Vec::new(),
+        justification: Vec::new(),
+    }
 }
 
 /// Marshal a chain `Block` into a proto `Block`. The proto schema mirrors
@@ -261,12 +299,24 @@ impl Sentrix for SentrixServiceImpl {
         }))
     }
 
-    /// Server-streaming chain events. **DEFERRED** to fresh-brain — needs
-    /// integration with `sentrix-rpc::events::EventBus` (existing
-    /// `tokio::sync::broadcast` infrastructure used by the JSON-RPC
-    /// WebSocket handlers). The pattern will mirror those handlers'
-    /// `RecvError::Lagged` handling, emitting a synthetic `StreamLagged`
-    /// sentinel on the gRPC stream.
+    /// Server-streaming chain events. v0.3 implements the BlockFinalized
+    /// channel by subscribing to the existing `EventBus.new_heads`
+    /// broadcast (Sentrix has instant BFT finality so new_heads ARE
+    /// finalized — same payload, different name). Other variants
+    /// (PendingTx, ValidatorSetChange, LogEmitted) deferred to v0.4 — same
+    /// pattern, just additional broadcast::Sender subscriptions multiplexed
+    /// onto this stream.
+    ///
+    /// Backpressure: when a slow consumer falls behind the broadcast
+    /// channel's per-receiver capacity (1024 events ≈ 17 minutes at 1
+    /// block/s), the receiver gets `RecvError::Lagged(skipped)`. We forward
+    /// that as a synthetic `ChainEvent::Lagged(StreamLagged{skipped_count})`
+    /// sentinel so the client can decide to resync state via GetBlock
+    /// instead of silently missing events. Mirrors the WS handler's
+    /// `RecvError::Lagged` semantics.
+    ///
+    /// Filter / from_sequence support deferred to v0.4 — current impl
+    /// always subscribes to all BlockFinalized events from "now".
     type StreamEventsStream =
         std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<ChainEvent, Status>> + Send>>;
 
@@ -274,11 +324,54 @@ impl Sentrix for SentrixServiceImpl {
         &self,
         _request: Request<StreamEventsRequest>,
     ) -> Result<Response<Self::StreamEventsStream>, Status> {
-        Err(Status::unimplemented(
-            "StreamEvents: event-bus subscription deferred to v0.3 — \
-             will plumb sentrix-rpc::events::EventBus broadcast::Receiver \
-             through a tokio_stream::wrappers::BroadcastStream adapter",
-        ))
+        use chain_event::Event as EventVariant;
+        use std::time::{SystemTime, UNIX_EPOCH};
+        use tokio::sync::broadcast::error::RecvError;
+
+        let mut rx = self.event_bus.new_heads.subscribe();
+        let now_secs = || {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0)
+        };
+
+        let stream = async_stream::stream! {
+            let mut sequence: u64 = 0;
+            loop {
+                match rx.recv().await {
+                    Ok(head) => {
+                        sequence = sequence.saturating_add(1);
+                        let block = newhead_to_proto_block(&head);
+                        yield Ok(ChainEvent {
+                            event: Some(EventVariant::BlockFinalized(BlockFinalized {
+                                block: Some(block),
+                            })),
+                            sequence,
+                            timestamp: now_secs(),
+                        });
+                    }
+                    Err(RecvError::Lagged(skipped)) => {
+                        sequence = sequence.saturating_add(1);
+                        yield Ok(ChainEvent {
+                            event: Some(EventVariant::Lagged(StreamLagged {
+                                skipped_count: skipped,
+                            })),
+                            sequence,
+                            timestamp: now_secs(),
+                        });
+                    }
+                    Err(RecvError::Closed) => {
+                        // Sender dropped — process is shutting down. Close
+                        // the stream cleanly so the client sees an end-of-
+                        // stream rather than a connection reset.
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(stream)))
     }
 }
 

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.70"
+version = "2.1.71"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Push architecture for the side-car: subscribes to EventBus.new_heads, yields BlockFinalized as blocks land. Lagged → StreamLagged sentinel. Filter / from_sequence / other event variants deferred to v0.4.