### PR TITLE
test: AccountDB supply-invariant proptest + EVM e2e harness scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5191,6 +5191,7 @@ name = "sentrix-primitives"
 version = "2.1.79"
 dependencies = [
  "hex",
+ "proptest",
  "secp256k1 0.31.1",
  "serde",
  "serde_json",

--- a/crates/sentrix-core/tests/evm_e2e_harness.rs
+++ b/crates/sentrix-core/tests/evm_e2e_harness.rs
@@ -1,0 +1,212 @@
+//! End-to-end Blockchain harness — scaffold for EVM tx integration tests.
+//!
+//! Background: the 2026-05-06 rust-workspace audit flagged `sentrix-evm`
+//! at 0% line coverage. Existing unit tests use `InMemoryDB` and don't
+//! exercise the full `add_block` → `apply_block_pass2` →
+//! `execute_evm_tx_in_block` → `commit_state_to_account_db` chain. State
+//! divergence bugs (5 mainnet halts in April–May 2026) keep slipping
+//! through unit tests because they only manifest in the real-MDBX +
+//! real-trie post-block path.
+//!
+//! This file provides a working `Blockchain` harness with EVM activated
+//! at h=0, plus reference test patterns:
+//!
+//!   - `setup_evm_active_chain()` — chain ready to accept EVM txs.
+//!   - `test_native_tx_through_full_block_apply` — sanity that a real
+//!     signed Tx reaches `apply_block_pass2` and updates state. Catches
+//!     "harness broken" before any EVM-specific test runs.
+//!   - `test_evm_tx_e2e_TODO` — ignored skeleton showing the steps to
+//!     construct + apply a real EVM tx. Filling this in lands the audit's
+//!     #2 untested-critical-function (`execute_evm_tx_in_block` against
+//!     real MDBX) and creates a harness for H3 supply-leak regression.
+//!
+//! Run: `cargo test -p sentrix-core --test evm_e2e_harness`
+//!
+//! Audit reference: founder-private/audits/2026-05-06-rust-workspace-security-audit.md
+
+use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use sentrix_core::blockchain::Blockchain;
+use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
+use sentrix_storage::MdbxStorage;
+use sentrix_wallet::Wallet;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+const VALIDATOR: &str = "validator1";
+
+fn deterministic_keypair(seed: u8) -> (SecretKey, PublicKey) {
+    let sk = SecretKey::from_byte_array([seed.max(1); 32]).expect("non-zero seed");
+    let secp = Secp256k1::new();
+    let pk = PublicKey::from_secret_key(&secp, &sk);
+    (sk, pk)
+}
+
+fn temp_mdbx() -> (TempDir, Arc<MdbxStorage>) {
+    let dir = TempDir::new().expect("tempdir");
+    let mdbx = Arc::new(MdbxStorage::open(dir.path()).expect("mdbx open"));
+    (dir, mdbx)
+}
+
+/// Build a fresh `Blockchain` with Voyager + EVM forks already active at
+/// h=0. The env-var path is the same one production uses; we set it to
+/// `0` so the gate `is_voyager_height(0)` and `is_evm_active_height(0)`
+/// both return true.
+///
+/// SAFETY (Rust 1.78+): `std::env::set_var` is unsafe across threads
+/// because it mutates process-global state. Tests in this file are
+/// `#[serial]`-equivalent through cargo's per-target serialization (each
+/// integration test file is its own binary), so cross-test bleed is not
+/// a concern; cross-thread bleed within this binary is avoided by
+/// setting the env once at chain construction and never mutating
+/// afterwards.
+fn setup_evm_active_chain() -> (TempDir, Arc<MdbxStorage>, Blockchain) {
+    // SAFETY: see fn doc.
+    unsafe {
+        std::env::set_var("VOYAGER_FORK_HEIGHT", "0");
+        std::env::set_var("VOYAGER_EVM_HEIGHT", "0");
+    }
+
+    let (dir, mdbx) = temp_mdbx();
+    let mut bc = Blockchain::new("admin".to_string());
+    bc.authority.add_validator_unchecked(
+        VALIDATOR.to_string(),
+        "Validator 1".to_string(),
+        "pk1".to_string(),
+    );
+    bc.init_trie(Arc::clone(&mdbx)).unwrap();
+
+    (dir, mdbx, bc)
+}
+
+/// Sanity test: a real signed native Tx flows through `add_to_mempool`
+/// → `create_block` → `add_block` and updates account state as expected.
+/// If this breaks, no EVM-specific test in this file can be trusted —
+/// the harness itself is wrong.
+#[test]
+fn test_native_tx_through_full_block_apply() {
+    let (_dir, _mdbx, mut bc) = setup_evm_active_chain();
+
+    let (sk, pk) = deterministic_keypair(1);
+    let sender = Wallet::derive_address(&pk);
+    let recv = format!("0x{}", "deadbeef".repeat(5));
+
+    // 100 SRX = 10^10 sentri
+    bc.accounts.credit(&sender, 10_000_000_000).unwrap();
+    let initial_supply = bc.accounts.total_supply();
+    let initial_burned = bc.accounts.total_burned;
+
+    let chain_id = bc.chain_id;
+    let amount = 1_000_000u64;
+    let tx = Transaction::new(
+        sender.clone(),
+        recv.clone(),
+        amount,
+        MIN_TX_FEE,
+        0, // first nonce
+        String::new(),
+        chain_id,
+        &sk,
+        &pk,
+    )
+    .expect("tx build");
+
+    bc.add_to_mempool(tx).expect("mempool accept");
+    let block = bc.create_block(VALIDATOR).expect("create_block");
+    bc.add_block(block).expect("add_block");
+
+    // State assertions.
+    assert_eq!(bc.height(), 1, "block applied");
+    assert_eq!(
+        bc.accounts.get_balance(&recv),
+        amount,
+        "recipient credited",
+    );
+    assert_eq!(
+        bc.accounts.get_balance(&sender),
+        10_000_000_000 - amount - MIN_TX_FEE,
+        "sender debited amount + fee",
+    );
+
+    // Supply conservation: half the fee was burned, half stays in the
+    // validator pool (credited to VALIDATOR by the block-end coinbase).
+    let burn_delta = bc.accounts.total_burned - initial_burned;
+    let supply_delta = initial_supply.saturating_sub(bc.accounts.total_supply());
+    assert_eq!(
+        burn_delta,
+        MIN_TX_FEE.div_ceil(2),
+        "exactly ceil(fee/2) burned",
+    );
+    // Block reward credits the validator with `block_reward + fee_share`.
+    // Net supply change over the block = +block_reward - burned. The
+    // exact reward varies with the fork height schedule, so just assert
+    // the burn portion accounts for the expected fee/2 burn.
+    assert!(
+        burn_delta <= supply_delta || supply_delta == 0,
+        "burn must not exceed observable supply drop (block reward may have offset)",
+    );
+}
+
+/// **TODO scaffold** — fill in to land audit #2 (untested
+/// `execute_evm_tx_in_block` against real MDBX) and to wire H3 supply-
+/// leak regression at the e2e level.
+///
+/// Construction steps for an EVM tx through Sentrix's wire format:
+///
+///   1. Build an `alloy_consensus::TxLegacy` (or `TxEip1559`) with the
+///      target `chain_id`, `nonce`, `gas_price`, `gas_limit`, `to`,
+///      `value`, `input`. Set `gas_price = sentrix_evm::gas::INITIAL_BASE_FEE`
+///      to match what `block_executor/evm.rs:189` injects.
+///   2. Sign via secp256k1 → `alloy_consensus::Signed<TxLegacy>` →
+///      `TxEnvelope::Legacy(...)`.
+///   3. RLP-encode via `Decodable2718::encode_2718` (or equivalent
+///      eip-2718 wrapper) into a `Vec<u8>`; hex-encode for the Sentrix
+///      `tx.signature` field (Sentrix re-decodes via
+///      `TxEnvelope::decode_2718` in `block_executor/evm.rs:74`).
+///   4. Build `tx.data = format!("EVM:{}:{}", gas_limit, hex::encode(calldata))`.
+///   5. Wrap in `Transaction::new(...)` — note `from_address` MUST
+///      equal `Wallet::derive_address(&pk)` of the EVM signer's
+///      pubkey, because Pass-1 native debits `from_address` via
+///      `charge_fee_only`. If the EVM signer differs from the Sentrix
+///      tx signer, accounting drifts.
+///   6. `bc.add_to_mempool(tx)`; build + apply block; assert receipt
+///      via `eth_getTransactionReceipt`-equivalent path
+///      (`bc.mdbx_storage.get_bincode::<StoredReceipt>(TABLE_RECEIPTS, &key)`).
+///
+/// Reference: `crates/sentrix-rpc/src/jsonrpc/eth.rs::send_raw_transaction`
+/// constructs the inverse direction (raw EVM tx hex → Sentrix Tx).
+#[test]
+#[ignore = "TODO scaffold — fill in EVM tx construction per fn doc to land audit #2"]
+fn test_evm_tx_e2e_landing_pad() {
+    let (_dir, _mdbx, mut bc) = setup_evm_active_chain();
+    let (_sk, pk) = deterministic_keypair(2);
+    let sender = Wallet::derive_address(&pk);
+    bc.accounts.credit(&sender, 100_000_000_000).unwrap(); // 1000 SRX
+
+    // Step 1–4: construct the raw EVM tx. (Body intentionally absent;
+    // see fn doc for the recipe.)
+
+    // Step 5: wrap in Sentrix Transaction::new(...) — REMEMBER that the
+    // EVM signer's secp256k1 pubkey must match `from_address` so Pass-1
+    // native fee accounting lines up with revm's caller.
+
+    // Step 6: bc.add_to_mempool + create_block + add_block, then assert:
+    //   - bc.accounts.get_balance(&sender) reflects amount + Pass-1 fee
+    //     (and, post-H3 fix, the gas portion via burn or validator credit
+    //     as decided in the audit's H3 design call).
+    //   - if Call: `bc.accounts.get_contract_storage(&target, &slot)`
+    //     matches the SSTORE.
+    //   - if Create: `bc.accounts.get_contract_code(&code_hash_hex)` is
+    //     non-empty.
+    //   - the receipt key persists: `mdbx.get(TABLE_RECEIPTS, &receipt_key(&txid))`.
+
+    // Once this body lands, also un-ignore `test_h3_evm_writeback_set_balance_breaks_supply_invariant`
+    // in `crates/sentrix-primitives/src/account.rs` and rewrite it to use
+    // this harness instead of the synthetic AccountDB calls — that closes
+    // the audit's H3 reproducer gap properly.
+
+    panic!(
+        "TODO scaffold — fill in EVM tx construction per the fn-level \
+         docstring on this test. Harness is verified by \
+         test_native_tx_through_full_block_apply above."
+    );
+}

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -16,3 +16,11 @@ secp256k1 = { version = "0.31", features = ["rand", "recovery", "serde"] }
 sha2 = "0.11"
 sha3 = "0.11"
 hex = "0.4"
+
+[dev-dependencies]
+# Property-based testing for AccountDB invariant sweeps. See
+# `tests/account_proptest.rs` — generates random op sequences and
+# asserts `total_supply()` and `total_burned` match an independent
+# ledger model. Catches the H3-class supply leak (audit 2026-05-06)
+# at the unit level before it ships.
+proptest = "1"

--- a/crates/sentrix-primitives/tests/account_proptest.rs
+++ b/crates/sentrix-primitives/tests/account_proptest.rs
@@ -1,0 +1,312 @@
+//! Property-based invariant tests for AccountDB.
+//!
+//! Background: the 2026-05-06 rust-workspace audit flagged H3 — a supply
+//! leak in the EVM tx path where `commit_state_to_account_db` calls
+//! `set_balance` to write a post-revm balance back, and the wei-side gas
+//! deduction silently disappears from `total_supply()`. The mechanism is
+//! generic: ANY caller that uses `set_balance` to drop an account
+//! balance without crediting another account or calling `burn` violates
+//! the supply-conservation invariant.
+//!
+//! These tests treat AccountDB as a state machine and assert two
+//! invariants across random op sequences:
+//!
+//!   I1 (positive): `credit`, `charge_fee_only`, and `transfer` together
+//!      preserve `total_supply() + total_burned + validator_pool` where
+//!      `validator_pool` is the per-tx `floor(fee/2)` that the caller
+//!      tracks for end-of-block `apply_block_reward`. The model ledger
+//!      mirrors AccountDB.
+//!
+//!   I2 (negative — H3 hazard demonstration): `set_balance` reductions
+//!      DO break the invariant unless the caller bookkeeps the delta
+//!      elsewhere. We assert this directly so a future PR that tightens
+//!      the AccountDB API (private `set_balance`, force `credit`/`burn`
+//!      for all balance changes) is a regression-guarded refactor.
+//!
+//! Run with: `cargo test -p sentrix-primitives --test account_proptest`
+//!
+//! Audit reference: founder-private/audits/2026-05-06-rust-workspace-security-audit.md
+
+use proptest::prelude::*;
+use sentrix_primitives::account::AccountDB;
+
+/// Address pool kept small so transfer ops have a non-trivial chance of
+/// picking sender == recipient (which AccountDB tolerates) and so the
+/// state space is dense enough for shrinking to find minimal counter-
+/// examples on regression.
+const ADDRESSES: &[&str] = &["alice", "bob", "carol", "dave", "eve"];
+
+/// Operations the model supports. Mirrors AccountDB's bookkeeping
+/// surface; deliberately excludes `set_balance` / `set_nonce` which the
+/// negative test (`H3-style hazard`) covers separately.
+#[derive(Debug, Clone)]
+enum Op {
+    /// Mint into `addr`. Models block-reward credit / genesis funding.
+    Credit { addr: usize, amount: u64 },
+    /// Pass-1 EVM fee deduction. Half is burned, half is implicitly
+    /// validator-share (caller responsibility to credit at block-end;
+    /// the model tracks it as `validator_pool`).
+    ChargeFee { from: usize, fee: u64 },
+    /// Native value transfer with fee. Same fee-split semantics as
+    /// ChargeFee — `floor(fee/2)` to validator_pool, `ceil(fee/2)` burned.
+    Transfer {
+        from: usize,
+        to: usize,
+        amount: u64,
+        fee: u64,
+    },
+}
+
+fn op_strategy() -> impl Strategy<Value = Op> {
+    let addr = 0usize..ADDRESSES.len();
+    // Small bounds keep test runs fast while still surfacing arithmetic
+    // edge cases (rounding direction on odd fees, zero-amount transfers).
+    let small_amount = 0u64..1_000_000_000u64; // 0..10 SRX
+    let small_fee = 0u64..100_000u64; // 0..0.001 SRX
+
+    prop_oneof![
+        (addr.clone(), small_amount.clone()).prop_map(|(addr, amount)| Op::Credit { addr, amount }),
+        (addr.clone(), small_fee.clone()).prop_map(|(from, fee)| Op::ChargeFee { from, fee }),
+        (
+            addr.clone(),
+            addr.clone(),
+            small_amount,
+            small_fee,
+        )
+            .prop_map(|(from, to, amount, fee)| Op::Transfer {
+                from,
+                to,
+                amount,
+                fee,
+            }),
+    ]
+}
+
+/// Independent ledger model. Tracks the same state as AccountDB plus an
+/// implicit `validator_pool` for collected fees that haven't yet been
+/// credited via `apply_block_reward`. AccountDB doesn't expose this pool
+/// directly because `transfer` / `charge_fee_only` only update
+/// `total_burned`; the validator share is reconciled at block-end.
+#[derive(Default, Clone)]
+struct ModelLedger {
+    balances: std::collections::HashMap<String, u64>,
+    total_burned: u64,
+    /// `floor(fee/2)` collected per fee-op. Stays in escrow until the
+    /// caller calls `apply_block_reward(validator, reward, fee_share)`
+    /// at end of block. Conserved-supply invariant assumes this pool
+    /// IS still part of the system's total tokens.
+    validator_pool: u64,
+    /// Cumulative tokens introduced via `credit` (new mint) — block
+    /// rewards, genesis funding, etc. Conservation invariant:
+    ///     supply + burned + validator_pool == initial_seed + total_minted
+    total_minted: u64,
+}
+
+impl ModelLedger {
+    fn balance(&self, addr: &str) -> u64 {
+        self.balances.get(addr).copied().unwrap_or(0)
+    }
+
+    fn credit(&mut self, addr: &str, amount: u64) {
+        let entry = self.balances.entry(addr.to_string()).or_insert(0);
+        *entry = entry.saturating_add(amount);
+    }
+
+    /// Returns true if op was applicable (sufficient balance / no overflow).
+    /// Matches AccountDB's Err-on-insufficient-balance semantics — when
+    /// AccountDB would Err, the model returns false and skips the change.
+    fn apply(&mut self, op: &Op) -> bool {
+        match op {
+            Op::Credit { addr, amount } => {
+                let key = ADDRESSES[*addr];
+                let new = self.balance(key).checked_add(*amount);
+                match new {
+                    Some(v) => {
+                        self.balances.insert(key.to_string(), v);
+                        self.total_minted = self.total_minted.saturating_add(*amount);
+                        true
+                    }
+                    None => false, // overflow — AccountDB Errs, model skips
+                }
+            }
+            Op::ChargeFee { from, fee } => {
+                let key = ADDRESSES[*from];
+                if self.balance(key) < *fee {
+                    return false;
+                }
+                let entry = self.balances.entry(key.to_string()).or_insert(0);
+                *entry -= fee;
+                let burn = fee.div_ceil(2);
+                self.total_burned = self.total_burned.saturating_add(burn);
+                self.validator_pool = self.validator_pool.saturating_add(fee - burn);
+                true
+            }
+            Op::Transfer {
+                from,
+                to,
+                amount,
+                fee,
+            } => {
+                let from_key = ADDRESSES[*from];
+                let to_key = ADDRESSES[*to];
+                let total = match amount.checked_add(*fee) {
+                    Some(t) => t,
+                    None => return false,
+                };
+                if self.balance(from_key) < total {
+                    return false;
+                }
+                // Match AccountDB::credit — it fails on overflow rather
+                // than wrapping. If recipient overflow would happen,
+                // AccountDB returns Err and rolls the sender deduction
+                // back via early-return BEFORE the mutation. Model
+                // mirrors by checking the recipient first.
+                if self.balance(to_key).checked_add(*amount).is_none() {
+                    return false;
+                }
+                let from_entry = self.balances.entry(from_key.to_string()).or_insert(0);
+                *from_entry -= total;
+                let to_entry = self.balances.entry(to_key.to_string()).or_insert(0);
+                *to_entry = to_entry.saturating_add(*amount);
+                let burn = fee.div_ceil(2);
+                self.total_burned = self.total_burned.saturating_add(burn);
+                self.validator_pool = self.validator_pool.saturating_add(fee - burn);
+                true
+            }
+        }
+    }
+
+    fn account_db_supply(&self) -> u64 {
+        self.balances.values().sum()
+    }
+}
+
+// I1 — across any sequence of `credit` / `charge_fee_only` / `transfer`,
+// AccountDB's observed `total_supply()` and `total_burned` match a
+// from-scratch model ledger applied to the same op sequence. Validates
+// the bookkeeping discipline of every public mutation that's allowed
+// to change supply.
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+    #[test]
+    fn supply_invariant_holds_under_random_op_sequences(
+        ops in prop::collection::vec(op_strategy(), 1..50),
+        initial_funding in 1_000_000_000u64..10_000_000_000u64, // 10..100 SRX per address
+    ) {
+        let mut db = AccountDB::new();
+        let mut model = ModelLedger::default();
+
+        // Seed every address with `initial_funding` so most ops have a
+        // non-trivial chance of succeeding instead of dying instantly on
+        // InsufficientBalance.
+        for addr in ADDRESSES {
+            db.credit(addr, initial_funding).unwrap();
+            model.credit(addr, initial_funding);
+        }
+
+        for op in &ops {
+            match op {
+                Op::Credit { addr, amount } => {
+                    let key = ADDRESSES[*addr];
+                    let real_ok = db.credit(key, *amount).is_ok();
+                    let model_ok = model.apply(op);
+                    prop_assert_eq!(real_ok, model_ok, "credit ok-status drift");
+                }
+                Op::ChargeFee { from, fee } => {
+                    let key = ADDRESSES[*from];
+                    let real_ok = db.charge_fee_only(key, *fee).is_ok();
+                    let model_ok = model.apply(op);
+                    prop_assert_eq!(real_ok, model_ok, "charge_fee_only ok-status drift");
+                }
+                Op::Transfer { from, to, amount, fee } => {
+                    let from_key = ADDRESSES[*from];
+                    let to_key = ADDRESSES[*to];
+                    let real_ok = db.transfer(from_key, to_key, *amount, *fee).is_ok();
+                    let model_ok = model.apply(op);
+                    prop_assert_eq!(real_ok, model_ok, "transfer ok-status drift");
+                }
+            }
+
+            // Per-step invariants. We re-check after every op so
+            // shrinking pinpoints the offending op.
+            for addr in ADDRESSES {
+                prop_assert_eq!(
+                    db.get_balance(addr),
+                    model.balance(addr),
+                    "balance drift on {}",
+                    addr,
+                );
+            }
+            prop_assert_eq!(
+                db.total_supply(),
+                model.account_db_supply(),
+                "total_supply drift",
+            );
+            prop_assert_eq!(
+                db.total_burned,
+                model.total_burned,
+                "total_burned drift",
+            );
+
+            // Conservation: total tokens in the system =
+            //     supply (held in accounts) + total_burned + validator_pool
+            // and grows by exactly the amount of any new `credit` mint.
+            // Anything else (transfer, charge_fee_only) is zero-sum on the
+            // (supply + burned + pool) total.
+            let initial_seed = ADDRESSES.len() as u64 * initial_funding;
+            let supply_now = db.total_supply();
+            let conserved = supply_now
+                .saturating_add(db.total_burned)
+                .saturating_add(model.validator_pool);
+            let expected = initial_seed.saturating_add(model.total_minted);
+            prop_assert_eq!(
+                conserved, expected,
+                "supply conservation broken: supply={} burned={} validator_pool={} initial_seed={} minted_via_credit={}",
+                supply_now, db.total_burned, model.validator_pool, initial_seed, model.total_minted,
+            );
+        }
+    }
+}
+
+/// I2 — `set_balance` is the H3 hazard. Reducing a balance via
+/// `set_balance` without bookkeeping the delta DOES break the supply
+/// invariant. This test is a deliberate negative: it asserts the bug
+/// EXISTS today so a future PR that fixes it (e.g. by making
+/// `set_balance` private + introducing `credit_absolute` / `burn_to`
+/// pairing) is forced to also remove or update this test. That's the
+/// regression-guard pattern we want.
+#[test]
+fn set_balance_reduction_leaks_supply_h3_class() {
+    let mut db = AccountDB::new();
+    db.credit("alice", 1_000_000_000).unwrap();
+    let initial_supply = db.total_supply();
+    let initial_burned = db.total_burned;
+
+    // Simulate the EVM writeback path: alice's wei balance drops by the
+    // gas-deduction equivalent. set_balance writes the absolute new
+    // value; no `burn` or `credit` paired with it.
+    let post_evm_balance = db.get_balance("alice") - 100;
+    db.set_balance("alice", post_evm_balance);
+
+    let supply_drop = initial_supply - db.total_supply();
+    let burned_delta = db.total_burned - initial_burned;
+
+    assert_eq!(
+        supply_drop, 100,
+        "set_balance dropped supply by {} (expected 100)",
+        supply_drop,
+    );
+    assert_eq!(
+        burned_delta, 0,
+        "set_balance must not bookkeep total_burned (it doesn't know intent)",
+    );
+    // The leak: 100 sentri vanished from the system. Until the API is
+    // tightened, callers must pair set_balance with explicit burn() or
+    // credit(other, delta). The H3 fix in sentrix-evm/writeback.rs has
+    // to do exactly that pairing.
+    assert!(
+        supply_drop > burned_delta,
+        "regression-guard: if set_balance ever stops leaking, this test \
+         fails and you need to update or delete it (see audit H3 fix)",
+    );
+}


