### PR TITLE
docs(operations): refresh VALIDATOR_ONBOARDING for Voyager + ops reality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "bincode",
  "hex",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5195,14 +5195,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5246,14 +5246,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "bincode",
  "blake3",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.74"
+version = "2.1.75"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -7,7 +7,7 @@ use sentrix_primitives::account::AccountDB;
 use sentrix_primitives::block::Block;
 use sentrix_primitives::error::{SentrixError, SentrixResult};
 use sentrix_primitives::merkle::merkle_root;
-use sentrix_primitives::transaction::TOKEN_OP_ADDRESS;
+use sentrix_primitives::transaction::{PROTOCOL_TREASURY, TOKEN_OP_ADDRESS};
 use sentrix_primitives::transaction::Transaction;
 use sentrix_storage::{MdbxStorage, height_key, key_to_height, tables};
 use sentrix_trie::address::{account_value_bytes, address_to_key};
@@ -1490,6 +1490,50 @@ impl Blockchain {
             }
             if is_valid_sentrix_address(&block.validator) {
                 addrs.push(block.validator.clone());
+            }
+            // STATE_ROOT_V2 fix (gated by STATE_ROOT_V2_HEIGHT env var):
+            //
+            // Pre-fix `update_trie_for_block` derived `touched_addrs`
+            // strictly from each tx's `from`/`to` plus the proposer's
+            // address. Coinbase txs render `to_address = <validator>`
+            // for human display — but per V4 reward v2 fork (active
+            // since h=590,100) the actual state mutation routes the
+            // mint to PROTOCOL_TREASURY (`0x...0002`). PROTOCOL_TREASURY
+            // never appeared in `touched_addrs`, so the trie never saw
+            // its balance change, and the state_root froze the moment
+            // coinbase-only blocks became the steady state (~h=1.25M).
+            //
+            // 2026-05-05 audit confirmed: state_root identical across
+            // h=1.5M / 1.6M / 1.62M while PROTOCOL_TREASURY's actual
+            // balance grew by ~370K SRX over the same window. State
+            // commitment honestly represented the trie's view; the
+            // trie just wasn't tracking the system account.
+            //
+            // Activation is fork-gated to keep all 4 mainnet validators
+            // in lockstep: until every host has the same env-set
+            // `STATE_ROOT_V2_HEIGHT`, leaving the touch list intact
+            // preserves the existing (frozen-but-agreed) state_root
+            // chain. Past activation, every block also re-roots
+            // PROTOCOL_TREASURY into the trie so the commitment
+            // matches actual on-chain state.
+            //
+            // Operator runbook for activation:
+            //   1. Pick activation_height = current_tip + 600 (~10min lead)
+            //   2. Halt all 4 mainnet validators in parallel
+            //   3. Append `STATE_ROOT_V2_HEIGHT=<h>` to each /etc/<svc>/<svc>.env
+            //   4. Simul-start; chain crosses h, all 4 simultaneously
+            //      flip to including PROTOCOL_TREASURY in touch set
+            //   5. New state_root from h onward correctly commits to
+            //      PROTOCOL_TREASURY balance
+            //
+            // The default of u64::MAX leaves the fix dormant on hosts
+            // without the env var so it ships safely.
+            let state_root_v2_height = std::env::var("STATE_ROOT_V2_HEIGHT")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(u64::MAX);
+            if block.index >= state_root_v2_height {
+                addrs.push(PROTOCOL_TREASURY.to_string());
             }
             (addrs, block.index)
         };

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -34,6 +34,40 @@ pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) 
                 Ok(a) => a,
                 Err(e) => return Err((-32602, e.into())),
             };
+            // Pre-2026-05-05 this handler silently ignored params[1]
+            // (block tag) and always returned the latest balance —
+            // callers asking for a specific historical height got the
+            // current value with no error. Audit surfaced the gap when
+            // probing balance at h=1M / 1.5M / 1.62M all returned
+            // identical hex.
+            //
+            // Sentrix doesn't yet have MDBX snapshot isolation for
+            // historical state reads (deferred refactor). For now:
+            //   - `latest` / `earliest` / `pending` / `finalized` / `safe`
+            //     → return current state (close enough for these tags)
+            //   - specific block number → return -32004 with a
+            //     "historical state reads not yet supported" message
+            //     so callers see the gap instead of stale data
+            let block_tag = params[1].as_str().unwrap_or("latest");
+            let is_height = block_tag.starts_with("0x")
+                && block_tag.len() > 2
+                && block_tag[2..].chars().all(|c| c.is_ascii_hexdigit());
+            if is_height {
+                let bc = state.read().await;
+                let head = bc.height();
+                let requested =
+                    u64::from_str_radix(block_tag.trim_start_matches("0x"), 16).unwrap_or(0);
+                if requested != head {
+                    return Err((
+                        -32004,
+                        format!(
+                            "historical state reads not yet supported (asked h={}, head h={}). \
+                             Use 'latest' until MDBX snapshot isolation lands.",
+                            requested, head
+                        ),
+                    ));
+                }
+            }
             let bc = state.read().await;
             let balance = bc.accounts.get_balance(&address);
             let wei = balance as u128 * 10_000_000_000u128;

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.75"
+version = "2.1.76"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."

