### PR TITLE
chore(audit): close M1, M5, L1, L3 (logging + dead-code cleanup)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -427,7 +427,20 @@ impl Blockchain {
                             ));
                         }
                     }
-                    _ => unreachable!("TokenOp variant handled above"),
+                    // Audit L3 (2026-05-06): pre-fix this was
+                    // `unreachable!("TokenOp variant handled above")`,
+                    // which would `panic!` + `std::process::abort()` if a
+                    // future TokenOp variant landed without being added to
+                    // an arm above. Reject as InvalidTransaction so the
+                    // failing tx surfaces a normal block-apply error
+                    // instead of taking the validator down.
+                    _ => {
+                        return Err(SentrixError::InvalidTransaction(
+                            "unhandled TokenOp variant — add a Pass-1 \
+                             validation arm above before shipping"
+                                .into(),
+                        ));
+                    }
                 }
             }
 
@@ -776,7 +789,16 @@ impl Blockchain {
                                 .into(),
                         ));
                     }
-                    _ => unreachable!("TokenOp variant handled above"),
+                    // Audit L3 sister site (Pass-2 dispatch). Same
+                    // rationale as the Pass-1 fallthrough above — fail
+                    // the tx, don't abort the validator.
+                    _ => {
+                        return Err(SentrixError::InvalidTransaction(
+                            "unhandled TokenOp variant in dispatch — add \
+                             a handler arm above before shipping"
+                                .into(),
+                        ));
+                    }
                 }
             }
 

--- a/crates/sentrix-core/src/block_executor/evm.rs
+++ b/crates/sentrix-core/src/block_executor/evm.rs
@@ -68,14 +68,18 @@ impl Blockchain {
 
         use alloy_consensus::TxEnvelope;
         use alloy_consensus::Transaction as AlloyTx; // brings .value() into scope
-        use alloy_consensus::transaction::SignerRecoverable;
         use alloy_eips::eip2718::Decodable2718;
 
         let envelope: TxEnvelope = match TxEnvelope::decode_2718(&mut raw_bytes.as_slice()) {
             Ok(e) => e,
             Err(_) => return Ok(()),
         };
-        let _sender = envelope.recover_signer().ok();
+        // Audit L1 (2026-05-06): a stray `let _sender = envelope.recover_signer().ok();`
+        // here was burning a secp256k1 recovery (~100µs/tx) without using
+        // the result. The actual sender comes from `tx.from_address` (set
+        // by Pass-1 native flow); the EVM caller is derived below from
+        // `parse_sentrix_address(&tx.from_address)`. No correctness role for
+        // this line; deleted.
 
         // Pull native-value out of the envelope, but gate it. Flat-shipping
         // the `.value()` plumbing in v2.1.49 produced 3 same-day mainnet
@@ -234,11 +238,23 @@ impl Blockchain {
                     && let Some(key) = sentrix_evm::receipt_key(&tx.txid)
                 {
                     let stored = sentrix_evm::StoredReceipt::from_tx_receipt(&receipt);
-                    let _ = storage.put_bincode(
+                    // Audit M1 (2026-05-06): pre-fix this swallowed the put
+                    // error silently. A failed receipt persist means
+                    // `eth_getTransactionReceipt` 404s for a tx that DID
+                    // execute and DID move state — surface so ops can spot
+                    // it. Don't propagate: block apply already succeeded,
+                    // chain state is canonical.
+                    if let Err(e) = storage.put_bincode(
                         sentrix_storage::tables::TABLE_RECEIPTS,
                         &key,
                         &stored,
-                    );
+                    ) {
+                        tracing::warn!(
+                            "EVM tx {}: receipt persist failed: {}",
+                            &tx.txid[..16.min(tx.txid.len())],
+                            e,
+                        );
+                    }
                 }
                 // Sprint 2: persist every log emitted by this tx. Key is
                 // (height, tx_index, log_index) BE-packed so range scans
@@ -265,8 +281,22 @@ impl Blockchain {
                             log_idx as u32,
                         );
                         let key = log_key(block_height, tx_index, log_idx as u32);
-                        let _ =
-                            storage.put_bincode(sentrix_storage::tables::TABLE_LOGS, &key, &stored);
+                        // Audit M1 (sister site): same warn-on-Err pattern
+                        // as the receipt persist above. Failed log persist
+                        // means `eth_getLogs` misses an entry; emit_log
+                        // below still notifies live WS subscribers.
+                        if let Err(e) = storage.put_bincode(
+                            sentrix_storage::tables::TABLE_LOGS,
+                            &key,
+                            &stored,
+                        ) {
+                            tracing::warn!(
+                                "EVM tx {}: log persist failed (idx={}): {}",
+                                &tx.txid[..16.min(tx.txid.len())],
+                                log_idx,
+                                e,
+                            );
+                        }
 
                         // Notify WebSocket subscribers — eth_subscribe(logs).
                         // Convert StoredLog to the trait-friendly LogData

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -689,11 +689,22 @@ impl Blockchain {
     /// never called (e.g. unit tests with no storage backing).
     pub fn record_tx_in_index(&self, txid: &str, block_index: u64) {
         if let Some(mdbx) = &self.mdbx_storage {
-            let _ = mdbx.put(
+            // Audit M5 (2026-05-06): pre-fix this swallowed put errors,
+            // which would silently 404 `eth_getTransactionByHash` for a
+            // tx already canonical in chain state. Don't propagate (block
+            // apply already succeeded), but surface for ops.
+            if let Err(e) = mdbx.put(
                 tables::TABLE_TX_INDEX,
                 txid.as_bytes(),
                 &height_key(block_index),
-            );
+            ) {
+                tracing::warn!(
+                    "record_tx_in_index({}, h={}): MDBX put failed: {}",
+                    txid,
+                    block_index,
+                    e,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Why
Pure-cleanup batch from the 2026-05-06 rust-workspace audit. None of the changes affect block-apply state or consensus output.

| ID | File | Change |
|---|---|---|
| **M1** | \`block_executor/evm.rs:188, :286\` | Receipt + log MDBX put errors → \`tracing::warn!\` instead of silent swallow |
| **M5** | \`blockchain.rs::record_tx_in_index\` | Same pattern, same fix |
| **L1** | \`block_executor/evm.rs:47\` | Delete dead \`let _sender = recover_signer().ok();\` (~100µs/tx) + orphaned import |
| **L3** | \`block_executor.rs:430, :779\` | \`unreachable!\` → \`Err(InvalidTransaction)\` so unknown TokenOp variant doesn't abort the validator |

## State / consensus impact
None. M1 and M5 only touch error-handling paths that were silently dropped; the data they fail to write is metadata for RPC reads, not consensus state. L1 deletes a no-op. L3 only triggers if a TokenOp variant is added without an arm above — currently unreachable.

## Test plan
- [x] cargo clippy -p sentrix-core --tests -- -D warnings
- [x] cargo test -p sentrix-core --lib (212 passed)
- [ ] CI green