### PR TITLE
docs + rpc: state_root v2 post-mortem + extend historical-state honesty across 5 methods

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -1509,22 +1509,55 @@ impl Blockchain {
             // commitment honestly represented the trie's view; the
             // trie just wasn't tracking the system account.
             //
-            // Activation is fork-gated to keep all 4 mainnet validators
-            // in lockstep: until every host has the same env-set
-            // `STATE_ROOT_V2_HEIGHT`, leaving the touch list intact
-            // preserves the existing (frozen-but-agreed) state_root
-            // chain. Past activation, every block also re-roots
-            // PROTOCOL_TREASURY into the trie so the commitment
-            // matches actual on-chain state.
+            // !!! ACTIVATION POST-MORTEM 2026-05-06 !!!
             //
-            // Operator runbook for activation:
-            //   1. Pick activation_height = current_tip + 600 (~10min lead)
-            //   2. Halt all 4 mainnet validators in parallel
-            //   3. Append `STATE_ROOT_V2_HEIGHT=<h>` to each /etc/<svc>/<svc>.env
-            //   4. Simul-start; chain crosses h, all 4 simultaneously
-            //      flip to including PROTOCOL_TREASURY in touch set
-            //   5. New state_root from h onward correctly commits to
-            //      PROTOCOL_TREASURY balance
+            // First activation attempt FORKED the cluster within 30s.
+            // Root cause: PROTOCOL_TREASURY in-memory balance had
+            // silently drifted across the 4 validators for ~700K
+            // blocks, because the very bug this fix targets was the
+            // mechanism that prevented consensus from detecting drift.
+            // Snapshot at activation:
+            //   vps1: 1036005.66 SRX
+            //   vps2: 1035994.66 SRX (~11 SRX less)
+            //   vps3: 1035916.66 SRX (~89 SRX less)
+            //   vps5: 1036005.66 SRX (matches vps1)
+            //
+            // Activation makes each node insert its OWN local balance
+            // into the trie, so the 2-of-4 split (vps1+vps5 vs vps2+vps3)
+            // produced two competing state_roots. BFT couldn't reach
+            // 3-of-4 majority. Recovery: chain.db rsync from canonical
+            // (vps1) to the drifted nodes, restart with v2 disabled.
+            //
+            // Lesson: the simple touch-list addition is NOT a self-
+            // sufficient fix. Reactivation requires ONE of these
+            // companion mechanisms FIRST:
+            //
+            //   Option A (preferred): canonical balance reconciliation
+            //     pre-activation. Sample PROTOCOL_TREASURY across all
+            //     validators, pick canonical, sync via chain.db rsync,
+            //     THEN activate. Requires operator pre-flight pass.
+            //
+            //   Option B (cleanest): rewrite this block to recompute
+            //     PROTOCOL_TREASURY balance from chain history (sum of
+            //     coinbase mints since h=590,100) rather than reading
+            //     in-memory state. Makes activation deterministic
+            //     regardless of local drift. Bigger change.
+            //
+            //   Option C (current default): leave dormant indefinitely.
+            //     state_root commitment cosmetically broken but chain
+            //     functional. Acceptable until a light-client / SPV
+            //     consumer actually needs to verify treasury state.
+            //
+            // Operator runbook for activation (only after Option A or B):
+            //   1. Run canonical balance reconciliation pass (Option A)
+            //      OR confirm history-recompute logic deployed (Option B)
+            //   2. Pick activation_height = current_tip + 600 (~10min lead)
+            //   3. Halt all 4 mainnet validators in parallel
+            //   4. Append `STATE_ROOT_V2_HEIGHT=<h>` to each /etc/<svc>/<svc>.env
+            //   5. Simul-start; verify post-flip state_root agreement
+            //      across all 4 within 60s of activation block
+            //   6. If divergence detected, halt-all immediately and
+            //      revert to default (set env to far-future height)
             //
             // The default of u64::MAX leaves the fix dormant on hosts
             // without the env var so it ships safely.

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -13,8 +13,8 @@ use serde_json::{Value, json};
 use super::DispatchResult;
 use super::helpers::{
     block_gas_used_ratio, collect_logs, load_logs_for_tx, normalize_rpc_address,
-    normalize_rpc_hash, parse_address_filter, parse_hex_u64, parse_topic_filter, resolve_block_tag,
-    to_hex, to_hex_u128,
+    normalize_rpc_hash, parse_address_filter, parse_hex_u64, parse_topic_filter,
+    require_latest_state_read, resolve_block_tag, to_hex, to_hex_u128,
 };
 
 pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) -> DispatchResult {
@@ -34,41 +34,8 @@ pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) 
                 Ok(a) => a,
                 Err(e) => return Err((-32602, e.into())),
             };
