### PR TITLE
fix(consensus): LivenessTracker record_signed idempotent at same height

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.78"
+version = "2.1.79"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.78"
+version = "2.1.79"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "sentrix-primitives",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.78"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.78"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-staking/src/slashing.rs
+++ b/crates/sentrix-staking/src/slashing.rs
@@ -766,4 +766,53 @@ mod tests {
             "validator inside grace period must not produce evidence"
         );
     }
+
+    /// Idempotency: record_signed called twice for the same
+    /// (validator, height) must produce a single entry.
+    /// record_block_signatures fires from four code paths
+    /// (main.rs:2541/3065 + libp2p_node.rs:1092/1542); a block flowing
+    /// through gossip-race + sync-fallback can hit the recorder twice
+    /// on one validator. Without idempotency, that node's
+    /// signed_in_window inflates by one, biasing its is_downtime_at
+    /// verdict relative to peers and producing divergent
+    /// JailEvidenceBundle outputs across the fleet.
+    #[test]
+    fn test_record_signed_idempotent_at_same_height() {
+        let mut tracker = LivenessTracker::new();
+        tracker.record_signed("0xval1", 100);
+        tracker.record_signed("0xval1", 100);
+        tracker.record_signed("0xval1", 100);
+        let (signed, missed) = tracker.get_stats("0xval1");
+        assert_eq!(signed, 1, "duplicate calls at h=100 must collapse");
+        assert_eq!(missed, 0);
+    }
+
+    /// Idempotency must NOT swallow legitimate distinct heights.
+    /// Sequential blocks 100, 101, 102 each produce one entry.
+    #[test]
+    fn test_record_signed_distinct_heights_persist() {
+        let mut tracker = LivenessTracker::new();
+        tracker.record_signed("0xval1", 100);
+        tracker.record_signed("0xval1", 101);
+        tracker.record_signed("0xval1", 102);
+        let (signed, _) = tracker.get_stats("0xval1");
+        assert_eq!(signed, 3, "distinct heights must each record once");
+    }
+
+    /// Mixed double-fire pattern matching the multi-path call sites:
+    /// gossip + validator-finalize for h=100, then h=101, then double
+    /// for h=102, ending with single for h=103. Final count = 4 unique
+    /// heights, regardless of the duplication pattern.
+    #[test]
+    fn test_record_signed_mixed_double_fire() {
+        let mut tracker = LivenessTracker::new();
+        tracker.record_signed("0xval1", 100);
+        tracker.record_signed("0xval1", 100); // duplicate
+        tracker.record_signed("0xval1", 101);
+        tracker.record_signed("0xval1", 102);
+        tracker.record_signed("0xval1", 102); // duplicate
+        tracker.record_signed("0xval1", 103);
+        let (signed, _) = tracker.get_stats("0xval1");
+        assert_eq!(signed, 4, "4 unique heights, duplicates collapsed");
+    }
 }

