### PR TITLE
chore: refresh Cargo.lock for all-crates 2.1.79

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "bincode",
  "hex",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5195,14 +5195,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "hex",
  "secp256k1 0.31.1",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -5246,7 +5246,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "serde_json",
 ]
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "bincode",
  "blake3",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.77"
+version = "2.1.79"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",


### PR DESCRIPTION
Squash-merged PR #500 dropped the post-bump Cargo.lock update because the lock-file commit landed on the feature branch AFTER the merge. This PR re-applies the lock-file update so cargo build doesn't fail trying to reconcile the lock file mid-build.

15 entries bumped 2.1.77 → 2.1.79 to match the Cargo.toml version on each crate.