### PR TITLE
chore(audit): document hickory-proto + tracing-subscriber RUSTSEC ign…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,15 +121,22 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run cargo audit
+        # Ignore list mirrors deny.toml [advisories].ignore — each ID has
+        # a documented reason there; if you add one here, add it there too.
+        # 2026-05-06: dropped RUSTSEC-2026-0105 (core2 yanked) — `cargo
+        # update -p multihash` to 0.19.5 removed core2 from Cargo.lock.
+        # 2026-05-06: added RUSTSEC-2026-0118, RUSTSEC-2026-0119
+        # (hickory-proto pinned by libp2p 0.56.0; awaiting libp2p 0.57+).
         run: |
           cargo audit \
             --ignore RUSTSEC-2020-0105 \
             --ignore RUSTSEC-2026-0097 \
-            --ignore RUSTSEC-2026-0105 \
             --ignore RUSTSEC-2025-0141 \
             --ignore RUSTSEC-2024-0388 \
             --ignore RUSTSEC-2024-0436 \
             --ignore RUSTSEC-2025-0055 \
+            --ignore RUSTSEC-2026-0118 \
+            --ignore RUSTSEC-2026-0119 \
             || echo "::warning::cargo audit findings (non-blocking, see deny.toml for ignored IDs)"
 
   # Second-layer secret scan — complements .githooks/pre-commit which only

--- a/deny.toml
+++ b/deny.toml
@@ -19,18 +19,43 @@ ignore = [
     # issue). Transitive pullers include libp2p and sled descendants.
     "RUSTSEC-2025-0141",
 
-    # RUSTSEC-2026-0105 — `core2 0.4.0` unmaintained AND yanked upstream.
-    # Pulled only by `multihash 0.19.3` → libp2p-core. core2 is a no_std
-    # std::io::Read/Write shim; no unsafe / security surface. Will drop
-    # automatically when multihash 0.20+ releases with core2 removed.
-    "RUSTSEC-2026-0105",
-
     # RUSTSEC-2024-0436 — `paste 1.0.15` unmaintained (informational).
     # Pulled transitively by too many crates to enumerate (revm, libp2p,
     # arkworks all use it for name concatenation in proc-macros).
     # Proc-macro only, compile-time expansion.
     "RUSTSEC-2024-0436",
 
+    # ── Real vulnerabilities pinned upstream — accepted with reasoning ──
+    #
+    # RUSTSEC-2026-0118 — hickory-proto 0.25.2 NSEC3 closest-encloser
+    # unbounded-loop on cross-zone DNS responses. Hickory's own advisory
+    # says "No fixed upgrade is available!" — upstream hasn't shipped a
+    # patch as of 2026-05-06. Sentrix pulls hickory-proto only via
+    # libp2p-mdns 0.48.0 + libp2p-dns 0.44.0 (both pinned by libp2p
+    # 0.56.0 with `hickory-proto = ^0.25.2`, blocking the 0.26.1 fix).
+    # Mitigation context: validator mDNS is bound to the private
+    # validator mesh, not internet-exposed; libp2p-dns is for bootstrap
+    # peer name resolution only. Drop this ignore once libp2p ships a
+    # 0.57+ that bumps the hickory-proto floor.
+    "RUSTSEC-2026-0118",
+
+    # RUSTSEC-2026-0119 — hickory-proto 0.25.2 O(n²) name compression
+    # CPU exhaustion during message encoding. Fix exists in 0.26.1 but
+    # same upstream pin — libp2p-mdns 0.48.0 / libp2p-dns 0.44.0 require
+    # `^0.25.2`, locking us out. Same mitigation context as -0118.
+    # Drop alongside -0118 when libp2p 0.57+ lands.
+    "RUSTSEC-2026-0119",
+
+    # RUSTSEC-2025-0055 — tracing-subscriber 0.2.25 ANSI escape log
+    # injection. Fix in 0.3.20+. Sentrix uses tracing-subscriber 0.3.x
+    # directly (in main.rs / sentrix-rpc/etc.); the 0.2.25 entry is
+    # pulled exclusively by ark-relations 0.5.1 → ark-r1cs-std →
+    # ark-bn254 → revm-precompile 34.0.0. Arkworks is the zk-circuit
+    # framework; revm pulls it for BN254/BLS12-381 EC precompiles.
+    # ark-relations doesn't subscribe its own logs to user input, so
+    # the practical exploit surface is nil. Drop when arkworks ships
+    # a release that bumps tracing-subscriber to 0.3.x.
+    "RUSTSEC-2025-0055",
 ]
 
 # ── Licenses ────────────────────────────────────────────────