--- a/docs/operations/VALIDATOR_ONBOARDING.md
+++ b/docs/operations/VALIDATOR_ONBOARDING.md
@@ -19,20 +19,25 @@ the operator's private fleet" is required.
 
 ### Consensus responsibility
 
-Sentrix runs **Pioneer PoA** today (4-validator round-robin —
-Foundation, Treasury, Core, Beacon — expanding as operators join)
-and will upgrade to **Voyager DPoS + BFT**
-(stake-weighted, unbounded validator set) at a fork height TBD. As a
-validator:
+Sentrix runs **Voyager DPoS + BFT** on mainnet, live since
+h=579,047 (2026-04-25). Stake-weighted, unbounded validator set;
+3-phase BFT round (propose / prevote / precommit) per block; 2/3+1
+of stake-weighted active set finalises. Active validators today
+(reference set): Foundation, Treasury, Core, Beacon — additional
+operators expand the set without protocol changes.
 
 - Your node is expected to be online **>99.5%**. The in-chain liveness
   tracker jails validators that miss more than 70% of their slots in a
   rolling 14,400-block window (~4 hours at 1 s block time).
-- You sign every block in your slot; double-signing is slashable
-  (stake cut 20% on Voyager; removal from the authority registry on
-  Pioneer).
-- You do **not** need to hold the chain's native token to validate on
-  Pioneer. On Voyager you'll need to self-bond the DPoS minimum.
+- You sign every block in your turn; double-signing is slashable
+  (stake cut 20%, plus auto-jail).
+- **Self-stake minimum: 15,000 SRX** (1,500,000,000,000 sentri) —
+  matches the reference active set. The protocol enforces no hard
+  floor; the threshold is a coordination expectation so a new validator
+  carries comparable weight in the BFT supermajority. See
+  `docs/operations/CLAIM_REWARDS.md` for the post-V4-fork reward
+  flow (coinbase routes to protocol treasury; validators + delegators
+  claim accrued rewards via `StakingOp::ClaimRewards`).
 
 ### Operational responsibility
 
@@ -51,20 +56,24 @@ validator:
 
 ## 2. Hardware + network
 
-Minimum (reference mainnet today):
+Minimum (reference mainnet at h≈1.6M, 2026-05):
 
 | Resource | Minimum | Comfortable |
 |---|---|---|
 | vCPU  | 4       | 6 – 8 |
-| RAM   | 4 GiB   | 8 – 16 GiB |
+| RAM   | **8 GiB** | 16 GiB |
+| Swap  | **8 GiB** persistent (`/etc/fstab`) | 16 GiB |
 | Disk  | 60 GiB SSD | 120 GiB NVMe |
 | Bandwidth | 100 Mbit sustained | 1 Gbit |
 
-Any mainstream 64-bit Linux works. **We have deployed on Ubuntu 22.04
-and 24.04 in production; the consensus binary is OS-deterministic
-across kernel, glibc, and CPU family** — see the
-2026-04-23 Core node RCA addendum #9 in the project's incident archive for
-the cross-host determinism test result.
+The RAM/swap floor is non-negotiable: chain.db is mmap'd, and
+empirically tight memory + zero swap = page-cache thrash under
+sustained tx load = tokio worker stalls = silent halts. Any 64-bit
+Linux works; we have deployed on Ubuntu 22.04 + 24.04 in production.
+
+**The consensus binary is OS-deterministic across kernel, glibc, and
+CPU family** — verified across the Ubuntu 22.04 (glibc 2.35) and
+24.04 (glibc 2.39) hosts in the reference fleet.
 
 Open inbound ports:
 