--- a/crates/sentrix-staking/src/slashing/liveness.rs
+++ b/crates/sentrix-staking/src/slashing/liveness.rs
@@ -131,6 +131,25 @@ impl LivenessTracker {
             .entry(validator.to_string())
             .or_insert(height);
         let entries = self.records.entry(validator.to_string()).or_default();
+        // Idempotent: skip push if we already recorded this height.
+        // record_block_signatures fires from four code paths
+        // (main.rs:2541/3065 + libp2p_node.rs:1092/1542). The same
+        // block can flow through more than one without violating any
+        // chain-state invariant — gossip-race + sync-fallback in
+        // particular — but a duplicate entry inflates signed_in_window
+        // past MIN_SIGNED_PER_WINDOW on whichever node gets the
+        // double-fire and breaks consensus-jail determinism: nodes that
+        // recorded once vs nodes that recorded twice for the same
+        // (validator, height) produce different is_downtime_at verdicts
+        // → divergent JailEvidenceBundle → halt at first epoch boundary
+        // past JAIL_CONSENSUS_HEIGHT activation. Why this is safe to
+        // skip: blocks are processed in monotonic height order per
+        // validator (the chain extends forward), so the most-recent
+        // entry's height equalling the call's height is the
+        // double-fire signature, not a reorg.
+        if entries.last().map(|e| e.height) == Some(height) {
+            return;
+        }
         entries.push(LivenessRecord {
             height,
             signed: true,

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.77"
+version = "2.1.79"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Why

`record_signed` was unconditionally pushing a new `LivenessRecord` on every call. `record_block_signatures` fires from FOUR code paths in production:

```
bin/sentrix/src/main.rs:2541          validator-finalize (local proposer's own block)
bin/sentrix/src/main.rs:3065          peer-finalize (peer block via validator-loop)
crates/sentrix-network/src/libp2p_node.rs:1092   gossip path
crates/sentrix-network/src/libp2p_node.rs:1542   sync path
```

For one block at height N, exactly one of those paths SHOULD fire per validator. In practice, race conditions or retry paths fire two — gossip-race + sync-fallback being the obvious scenario. The same `(validator, height)` pair gets recorded twice on the affected node; `is_downtime_at` counts BOTH entries as separate `signed` marks; that node's `signed_in_window` inflates past `MIN_SIGNED_PER_WINDOW`; downtime that should fire is hidden. Other nodes with single-recording return the correct verdict. **Different `is_downtime_at` outputs across the fleet on identical chain history → divergent `JailEvidenceBundle` → consensus halt at first epoch boundary past `JAIL_CONSENSUS_HEIGHT` activation.**

This is the bug class warned about in `blockchain.rs:241-264` ("Known to halt mainnet via LivenessTracker non-determinism") and the cause of the 2026-04-29 (h=892799) and 2026-04-30 (h=979199) mainnet halts. Reproduced on testnet today (2026-05-06) when `JAIL_CONSENSUS_HEIGHT` was flipped to 2714030 to validate the V2 patch — testnet halted on first liveness check past activation, watchdog ABORT cycle 86 times before recovery.

## Fix

Skip the push when `entries.last().height == call's height`. The chain extends in monotonic height order per validator, so "last entry's height equals call's height" is unambiguously the duplicate signal — not a reorg, not a sequential block.

```rust
if entries.last().map(|e| e.height) == Some(height) {
    return;
}
```

Two-line change in `crates/sentrix-staking/src/slashing/liveness.rs::record_signed`.

## Tests

Three new tests in `slashing.rs`:

- `test_record_signed_idempotent_at_same_height`: triple-call collapses to 1 entry
- `test_record_signed_distinct_heights_persist`: heights 100/101/102 → 3 entries
- `test_record_signed_mixed_double_fire`: realistic call pattern with mixed duplication, 4 unique heights → 4 entries

All 32 slashing tests pass. Clippy clean.

## Pairs with PR #497 (V2 active_set patch)

PR #497 ensures every validator iterates the SAME `active_set` when computing jail evidence. This PR ensures every validator's `LivenessTracker` contents are byte-identical for any given chain history. **Both fixes required to enable consensus-jail dispatch on production.**

After this lands:
1. Bake on testnet with `JAIL_CONSENSUS_HEIGHT=<near_future_block>`, monitor 2-3 epoch boundaries with no halt.
2. Ship to mainnet via `safe-halt-all.sh --binary <new>`.
3. Flip `JAIL_CONSENSUS_HEIGHT` to a real height — consensus jail dispatch finally operational.

## Audit

Full reasoning at `founder-private/infrastructure/livenesstracker-double-record-bug-2026-05-06.md` (private repo).

## Risk

Low — single function changed, idempotency check is a one-shot gate before existing logic, all existing tests pass. Worst case: the check skips a legitimate distinct write (impossible if blocks process in monotonic height order, which is the chain invariant).

## Version bump

2.1.78 → 2.1.79 (workspace + sentrix-node + sentrix-staking).