### PR TITLE
fix(scripts): chown $INSTALL_DIR to service user immediately after binary copy

### DIFF
--- a/scripts/install-validator.sh
+++ b/scripts/install-validator.sh
@@ -255,8 +255,16 @@ else
     sudo mkdir -p "$INSTALL_DIR"
     sudo cp "$SRC_DIR/target/release/sentrix" "$INSTALL_DIR/sentrix"
     sudo chmod +x "$INSTALL_DIR/sentrix"
-    ok "binary installed at ${INSTALL_DIR}/sentrix"
-    "$INSTALL_DIR/sentrix" --version
+    # The binary's `get_data_dir()` falls back to `<exe_dir>/data` when
+    # `SENTRIX_DATA_DIR` is unset, and `main` calls `create_dir_all` on
+    # that path at startup — even for `--version`. If $INSTALL_DIR is
+    # root-owned, every invocation as the service user fails Permission
+    # denied before reaching the subcommand. chown the whole tree to the
+    # service user up-front; the systemd unit (which also runs as $USER)
+    # then has the same write permissions for chain.db, the wallets dir,
+    # and any future state files.
+    sudo chown -R "$USER:$USER" "$INSTALL_DIR"
+    ok "binary installed at ${INSTALL_DIR}/sentrix ($("$INSTALL_DIR/sentrix" --version))"
 fi
 
 # Genesis config — mainnet uses the embedded canonical TOML (no flag),


### PR DESCRIPTION
## Summary
Caught during docker smoke test #4. The chain binary's `get_data_dir()` falls back to `<exe_dir>/data` when `SENTRIX_DATA_DIR` is unset, and `main` calls `create_dir_all` on that path BEFORE clap argument parsing — so even `sentrix --version` triggers the dir-create. With `$INSTALL_DIR` (default `/opt/sentrix`) root-owned post-`sudo cp`, every invocation as the non-root service user crashed with `Permission denied (os error 13)` before reaching any subcommand.

Pre-fix the installer chowned `$INSTALL_DIR` only at the end of the systemd step — already too late: keystore generation hit the same wall, and the unrelated `--version` line earlier was the first observable failure.

## Fix
- `sudo chown -R $USER:$USER $INSTALL_DIR` runs immediately after `sudo cp` lands the binary
- Trailing chown in the systemd step kept as a belt-and-suspenders guard for `--skip-build` re-runs that bypass step 5
- Inline `--version` print into the install-OK line so operators see the deployed version

## Test plan
- [x] `bash -n` clean
- [x] Reproduces in smoke test #4: log shows `Error: Permission denied (os error 13)` immediately after `binary installed at /opt/sentrix/sentrix`
- [ ] Re-run smoke test #5 in clean container after merge → expected to clear this and reach keystore + final block