### PR TITLE
chore(audit): close L2 — mark_evm_tx_failed on malformed-input early returns

### DIFF
--- a/crates/sentrix-core/src/block_executor/evm.rs
+++ b/crates/sentrix-core/src/block_executor/evm.rs
@@ -60,10 +60,26 @@ impl Blockchain {
         }
         let calldata = hex::decode(parts[2]).unwrap_or_default();
 
-        // Decode raw Ethereum tx from signature field for re-validation
+        // Decode raw Ethereum tx from signature field for re-validation.
+        // Audit L2 (2026-05-06): pre-fix the two early returns below were
+        // `return Ok(())` with no visibility — a malformed RLP-hex
+        // signature or an undecodable EIP-2718 envelope on a tx already
+        // marked `EVM:` (i.e. the sender intended an EVM tx) silently
+        // succeeded with status=0x1, hiding the failure from
+        // `eth_getTransactionReceipt`. Pass-1 had already debited
+        // tx.fee, so the tx is still on-chain — surface the malformation
+        // and mark the receipt failed so wallets see status=0x0.
         let raw_bytes = match hex::decode(&tx.signature) {
             Ok(b) => b,
-            Err(_) => return Ok(()), // malformed, skip silently
+            Err(e) => {
+                tracing::warn!(
+                    "EVM tx {}: malformed RLP hex in signature field: {}",
+                    &tx.txid[..16.min(tx.txid.len())],
+                    e,
+                );
+                self.accounts.mark_evm_tx_failed(&tx.txid);
+                return Ok(());
+            }
         };
 
         use alloy_consensus::TxEnvelope;
@@ -72,7 +88,15 @@ impl Blockchain {
 
         let envelope: TxEnvelope = match TxEnvelope::decode_2718(&mut raw_bytes.as_slice()) {
             Ok(e) => e,
-            Err(_) => return Ok(()),
+            Err(e) => {
+                tracing::warn!(
+                    "EVM tx {}: TxEnvelope::decode_2718 failed: {}",
+                    &tx.txid[..16.min(tx.txid.len())],
+                    e,
+                );
+                self.accounts.mark_evm_tx_failed(&tx.txid);
+                return Ok(());
+            }
         };
         // Audit L1 (2026-05-06): a stray `let _sender = envelope.recover_signer().ok();`
         // here was burning a secp256k1 recovery (~100µs/tx) without using


### PR DESCRIPTION
## Why
Two early-returns in \`execute_evm_tx_in_block\` previously silently succeeded when a tx tagged \`EVM:\` had a malformed payload (audit 2026-05-06 L2):

| Site | Pre-fix |
|---|---|
| \`hex::decode(tx.signature)\` Err | silent \`return Ok(())\` |
| \`TxEnvelope::decode_2718\` Err   | silent \`return Ok(())\` |

Pass-1 had already debited \`tx.fee\`, so the tx persists on-chain — but the receipt defaulted to \`status = 0x1\` because nothing called \`mark_evm_tx_failed\`. Wallets and explorers see "success" for a tx that never actually executed.

## What changed
Each path now: \`tracing::warn!\` + \`mark_evm_tx_failed(&tx.txid)\` + \`return Ok(())\`. Block progresses normally; receipt correctly reports \`status = 0x0\`.

## Why no fork gate
Same as PR #511 (H1 + H2): paths only trigger on malformed input. RPC ingress validates the \`EVM:gas_limit:hex\` format, so historical mainnet txs all have well-formed payloads. Identity for every valid tx; only crafted/malformed txs see a different (correct) outcome.

## Test plan
- [x] cargo clippy -p sentrix-core --tests -- -D warnings
- [x] cargo test -p sentrix-core --lib (212 passed)
- [ ] CI green