### PR TITLE
fix(rewards): peek-transfer-drain on ClaimRewards (audit H5)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -831,23 +831,54 @@ impl Blockchain {
                 }
                 match staking_op {
                     StakingOp::ClaimRewards => {
-                        // Drain claimer's accumulator (delegator + validator).
+                        // Audit H5 (2026-05-06): peek-then-transfer-then-drain.
+                        // Pre-fix this drained the accumulators FIRST
+                        // (`take_delegator_rewards` + `std::mem::take` on
+                        // pending_rewards), then attempted the
+                        // PROTOCOL_TREASURY → claimer transfer. If the
+                        // transfer failed (treasury transient
+                        // insufficiency, error in transfer arithmetic),
+                        // Pass-2 rollback restores `accounts` from
+                        // BlockchainSnapshot but the snapshot doesn't
+                        // capture stake_registry — accumulators stay
+                        // zero, claimer's rewards permanently lost with
+                        // no error surfaced to the wallet.
+                        //
+                        // Now: peek both accumulators without mutation,
+                        // run the transfer, drain on success only. If
+                        // the transfer Errs, accumulators stay intact
+                        // and the claimer can re-submit later.
                         let claimer = tx.from_address.clone();
-                        let delegator_amount = self.stake_registry.take_delegator_rewards(&claimer);
+                        let delegator_amount =
+                            self.stake_registry.peek_delegator_rewards(&claimer);
                         let validator_amount = self
                             .stake_registry
                             .validators
-                            .get_mut(&claimer)
-                            .map(|v| std::mem::take(&mut v.pending_rewards))
+                            .get(&claimer)
+                            .map(|v| v.pending_rewards)
                             .unwrap_or(0);
                         let total_claim = delegator_amount.saturating_add(validator_amount);
                         if total_claim > 0 {
+                            // Transfer first; only drain on success.
                             self.accounts.transfer(
                                 PROTOCOL_TREASURY,
                                 &claimer,
                                 total_claim,
                                 0,
                             )?;
+                            // Transfer succeeded — drain accumulators.
+                            // `take_delegator_rewards` removes the entry
+                            // entirely (matches semantics — claimer
+                            // collected everything available at peek).
+                            // For the validator side we explicitly zero
+                            // `pending_rewards` rather than std::mem::take
+                            // because we already consumed the value at
+                            // peek and the assignment is clearer about
+                            // the post-condition.
+                            let _ = self.stake_registry.take_delegator_rewards(&claimer);
+                            if let Some(v) = self.stake_registry.validators.get_mut(&claimer) {
+                                v.pending_rewards = 0;
+                            }
                         }
                         // Phase 3 WS: notify sentrix_subscribe(stakingOps).
                         if let Some(emitter) = &self.event_emitter {

--- a/crates/sentrix-staking/src/staking.rs
+++ b/crates/sentrix-staking/src/staking.rs
@@ -1025,6 +1025,16 @@ impl StakeRegistry {
         self.delegator_rewards.remove(delegator).unwrap_or(0)
     }
 
+    /// Audit H5 (2026-05-06): non-mutating sibling of
+    /// `take_delegator_rewards`. Used by the ClaimRewards apply path to
+    /// peek the amount BEFORE the balance transfer fires; the drain
+    /// only happens after the transfer succeeds, so a transfer failure
+    /// can't leave accumulators zeroed with no corresponding balance
+    /// credit.
+    pub fn peek_delegator_rewards(&self, delegator: &str) -> u64 {
+        self.delegator_rewards.get(delegator).copied().unwrap_or(0)
+    }
+
     pub fn weighted_proposer(&self, height: u64, round: u32) -> Option<String> {
         if self.active_set.is_empty() {
             return None;

--- a/crates/sentrix-staking/src/staking.rs
+++ b/crates/sentrix-staking/src/staking.rs
@@ -1449,6 +1449,50 @@ mod tests {
         assert!(reg.unbonding_queue.is_empty());
     }
 
+    /// Audit H5 (2026-05-06): regression guard for the
+    /// peek-then-transfer-then-drain pattern in the ClaimRewards
+    /// dispatch. `peek_delegator_rewards` must be a true read — no
+    /// mutation — so the apply path can check the amount BEFORE
+    /// running the balance transfer and only call
+    /// `take_delegator_rewards` when the transfer succeeds. Pre-fix
+    /// the ClaimRewards path drained accumulators FIRST and lost
+    /// rewards permanently if the transfer Erred.
+    #[test]
+    fn test_peek_delegator_rewards_is_non_mutating() {
+        let mut reg = new_registry();
+        // Seed delegator_rewards directly to isolate the peek/take
+        // pair from the distribute_reward plumbing.
+        reg.delegator_rewards.insert("0xdel1".to_string(), 12_345);
+
+        // Peek twice — both should return the same value with no
+        // mutation in between.
+        assert_eq!(reg.peek_delegator_rewards("0xdel1"), 12_345);
+        assert_eq!(reg.peek_delegator_rewards("0xdel1"), 12_345);
+        // The map entry survives.
+        assert_eq!(
+            reg.delegator_rewards.get("0xdel1").copied(),
+            Some(12_345),
+            "peek must not remove the entry",
+        );
+
+        // Now take — that DOES mutate.
+        let taken = reg.take_delegator_rewards("0xdel1");
+        assert_eq!(taken, 12_345);
+        assert_eq!(
+            reg.peek_delegator_rewards("0xdel1"),
+            0,
+            "after take, peek returns 0",
+        );
+        assert!(
+            !reg.delegator_rewards.contains_key("0xdel1"),
+            "after take, the entry is removed",
+        );
+
+        // Peek on an unknown delegator returns 0 without inserting.
+        assert_eq!(reg.peek_delegator_rewards("0xdel-unknown"), 0);
+        assert!(!reg.delegator_rewards.contains_key("0xdel-unknown"));
+    }
+
     #[test]
     fn test_distribute_reward() {
         let mut reg = new_registry();


### PR DESCRIPTION
## Why
Pre-fix \`StakingOp::ClaimRewards\` drained both reward accumulators (\`take_delegator_rewards\` + \`std::mem::take\` on \`pending_rewards\`) BEFORE attempting the PROTOCOL_TREASURY → claimer balance transfer. If the transfer Erred (treasury transient insufficiency, arithmetic error), Pass-2 snapshot rollback would restore \`accounts\` — but the snapshot doesn't capture \`stake_registry\`. Accumulators stayed zero, claimer's rewards permanently lost.

## What changed
Peek-transfer-drain ordering:

1. Peek both accumulators (new \`peek_delegator_rewards\` non-mutating getter)
2. Compute total
3. \`accounts.transfer(treasury, claimer, total, 0)?;\` — Errs if treasury insufficient
4. On success: drain accumulators (\`take_delegator_rewards\` + zero \`pending_rewards\`)

If transfer Errs, accumulators stay intact and the claimer can re-submit at any later block.

## State / consensus impact
Matters when transfer fails. In the happy path end-state is identical regardless of ordering — the only change is recovery semantics of the failure mode (strictly biases toward not losing user funds).

## Test plan
- [x] cargo clippy -p sentrix-core --tests -- -D warnings
- [x] cargo test -p sentrix-core --lib (212 passed)
- [x] cargo test -p sentrix-staking --lib (103 passed)
- [ ] CI green