### PR TITLE
fix(scripts): installer fails loud when SRC_DIR exists but is not a git repo

### DIFF
--- a/scripts/install-validator.sh
+++ b/scripts/install-validator.sh
@@ -217,8 +217,16 @@ if [[ -d "$SRC_DIR/.git" ]]; then
     git -C "$SRC_DIR" checkout "$REPO_REF" --quiet
     git -C "$SRC_DIR" pull --ff-only origin "$REPO_REF" --quiet
     ok "updated to $(git -C "$SRC_DIR" rev-parse --short HEAD)"
+elif [[ -d "$SRC_DIR" ]] && [[ -n "$(ls -A "$SRC_DIR" 2>/dev/null)" ]]; then
+    # Directory exists, has contents, but isn't a git checkout — likely a
+    # half-finished previous install, or an operator pre-created the path
+    # for a bind-mount cache. Refusing to clone-into-non-empty avoids a
+    # cryptic "destination path … already exists" git error and a partial
+    # state where the build lands in someone's unrelated tree.
+    fail "$SRC_DIR exists but is not a git checkout. Remove it (or pick another --src-dir) and re-run."
 else
     info "git clone ${REPO_URL}"
+    sudo mkdir -p "$(dirname "$SRC_DIR")"
     git clone --branch "$REPO_REF" --depth 1 "$REPO_URL" "$SRC_DIR" --quiet
     ok "cloned at $(git -C "$SRC_DIR" rev-parse --short HEAD)"
 fi


### PR DESCRIPTION
## Summary
Caught during smoke test in a fresh Ubuntu 22.04 docker container. When `$SRC_DIR` exists but isn't a git checkout (operator pre-created the parent for a bind-mount cache, half-finished a previous install, or has an unrelated tree there), `git clone` failed with the cryptic "destination path '…' already exists and is not an empty directory" — correct but not actionable. Now we explicitly detect dir-exists-but-not-git and fail with the remediation step inline.

Empty-dir path still proceeds to clone (operators commonly pre-create the parent for permissions).

## Test plan
- [x] `bash -n` clean
- [x] Reproduces the original failure in `/tmp/installer-smoke.log` (docker container with bind-mount target dir at `/home/testop/sentrix-src/target` pre-created the parent path before clone)
- [ ] Re-run smoke test in fresh container after merge → expected to clear this failure mode