### PR TITLE
fix(scripts): installer pulls protobuf-compiler for sentrix-grpc build

### DIFF
--- a/scripts/install-validator.sh
+++ b/scripts/install-validator.sh
@@ -158,7 +158,7 @@ ok "disk free: ${free_gib} GiB on /"
 # ── Step 2: install apt deps ────────────────────────────────
 step "Install apt dependencies"
 
-DEPS=(git curl build-essential pkg-config libssl-dev clang jq ca-certificates)
+DEPS=(git curl build-essential pkg-config libssl-dev clang jq ca-certificates protobuf-compiler)
 MISSING=()
 for pkg in "${DEPS[@]}"; do
     dpkg -s "$pkg" >/dev/null 2>&1 || MISSING+=("$pkg")


### PR DESCRIPTION
## Summary
`crates/sentrix-grpc/build.rs` invokes prost-build/tonic-build against `proto/sentrix.proto`. Pre-fix, the installer's apt deps list missed `protobuf-compiler`, so cargo build aborted at the sentrix-grpc step with the prost-build "Could not find `protoc`" error (which gave the operator the right install hint inline, but the installer should have prevented hitting it).

## Test plan
- [x] `bash -n` clean
- [x] Reproduced: smoke test #3 logged `Error: Could not find `protoc`...` from prost-build
- [ ] Re-run smoke test #4 in clean container after merge → expected to clear this dep and reach the keystore step