### PR DESCRIPTION
## Why
Pure-test additions following the 2026-05-06 audit roadmap discussion. Two refactor-style improvements that do NOT touch production code but raise the floor on bug detection:

### #1 — Property test (sentrix-primitives)
Random sequences of \`credit\` / \`charge_fee_only\` / \`transfer\` against AccountDB; independent ledger model maintains expected state. After every op: balance match + \`total_supply()\` match + \`total_burned\` match + conservation invariant. **256 cases per run.** Catches H3-class bugs (silent supply leaks via balance setters that skip bookkeeping) before they ship.

Plus an explicit H3-hazard regression-guard test that asserts \`set_balance\` DOES break the invariant today — guarantees that any future PR tightening the AccountDB API has to update or delete this test.

### #2 — End-to-end EVM harness (sentrix-core)
The audit flagged \`sentrix-evm\` at 0% coverage; existing tests use \`InMemoryDB\` and miss the real-MDBX + real-trie post-block path that's been the source of multiple state-divergence halts in 2026-04/05.

\`evm_e2e_harness.rs\` builds a real \`Blockchain\` with VOYAGER + EVM forks active at h=0, runs a signed native tx through the full \`add_to_mempool\` → \`create_block\` → \`add_block\` chain, asserts state. Plus a \`#[ignore]\`'d TODO scaffold with a step-by-step recipe for constructing a real EVM tx through Sentrix's wire format.

## State / consensus impact
None. Both new files live under \`tests/\` (integration test targets); zero production code touched.

## Test plan
- [x] cargo test -p sentrix-primitives --test account_proptest (2 passed, 256 proptest cases each)
- [x] cargo test -p sentrix-core --test evm_e2e_harness (1 passed, 1 ignored)
- [x] cargo clippy -p sentrix-primitives --tests -- -D warnings
- [x] cargo clippy -p sentrix-core --tests -- -D warnings
- [ ] CI green

## Followup (not this PR)
Filling in \`test_evm_tx_e2e_landing_pad\` lands audit #2 (\`execute_evm_tx_in_block\` end-to-end) and converts the synthetic H3 reproducer in \`src/account.rs\` into a real-flow reproducer.