### PR DESCRIPTION
…ores

cargo audit was surfacing 3 actual RUSTSEC vulnerabilities + 1 yanked warning post-PR #505 (multihash bump that cleared core2). The yanked warning is gone; the 3 vulnerabilities have no upstream fix path without a libp2p major bump:

- RUSTSEC-2026-0118 (hickory-proto NSEC3 unbounded loop) — upstream advisory says "no fix available". Pulled by libp2p-mdns 0.48.0 + libp2p-dns 0.44.0; libp2p 0.56.0 pins hickory-proto = ^0.25.2 so even when 0.26.1 ships a patch (-0119) we can't take it.
- RUSTSEC-2026-0119 (hickory-proto O(n²) name compression) — fix in 0.26.1 but blocked by the same libp2p pin.
- RUSTSEC-2025-0055 (tracing-subscriber 0.2.25 ANSI escape) — buried under arkworks → revm-precompile. Sentrix uses 0.3.x directly; the 0.2.25 entry is exclusively in the ark-relations zk-circuit chain.

Mitigation context for the hickory pair: validator mDNS is bound to the private validator mesh (not internet-exposed); libp2p-dns is for bootstrap peer name resolution only. ANSI escape: ark-relations doesn't subscribe its own logs to user-controlled input so the practical exploit surface is nil.

Add all three to deny.toml advisories.ignore + ci.yml cargo-audit --ignore list, with documented reason + the upstream condition that will let us drop each one. Drop RUSTSEC-2026-0105 (core2) from both lists since multihash 0.19.5 removed it.

Net: cargo audit exit 0 cleanly with zero unhandled advisories.

<!--
Thanks for the PR. Fill in the relevant sections + check the boxes that apply.
The risk-tier checklist below is the gate — it codifies discipline rules that
existed in `feedback_*.md` memory but kept getting skipped under time pressure.
-->

## Summary

<!-- 1-3 lines: what changed and why. Link the issue if applicable. -->

## Risk tier

Check ONE:

- [ ] **🟢 Low** — docs, tools/, tests/, CI configs, dependency patch bumps in dev-only crates, comments
- [ ] **🟡 Medium** — non-consensus production code (RPC handlers, network plumbing, observability, ops scripts)
- [ ] **🟠 High** — consensus-critical crates (`sentrix-core`, `sentrix-trie`, `sentrix-staking`, `sentrix-bft`), `block_executor`, `apply_block_*`, `state_root` path
- [ ] **🔴 Critical** — Voyager activation, fork-height changes, hard-fork rollouts, anything that flips env vars on mainnet

## Required by tier

### 🟢 Low — minimum bar
- [ ] CI green (tests + clippy + audit + gitleaks)

### 🟡 Medium — adds
- [ ] New public function or behavioural change has at least one corresponding `#[test]` in same PR
- [ ] Brief description of how this was tested (manual run, integration test, etc.)

### 🟠 High — adds
- [ ] Regression test that **fails on main** and **passes with this change** — paste test name in PR body
- [ ] Designed against documented invariant (link the audit/runbook/design doc)
- [ ] Fresh-brain review by someone other than the author (per `feedback_consensus_change_review`)
- [ ] Single conceptual unit per PR (no bundling — bundling consensus changes burned us on v2.1.12 → 2026-04-25 livelock)

### 🔴 Critical — adds
- [ ] **Testnet rehearsal completed** with success criteria + log evidence linked here
- [ ] **Bake window** observed: minimum 2h on testnet at the same configuration before mainnet
- [ ] **Coordinated rollback plan** documented in PR body — exact commands operator runs if it fails
- [ ] **Operator sign-off** at activation moment (not just PR approval — separate moment for the actual flip)

## Test plan

<!-- Bullet list. For 🟠 / 🔴 PRs the regression test must be specific. -->

-

## Rollback plan

<!-- Required for 🔴 PRs. Recommended for 🟠. The exact commands an on-call operator would run if this PR causes incidents post-deploy. -->

## Related

<!-- Issue numbers, prior PRs, design docs in internal operator docs, etc. -->
