### PR TITLE
fix(rpc): bare /address/{addr} + /accounts/{addr} aliases; accurate root docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "bincode",
  "hex",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5195,14 +5195,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5246,14 +5246,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "bincode",
  "blake3",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.72"
+version = "2.1.73"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/routes/mod.rs
+++ b/crates/sentrix-rpc/src/routes/mod.rs
@@ -196,6 +196,15 @@ pub fn create_router_with_bus(
         // ── Address history ──────────────────────────────────────
         .route("/address/{address}/history", get(get_address_history))
         .route("/address/{address}/info", get(get_address_info))
+        // Bare `/address/{addr}` and `/accounts/{addr}` were 404-only —
+        // sub-paths like `/info` / `/history` / `/balance` worked but
+        // the bare path that the root `/` docs string advertised did
+        // not. Surfaced by the chainlist reviewer who pasted a bare
+        // address URL and got 404 instead of the info shape every
+        // other registry chain returns at the bare path. Both now
+        // alias to `get_address_info` (the same shape as `/info`).
+        .route("/address/{address}", get(get_address_info))
+        .route("/accounts/{address}", get(get_address_info))
         // ── State trie ───────────────────────────────────────────
         .route("/address/{address}/proof", get(get_address_proof))
         .route("/chain/state-root/{height}", get(get_state_root))

--- a/crates/sentrix-rpc/src/routes/ops.rs
+++ b/crates/sentrix-rpc/src/routes/ops.rs
@@ -42,17 +42,26 @@ pub(super) async fn root(State(state): State<SharedState>) -> Json<serde_json::V
             "rest": {
                 "chain_info": "/chain/info",
                 "blocks": "/chain/blocks",
+                "block": "/chain/blocks/{height}",
                 "transactions": "/transactions",
+                "transaction": "/transactions/{txid}",
+                "address": "/address/{address}",
+                "address_history": "/address/{address}/history",
                 "accounts": "/accounts/{address}",
+                "account_balance": "/accounts/{address}/balance",
+                "account_nonce": "/accounts/{address}/nonce",
+                "account_code": "/accounts/{address}/code",
                 "tokens": "/tokens",
+                "token_info": "/tokens/{contract}",
                 "validators": "/validators",
-                "staking": "/staking",
+                "staking": "/staking/validators",
                 "epoch": "/epoch/current",
                 "mempool": "/mempool"
             },
             "ops": {
                 "health": "/health",
                 "status": "/sentrix_status",
+                "status_extended": "/sentrix_status_extended",
                 "metrics": "/metrics",
                 "explorer_builtin": "/explorer"
             }

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.72"
+version = "2.1.73"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Two cosmetic gaps surfaced by the chainlist reviewer who pasted bare address URLs and got 404. Sub-paths /info /history /balance /code worked, but the bare paths the root `/` docs string advertised did not.

- Add `/address/{address}` and `/accounts/{address}` route aliases pointing at `get_address_info` (same shape as /info).
- Update root `/` docs string to list every actually-served REST path (block, transaction, address_history, account_balance, account_nonce, account_code, token_info, status_extended) instead of stub'ing `accounts: /accounts/{address}` that 404'd before this fix.

Workspace 2.1.72 → 2.1.73. **Zero consensus surface** — pure RPC routing.

Already deployed to testnet + mainnet via halt-all + simul-start. Verified:
- Mainnet `https://api.sentrixchain.com/address/0x5b5b06688dcdbe532353ac610aaff41af825279d` → 200 with full info shape (Founder v3, 20.98M SRX)
- Mainnet `/` → version 2.1.73, 17 accurate REST paths listed
- Testnet `https://testnet-api.sentrixchain.com/address/0x21a24d63...` → 200