### PR TITLE
fix(evm): tighten input-validation guards (audit H1 + H2)

### DIFF
--- a/crates/sentrix-core/src/block_executor/evm.rs
+++ b/crates/sentrix-core/src/block_executor/evm.rs
@@ -26,7 +26,38 @@ impl Blockchain {
         if parts.len() != 3 || parts[0] != "EVM" {
             return Ok(()); // not an EVM tx, skip
         }
-        let gas_limit: u64 = parts[1].parse().unwrap_or(30_000_000);
+        // Audit H2 (2026-05-06): a malformed gas_limit field used to fall
+        // back to 30_000_000 — equal to BLOCK_GAS_LIMIT — letting one tx
+        // consume the entire block budget and bypass TX_GAS_LIMIT_CAP. RPC
+        // ingress validates this field for client-built txs, so historical
+        // mainnet txs all have well-formed values; the silent fallback was
+        // a hostile-input safety net that defaulted in the wrong direction.
+        // Now: parse strictly, cap at TX_GAS_LIMIT_CAP, mark the tx failed
+        // on either error so the block still progresses (Pass-1 already
+        // debited tx.fee).
+        let gas_limit: u64 = match parts[1].parse() {
+            Ok(g) => g,
+            Err(e) => {
+                tracing::warn!(
+                    "EVM tx {}: malformed gas_limit {:?}: {}",
+                    &tx.txid[..16.min(tx.txid.len())],
+                    parts[1],
+                    e,
+                );
+                self.accounts.mark_evm_tx_failed(&tx.txid);
+                return Ok(());
+            }
+        };
+        if gas_limit > sentrix_evm::gas::TX_GAS_LIMIT_CAP {
+            tracing::warn!(
+                "EVM tx {}: gas_limit {} exceeds TX_GAS_LIMIT_CAP {}",
+                &tx.txid[..16.min(tx.txid.len())],
+                gas_limit,
+                sentrix_evm::gas::TX_GAS_LIMIT_CAP,
+            );
+            self.accounts.mark_evm_tx_failed(&tx.txid);
+            return Ok(());
+        }
         let calldata = hex::decode(parts[2]).unwrap_or_default();
 
         // Decode raw Ethereum tx from signature field for re-validation
@@ -137,7 +168,15 @@ impl Blockchain {
             }
         }
 
-        let evm_tx = TxEnv::builder()
+        // Audit H1 (2026-05-06): pre-fix this trailed `.unwrap_or_default()`,
+        // substituting a zero TxEnv (caller=0x0, gas=0, chain_id=None) on
+        // build failure. revm would then execute that zero-env against state,
+        // producing non-deterministic results across revm versions / validator
+        // builds — same shape as the 2026-05-01 EVM-value-transfer split-brain.
+        // build() can only fail when a required field is unset; we set them
+        // all above, so this path is unreachable in practice. Surface the
+        // error explicitly anyway and mark the tx failed if it ever fires.
+        let evm_tx = match TxEnv::builder()
             .caller(from_addr)
             .kind(tx_kind)
             .data(alloy_primitives::Bytes::from(calldata))
@@ -156,7 +195,18 @@ impl Blockchain {
             .nonce(sender_nonce)
             .chain_id(Some(tx.chain_id))
             .build()
-            .unwrap_or_default();
+        {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(
+                    "EVM tx {}: TxEnv::builder().build() failed: {}",
+                    &tx.txid[..16.min(tx.txid.len())],
+                    e,
+                );
+                self.accounts.mark_evm_tx_failed(&tx.txid);
+                return Ok(());
+            }
+        };
 
         match execute_tx_with_state(evm_db, evm_tx, INITIAL_BASE_FEE, self.chain_id) {
             Ok((receipt, state)) => {


### PR DESCRIPTION
## Why
Two silent fallbacks in `crates/sentrix-core/src/block_executor/evm.rs::execute_evm_tx_in_block` flagged HIGH in the 2026-05-06 rust-workspace security audit (`founder-private/audits/2026-05-06-rust-workspace-security-audit.md`).

### H2 — gas_limit fallback bypasses TX_GAS_LIMIT_CAP
`evm.rs:29` previously: \`parts[1].parse().unwrap_or(30_000_000)\`. A malformed gas_limit field (RPC ingress validates, but the path was reachable for crafted raw txs) silently fell back to 30M = BLOCK_GAS_LIMIT, letting one tx consume the entire block budget and bypass TX_GAS_LIMIT_CAP (16,777,216).

### H1 — TxEnv::builder().build().unwrap_or_default()
\`evm.rs:158-159\`. On build failure revm would receive a zero TxEnv (caller=0x0, gas=0, chain_id=None) and execute it against real state — non-deterministic across revm versions. Same class as the 2026-05-01 value-transfer split-brain.

## What changed
- Strict parse for gas_limit + explicit TX_GAS_LIMIT_CAP check; on either error: \`tracing::warn!\` + \`mark_evm_tx_failed\` + return Ok(()). Block still progresses (Pass-1 already debited tx.fee).
- Explicit match on \`TxEnv::builder().build()\`; same warn + mark_failed + return Ok() on Err.

## Why no fork gate
Both paths only trigger on malformed \`data\` field input. RPC ingress validates the \`EVM:gas_limit:hex\` format, so historical mainnet txs all have well-formed values. The change is identity for every valid tx; only crafted/malformed txs get a different (correct) outcome. No historical mainnet state diff possible.

## H3 (supply leak) — deferred
H3 is a consensus-touching architectural change (gas accounting) that requires:
- Fork height gate (state divergence post-fix)
- Real EVM harness for the regression test (current reproducer in main is synthetic at AccountDB level)
- Testnet bake
- Fresh-brain review per consensus discipline

Not bundling here. Followup session will own H3 with proper testnet path.

## Test plan
- [x] cargo check -p sentrix-core
- [x] cargo clippy -p sentrix-core --tests -- -D warnings
- [x] cargo test -p sentrix-core --lib (212 passed)
- [ ] CI green
- [ ] Fresh-brain review (input-validation, not consensus-touching, but second pair of eyes still welcome)