### PR TITLE
ci: cargo-llvm-cov coverage workflow + Codecov badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,99 @@
+name: Coverage
+
+# Coverage runs on every push to main + every PR. Sentrix is workspace-
+# wide Rust + revm; cargo-tarpaulin's ptrace engine trips a const-eval
+# bug inside the ruint crate when instrumenting revm's dep tree
+# (verified locally 2026-05-06). cargo-llvm-cov uses LLVM source-based
+# coverage instead — the same engine cargo-tarpaulin's `--engine llvm`
+# flag wraps — with cleaner setup, no const-eval interaction, and
+# direct Codecov upload via lcov.
+#
+# Scope: EVM-free crates only for now (primitives, bft, staking,
+# trie, codec, wallet). The EVM-touching set (sentrix-evm, sentrix-
+# precompiles, sentrix-core, sentrix-rpc, sentrix-network, sentrix-
+# grpc, sentrix-storage, bin/sentrix) compiles and tests fine but
+# llvm-cov instrumentation against the revm dep tree is brittle on
+# CI runners; revisit when we drop a revm version that ships
+# explicit const-eval guard.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  llvm-cov:
+    name: cargo-llvm-cov
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable + llvm-tools-preview
+        run: |
+          rustup default stable
+          rustup component add llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cov-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cov-${{ runner.os }}-
+
+      - name: Run coverage on EVM-free crates
+        run: |
+          cargo llvm-cov \
+            --package sentrix-primitives \
+            --package sentrix-bft \
+            --package sentrix-staking \
+            --package sentrix-trie \
+            --package sentrix-codec \
+            --package sentrix-wallet \
+            --lcov --output-path lcov.info \
+            --ignore-filename-regex '/(tests|benches)/'
+
+      - name: Coverage summary
+        run: |
+          cargo llvm-cov report \
+            --package sentrix-primitives \
+            --package sentrix-bft \
+            --package sentrix-staking \
+            --package sentrix-trie \
+            --package sentrix-codec \
+            --package sentrix-wallet \
+            --summary-only
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false  # Codecov upload failures shouldn't break the pipeline
+          # token: required only for private repos. sentrix-labs/sentrix is
+          # public + open-source under BUSL-1.1, so Codecov tokenless upload
+          # works after enabling the repo at https://codecov.io.
+        continue-on-error: true
+
+      - name: Upload lcov.info as artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: lcov-report
+          path: lcov.info
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Real chain, real blocks, real code. Sentrix (SRX) is a purpose-built Layer-1 wit
 
 [![Website](https://img.shields.io/badge/website-sentrixchain.com-8A5A11)](https://sentrixchain.com)
 [![CI/CD](https://github.com/sentrix-labs/sentrix/actions/workflows/ci.yml/badge.svg)](https://github.com/sentrix-labs/sentrix/actions)
+[![Coverage](https://codecov.io/gh/sentrix-labs/sentrix/branch/main/graph/badge.svg)](https://codecov.io/gh/sentrix-labs/sentrix)
 [![Release](https://img.shields.io/github/v/release/sentrix-labs/sentrix)](https://github.com/sentrix-labs/sentrix/releases/latest)
 [![Tests](https://img.shields.io/badge/tests-700%2B%20passing-brightgreen)](https://github.com/sentrix-labs/sentrix/actions)
 [![Rust](https://img.shields.io/badge/rust-stable-orange)](Cargo.toml)


### PR DESCRIPTION
## Summary
Wires automated coverage on every push to `main` + PR, uploads to Codecov, adds a coverage badge to the README. Local one-off run (2026-05-06) reported **63.06% line coverage** on the included EVM-free crate set (1975/3132 lines).

## Why cargo-llvm-cov vs tarpaulin
Tarpaulin's default ptrace engine trips a const-eval bug inside `ruint` (used by revm) when instrumenting the workspace — verified locally:
```
error[E0080]: evaluation panicked: BYTES must be equal to Self::BYTES
  --> ruint-1.17.2/src/bytes.rs:96:17
```
cargo-llvm-cov uses LLVM source-based coverage (same engine `tarpaulin --engine llvm` wraps internally) and compiles cleanly. Standard `taiki-e/install-action` setup, `lcov.info` output flows directly to Codecov.

## Scope
EVM-free crates first: `sentrix-primitives`, `sentrix-bft`, `sentrix-staking`, `sentrix-trie`, `sentrix-codec`, `sentrix-wallet`. The EVM-touching set (sentrix-evm, sentrix-rpc, sentrix-network, sentrix-storage, sentrix-grpc, sentrix-core, bin/sentrix) compiles + tests fine but llvm-cov instrumentation against the revm dep tree is brittle on shared CI runners; revisit once revm ships an explicit const-eval guard.

## Local coverage breakdown (sample)
| Crate / file | Lines covered |
|---|---|
| sentrix-wallet/{keystore,wallet} | 100% (96/96, 33/33) |
| sentrix-trie/address | 100% (17/17) |
| sentrix-trie/storage | 96% (144/150) |
| sentrix-bft/engine + messages | 87–91% |
| sentrix-staking/staking | 89% (392/440) |
| sentrix-staking/epoch | 95% (69/73) |
| sentrix-primitives/transaction | 73% (101/138) |
| sentrix-primitives/account | 80% (84/105) |
| sentrix-trie/tree | 63% (207/331) |
| sentrix-evm/executor | **0% (0/45)** ← audit-flagged untested |

## Operator action required to light the badge
1. Visit https://codecov.io and "Add Repository" → `sentrix-labs/sentrix`. Public repo, no token needed.
2. After the first push to main / PR merge, the badge populates from the lcov upload.

## Test plan
- [x] Local `cargo llvm-cov` run on the same crate set succeeds with 63.06% reported
- [x] Workflow YAML lints (`actionlint`-equivalent: explicit timeouts, least-priv `permissions`, pinned action versions matching the existing ci.yml conventions)
- [ ] First CI run after merge produces a non-empty `lcov.info` artifact
- [ ] Codecov ingests the lcov upload and the badge in README turns green