### PR TITLE
fix(staking): SubmitEvidence submitter/offender split + Err propagation (audit H4)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -1001,34 +1001,69 @@ impl Blockchain {
                         block_hash_b,
                         signature_a,
                         signature_b,
+                        offender,
                     } => {
                         if tx.amount != 0 {
                             return Err(SentrixError::InvalidTransaction(
                                 "SubmitEvidence: tx.amount must be 0".into(),
                             ));
                         }
-                        // Evidence targets the validator accused of
-                        // double-signing. Slashing engine verifies the
-                        // evidence + applies slash + tombstone if valid.
+                        // Audit H4 (2026-05-06): submitter / offender split.
+                        // Pre-fix `evidence.validator` was forced to
+                        // `tx.from_address`, meaning the submitter
+                        // accused themselves. Now `offender` is a
+                        // dedicated field on the variant; reject the
+                        // tx if it's empty so the wire-format change
+                        // is mandatory going forward (back-compat
+                        // payloads with empty offender can't slash
+                        // anyone, which is the desired behaviour
+                        // anyway — JAIL_CONSENSUS_HEIGHT=u64::MAX
+                        // already rejects auto-jail dispatch).
+                        if offender.is_empty() {
+                            return Err(SentrixError::InvalidTransaction(
+                                "SubmitEvidence: offender field must be populated"
+                                    .into(),
+                            ));
+                        }
+                        // Evidence targets the validator named in the
+                        // `offender` field, NOT the submitter.
                         let evidence = sentrix_staking::slashing::DoubleSignEvidence {
-                            validator: tx.from_address.clone(),
+                            validator: offender.clone(),
                             height,
                             block_hash_a,
                             block_hash_b,
                             signature_a,
                             signature_b,
                         };
-                        let _ = self
+                        // Audit H4: surface process_double_sign Err
+                        // and reject the tx instead of silently
+                        // swallowing. Pre-fix `let _ =` discarded the
+                        // Result, so a malformed or already-processed
+                        // evidence claim would silently succeed at the
+                        // outer apply-Pass-2 level.
+                        if let Err(e) = self
                             .slashing
-                            .process_double_sign(&mut self.stake_registry, &evidence);
-                        // Bounty to submitter deferred — current design
-                        // has no reporter field in SubmitEvidence (the
-                        // submitter IS the offender in this naive shape).
-                        // Follow-up: separate submitter + offender fields.
+                            .process_double_sign(&mut self.stake_registry, &evidence)
+                        {
+                            tracing::warn!(
+                                "SubmitEvidence (offender={}): process_double_sign failed: {}",
+                                offender,
+                                e,
+                            );
+                            return Err(e);
+                        }
+                        // Note: full signature verification of
+                        // signature_a / signature_b against
+                        // `Precommit::signing_payload(height, round,
+                        // block_hash, chain_id)` is deferred — the
+                        // wire format doesn't carry `round_a` /
+                        // `round_b` yet, and adding them is a
+                        // fork-gated wire-format extension separate
+                        // from this submitter/offender split.
                         if let Some(emitter) = &self.event_emitter {
                             emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
                                 op: "submit_evidence".to_string(),
-                                validator: tx.from_address.clone(),
+                                validator: offender.clone(),
                                 delegator: tx.from_address.clone(),
                                 amount: 0,
                                 txid: tx.txid.clone(),

--- a/crates/sentrix-primitives/src/transaction.rs
+++ b/crates/sentrix-primitives/src/transaction.rs
@@ -238,6 +238,30 @@ pub enum StakingOp {
         block_hash_b: String,
         signature_a: String,
         signature_b: String,
+        /// Audit H4 (2026-05-06): the address of the validator
+        /// accused of double-signing. Pre-fix the apply path forced
+        /// `evidence.validator = tx.from_address` — submitter and
+        /// offender collapsed into one field, meaning a third-party
+        /// reporter would have ended up accusing themselves. Now the
+        /// submitter (`tx.from_address`) is independent of the
+        /// offender (this field).
+        ///
+        /// `#[serde(default)]` for back-compat: all historical
+        /// SubmitEvidence payloads on chain.db have this empty (none
+        /// reached mainnet — `JAIL_CONSENSUS_HEIGHT = u64::MAX`
+        /// rejects this op type at the consensus boundary anyway).
+        /// Apply-side guards against an empty offender by returning
+        /// InvalidTransaction; submitters MUST populate it.
+        ///
+        /// Note: full signature verification of `signature_a` /
+        /// `signature_b` against `Precommit::signing_payload(height,
+        /// round, block_hash, chain_id)` requires `round_a` /
+        /// `round_b` fields which this variant doesn't carry yet.
+        /// That's a separate fork-gated wire-format extension; this
+        /// PR closes the submitter/offender split + Err propagation
+        /// only.
+        #[serde(default)]
+        offender: String,
     },
     /// Phase A: Consensus-computed jail evidence (data plumbing only —
     /// no dispatch wired yet). Activated post `JAIL_CONSENSUS_HEIGHT` fork


### PR DESCRIPTION
## Why
Closes audit H4 layers 1 + 2 (mitigated by JAIL_CONSENSUS_HEIGHT=u64::MAX today; preventive fix lands before any future activation).

## What changed
**Layer 1 — Surface \`process_double_sign\` Err**: pre-fix \`let _ = ...\` discarded the Result. Now: \`tracing::warn!\` + return Err so Pass-2 rolls back the tx instead of silently succeeding with no slash applied.

**Layer 2 — Submitter / offender split**: pre-fix \`evidence.validator = tx.from_address\` forced submitter == offender (a third-party reporter would accuse themselves). Added \`offender: String\` field on \`StakingOp::SubmitEvidence\` with \`#[serde(default)]\` for back-compat. Apply path uses \`offender\` for the accused; rejects the tx with InvalidTransaction if empty — mandatory wire change going forward.

## Layer 3 deferred
Full signature verification (signature_a / signature_b against \`Precommit::signing_payload(height, round, block_hash, chain_id)\`) requires \`round_a\` / \`round_b\` fields the variant doesn't carry. That's a fork-gated wire-format extension separate from this PR.

## State / consensus impact
Changes only when SubmitEvidence is actually applied — JAIL_CONSENSUS_HEIGHT=u64::MAX keeps the related auto-jail dispatch off. No mainnet SubmitEvidence has ever been submitted (per audit), so the back-compat empty-offender rejection is the right preventive behaviour.

## Test plan
- [x] cargo test --workspace --tests (all green)
- [x] CI green