-            // Pre-2026-05-05 this handler silently ignored params[1]
-            // (block tag) and always returned the latest balance —
-            // callers asking for a specific historical height got the
-            // current value with no error. Audit surfaced the gap when
-            // probing balance at h=1M / 1.5M / 1.62M all returned
-            // identical hex.
-            //
-            // Sentrix doesn't yet have MDBX snapshot isolation for
-            // historical state reads (deferred refactor). For now:
-            //   - `latest` / `earliest` / `pending` / `finalized` / `safe`
-            //     → return current state (close enough for these tags)
-            //   - specific block number → return -32004 with a
-            //     "historical state reads not yet supported" message
-            //     so callers see the gap instead of stale data
-            let block_tag = params[1].as_str().unwrap_or("latest");
-            let is_height = block_tag.starts_with("0x")
-                && block_tag.len() > 2
-                && block_tag[2..].chars().all(|c| c.is_ascii_hexdigit());
-            if is_height {
-                let bc = state.read().await;
-                let head = bc.height();
-                let requested =
-                    u64::from_str_radix(block_tag.trim_start_matches("0x"), 16).unwrap_or(0);
-                if requested != head {
-                    return Err((
-                        -32004,
-                        format!(
-                            "historical state reads not yet supported (asked h={}, head h={}). \
-                             Use 'latest' until MDBX snapshot isolation lands.",
-                            requested, head
-                        ),
-                    ));
-                }
-            }
             let bc = state.read().await;
+            require_latest_state_read(params.get(1), bc.height())?;
             let balance = bc.accounts.get_balance(&address);
             let wei = balance as u128 * 10_000_000_000u128;
             Ok(json!(to_hex_u128(wei)))
@@ -86,8 +53,16 @@ pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) 
             // quick succession would all sign the same nonce — chain
             // accepted only the first, the rest piled up rejected
             // mid-block. Live discovery 2026-05-02.
-            let block_tag = params[1].as_str().unwrap_or("latest");
+            //
+            // 2026-05-06: extend the same historical-state honesty
+            // pattern Bug A applied to eth_getBalance — specific past
+            // heights return -32004 instead of silently returning
+            // current nonce. `pending` keeps its mempool-aware path.
+            let block_tag = params.get(1).and_then(|v| v.as_str()).unwrap_or("latest");
             let bc = state.read().await;
