### PR TITLE
perf(mempool): O(1) duplicate + per-sender lookup via sidecar indexes (audit M6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ __pycache__/
 .cl[a-z]ude/
 .cur[a-z]or/
 target-docker/
+*.proptest-regressions

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -517,6 +517,10 @@ impl Blockchain {
                 self.contracts = snap.contracts;
                 self.authority = snap.authority;
                 self.mempool = snap.mempool;
+                // Audit M6: snapshot-restored `mempool` is the
+                // authoritative state; rebuild sidecars before any
+                // subsequent admission reads them.
+                self.rebuild_mempool_sidecars();
                 self.total_minted = snap.total_minted;
                 self.chain.truncate(snap.chain_len);
                 // Rewind trie to pre-Pass-2 root if one was captured.
@@ -1294,6 +1298,10 @@ impl Blockchain {
             .map(|tx| tx.txid.clone())
             .collect();
         self.mempool.retain(|tx| !mined_txids.contains(&tx.txid));
+        // Audit M6 (2026-05-06): retain mutated `mempool`; the txid +
+        // sender-count sidecars must rebuild before the next
+        // `add_to_mempool` reads them.
+        self.rebuild_mempool_sidecars();
 
         // Evict stale-nonce poison pills from senders that just had a
         // nonce-bumping tx finalize in this block. v2.1.58 did this

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -361,6 +361,23 @@ pub struct Blockchain {
     pub authority: AuthorityManager, // pub: main.rs uses authority.* for validator management
     pub contracts: ContractRegistry,
     pub mempool: VecDeque<Transaction>,
+    /// Audit M6 (2026-05-06): O(1) duplicate-txid check sidecar for
+    /// `add_to_mempool`. Pre-fix the dup-scan was `mempool.iter().any(...)`
+    /// — at MAX_MEMPOOL_SIZE=10K + a 5K-tx burst the per-block cost is
+    /// 25M string comparisons. The sidecar is fully derived from
+    /// `mempool` (txid set), so anything that mutates `mempool`
+    /// rebuilds it via `rebuild_mempool_sidecars` (the snapshot
+    /// rollback path does, and so does each mempool `retain` call).
+    /// `#[serde(skip)]` because it's a derived index — chain.db only
+    /// needs to persist the authoritative `mempool` itself.
+    #[serde(skip)]
+    pub mempool_txids: std::collections::HashSet<String>,
+    /// Audit M6 (sister index): O(1) per-sender pending count. Backs
+    /// `mempool_pending_count`, called twice per `add_to_mempool` (once
+    /// for the per-sender cap check, once to compute the next nonce);
+    /// pre-fix each call was an O(n) iter+filter+count.
+    #[serde(skip)]
+    pub mempool_sender_count: std::collections::HashMap<String, u32>,
     pub total_minted: u64,
     pub chain_id: u64, // kept pub — read-only constant used by external clients
     /// Binary Sparse Merkle Tree for account state.
@@ -553,6 +570,8 @@ impl Blockchain {
             authority: AuthorityManager::new(admin_address),
             contracts: ContractRegistry::new(),
             mempool: VecDeque::new(),
+            mempool_txids: std::collections::HashSet::new(),
+            mempool_sender_count: std::collections::HashMap::new(),
             total_minted: 0,
             // Prefer the TOML's declared chain_id, but defer to the
             // SENTRIX_CHAIN_ID env var when set (matches previous semantics

--- a/crates/sentrix-core/src/mempool.rs
+++ b/crates/sentrix-core/src/mempool.rs
@@ -87,8 +87,15 @@ impl Blockchain {
             )));
         }
 
-        // Reject duplicate txid — same transaction must not enter the mempool twice
-        if self.mempool.iter().any(|existing| existing.txid == tx.txid) {
+        // Reject duplicate txid — same transaction must not enter the mempool twice.
+        // Audit M6 (2026-05-06): O(1) HashSet lookup; pre-fix this was an
+        // `any()` linear scan that became a bottleneck under sustained
+        // submission load. The `mempool_txids` set is maintained as a
+        // mirror of the txid column of `mempool` — see
+        // `rebuild_mempool_sidecars` for the invariant restoration path
+        // any time the mempool itself is mutated outside `add_to_mempool`
+        // (retain, clear, snapshot rollback, post-storage-load).
+        if self.mempool_txids.contains(&tx.txid) {
             return Err(SentrixError::InvalidTransaction(format!(
                 "duplicate txid in mempool: {}",
                 tx.txid
@@ -154,11 +161,16 @@ impl Blockchain {
             Some(min_pos) => fee_pos.max(min_pos),
             None => fee_pos,
         };
-        // Capture txid BEFORE the move so we can emit the event after.
-        // The vec mutation borrows tx; emitting after the borrow ends
-        // keeps the lifetime simple.
+        // Capture txid + sender BEFORE the move so we can emit the event
+        // and update the M6 sidecars after. The vec mutation borrows tx;
+        // ending the borrow before the sidecar updates keeps the lifetime
+        // simple.
         let txid_for_event = tx.txid.clone();
+        let sender_for_count = tx.from_address.clone();
         self.mempool.insert(pos, tx);
+        // Audit M6: maintain sidecars on every successful admission.
+        self.mempool_txids.insert(txid_for_event.clone());
+        *self.mempool_sender_count.entry(sender_for_count).or_insert(0) += 1;
 
         // Notify WebSocket subscribers — eth_subscribe(newPendingTransactions).
         // Non-blocking, infallible by trait contract. Fires only on
@@ -175,10 +187,14 @@ impl Blockchain {
     /// without it, faucets and dapps that need the next-usable nonce keep
     /// signing with stale values and pile up un-includable txs.
     pub fn mempool_pending_count(&self, address: &str) -> u64 {
-        self.mempool
-            .iter()
-            .filter(|tx| tx.from_address == address)
-            .count() as u64
+        // Audit M6: O(1) HashMap lookup. Pre-fix this was an
+        // iter+filter+count which `add_to_mempool` called twice per
+        // admission (per-sender cap + expected-nonce computation),
+        // each scan O(n) on a 10K-entry mempool.
+        self.mempool_sender_count
+            .get(address)
+            .copied()
+            .unwrap_or(0) as u64
     }
 
     fn mempool_pending_spend(&self, address: &str) -> u64 {
@@ -205,6 +221,27 @@ impl Blockchain {
     /// incident (e.g. batch of bad-nonce txs blocking block production).
     pub fn clear_mempool(&mut self) {
         self.mempool.clear();
+        self.mempool_txids.clear();
+        self.mempool_sender_count.clear();
+    }
+
+    /// Audit M6 (2026-05-06): rebuild the txid + sender-count sidecars
+    /// from the authoritative `mempool` VecDeque. Called from any path
+    /// that mutates `mempool` outside `add_to_mempool` — VecDeque
+    /// `retain`, snapshot rollback, post-load from storage. The
+    /// alternative (incremental delta updates per call site) is more
+    /// efficient but bug-prone; rebuilding is O(n) where n ≤
+    /// MAX_MEMPOOL_SIZE = 10K, costing roughly 1ms once per block.
+    pub fn rebuild_mempool_sidecars(&mut self) {
+        self.mempool_txids.clear();
+        self.mempool_sender_count.clear();
+        for tx in &self.mempool {
+            self.mempool_txids.insert(tx.txid.clone());
+            *self
+                .mempool_sender_count
+                .entry(tx.from_address.clone())
+                .or_insert(0) += 1;
+        }
     }
 
     /// Age-only prune. Removes any tx older than MEMPOOL_MAX_AGE_SECS.
@@ -229,6 +266,9 @@ impl Blockchain {
             .as_secs();
         self.mempool
             .retain(|tx| now <= tx.timestamp.saturating_add(MEMPOOL_MAX_AGE_SECS));
+        // Audit M6: retain mutated `mempool`, rebuild sidecars to keep
+        // `mempool_txids` and `mempool_sender_count` in sync.
+        self.rebuild_mempool_sidecars();
     }
 
     /// Evict mempool txs whose sender's finalized nonce has overtaken
@@ -258,6 +298,9 @@ impl Blockchain {
             Some(&finalized) => tx.nonce >= finalized,
             None => true,
         });
+        // Audit M6: retain mutated `mempool`, rebuild sidecars to keep
+        // them consistent.
+        self.rebuild_mempool_sidecars();
     }
 }
 

--- a/crates/sentrix-core/src/storage.rs
+++ b/crates/sentrix-core/src/storage.rs
@@ -162,6 +162,15 @@ impl Storage {
             }
         }
 
+        // Audit M6 (2026-05-06): chain.db doesn't persist the derived
+        // mempool sidecars (they're `#[serde(skip)]`), so after
+        // deserialise rebuild them from the loaded mempool. Skipping
+        // this would have `mempool_txids` empty while `mempool` holds
+        // entries — duplicate-tx detection would silently let
+        // duplicates back in until the next post-block retain
+        // rebuilt the index.
+        bc.rebuild_mempool_sidecars();
+
         Ok(Some(bc))
     }
 


### PR DESCRIPTION
## Why
Closes audit M6 (2026-05-06 rust-workspace audit). Pre-fix \`add_to_mempool\` had three O(n) scans on the hot path:

- duplicate-txid \`mempool.iter().any(...)\`
- \`mempool_pending_count\` called twice (per-sender cap + nonce computation)

At \`MAX_MEMPOOL_SIZE=10K\` + a 5K-tx submission burst that's **~25M string comparisons per block**.

## What changed
Two derived sidecars on \`Blockchain\`:

| Sidecar | Type | Backs |
|---|---|---|
| \`mempool_txids\` | \`HashSet<String>\` | O(1) duplicate detection |
| \`mempool_sender_count\` | \`HashMap<String, u32>\` | O(1) per-sender count |

Both maintained on \`add_to_mempool\` insert and on \`clear_mempool\`. Anywhere else that mutates the authoritative \`mempool\` VecDeque (\`retain\`, snapshot rollback, post-storage-load) calls \`rebuild_mempool_sidecars()\` which is O(n) where n ≤ MAX_MEMPOOL_SIZE — ~1ms once per block, negligible vs the per-admission O(n) scans it replaces.

## Why no fork gate
Zero state / consensus impact. Sidecars are derived indexes, \`#[serde(skip)]\`, never read for state-root or block validation. They only short-circuit admission-control checks that previously walked the VecDeque linearly.

## Test plan
- [x] cargo check -p sentrix-core
- [x] cargo clippy -p sentrix-core --tests -- -D warnings
- [x] cargo test -p sentrix-core --lib (212 passed)
- [x] cargo test -p sentrix-core --test fork_determinism (8 passed, includes \`test_signed_tx_blocks_self_vs_peer_determinism\` which exercises mempool admission + retain)
- [x] cargo test -p sentrix-core --test evm_e2e_harness (1 passed, 1 ignored)
- [x] cargo test -p sentrix-core --test phase_d_4validator_determinism (2 passed)
- [ ] CI green