### PR TITLE
ci: owner auto-merge workflow (PRs from satyakwok only)

### DIFF
--- a/.github/workflows/owner-auto-merge.yml
+++ b/.github/workflows/owner-auto-merge.yml
@@ -1,0 +1,46 @@
+name: Owner auto-merge
+
+# Auto-enable GitHub native auto-merge on PRs authored by the repo owner
+# (`satyakwok`). External contributors keep manual review + merge — this
+# workflow only flips the auto-merge bit; it does NOT bypass branch
+# protection, required reviews, or required status checks. Once enabled
+# GitHub merges as soon as the configured required checks turn green.
+#
+# Why a workflow instead of a default org-wide setting: GitHub doesn't
+# expose a per-PR "auto-merge by author" toggle, and we want third-party
+# contribs to require explicit operator review. This is the smallest
+# wrapper that gates auto-merge on author identity.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-22.04
+    if: >
+      github.event.pull_request.user.login == 'satyakwok' &&
+      github.event.pull_request.draft == false
+    steps:
+      - name: Enable auto-merge (squash) for owner PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -e
+          # `gh pr merge --auto` queues the merge for when all required
+          # checks pass. If checks already passed (rare on PR open),
+          # GitHub merges immediately. Squash strategy matches the
+          # operator's manual cadence on this repo.
+          gh pr merge --auto --squash "$PR_URL" || {
+            # Common no-op causes that should NOT fail the workflow:
+            #   - PR already merged
+            #   - PR has merge conflicts (operator must rebase)
+            #   - "auto-merge" already enabled
+            echo "::warning::auto-merge enable returned non-zero — PR may already be merged, conflicted, or have auto-merge already enabled."
+            exit 0
+          }


### PR DESCRIPTION
## Why
Operator wants auto-merge on hijau-semua CI for their own PRs only — external contributors keep manual review.

## How
\`.github/workflows/owner-auto-merge.yml\`:
- Trigger: \`pull_request_target\` on opened / reopened / synchronize / ready_for_review
- Filter: \`user.login == 'satyakwok'\` AND \`draft == false\`
- Action: \`gh pr merge --auto --squash <PR_URL>\`

GitHub's native auto-merge then waits for required checks to turn green and merges automatically. Branch protection (required reviews, required status checks) still applies — this workflow only removes the manual "Merge" click for owner PRs.

## Notes
- \`pull_request_target\` chosen over \`pull_request\` so the workflow can write a merge command from satyakwok's own branches without exposing the GITHUB_TOKEN to PR-introduced workflow code. External-contrib PRs are filtered out before any token-bearing step runs.
- Squash strategy matches the operator's manual merge cadence on this repo.
- Errors from already-merged / conflicted / already-auto-merged PRs emit a warning and exit 0; they don't fail the workflow.

## Test plan
- [x] YAML syntax valid (workflow loads)
- [x] Once merged, next owner PR opens with auto-merge ON visible in the GitHub UI