+            if block_tag != "pending" {
+                require_latest_state_read(params.get(1), bc.height())?;
+            }
             let mut nonce = bc.accounts.get_nonce(&address);
             if block_tag == "pending" {
                 nonce = nonce.saturating_add(bc.mempool_pending_count(&address));
@@ -793,6 +768,12 @@ async fn run_evm_dry_run(
 async fn eth_call(params: &Value, state: &SharedState) -> DispatchResult {
     // Execute a read-only EVM call without state mutation.
     // params[0] = {from, to, data, value, gas}
+    // params[1] = block tag (latest by default; specific historical
+    // heights gated until snapshot isolation lands)
+    {
+        let bc = state.read().await;
+        require_latest_state_read(params.get(1), bc.height())?;
+    }
     match run_evm_dry_run(&params[0], state).await {
         Ok(receipt) => {
             let output_hex = format!("0x{}", hex::encode(&receipt.output));
@@ -882,6 +863,11 @@ async fn eth_get_code(params: &Value, state: &SharedState) -> DispatchResult {
         Err(e) => return Err((-32602, e.into())),
     };
     let bc = state.read().await;
+    // 2026-05-06: same historical-state gate as eth_getBalance — pre-fix
+    // ignored the block-tag arg and always returned latest code. A caller
+    // probing "code at h=1M" got the same bytes as "code at tip" with no
+    // error. require_latest_state_read makes the gap visible.
+    require_latest_state_read(params.get(1), bc.height())?;
     if let Some(account) = bc.accounts.accounts.get(&address) {
         if account.is_contract() {
             let code_hash_hex = hex::encode(account.code_hash);
@@ -913,6 +899,10 @@ async fn eth_get_storage_at(params: &Value, state: &SharedState) -> DispatchResu
         return Err((-32602, "invalid storage slot (must be hex, ≤ 32 bytes)".into()));
     }
     let bc = state.read().await;
+    // 2026-05-06: storage block tag is params[2] per spec (params[0]=addr,
+    // params[1]=slot, params[2]=block). Pre-fix it was ignored. Same
+    // honest-error pattern as eth_getBalance.
+    require_latest_state_read(params.get(2), bc.height())?;
     if let Some(value) = bc.accounts.get_contract_storage(&address, slot_hex) {
         Ok(json!(format!("0x{}", hex::encode(value))))
     } else {

--- a/crates/sentrix-rpc/src/jsonrpc/helpers.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/helpers.rs
@@ -32,6 +32,75 @@ pub(super) fn resolve_block_tag(v: Option<&Value>, latest: u64) -> Result<u64, &
     }
 }
 
+/// Gate state-read methods (`eth_getBalance`, `eth_getCode`,
+/// `eth_getStorageAt`, `eth_getTransactionCount`, `eth_call`) against
+/// historical-specific block heights.
+///
+/// Sentrix doesn't yet have MDBX snapshot isolation, so account state
+/// reads always serve current-tip data regardless of the block tag
+/// the caller passed. Pre-2026-05-05 these handlers silently ignored
+/// `params[block_tag_index]` and returned latest, so a caller probing
+/// "balance at h=1M" got the same answer as "balance at h=tip" — no
+/// way to tell. The 2026-05-05 audit caught it for `eth_getBalance`;
+/// this helper extends the same honesty to the rest of the namespace.
+///
+/// Returns Ok(()) when the read can be served from current state:
+///   - `None` / `Null` (tag arg omitted)
+///   - `""` / `"latest"` / `"pending"` / `"safe"` / `"finalized"`
+///   - `"earliest"` only when chain is at h=0
+///   - hex block number that equals current `latest`
+///
+/// Returns -32004 for any specific historical height. Returns -32602
+/// for malformed inputs.
+///
+/// Block-content methods (`eth_getBlockByNumber`, etc.) do NOT use
+/// this gate — historical block bodies live in chain.db and can be
+/// served correctly. Only the account-state subset is gated.
+pub(super) fn require_latest_state_read(
+    block_tag: Option<&Value>,
+    latest: u64,
+) -> Result<(), (i32, String)> {
+    let tag = match block_tag {
+        None | Some(Value::Null) => return Ok(()),
+        Some(Value::String(s)) => s.as_str(),
+        Some(Value::Number(n)) => {
+            return match n.as_u64() {
+                Some(h) if h == latest => Ok(()),
+                Some(_) => Err((
+                    -32004,
+                    "historical state reads not yet supported; use 'latest'".into(),
+                )),
+                None => Err((-32602, "invalid block number".into())),
+            };
+        }
+        Some(other) => {
+            return Err((-32602, format!("invalid block tag: {other}")));
+        }
+    };
+    match tag {
+        "" | "latest" | "pending" | "safe" | "finalized" => Ok(()),
+        "earliest" => {
+            if latest == 0 {
+                Ok(())
+            } else {
+                Err((
+                    -32004,
+                    "historical state reads not yet supported; use 'latest'".into(),
+                ))
+            }
+        }
+        hex if hex.starts_with("0x") => match u64::from_str_radix(&hex[2..], 16) {
+            Ok(h) if h == latest => Ok(()),
+            Ok(_) => Err((
+                -32004,
+                "historical state reads not yet supported; use 'latest'".into(),
+            )),
+            Err(_) => Err((-32602, format!("invalid hex block number: {hex}"))),
+        },
+        _ => Err((-32602, format!("invalid block tag: {tag}"))),
+    }
+}
+
 /// Address filter accepts either a single string or an array. Normalizes to
 /// lowercase 20-byte arrays; unparseable entries are silently skipped so
 /// malformed filters still work against the rest of the query.
@@ -222,4 +291,82 @@ pub(super) fn block_gas_used_ratio(bc: &sentrix_core::blockchain::Blockchain, he
         .map(|_| 21_000u64)
         .sum();
     (total_gas as f64) / (sentrix_evm::gas::BLOCK_GAS_LIMIT as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Locks down the historical-state gate behavior so regressions
+    // surface in CI rather than in a wallet returning stale data.
+    #[test]
+    fn require_latest_state_read_passes_when_no_tag() {
+        assert!(require_latest_state_read(None, 1_000_000).is_ok());
+    }
+
+    #[test]
+    fn require_latest_state_read_passes_for_string_tags() {
+        let latest = 1_000_000;
+        for tag in ["", "latest", "pending", "safe", "finalized"] {
+            let v = json!(tag);
+            assert!(
+                require_latest_state_read(Some(&v), latest).is_ok(),
+                "tag {tag:?} should pass"
+            );
+        }
+    }
+
+    #[test]
+    fn require_latest_state_read_passes_for_hex_at_tip() {
+        let v = json!("0xf4240"); // 1_000_000
+        assert!(require_latest_state_read(Some(&v), 1_000_000).is_ok());
+    }
+
+    #[test]
+    fn require_latest_state_read_passes_for_number_at_tip() {
+        let v = json!(1_000_000);
+        assert!(require_latest_state_read(Some(&v), 1_000_000).is_ok());
+    }
+
+    #[test]
+    fn require_latest_state_read_rejects_historical_hex() {
+        let v = json!("0x1");
+        let err = require_latest_state_read(Some(&v), 1_000_000).unwrap_err();
+        assert_eq!(err.0, -32004);
+    }
+
+    #[test]
+    fn require_latest_state_read_rejects_historical_number() {
+        let v = json!(1);
+        let err = require_latest_state_read(Some(&v), 1_000_000).unwrap_err();
+        assert_eq!(err.0, -32004);
+    }
+
+    #[test]
+    fn require_latest_state_read_rejects_earliest_when_chain_progressed() {
+        let v = json!("earliest");
+        let err = require_latest_state_read(Some(&v), 1_000_000).unwrap_err();
+        assert_eq!(err.0, -32004);
+    }
+
+    #[test]
+    fn require_latest_state_read_passes_earliest_at_genesis() {
+        let v = json!("earliest");
+        assert!(require_latest_state_read(Some(&v), 0).is_ok());
+    }
+
+    #[test]
+    fn require_latest_state_read_rejects_invalid_hex() {
+        let v = json!("0xZZ");
+        let err = require_latest_state_read(Some(&v), 1_000_000).unwrap_err();
+        assert_eq!(err.0, -32602);
+    }
+
+    #[test]
+    fn require_latest_state_read_rejects_garbage_tag() {
+        let v = json!("not-a-block");
+        let err = require_latest_state_read(Some(&v), 1_000_000).unwrap_err();
+        assert_eq!(err.0, -32602);
+    }
 }


### PR DESCRIPTION
## Summary

Two follow-ups to the v2.1.76 release that landed via PR #480's squash. Now that the original Bug A + Bug B fix is on main, this PR adds:

1. **Activation post-mortem doc** in the `STATE_ROOT_V2` comment block (commit 9d127f2). The first activation attempt 2026-05-06 22:30 UTC at h=1627100 forked the cluster within 30s — PROTOCOL_TREASURY in-memory balance had silently drifted across the 4 validators for ~700K blocks, the activation made it visible. Recovery via chain.db rsync, v2 now disabled. Comment now documents the post-mortem + 3 reactivation options (canonical balance reconciliation / chain-history recompute / leave dormant).

2. **Extended Bug A pattern** to all 5 state-read methods (commit 496f063). PR #479 originally only fixed `eth_getBalance`. Same silent-stale issue existed in:
   - `eth_getCode` — ignored block-tag arg, always returned latest code
   - `eth_getStorageAt` — ignored block-tag arg, always returned latest storage
   - `eth_getTransactionCount` — ignored block-tag arg (except `pending`)
   - `eth_call` — ignored block-tag arg, always ran against current state

   Factored a `require_latest_state_read` helper in `helpers.rs` and applied across all 5. Block-content methods (`eth_getBlockByNumber`, etc.) intentionally NOT gated — historical block bodies live in chain.db and serve correctly.

## Behavior

| Block tag input | Behavior |
|---|---|
| omitted / `latest` / `pending` / `safe` / `finalized` | OK |
| `earliest` (only when chain at h=0) | OK |
| hex/number `== latest` | OK |
| hex/number `!= latest` | -32004 `historical state reads not yet supported; use 'latest'` |
| malformed | -32602 |

## Consumer compatibility

Surveyed `indexer-deploy`, `sentriscloud-frontend`, `sentrix-explorer-v2` for callers passing specific block tags to the 5 gated methods — **zero hits**. All consumers implicitly use `latest`. Backward-compatible.

## Tests

- 10 new unit tests in `helpers.rs::tests` lock down each `require_latest_state_read` branch
- 36 passed, 0 failed in `cargo test -p sentrix-rpc`

## Reactivation status (Bug B)

Still **dormant** — `STATE_ROOT_V2_HEIGHT=u64::MAX` default, in-env override disabled on all 4 mainnet validators after the failed first activation. Reactivation requires Option A (operator-side canonical balance reconciliation pre-step) or Option B (rewrite to recompute treasury from chain history) — both deferred.

## Test plan

- [x] `cargo check -p sentrix-rpc` clean
- [x] `cargo test -p sentrix-rpc` — 36 passed
- [x] Activation post-mortem documented in code comment + audit doc
- [x] All 5 state-read methods covered
- [x] Consumer survey clean
- [ ] CI pipeline pass (auto-running)
- [ ] Mainnet deploy of extension: deferred until next regular deploy cycle (additive RPC change, no rush)

Audit doc: `founder-private/audits/2026-05-05-pr8266-v3-marco-review-deep-audit.md` (Audit-9 + Audit-10 + follow-up).