### PR TITLE
feat(consensus): Option B — env-driven canonical treasury rebase for STATE_ROOT_V2 activation (v2.1.77)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "bincode",
  "hex",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5195,14 +5195,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5246,14 +5246,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "bincode",
  "blake3",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.75"
+version = "2.1.77"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -1448,6 +1448,50 @@ impl Blockchain {
     ///   Phase 1 — immutable borrows of `chain` and `accounts` → collect owned data.
     ///   Phase 2 — mutable borrow of `state_trie` → insert + commit.
     pub fn update_trie_for_block(&mut self) -> SentrixResult<Option<[u8; 32]>> {
+        // Option B canonical-treasury rebase — fire BEFORE the trie-init
+        // check so it runs independent of trie readiness. Targets the
+        // exact activation block; force-sets in-memory PROTOCOL_TREASURY
+        // to the operator-set canonical so all 4 validators agree on
+        // the value the trie is about to commit. Detailed runbook lives
+        // a few hundred lines down in the touch-list section. Without
+        // either env var, this is a no-op.
+        let state_root_v2_height_for_rebase = std::env::var("STATE_ROOT_V2_HEIGHT")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(u64::MAX);
+        let activation_block_index = self.chain.last().map(|b| b.index);
+        if activation_block_index == Some(state_root_v2_height_for_rebase) {
+            if let Some(canonical) = std::env::var("STATE_ROOT_V2_TREASURY_BALANCE")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+            {
+                let prior = self.accounts.get_balance(PROTOCOL_TREASURY);
+                if prior != canonical {
+                    let delta = canonical as i128 - prior as i128;
+                    tracing::warn!(
+                        "STATE_ROOT_V2 activation rebase at h={}: PROTOCOL_TREASURY \
+                         {} → {} (delta {} sentri). Operator-set canonical override.",
+                        state_root_v2_height_for_rebase, prior, canonical, delta
+                    );
+                } else {
+                    tracing::info!(
+                        "STATE_ROOT_V2 activation at h={}: PROTOCOL_TREASURY \
+                         balance already matches canonical {} sentri (no rebase)",
+                        state_root_v2_height_for_rebase, canonical
+                    );
+                }
+                self.accounts.set_balance(PROTOCOL_TREASURY, canonical);
+            } else {
+                tracing::warn!(
+                    "STATE_ROOT_V2 activation at h={} WITHOUT \
+                     STATE_ROOT_V2_TREASURY_BALANCE override — fork risk if \
+                     in-memory PROTOCOL_TREASURY balance differs across validators. \
+                     See blockchain.rs::update_trie_for_block runbook.",
+                    state_root_v2_height_for_rebase
+                );
+            }
+        }
+
         if self.state_trie.is_none() {
             // Pre-STATE_ROOT_FORK_HEIGHT, missing trie is acceptable —
             // state_root isn't part of the block hash. Past the fork
@@ -1571,6 +1615,8 @@ impl Blockchain {
             (addrs, block.index)
         };
         // All borrows on `self.chain` released here.
+        // (Option B canonical-treasury rebase already fired at function
+        // entry — see top of update_trie_for_block.)
 
         // Phase 1b: snapshot current balances + nonces (immutable borrow of `accounts`)
         // CRITICAL: Use BTreeSet (sorted, deterministic) — NOT HashSet (random per-process).
@@ -3456,6 +3502,157 @@ mod tests {
 
         unsafe {
             std::env::remove_var("JAIL_CONSENSUS_HEIGHT");
+        }
+    }
+
+    /// Option B: the env-driven canonical balance override force-sets
+    /// PROTOCOL_TREASURY at the activation block. Two nodes with
+    /// divergent in-memory PROTOCOL_TREASURY balances should converge
+    /// to the same value once activated.
+    #[test]
+    fn test_state_root_v2_canonical_override_rebases_drifted_balance() {
+        use sentrix_primitives::transaction::PROTOCOL_TREASURY;
+
+        let _guard = env_test_lock();
+        unsafe {
+            std::env::set_var("STATE_ROOT_V2_HEIGHT", "1");
+            std::env::set_var("STATE_ROOT_V2_TREASURY_BALANCE", "1000000000000");
+        }
+
+        let mut bc = Blockchain::new("admin".to_string());
+        // Pretend chain progressed past genesis with a divergent treasury
+        // balance — simulates the 2026-05-06 drift scenario.
+        bc.accounts.set_balance(PROTOCOL_TREASURY, 999_999_000_000);
+        let prior = bc.accounts.get_balance(PROTOCOL_TREASURY);
+        assert_eq!(prior, 999_999_000_000);
+
+        // Append an empty block at h=1 so update_trie_for_block sees
+        // it as `chain.last()`. Genesis is h=0 so this lands on the
+        // activation height.
+        let prev_hash = bc.latest_block().unwrap().hash.clone();
+        let activation_block = sentrix_primitives::block::Block::new(
+            1,
+            prev_hash,
+            vec![sentrix_primitives::transaction::Transaction::new_coinbase(
+                "validator1".into(),
+                0,
+                1,
+                1_700_000_000,
+            )],
+            "validator1".into(),
+        );
+        bc.chain.push(activation_block);
+
+        let _ = bc.update_trie_for_block();
+
+        // After update_trie_for_block, in-memory PROTOCOL_TREASURY should
+        // be force-set to the canonical regardless of prior drift.
+        let post = bc.accounts.get_balance(PROTOCOL_TREASURY);
+        assert_eq!(
+            post, 1_000_000_000_000,
+            "Option B rebase must force PROTOCOL_TREASURY to env canonical"
+        );
+
+        unsafe {
+            std::env::remove_var("STATE_ROOT_V2_HEIGHT");
+            std::env::remove_var("STATE_ROOT_V2_TREASURY_BALANCE");
+        }
+    }
+
+    /// Option B is opt-in: without `STATE_ROOT_V2_TREASURY_BALANCE`,
+    /// no rebase happens. Preserves the v2.1.76 behavior on hosts that
+    /// only set the height gate.
+    #[test]
+    fn test_state_root_v2_no_rebase_without_canonical_env() {
+        use sentrix_primitives::transaction::PROTOCOL_TREASURY;
+
+        let _guard = env_test_lock();
+        unsafe {
+            std::env::set_var("STATE_ROOT_V2_HEIGHT", "1");
+            std::env::remove_var("STATE_ROOT_V2_TREASURY_BALANCE");
+        }
+
+        let mut bc = Blockchain::new("admin".to_string());
+        bc.accounts.set_balance(PROTOCOL_TREASURY, 999_999_000_000);
+
+        let prev_hash = bc.latest_block().unwrap().hash.clone();
+        let activation_block = sentrix_primitives::block::Block::new(
+            1,
+            prev_hash,
+            vec![sentrix_primitives::transaction::Transaction::new_coinbase(
+                "validator1".into(),
+                0,
+                1,
+                1_700_000_000,
+            )],
+            "validator1".into(),
+        );
+        bc.chain.push(activation_block);
+
+        let _ = bc.update_trie_for_block();
+
+        let post = bc.accounts.get_balance(PROTOCOL_TREASURY);
+        assert_eq!(
+            post, 999_999_000_000,
+            "without canonical env, PROTOCOL_TREASURY must keep its in-memory value"
+        );
+
+        unsafe {
+            std::env::remove_var("STATE_ROOT_V2_HEIGHT");
+        }
+    }
+
+    /// Option B only fires AT the activation block, not at every block
+    /// past it. This is critical: subsequent blocks must let the trie
+    /// track real treasury growth via coinbase mints, not freeze the
+    /// canonical forever.
+    #[test]
+    fn test_state_root_v2_rebase_only_at_activation_block() {
+        use sentrix_primitives::transaction::PROTOCOL_TREASURY;
+
+        let _guard = env_test_lock();
+        unsafe {
+            std::env::set_var("STATE_ROOT_V2_HEIGHT", "1");
+            std::env::set_var("STATE_ROOT_V2_TREASURY_BALANCE", "500");
+        }
+
+        let mut bc = Blockchain::new("admin".to_string());
+        bc.accounts.set_balance(PROTOCOL_TREASURY, 999);
+
+        // Push activation block (h=1) — rebases to 500.
+        let h0_hash = bc.latest_block().unwrap().hash.clone();
+        bc.chain.push(sentrix_primitives::block::Block::new(
+            1,
+            h0_hash,
+            vec![sentrix_primitives::transaction::Transaction::new_coinbase(
+                "v1".into(), 0, 1, 1_700_000_000,
+            )],
+            "v1".into(),
+        ));
+        let _ = bc.update_trie_for_block();
+        assert_eq!(bc.accounts.get_balance(PROTOCOL_TREASURY), 500);
+
+        // Subsequent block (h=2) — should NOT rebase; balance stays
+        // unless block apply mutates it (which this test bypasses).
+        bc.accounts.set_balance(PROTOCOL_TREASURY, 750);
+        let h1_hash = bc.latest_block().unwrap().hash.clone();
+        bc.chain.push(sentrix_primitives::block::Block::new(
+            2,
+            h1_hash,
+            vec![sentrix_primitives::transaction::Transaction::new_coinbase(
+                "v1".into(), 0, 2, 1_700_000_000,
+            )],
+            "v1".into(),
+        ));
+        let _ = bc.update_trie_for_block();
+        assert_eq!(
+            bc.accounts.get_balance(PROTOCOL_TREASURY), 750,
+            "post-activation blocks must not rebase — let coinbase + ClaimRewards drive treasury"
+        );
+
+        unsafe {
+            std::env::remove_var("STATE_ROOT_V2_HEIGHT");
+            std::env::remove_var("STATE_ROOT_V2_TREASURY_BALANCE");
         }
     }
 }

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.76"
+version = "2.1.77"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Adds the **Option B** safety mechanism for `STATE_ROOT_V2` reactivation. PR #479's first activation attempt (2026-05-06 22:30 UTC at h=1627100) forked the cluster within 30s because each validator's in-memory PROTOCOL_TREASURY balance had silently drifted across nodes. At activation, each node inserted its own drifted value into the trie → 2-of-2 fork → BFT couldn't reach majority. Recovery required halt-all + chain.db rsync from canonical.

This PR adds an env-driven override that makes activation deterministic regardless of historical drift.

## Mechanism

When the chain reaches `STATE_ROOT_V2_HEIGHT` AND `STATE_ROOT_V2_TREASURY_BALANCE=<sentri>` is set, the activation block force-sets in-memory PROTOCOL_TREASURY to that operator-picked canonical value before the trie insert reads it. All 4 validators running the same env converge on the same trie root.

Logs:
- INFO if balance already matches canonical (no rebase needed)
- WARN if balance differs (rebase fires, with delta logged)
- WARN if no canonical env at activation (fork risk surfaced loudly)

The rebase fires at the **exact** activation block, not subsequent blocks. Post-activation, normal coinbase + ClaimRewards flow drives treasury growth — pinned by `test_state_root_v2_rebase_only_at_activation_block`.

## Operator workflow

```
1. (recommended) chain.db rsync from canonical → all 4
   to align in-memory state from a single source
2. Sample PROTOCOL_TREASURY balance across all 4:
     curl /accounts/0x0000000000000000000000000000000000000002/balance
   Pick the majority value (or canonical-source value).
3. Set on every host:
     STATE_ROOT_V2_HEIGHT=<future_height>
     STATE_ROOT_V2_TREASURY_BALANCE=<canonical_sentri>
4. Halt-all + simul-start
5. Watch all 4 cross activation_height; sample state_root from all 4 within 60s
6. If divergence detected: halt-all, revert env, recover via chain.db rsync
```

## Without canonical env

Behavior unchanged from v2.1.76 — same fork risk on local drift. Logs a WARN at activation block so the operator notices the gap if they activate without setting the canonical.

## Why not chain-history recompute?

Considered Option B-original (recompute treasury from chain history by summing coinbase mints since h=590,100). Rejected for now:
- Larger change, harder to verify correctness
- chain.db itself can drift if BFT historically didn't strictly enforce identical blocks (which is what we saw — different stored hashes pre-rsync)
- The env-driven approach is content-neutral: operator picks canonical regardless of chain.db state

Recompute remains a follow-up if Option B's env coordination proves brittle.

## Tests

- `test_state_root_v2_canonical_override_rebases_drifted_balance` — divergent in-memory balance + canonical env → rebased to canonical
- `test_state_root_v2_no_rebase_without_canonical_env` — no canonical env → in-memory unchanged
- `test_state_root_v2_rebase_only_at_activation_block` — post-activation blocks don't re-rebase

`cargo test -p sentrix-core --lib` → 212 passed (3 new + 209 existing).
`cargo clippy -p sentrix-core --all-targets -- -D warnings` clean.

Workspace `2.1.76 → 2.1.77`.

## Test plan

- [x] cargo check + clippy clean
- [x] 3 new unit tests pin Option B behavior
- [x] 212 existing core tests still pass
- [ ] Testnet rehearsal: pick STATE_ROOT_V2_HEIGHT=<testnet_tip+50> + canonical=<testnet treasury balance>, halt-all 4 testnet, simul-start, verify lockstep
- [ ] Mainnet activation: deferred to separate operator session — must follow runbook + verify post-activation lockstep

Audit doc: `founder-private/audits/2026-05-05-pr8266-v3-marco-review-deep-audit.md` (Audit-9, Audit-10, Audit-11; this PR's results will land as Audit-12 after CI + merge).