### PR TITLE
fix(scripts): installer treats broken rustup state as "need rust"

### DIFF
--- a/scripts/install-validator.sh
+++ b/scripts/install-validator.sh
@@ -183,17 +183,25 @@ if [[ -f "$HOME/.cargo/env" ]]; then
 fi
 
 need_rust=1
-if command -v rustc >/dev/null 2>&1; then
-    rustc_ver=$(rustc --version | awk '{print $2}')
+# Use `rustc --version` rather than `command -v rustc` — operators can have
+# `rustc` on PATH but a broken rustup state (no default toolchain set, stale
+# settings.toml from a wiped install, etc.) where `rustc --version` fails.
+# Set -e would abort the script silently; treat any failure as "need rustup
+# install" instead.
+if rustc_out=$(rustc --version 2>&1); then
+    rustc_ver=$(echo "$rustc_out" | awk '{print $2}')
     rustc_major=$(echo "$rustc_ver" | cut -d. -f1)
     rustc_minor=$(echo "$rustc_ver" | cut -d. -f2)
-    if (( rustc_major > RUST_MIN_MAJOR )) || \
-       (( rustc_major == RUST_MIN_MAJOR && rustc_minor >= RUST_MIN_MINOR )); then
+    if [[ -n "$rustc_major" ]] && [[ -n "$rustc_minor" ]] && \
+       { (( rustc_major > RUST_MIN_MAJOR )) || \
+         (( rustc_major == RUST_MIN_MAJOR && rustc_minor >= RUST_MIN_MINOR )); }; then
         ok "rustc ${rustc_ver} (>= ${RUST_MIN_MAJOR}.${RUST_MIN_MINOR})"
         need_rust=0
     else
         warn "rustc ${rustc_ver} < ${RUST_MIN_MAJOR}.${RUST_MIN_MINOR}; will upgrade via rustup"
     fi
+else
+    info "rustc present but unusable (likely broken rustup state); will (re)install via rustup"
 fi
 
 if (( need_rust == 1 )); then
@@ -203,6 +211,8 @@ if (( need_rust == 1 )); then
         # shellcheck disable=SC1091
         source "$HOME/.cargo/env"
     fi
+    # `rustup default stable` will install stable if absent, repair the
+    # default-toolchain link if a stale settings.toml left it unset.
     rustup default stable >/dev/null
     rustup update stable >/dev/null
     ok "rustup default: $(rustc --version)"


### PR DESCRIPTION
## Summary
Caught during docker smoke test on Ubuntu 22.04. Operator can have `rustc` on PATH (from a prior install, wiped install, stale `~/.rustup/settings.toml` without a default toolchain set, etc.) but `rustc --version` fails non-zero. Pre-fix, the installer used `command -v rustc` to detect rust then called `rustc --version | awk` directly — `set -e` aborted on the non-zero exit before we could fall back to `rustup install`.

Fix: gate on `rustc --version` itself succeeding. Treat any non-zero exit as "need rust" and let the existing rustup install path heal the state via `rustup default stable`.

## Test plan
- [x] `bash -n` clean
- [x] Reproduces the original failure: bind-mounted .cargo cache from a previous test run had `settings.toml` with no default toolchain, smoke test 2 failed at the rust-detect step
- [ ] Re-run smoke test #3 in a clean container after merge → expected to clear this failure mode and proceed to cargo build