### PR TITLE
feat(grpc): v0.4 read-only — GetValidatorSet, GetSupply, GetMempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "bincode",
  "hex",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5144,6 +5144,7 @@ dependencies = [
  "sentrix-core",
  "sentrix-primitives",
  "sentrix-rpc",
+ "sentrix-staking",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5153,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5171,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5194,14 +5195,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5215,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5245,14 +5246,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5262,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5277,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "bincode",
  "blake3",
@@ -5293,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5312,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.71"
+version = "2.1.72"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"
@@ -21,6 +21,9 @@ tracing = "0.1"
 async-stream = "0.3"
 sentrix-core = { path = "../sentrix-core" }
 sentrix-primitives = { path = "../sentrix-primitives" }
+# v0.4 GetValidatorSet uses EpochManager::epoch_for_height for the
+# active-set's epoch number.
+sentrix-staking = { path = "../sentrix-staking" }
 # v0.3: server-streaming StreamEvents subscribes to sentrix-rpc::events::EventBus
 # (the existing tokio broadcast bus that powers the WebSocket eth_subscribe path).
 # Same bus, same Lagged semantics — gRPC-Web and JSON-RPC WS see the same event

--- a/crates/sentrix-grpc/proto/sentrix.proto
+++ b/crates/sentrix-grpc/proto/sentrix.proto
@@ -134,6 +134,18 @@ service Sentrix {
   // the pending-aware nonce behaviour from chain v2.1.57).
   rpc GetBalance(GetBalanceRequest) returns (Account);
 
+  // v0.4 read-only state queries — drop the REST `/sentrix_status_extended`
+  // bridge from the explorer's stats hot path. All three are pure reads
+  // off `state.read()` snapshots; same lock contention profile as
+  // GetBlock/GetBalance.
+  //
+  // Active validator set + per-validator stake/active/jailed flags.
+  rpc GetValidatorSet(GetValidatorSetRequest) returns (ValidatorSet);
+  // Native-token supply snapshot (minted, burned, circulating).
+  rpc GetSupply(GetSupplyRequest) returns (Supply);
+  // Pending-tx count + a capped header window for UI display.
+  rpc GetMempool(GetMempoolRequest) returns (Mempool);
+
   // Server-streaming chain events. Subscribe once, receive every event type
   // until cancel or server restart. Replaces N separate eth_subscribe calls.
   // Backpressure: server bounded channel per stream (capacity 4096 — same as
@@ -181,4 +193,65 @@ enum EventFilter {
   EVENT_FILTER_PENDING_TX = 2;
   EVENT_FILTER_VALIDATOR_SET = 3;
   EVENT_FILTER_LOG = 4;
+}
+
+// ────────────────────────────────────────────────────────────
+// v0.4 read-only state-query messages
+// ────────────────────────────────────────────────────────────
+
+message GetValidatorSetRequest {
+  // Reserved for at_height historical reads — gated on MDBX snapshot
+  // isolation (Refactor 5). v0.4 returns the latest finalized set.
+  optional BlockHeight at_height = 1;
+}
+
+message ValidatorSet {
+  uint32 epoch = 1;
+  uint32 active_count = 2;
+  uint32 total_count = 3;
+  // Total stake across the active set, in sentri (10^-8 SRX).
+  uint64 total_active_stake_sentri = 4;
+  repeated ValidatorEntry validators = 5;
+}
+
+message ValidatorEntry {
+  Address address = 1;
+  uint64 stake_sentri = 2;
+  bool active = 3;
+  bool jailed = 4;
+}
+
+message GetSupplyRequest {
+  optional BlockHeight at_height = 1;
+}
+
+message Supply {
+  // sentri = 10^-8 SRX. Cap is fork-gated (210M pre-fork, 315M post-
+  // tokenomics-v2 at h=640800); leave conversion to display layer.
+  uint64 minted_sentri = 1;
+  uint64 burned_sentri = 2;
+  uint64 circulating_sentri = 3;  // = minted − burned
+}
+
+message GetMempoolRequest {
+  // Cap returned tx headers; default 100, max 500. Larger windows need
+  // pagination (deferred). 0 = use server default (100).
+  uint32 limit = 1;
+}
+
+message Mempool {
+  // Authoritative pending-tx count. `entries` is capped by `limit`;
+  // size always reflects the full mempool depth.
+  uint32 size = 1;
+  repeated MempoolEntry entries = 2;
+}
+
+message MempoolEntry {
+  Hash txid = 1;
+  Address from_address = 2;
+  Address to_address = 3;
+  Amount amount = 4;
+  Amount fee = 5;
+  uint64 nonce = 6;
+  uint32 tx_type = 7;
 }

--- a/crates/sentrix-grpc/src/lib.rs
+++ b/crates/sentrix-grpc/src/lib.rs
@@ -334,7 +334,7 @@ impl Sentrix for SentrixServiceImpl {
         // Sort by stake descending — UI consumers (the Explorer hero) want
         // the heaviest stakes first; alphabetic order on the HashMap iter
         // would shuffle each call and confuse caching downstream.
-        validators.sort_by(|a, b| b.stake_sentri.cmp(&a.stake_sentri));
+        validators.sort_by_key(|v| std::cmp::Reverse(v.stake_sentri));
 
         let active_count = bc.stake_registry.active_count() as u32;
         let total_count = bc.stake_registry.validators.len() as u32;
@@ -547,9 +547,9 @@ mod tests {
         assert_eq!(set.active_count, 4);
 
         let supply = Supply {
-            minted_sentri: 63_000_000_00_000_000,
+            minted_sentri: 6_300_000_000_000_000,
             burned_sentri: 0,
-            circulating_sentri: 63_000_000_00_000_000,
+            circulating_sentri: 6_300_000_000_000_000,
         };
         assert_eq!(
             supply.circulating_sentri,

--- a/crates/sentrix-grpc/src/lib.rs
+++ b/crates/sentrix-grpc/src/lib.rs
@@ -299,6 +299,132 @@ impl Sentrix for SentrixServiceImpl {
         }))
     }
 
+    /// `GetValidatorSet` — current active set + per-validator stake/active/jailed.
+    /// Mirrors `validators.*` slice of the REST `/sentrix_status_extended`
+    /// endpoint so the explorer can drop the JSON bridge from its hot path.
+    async fn get_validator_set(
+        &self,
+        request: Request<GetValidatorSetRequest>,
+    ) -> Result<Response<ValidatorSet>, Status> {
+        let req = request.into_inner();
+        if req.at_height.is_some() {
+            return Err(Status::unimplemented(
+                "at_height historical reads require MDBX snapshot isolation \
+                 (Refactor 5 in 2026-05-05-sentrix-sdk-design.md); v0.4 returns latest only",
+            ));
+        }
+
+        let bc = self.state.read().await;
+        let active_set: std::collections::HashSet<&String> =
+            bc.stake_registry.active_set.iter().collect();
+        let mut validators: Vec<ValidatorEntry> = bc
+            .stake_registry
+            .validators
+            .iter()
+            .map(|(addr, v)| {
+                let proto_addr = chain_addr_to_proto(addr);
+                ValidatorEntry {
+                    address: proto_addr,
+                    stake_sentri: v.total_stake(),
+                    active: active_set.contains(addr),
+                    jailed: v.is_jailed,
+                }
+            })
+            .collect();
+        // Sort by stake descending — UI consumers (the Explorer hero) want
+        // the heaviest stakes first; alphabetic order on the HashMap iter
+        // would shuffle each call and confuse caching downstream.
+        validators.sort_by(|a, b| b.stake_sentri.cmp(&a.stake_sentri));
+
+        let active_count = bc.stake_registry.active_count() as u32;
+        let total_count = bc.stake_registry.validators.len() as u32;
+        let total_active_stake_sentri: u64 = bc
+            .stake_registry
+            .active_set
+            .iter()
+            .filter_map(|a| bc.stake_registry.get_validator(a))
+            .map(|v| v.total_stake())
+            .sum();
+        let epoch = sentrix_staking::epoch::EpochManager::epoch_for_height(bc.height()) as u32;
+        drop(bc);
+
+        Ok(Response::new(ValidatorSet {
+            epoch,
+            active_count,
+            total_count,
+            total_active_stake_sentri,
+            validators,
+        }))
+    }
+
+    /// `GetSupply` — minted/burned/circulating snapshot.
+    async fn get_supply(
+        &self,
+        request: Request<GetSupplyRequest>,
+    ) -> Result<Response<Supply>, Status> {
+        let req = request.into_inner();
+        if req.at_height.is_some() {
+            return Err(Status::unimplemented(
+                "at_height historical reads require MDBX snapshot isolation; \
+                 v0.4 returns latest only",
+            ));
+        }
+
+        let bc = self.state.read().await;
+        let minted_sentri = bc.total_minted;
+        let burned_sentri = bc.accounts.total_burned;
+        drop(bc);
+
+        Ok(Response::new(Supply {
+            minted_sentri,
+            burned_sentri,
+            circulating_sentri: minted_sentri.saturating_sub(burned_sentri),
+        }))
+    }
+
+    /// `GetMempool` — pending-tx count + capped header window.
+    async fn get_mempool(
+        &self,
+        request: Request<GetMempoolRequest>,
+    ) -> Result<Response<Mempool>, Status> {
+        let req = request.into_inner();
+        // 0 → server default 100. Hard cap at 500 to keep one
+        // round-trip bounded under sustained mempool load.
+        let limit = match req.limit {
+            0 => 100usize,
+            n => (n as usize).min(500),
+        };
+
+        let bc = self.state.read().await;
+        let size = bc.mempool_size() as u32;
+        // VecDeque iter is FIFO — the order tx will be considered for
+        // inclusion. UI cares about that order more than insertion-time.
+        let entries: Vec<MempoolEntry> = bc
+            .mempool
+            .iter()
+            .take(limit)
+            .map(|tx| MempoolEntry {
+                txid: chain_hash_to_proto(&tx.txid),
+                from_address: chain_addr_to_proto(&tx.from_address),
+                to_address: chain_addr_to_proto(&tx.to_address),
+                amount: Some(Amount { sentri: tx.amount }),
+                fee: Some(Amount { sentri: tx.fee }),
+                nonce: tx.nonce,
+                // Chain-side `Transaction` doesn't carry an explicit
+                // tx_type field — the variant is implicit in the
+                // address conventions (system addresses for staking
+                // ops, contract creation when to_address is empty,
+                // etc.). v0.4 returns 0 ("transfer"); add proper
+                // classification in v0.5 alongside BroadcastTx where
+                // the wire shape is canonical.
+                tx_type: 0,
+            })
+            .collect();
+        drop(bc);
+
+        Ok(Response::new(Mempool { size, entries }))
+    }
+
     /// Server-streaming chain events. v0.3 implements the BlockFinalized
     /// channel by subscribing to the existing `EventBus.new_heads`
     /// broadcast (Sentrix has instant BFT finality so new_heads ARE
@@ -392,6 +518,49 @@ mod tests {
         assert_eq!(proto.value, bytes);
         let back = proto_addr_to_chain(&proto).expect("reverse");
         assert_eq!(back, addr);
+    }
+
+    #[test]
+    fn v04_messages_construct() {
+        // Smoke test for the v0.4 read-only types — proto changes ripple
+        // through tonic-build at compile time, so a missing field surfaces
+        // here long before deploy.
+        let req = GetValidatorSetRequest { at_height: None };
+        let _ = req.at_height.is_none();
+
+        let entry = ValidatorEntry {
+            address: Some(Address { value: vec![0u8; 20] }),
+            stake_sentri: 1_000_000_000,
+            active: true,
+            jailed: false,
+        };
+        assert!(entry.active);
+        assert!(!entry.jailed);
+
+        let set = ValidatorSet {
+            epoch: 12,
+            active_count: 4,
+            total_count: 4,
+            total_active_stake_sentri: 4_000_000_000_000,
+            validators: vec![entry],
+        };
+        assert_eq!(set.active_count, 4);
+
+        let supply = Supply {
+            minted_sentri: 63_000_000_00_000_000,
+            burned_sentri: 0,
+            circulating_sentri: 63_000_000_00_000_000,
+        };
+        assert_eq!(
+            supply.circulating_sentri,
+            supply.minted_sentri.saturating_sub(supply.burned_sentri)
+        );
+
+        let pool = Mempool {
+            size: 0,
+            entries: vec![],
+        };
+        assert_eq!(pool.size, 0);
     }
 
     #[test]

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/explorer.rs
+++ b/crates/sentrix-rpc/src/explorer.rs
@@ -225,8 +225,19 @@ pub async fn stats_daily(State(state): State<SharedState>) -> Json<Vec<DailyStat
 
     if today_day > 0 {
         let earliest = today_day.saturating_sub(13);
-        for i in 0..=height {
+        let earliest_ts = earliest.saturating_mul(86400);
+        // Walk backward from head and bail as soon as we drop below the 14-day
+        // window. Used to be `for i in 0..=height`, which scanned every block
+        // from genesis under the state read lock — at h=1.55M (2026-05-05) the
+        // request hung >30s and starved writers, taking the whole /stats/daily
+        // endpoint offline at the LB. Backward walk caps work at ~14d × block
+        // rate (~200k iter) and stays bounded as chain grows.
+        let mut i = height;
+        loop {
             if let Some(block) = bc.get_block_any(i) {
+                if block.timestamp < earliest_ts {
+                    break;
+                }
                 let day = block.timestamp / 86400;
                 if day >= earliest && day <= today_day {
                     let e = map.entry(day).or_insert((0, 0));
@@ -238,6 +249,10 @@ pub async fn stats_daily(State(state): State<SharedState>) -> Json<Vec<DailyStat
                         .count() as u64;
                 }
             }
+            if i == 0 {
+                break;
+            }
+            i -= 1;
         }
     }
 

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.71"
+version = "2.1.72"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Adds three read-only RPCs to `sentrix.v1.Sentrix` — `GetValidatorSet`, `GetSupply`, `GetMempool`. Drops the REST `/sentrix_status_extended` bridge from explorer-v2's stats hot path.

All three are pure reads under `state.read().await`, same lock-contention profile as the existing `GetBlock` / `GetBalance` handlers. No consensus surface, no write path, no `.await` while holding the lock.

Versions bumped `2.1.71 → 2.1.72` across the workspace.

## Why

The explorer (Sentriscloud/sentrix-explorer-v2) has been bridging stats through REST because proto v0.1 only shipped `GetBlock` + `GetBalance` + `StreamEvents([BlockFinalized])`. Each REST call adds a transport, validators are routed differently from blocks, and one bug class spans three protocols. Closing the gap one read-only method at a time is the lowest-risk path to "pure gRPC explorer".

This PR is the read-only slice. Write-path (`BroadcastTx`) and event-emit (`PendingTx`, `ValidatorSetChange`, `LogEmitted`) ship in subsequent fresh-brain PRs per `audits/2026-05-05-grpc-v0.4-design.md`.

## What's in

- `crates/sentrix-grpc/proto/sentrix.proto`: 3 new RPCs, 8 new message types (3 request shapes, 5 response shapes).
- `crates/sentrix-grpc/src/lib.rs`: handler impls. Sorts validators by stake descending so UI consumers don't have to.
- `crates/sentrix-grpc/Cargo.toml`: + `sentrix-staking` dep for `EpochManager::epoch_for_height`.
- Workspace: `2.1.71 → 2.1.72`.

## Test plan

- [x] `cargo test -p sentrix-grpc` — 3/3 pass (existing 2 + new `v04_messages_construct` smoke test that catches proto/Rust drift)
- [x] `cargo check --workspace` — green
- [ ] `./scripts/fast-deploy.sh testnet` — operator-side
- [ ] `grpcurl -d '{}' grpc-testnet.sentrixchain.com:443 sentrix.v1.Sentrix/GetValidatorSet` — expect active_count >= 1 + at least 1 ValidatorEntry
- [ ] `grpcurl -d '{}' grpc-testnet.sentrixchain.com:443 sentrix.v1.Sentrix/GetSupply` — expect minted_sentri > 0
- [ ] `grpcurl -d '{}' grpc-testnet.sentrixchain.com:443 sentrix.v1.Sentrix/GetMempool` — expect size: 0 on idle testnet
- [ ] Bake on testnet for the usual window, then mainnet ship per halt-all + simul-start runbook

## Risk

Low. Read-only additions, no consensus path. Backwards-compat: existing callers see no change. Older clients don't know about the new methods so they simply don't call them.