### PR TITLE
v2.1.74: inbound libp2p watchdog — closes silent-peer halt class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Audit pass 2026-05-05 confirmed clean: no `std::sync::Mutex` / `RwLock` held across an `.await` point in workspace production code. The codebase already enforces this discipline (explicit comment at `crates/sentrix-rpc/src/routes/mod.rs:49`); audit verified zero violations.
 - WebSocket broadcaster (`crates/sentrix-rpc/src/ws/`) already uses `tokio::sync::broadcast` with `RecvError::Lagged` handling — slow consumers drop the oldest frames per-subscriber without affecting the broadcaster or other subscribers. No code change needed for the "slow consumer" hardening pattern.
 
+## [2.1.73] — 2026-05-05 — bare `/address/{addr}` and `/accounts/{addr}` route aliases; accurate root docs; BFT nil-skip prevote-tally diagnostic
+
+Two cosmetic gaps in the REST surface, plus one diagnostic-logging follow-up. Surfaced by an external chain-list reviewer who pasted bare address URLs into a browser and got 404s — sub-paths like `/address/{addr}/info`, `/address/{addr}/history`, `/accounts/{addr}/balance`, `/accounts/{addr}/code` worked, but the bare paths advertised in the root `/` docs string did not.
+
+- **Bare `/address/{address}` and `/accounts/{address}` routes** (PR #474). New aliases in `crates/sentrix-rpc/src/routes/mod.rs` pointing at the existing `get_address_info` handler — same response shape as `/address/{addr}/info`. Wallets and registries that deeplink to the bare path now resolve correctly instead of the "Cannot GET /" Express default.
+- **Root `/` docs string accuracy** (PR #474). Expanded from 9 path stubs to 17 actually-served REST paths: `block`, `transaction`, `address`, `address_history`, `account_balance`, `account_nonce`, `account_code`, `token_info`, `status_extended` added to the existing list. `curl https://api.sentrixchain.com/ | jq .docs.rest` is an authoritative discovery surface again.
+- **BFT nil-majority-skip diagnostic logging** (PR #475). The nil-skip path already logged the precommit tally, but without the prevote tally for comparison the log can't distinguish a healthy network-silence timeout from the silent-thread pattern (validators prevoted yes then went silent / flipped to nil on precommit). Added `VoteCollector::prevote_tally_snapshot()` mirror of the existing precommit equivalent; the nil-skip log now emits both tallies side-by-side. Pure diagnostic — zero consensus surface change. The next occurrence of the pattern surfaces unambiguously in journalctl as `prevote_tally=[hashX=full] precommit_tally=[hashX=partial, nil=partial]`, distinguishing it from a clean network-silence skip where both tallies would be thin.
+
+Build via `rust:1.95-bullseye` for glibc 2.31 baseline (Ubuntu 22.04 mainnet validator parity). Halt-all + simul-start mainnet deploy completed in ~7 seconds with no chain.db divergence (state-root parity verified pre-halt at h=1604000 across all four validators).
+
 ## [2.1.72] — 2026-05-05 — gRPC v0.4 read-only state queries (GetValidatorSet + GetSupply + GetMempool)
 
 Three new read-only RPCs on the side-car gRPC service, all served off the same `state.read().await` snapshot used by GetBlock/GetBalance:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "bincode",
  "hex",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5195,14 +5195,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5246,14 +5246,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "bincode",
  "blake3",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.73"
+version = "2.1.74"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/src/behaviour.rs
+++ b/crates/sentrix-network/src/behaviour.rs
@@ -73,7 +73,8 @@ fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
             Err(_) => {
                 tracing::warn!(
                     "sentrix-network: {} set to {:?} but failed to parse — using default",
-                    key, raw
+                    key,
+                    raw
                 );
                 default
             }
@@ -92,7 +93,9 @@ fn env_bool(key: &str, default: bool) -> bool {
             _ => {
                 tracing::warn!(
                     "sentrix-network: {} set to {:?} but not a boolean — using default {}",
-                    key, raw, default
+                    key,
+                    raw,
+                    default
                 );
                 default
             }
@@ -431,9 +434,9 @@ mod tests {
     use libp2p::identity;
     // Primitives needed by the roundtrip tests below — not used at top
     // level of the module anymore (wire types moved to sentrix-wire).
+    use libp2p::request_response::Codec;
     use sentrix_primitives::block::Block;
     use sentrix_primitives::transaction::Transaction;
-    use libp2p::request_response::Codec;
 
     fn make_keypair() -> identity::Keypair {
         identity::Keypair::generate_ed25519()

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -9,7 +9,6 @@
 // SwarmTask is spawned once in `LibP2pNode::new()`.  All swarm mutations go
 // through the `SwarmCommand` channel so callers never need to hold the swarm.
 
-
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -76,13 +75,48 @@ pub static SWARM_TICK: AtomicU64 = AtomicU64::new(0);
 /// next session) so the Telegram alerter can fire on `rate(...) > 0`.
 pub static DROPPED_BFT_BROADCASTS: AtomicU64 = AtomicU64::new(0);
 
+/// 2026-05-05 v2.1.74: cumulative count of peer connections force-
+/// disconnected by the inbound-silence watchdog. A "silent peer" is one
+/// where our local view shows zero inbound libp2p messages from that
+/// peer for INBOUND_SILENCE_THRESHOLD seconds (default 30 s) despite
+/// the connection still being established at the swarm layer.
+///
+/// Closes the silent-peer halt class observed on 2026-05-05 testnet at
+/// h=2,607,387 (and matching session-off v33 35-second round-skip
+/// recoveries at h=2,575,800): val1's libp2p inbound stream stalled
+/// while outbound stayed alive, so peers (val2/3/4) saw 64-69 outbound
+/// failures each targeting val1's PeerId, BFT prevote/precommit never
+/// reached val1's view, cluster halted for 5 min until the SWARM_TICK
+/// watchdog SIGABRT'd the stuck node.
+///
+/// The v2.1.66 SWARM_TICK watchdog catches the case where val1's swarm
+/// task is fully wedged. This watchdog catches the narrower case where
+/// the swarm task is healthy overall (sync_interval / kad_interval
+/// ticks fire, SWARM_TICK advances) but a SPECIFIC peer connection's
+/// inbound stream drained slow or got stuck — most likely under page-
+/// fault pressure on chain.db reads during memory-pressure events.
+/// Force-disconnecting the half-dead connection lets libp2p re-dial
+/// with a fresh TCP+Noise+yamux stack, abandoning the stuck stream.
+///
+/// Threshold rationale: testnet + mainnet run 1-second blocks with
+/// 4 validators each. Every height a validator should see ~3 inbound
+/// BFT messages from each peer (proposal/prevote/precommit, plus
+/// gossipsub blocks + round_status pings). 30 s with zero inbound from
+/// a verified peer is genuinely abnormal, well above any plausible
+/// quiet window.
+///
+/// Trade-off accepted: false-positive disconnect during a true silent
+/// period (e.g. validator legitimately has nothing to broadcast for
+/// 30 s — extremely unlikely on Sentrix's 1-s cadence). Counter is the
+/// canary; if `rate(...) > 0` during normal operation without halts
+/// the threshold is too tight, retune.
+pub static INBOUND_SILENCE_DISCONNECTS: AtomicU64 = AtomicU64::new(0);
+
 use futures::StreamExt;
 use libp2p::{
-    Multiaddr, PeerId, Swarm, SwarmBuilder,
-    gossipsub,
+    Multiaddr, PeerId, Swarm, SwarmBuilder, gossipsub,
     identity::Keypair,
-    kad,
-    noise,
+    kad, noise,
     request_response::{self, OutboundRequestId},
     swarm::SwarmEvent,
     tcp, yamux,
@@ -109,8 +143,8 @@ mod multiaddr;
 mod ratelimit;
 mod validators;
 
-pub use multiaddr::make_multiaddr;
 use multiaddr::extract_ip;
+pub use multiaddr::make_multiaddr;
 use ratelimit::IpRateLimiter;
 use validators::{block_boundary_reject_reason, is_active_bft_signer};
 
@@ -481,7 +515,6 @@ impl LibP2pNode {
     }
 }
 
-
 // ── Swarm event loop ─────────────────────────────────────
 
 // large_futures: the Swarm owns SentrixBehaviour which has internal caches;
@@ -556,6 +589,18 @@ async fn run_swarm(
     // Periodic Kademlia bootstrap: every 60s, random walk to discover new peers.
     let mut kad_interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
 
+    // 2026-05-05 v2.1.74: inbound-silence watchdog state. Tracks the
+    // last-seen inbound libp2p message timestamp per verified peer.
+    // Updated on every inbound RR Request, RR Response, and gossipsub
+    // Message; initialised on ConnectionEstablished, removed on
+    // ConnectionClosed. Tick interval polls the map and force-
+    // disconnects peers with elapsed > INBOUND_SILENCE_THRESHOLD —
+    // closes the silent-peer halt class. See `INBOUND_SILENCE_DISCONNECTS`
+    // doc above for the full rationale.
+    let mut last_inbound_ts: HashMap<PeerId, std::time::Instant> = HashMap::new();
+    let mut inbound_watchdog_interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
+    const INBOUND_SILENCE_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(30);
+
     // 2026-05-05 v2.1.66: spawn the swarm-task watchdog. It reads
     // SWARM_TICK every 5 s; if the counter stays still for ≥30 s past
     // the startup grace, the swarm select! loop has wedged and we
@@ -563,7 +608,7 @@ async fn run_swarm(
     // keep SWARM_TICK incrementing during quiet periods so we don't
     // false-positive on a chain with no traffic.
     tokio::spawn(async move {
-        use tokio::time::{Duration, sleep, Instant as TokioInstant};
+        use tokio::time::{Duration, Instant as TokioInstant, sleep};
         const STALL_THRESHOLD: Duration = Duration::from_secs(30);
         const STARTUP_GRACE: Duration = Duration::from_secs(60);
         const TICK: Duration = Duration::from_secs(5);
@@ -755,12 +800,82 @@ async fn run_swarm(
                     &mut pending_handshakes,
                     &mut pending_syncs,
                     &mut pending_variants,
+                    &mut last_inbound_ts,
                     our_chain_id,
                     &mut ip_limiter,
                     &mut multiaddr_cache,
                     MAX_CACHED_ADVERTS,
                 )
                 .await;
+            }
+
+            // ── Inbound-silence watchdog tick (v2.1.74) ──
+            // Force-disconnect any verified peer whose last inbound
+            // timestamp is older than INBOUND_SILENCE_THRESHOLD. libp2p
+            // will auto-redial via the dial-tick path or operator's
+            // --peers list, replacing the half-dead connection with a
+            // fresh stream stack. See INBOUND_SILENCE_DISCONNECTS doc.
+            _ = inbound_watchdog_interval.tick() => {
+                let now = std::time::Instant::now();
+                // Carry the elapsed Duration through the tuple so the
+                // disconnect loop logs the same elapsed value used to
+                // decide staleness — avoids a second Instant::now() that
+                // would drift by microseconds and produce mismatched logs.
+                let stale: Vec<(PeerId, std::time::Duration)> = verified_peers
+                    .iter()
+                    .filter_map(|peer_id| {
+                        last_inbound_ts.get(peer_id).and_then(|ts| {
+                            let elapsed = now.duration_since(*ts);
+                            if elapsed > INBOUND_SILENCE_THRESHOLD {
+                                Some((*peer_id, elapsed))
+                            } else {
+                                None
+                            }
+                        })
+                    })
+                    .collect();
+
+                // Storm guard: never disconnect down to <2 verified peers.
+                // On a 4-validator cluster, a coincident quiet window
+                // could otherwise flag all 3 peers stale in the same
+                // tick → mass-disconnect → 0 verified peers → no BFT
+                // quorum → induced halt. Inverting the original bug.
+                // If we'd drop below 2 peers, log + skip this tick.
+                // Below 2 (i.e. 1 or 0) is also where redial latency
+                // matters most; the safer move is keep the current
+                // peers and let the v2.1.66 SWARM_TICK watchdog fire if
+                // the swarm task is genuinely stuck.
+                let post_count = verified_peers.len().saturating_sub(stale.len());
+                if !stale.is_empty() && post_count < 2 && verified_peers.len() >= 2 {
+                    tracing::warn!(
+                        target: "inbound_watchdog",
+                        "libp2p inbound watchdog: would drop {} of {} peers (post-disconnect <2), \
+                         skipping this tick to preserve quorum. SWARM_TICK watchdog will catch \
+                         a genuinely-wedged swarm task at the 30s threshold.",
+                        stale.len(), verified_peers.len()
+                    );
+                } else {
+                    for (peer_id, elapsed) in stale {
+                        let total = INBOUND_SILENCE_DISCONNECTS
+                            .fetch_add(1, Ordering::Relaxed)
+                            + 1;
+                        tracing::warn!(
+                            target: "inbound_watchdog",
+                            "libp2p inbound watchdog: peer {} silent for {}s — \
+                             force-disconnect (total={}). Closes silent-peer \
+                             halt class; libp2p will auto-redial.",
+                            peer_id, elapsed.as_secs(), total
+                        );
+                        // Pre-emptive ts removal so the peer cannot be
+                        // re-flagged during the redial window before
+                        // ConnectionClosed fires. ConnectionClosed will
+                        // remove from verified_peers; we do NOT remove
+                        // it here so the storm-guard count stays correct
+                        // for any other stale peers in the same tick.
+                        last_inbound_ts.remove(&peer_id);
+                        let _ = swarm.disconnect_peer_id(peer_id);
+                    }
+                }
             }
 
             // ── Periodic sync + rate limiter cleanup ──
@@ -812,6 +927,7 @@ async fn on_swarm_event(
     pending_handshakes: &mut HashMap<OutboundRequestId, PeerId>,
     pending_syncs: &mut HashMap<OutboundRequestId, PeerId>,
     pending_variants: &mut HashMap<OutboundRequestId, &'static str>,
+    last_inbound_ts: &mut HashMap<PeerId, std::time::Instant>,
     our_chain_id: u64,
     ip_limiter: &mut IpRateLimiter,
     multiaddr_cache: &mut HashMap<String, MultiaddrAdvertisement>,
@@ -848,6 +964,10 @@ async fn on_swarm_event(
             }
 
             tracing::info!("libp2p: TCP connection to {}", peer_id);
+            // v2.1.74: seed inbound-watchdog ts at connection time so a
+            // peer that just connected gets the full SILENCE_THRESHOLD
+            // window before it can be flagged stale.
+            last_inbound_ts.insert(peer_id, std::time::Instant::now());
             let height = blockchain.read().await.height();
             let req = SentrixRequest::Handshake {
                 host: "0.0.0.0".to_string(),
@@ -876,6 +996,7 @@ async fn on_swarm_event(
             // Previously, we removed on ANY close, orphaning the surviving connection.
             if num_established == 0 {
                 verified_peers.remove(&peer_id);
+                last_inbound_ts.remove(&peer_id);
                 let _ = event_tx
                     .send(NodeEvent::PeerDisconnected(peer_id.to_string()))
                     .await;
@@ -892,6 +1013,7 @@ async fn on_swarm_event(
                 pending_handshakes,
                 pending_syncs,
                 pending_variants,
+                last_inbound_ts,
                 our_chain_id,
             )
             .await;
@@ -929,6 +1051,8 @@ async fn on_swarm_event(
             propagation_source,
             ..
         })) => {
+            // v2.1.74: any inbound gossipsub from a peer marks it alive.
+            last_inbound_ts.insert(propagation_source, std::time::Instant::now());
             let topic = message.topic.as_str();
             if topic == BLOCKS_TOPIC {
                 match bincode::deserialize::<GossipBlock>(&message.data) {
@@ -1124,6 +1248,7 @@ async fn on_rr_event(
     pending_handshakes: &mut HashMap<OutboundRequestId, PeerId>,
     pending_syncs: &mut HashMap<OutboundRequestId, PeerId>,
     pending_variants: &mut HashMap<OutboundRequestId, &'static str>,
+    last_inbound_ts: &mut HashMap<PeerId, std::time::Instant>,
     our_chain_id: u64,
 ) {
     use request_response::{Event as RrEvent, Message as RrMessage};
@@ -1137,6 +1262,8 @@ async fn on_rr_event(
             },
             ..
         } => {
+            // v2.1.74: any inbound RR request from a peer marks it alive.
+            last_inbound_ts.insert(peer, std::time::Instant::now());
             on_inbound_request(
                 peer,
                 request,
@@ -1160,6 +1287,8 @@ async fn on_rr_event(
                 },
             ..
         } => {
+            // v2.1.74: any inbound RR response from a peer marks it alive.
+            last_inbound_ts.insert(peer, std::time::Instant::now());
             // Bug #1d diagnostic: release variant slot on successful response.
             // Without this the map would grow unbounded across the process
             // lifetime.
@@ -1240,11 +1369,7 @@ async fn on_rr_event(
 // than wedging the swarm task. Halts caused by drops are at least
 // observable now via `rate(EVENT_TX_DROPPED) > 0` (use Telegram alerter
 // or /metrics scrape).
-fn try_send_event(
-    event_tx: &mpsc::Sender<NodeEvent>,
-    event: NodeEvent,
-    variant: &'static str,
-) {
+fn try_send_event(event_tx: &mpsc::Sender<NodeEvent>, event: NodeEvent, variant: &'static str) {
     let depth_pre = event_tx.max_capacity() - event_tx.capacity();
     let max = event_tx.max_capacity();
     let start = std::time::Instant::now();
@@ -1604,7 +1729,11 @@ async fn on_inbound_request(
                 );
                 return;
             }
-            try_send_event(event_tx, NodeEvent::BftRoundStatus(status), "BftRoundStatus");
+            try_send_event(
+                event_tx,
+                NodeEvent::BftRoundStatus(status),
+                "BftRoundStatus",
+            );
         }
     }
 }

--- a/crates/sentrix-network/src/node.rs
+++ b/crates/sentrix-network/src/node.rs
@@ -25,10 +25,7 @@ pub enum NodeEvent {
     NewTransaction(Transaction),
     PeerConnected(String),
     PeerDisconnected(String),
-    SyncNeeded {
-        peer_addr: String,
-        peer_height: u64,
-    },
+    SyncNeeded { peer_addr: String, peer_height: u64 },
     BftProposal(sentrix_bft::messages::Proposal),
     BftPrevote(sentrix_bft::messages::Prevote),
     BftPrecommit(sentrix_bft::messages::Precommit),

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.73"
+version = "2.1.74"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Adds per-peer inbound-silence detection to `libp2p_node.rs`. Force-disconnects verified peers that have been silent on inbound libp2p messages for >30s, so libp2p auto-redials with a fresh TCP+Noise+yamux stack, abandoning the stuck stream.

Closes the silent-peer halt class observed on testnet 2026-05-05 at h=2,607,387 — val1's libp2p inbound stream silently stalled under memory pressure (page-fault stall on chain.db reads), peers saw 64-69 outbound failures each targeting val1's PeerId, BFT prevote/precommit never reached val1's view, cluster halted for 5 min until the v2.1.66 SWARM_TICK watchdog SIGABRT'd.

Different layer than the v2.1.65/67/68 channel-cap fixes (which addressed outbound libp2p drops): this catches inbound stream stalls on the receiver.

## What changed

- New `INBOUND_SILENCE_DISCONNECTS: AtomicU64` counter (Relaxed ordering, matches existing pattern)
- New `last_inbound_ts: HashMap<PeerId, Instant>` in `run_swarm` — updated on RR Request/Response inbound + gossipsub Message + ConnectionEstablished; cleaned on ConnectionClosed
- New 5s watchdog tick in select! loop scans `verified_peers`; flags entries with elapsed > 30s
- **Storm guard**: skips the tick if disconnecting would drop verified_peers below 2 (4-validator cluster with coincident quiet window could otherwise mass-disconnect)
- Pre-emptive `last_inbound_ts.remove()` so peers in the redial window cannot be re-flagged
- Workspace bumped 2.1.73 → 2.1.74 across all 18 `Cargo.toml`

## Self-review

Reviewed by rust-reviewer agent. Two blockers raised + resolved:
- ✅ `cargo fmt` clean
- ✅ Storm guard preserves quorum

Deferred to follow-up: integration test for watchdog behaviour. Testnet bake will validate end-to-end.

## Test plan

- [x] `cargo check --release --workspace` clean
- [x] `cargo clippy --release -p sentrix-network -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Testnet bake — deploy via `make down` + binary swap + `make up` on vps4 testnet docker, observe ≥24h
  - watch `INBOUND_SILENCE_DISCONNECTS` counter (should stay near 0 in normal ops)
  - watch for "libp2p inbound watchdog: peer X silent for Ys" log lines
  - watch for "would drop X of Y peers (post-disconnect <2), skipping" — storm guard firing means threshold is too tight
- [ ] Mainnet promotion — only after ≥24h clean testnet bake. Halt-all + simul-start (per consensus discipline; no rolling deploy on consensus code)

## Consensus discipline

Per `feedback_consensus_discipline_no_relitigate.md`: this is consensus-touching code (libp2p network layer). No-self-merge rule applies — fresh-brain reviewer required before merge.

🤖 internal Sentrix Labs / SentrisCloud audit