### PR TITLE
ci(coverage): pass CODECOV_TOKEN secret to upload step

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,10 +85,15 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: lcov.info
-          fail_ci_if_error: false  # Codecov upload failures shouldn't break the pipeline
-          # token: required only for private repos. sentrix-labs/sentrix is
-          # public + open-source under BUSL-1.1, so Codecov tokenless upload
-          # works after enabling the repo at https://codecov.io.
+          # `main` on this repo is branch-protected, and Codecov v4 rejects
+          # tokenless upload to protected branches ("Token required because
+          # branch is protected") — even on public repos. Token must be
+          # configured at GitHub → Settings → Secrets and variables →
+          # Actions → New repository secret `CODECOV_TOKEN`, value taken
+          # from codecov.io after enabling the repo. With the secret unset
+          # the upload step warns + skips; the workflow itself stays green.
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
         continue-on-error: true
 
       - name: Upload lcov.info as artifact


### PR DESCRIPTION
## Why
First run of the coverage workflow on main (PR #503 merge, [run 25456050063](https://github.com/sentrix-labs/sentrix/actions/runs/25456050063)) had Codecov refuse the upload:

```
warning - Branch `main` is protected but no token was provided
error - Commit creating failed: {"message":"Token required because branch is protected"}
error - Report creating failed: same
```

codecov-action v4 + protected branch = mandatory token, even on public repos. The workflow itself stays green (`continue-on-error: true`), but the badge in README is "unknown" until the token lands.

## Fix
Wire `${{ secrets.CODECOV_TOKEN }}` into the upload step. With the secret absent the action still warns + skips silently — workflow keeps passing.

## Operator action required to light the badge

1. Visit https://codecov.io → log in with GitHub → "Add Repository" → `sentrix-labs/sentrix`.
2. Codecov shows an upload token like `12345678-aaaa-bbbb-cccc-dddddddddddd`.
3. GitHub repo: **Settings → Secrets and variables → Actions → New repository secret**.
   - Name: `CODECOV_TOKEN`
   - Value: paste the token from step 2.
4. Re-run the latest Coverage workflow OR push any commit to main. Next run uploads, badge populates.

## Test plan
- [x] Workflow YAML valid (one-line action change)
- [ ] Operator adds CODECOV_TOKEN secret + triggers new run
- [ ] Badge in README transitions from "unknown" → "X% coverage"