### PR TITLE
chore: bump 2.1.77 → 2.1.78

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.77"
+version = "2.1.78"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.77"
+version = "2.1.78"
 dependencies = [
  "anyhow",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.77"
+version = "2.1.78"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.77"
+version = "2.1.78"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"


### PR DESCRIPTION
Main now contains the V2 patch (PR #497) and the wire-compat test (PR #498). Bumps version so any artifact built off main going forward labels correctly.

Production validators stay on v2.1.77 binaries until the v2.1.78 testnet bake passes a clean epoch boundary with `JAIL_CONSENSUS_HEIGHT` flipped — the version label and the deploy decision are separate.