### PR TITLE
feat(jsonrpc): add net_peerCount + web3_sha3 + eth_getBlockTransactionCountByNumber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ __pycache__/
 # Bracket-expression patterns avoid naming third-party tools in public repo.
 .cl[a-z]ude/
 .cur[a-z]or/
+target-docker/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -74,6 +74,32 @@ pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) 
         "eth_accounts" => Ok(json!([])),
         "eth_getCode" => eth_get_code(params, state).await,
         "eth_getStorageAt" => eth_get_storage_at(params, state).await,
+        // `eth_getBlockTransactionCountByNumber` — added 2026-05-05 after
+        // a transport audit found it absent. Common ethers / wagmi probe
+        // when a wallet wants "how busy is this block." Mirrors the same
+        // block-resolution path as eth_getBlockByNumber.
+        "eth_getBlockTransactionCountByNumber" => {
+            let bc = state.read().await;
+            let block_param = params[0].as_str().unwrap_or("latest");
+            let index = if block_param == "latest" {
+                bc.height()
+            } else if block_param == "earliest" {
+                0
+            } else if block_param == "pending" || block_param == "finalized" || block_param == "safe" {
+                bc.height()
+            } else {
+                match u64::from_str_radix(block_param.trim_start_matches("0x"), 16) {
+                    Ok(n) => n,
+                    Err(_) => {
+                        return Err((-32602, format!("invalid block number: {block_param:?}")));
+                    }
+                }
+            };
+            match bc.get_block_any(index) {
+                Some(block) => Ok(json!(format!("0x{:x}", block.transactions.len()))),
+                None => Ok(json!(null)),
+            }
+        }
         // Subscriptions only make sense on a long-lived connection. HTTP is
         // request/response; clients that try to subscribe over HTTP get a
         // pointer to the right transport instead of a silent error.

--- a/crates/sentrix-rpc/src/jsonrpc/net.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/net.rs
@@ -19,6 +19,16 @@ pub(super) async fn dispatch(method: &str, _params: &Value, state: &SharedState)
             Ok(json!(bc.chain_id.to_string()))
         }
         "net_listening" => Ok(json!(true)),
+        // `net_peerCount` — wagmi / ethers occasionally probe this. We
+        // don't thread the libp2p Swarm handle through SharedState yet
+        // (would be a deeper refactor), so return active validator count
+        // minus self as a best-effort proxy — honest enough for the
+        // wallets that look at this since none branch on the exact value.
+        "net_peerCount" => {
+            let bc = state.read().await;
+            let n = bc.authority.active_count().saturating_sub(1);
+            Ok(json!(format!("0x{:x}", n)))
+        }
         _ => Err((-32601, format!("method not found: {}", method))),
     }
 }

--- a/crates/sentrix-rpc/src/jsonrpc/web3.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/web3.rs
@@ -3,21 +3,39 @@
 // Spec: https://ethereum.org/en/developers/docs/apis/json-rpc/#web3_clientversion
 //
 // Pulled out of the monolithic `mod.rs` during the backlog #11 phase 2
-// refactor. Currently a single method; more may arrive later (e.g.
-// `web3_sha3`).
+// refactor. `web3_sha3` (keccak256 utility) added 2026-05-05 after a
+// transport audit found it advertised by the namespace but absent.
 
 use crate::routes::SharedState;
 use serde_json::{Value, json};
+use sha3::{Digest, Keccak256};
 
 use super::DispatchResult;
 
 pub(super) async fn dispatch(
     method: &str,
-    _params: &Value,
+    params: &Value,
     _state: &SharedState,
 ) -> DispatchResult {
     match method {
         "web3_clientVersion" => Ok(json!(format!("Sentrix/{}/Rust", env!("CARGO_PKG_VERSION")))),
+        // `web3_sha3` — keccak256 hash of a hex-encoded byte string. The
+        // wagmi / ethers utility tier occasionally calls this for client-
+        // side hashing parity. Spec: input is a `0x`-prefixed hex string,
+        // output is the keccak256 hash, also `0x`-prefixed.
+        "web3_sha3" => {
+            let input = params
+                .get(0)
+                .and_then(|v| v.as_str())
+                .ok_or((-32602, "web3_sha3: expected hex string param".to_string()))?;
+            let hex = input.strip_prefix("0x").unwrap_or(input);
+            let bytes = hex::decode(hex)
+                .map_err(|e| (-32602, format!("web3_sha3: invalid hex: {}", e)))?;
+            let mut hasher = Keccak256::new();
+            hasher.update(&bytes);
+            let digest = hasher.finalize();
+            Ok(json!(format!("0x{}", hex::encode(digest))))
+        }
         _ => Err((-32601, format!("method not found: {}", method))),
     }
 }

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.74"
+version = "2.1.75"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Three standard JSON-RPC methods that wagmi / ethers / wallets occasionally probe were returning -32601 method-not-found. Surfaced via comprehensive transport audit tonight (gRPC ✅ all 5 methods, REST ✅ 22/22, JSON-RPC had these 3 gaps).

- `net_peerCount` — best-effort `active_count - 1` hex. Threading the libp2p Swarm handle into SharedState for a live peer count is a deeper refactor; this is honest enough for clients that only check non-zero (none branch on the exact value).
- `web3_sha3` — keccak256 utility (sha3 dep already in workspace).
- `eth_getBlockTransactionCountByNumber` — block-resolution path mirrors `eth_getBlockByNumber`, returns hex count or null for out-of-window heights.

Workspace 2.1.74 → 2.1.75. **Zero consensus surface; pure RPC additions.** Build via `rust:1.95-bullseye`, halt-all + simul-start when convenient. Not auto-deployed — v2.1.74 just shipped a few hours ago.

Also drops `target-docker/` into `.gitignore` — it accidentally got pulled into the staging area on this branch and the pre-commit hook hung scanning 3000+ generated artifacts. (Sneaky catch surfaced by this PR's commit dance.)