@@ -203,22 +212,31 @@ Peer connected: 12D3KooW…
 Your node is now running, but it's not yet a VALIDATOR — it's just a
 peer. To become an authority:
 
-1. Send your validator address + uncompressed public key (both are
-   printed by `./sentrix wallet info <keystore>`) to the chain's
-   current admin (see `docs/operations/GOVERNANCE.md` for the
-   current admin address + contact channel).
-2. The admin runs `sentrix validator add <your-addr> "<your-name>"
-   <your-pubkey> --admin-key <admin-key>`.
-3. Once added, you'll appear in `GET /chain/info → validators` and in
-   the explorer at `scan.sentrixchain.com/validators`.
+1. Email **`validators@sentrixchain.com`** with:
+   - Your validator address + uncompressed public key (both are
+     printed by `./sentrix wallet info <keystore>`).
+   - Your operator name as you want it displayed in the on-chain
+     registry + block explorer (e.g. `"Acme Validator Co"`).
+   - Self-stake amount you intend to bond (≥ 15,000 SRX) and the
+     funding source (we'll coordinate testnet first if you're
+     bootstrapping fresh).
+   - Optional: jurisdiction, host region, ops contact for incident
+     coordination.
+2. The chain admin co-signs `sentrix validator add` (mainnet) or
+   `RegisterValidator` (post-Voyager dispatch). Activation height
+   is shared back so you can verify your appearance in
+   `GET /chain/info → validators` and at `scan.sentrixchain.com/validators`.
+3. Self-bond via `StakingOp::Delegate` once activated — you can
+   delegate your own stake before external delegators do, raising
+   your active-set weight.
 
 Admin op is verified on-chain — your admission cannot be tampered with
 once in a block.
 
 **The `<your-name>` string lands in the on-chain validator registry and
 drives the block-explorer label. Choose it to represent your operation
-(e.g. `"Acme Validator Co"`, `"Operator Alice"`). It's not a
-hostname — it's a public-facing identity.**
+(e.g. `"Acme Validator Co"`, `"nodes.guru"`, `"Operator Alice"`). It's
+not a hostname — it's a public-facing identity.**
 
 ---
 
@@ -294,9 +312,15 @@ on Voyager you may be jailed and need an unjail op.
 
 ## 10. Where to ask
 
+- Validator onboarding + ops coordination: **`validators@sentrixchain.com`**
+- General docs: https://docs.sentrixchain.com/operations/
+- Block explorer: https://scan.sentrixchain.com (mainnet) · https://scan-testnet.sentrixchain.com (testnet)
+- Public RPC for sanity tests: `https://rpc.sentrixchain.com` (chain 7119) · `https://testnet-rpc.sentrixchain.com` (chain 7120)
+- Testnet faucet: https://faucet.sentrixchain.com
+- Sourcify verifier: https://verify.sentrixchain.com
+- gRPC + gRPC-Web (read-only state queries): https://grpc.sentrixchain.com · https://grpc-testnet.sentrixchain.com
 - GitHub issues: https://github.com/sentrix-labs/sentrix/issues
 - Security advisories: see `SECURITY.md` in the repo root.
-- Operator chat: see the pinned link in the repo README.
 
 **This doc describes a chain that supports many independent operators
 on diverse hosts and OS versions. If any step above assumes the operator's


### PR DESCRIPTION
## Summary
- Section 1 rewrite: Voyager DPoS+BFT is live (h=579,047, 2026-04-25), not "TBD". Adds 15,000 SRX self-stake minimum + cross-link to CLAIM_REWARDS for the post-V4-fork reward flow.
- Section 2 bump: RAM 4 GiB → 8 GiB minimum + 8 GiB persistent swap (per the May 2026 page-cache-thrash incident class).
- Section 6 rewrite: concrete `validators@sentrixchain.com` intake flow with address+pubkey+stake+ops-contact email template, plus explicit `StakingOp::Delegate` self-bond step.
- Section 10 expansion: all operator-facing endpoints (validators@, docs site, scan, scan-testnet, RPC, faucet, verifier, gRPC + gRPC-Web) clustered in one block.

Trigger: prepping the doc for an external operator (nodes.guru) onboarding pitch — the "Pioneer today / Voyager TBD" wording would have read as "this chain hasn't shipped consensus" to a serious validator.

## Test plan
- [x] `markdown-link-check` passes locally on the changed file
- [x] All listed URLs resolve (verified via curl during edit)
- [ ] After merge: `pnpm build` in `docs-site/` to publish the refresh