### PR TITLE
chore(audit): silence 14 cargo-deny duplicate warnings + drop 3 stale advisory ignores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,10 @@ jobs:
       - name: Run cargo audit
         # Ignore list mirrors deny.toml [advisories].ignore — each ID has
         # a documented reason there; if you add one here, add it there too.
-        # 2026-05-06: dropped RUSTSEC-2026-0105 (core2 yanked) — `cargo
-        # update -p multihash` to 0.19.5 removed core2 from Cargo.lock.
-        # 2026-05-06: added RUSTSEC-2026-0118, RUSTSEC-2026-0119
-        # (hickory-proto pinned by libp2p 0.56.0; awaiting libp2p 0.57+).
+        # 2026-05-07: dropped RUSTSEC-2026-0118 / -0119 (hickory-proto)
+        # and RUSTSEC-2025-0055 (tracing-subscriber 0.2) — none match
+        # in-tree crate versions any more (cargo-deny advisory-not-
+        # detected confirmed 2026-05-07).
         run: |
           cargo audit \
             --ignore RUSTSEC-2020-0105 \
@@ -134,9 +134,6 @@ jobs:
             --ignore RUSTSEC-2025-0141 \
             --ignore RUSTSEC-2024-0388 \
             --ignore RUSTSEC-2024-0436 \
-            --ignore RUSTSEC-2025-0055 \
-            --ignore RUSTSEC-2026-0118 \
-            --ignore RUSTSEC-2026-0119 \
             || echo "::warning::cargo audit findings (non-blocking, see deny.toml for ignored IDs)"
 
   # Second-layer secret scan — complements .githooks/pre-commit which only

--- a/deny.toml
+++ b/deny.toml
@@ -25,37 +25,11 @@ ignore = [
     # Proc-macro only, compile-time expansion.
     "RUSTSEC-2024-0436",
 
-    # ── Real vulnerabilities pinned upstream — accepted with reasoning ──
-    #
-    # RUSTSEC-2026-0118 — hickory-proto 0.25.2 NSEC3 closest-encloser
-    # unbounded-loop on cross-zone DNS responses. Hickory's own advisory
-    # says "No fixed upgrade is available!" — upstream hasn't shipped a
-    # patch as of 2026-05-06. Sentrix pulls hickory-proto only via
-    # libp2p-mdns 0.48.0 + libp2p-dns 0.44.0 (both pinned by libp2p
-    # 0.56.0 with `hickory-proto = ^0.25.2`, blocking the 0.26.1 fix).
-    # Mitigation context: validator mDNS is bound to the private
-    # validator mesh, not internet-exposed; libp2p-dns is for bootstrap
-    # peer name resolution only. Drop this ignore once libp2p ships a
-    # 0.57+ that bumps the hickory-proto floor.
-    "RUSTSEC-2026-0118",
-
-    # RUSTSEC-2026-0119 — hickory-proto 0.25.2 O(n²) name compression
-    # CPU exhaustion during message encoding. Fix exists in 0.26.1 but
-    # same upstream pin — libp2p-mdns 0.48.0 / libp2p-dns 0.44.0 require
-    # `^0.25.2`, locking us out. Same mitigation context as -0118.
-    # Drop alongside -0118 when libp2p 0.57+ lands.
-    "RUSTSEC-2026-0119",
-
-    # RUSTSEC-2025-0055 — tracing-subscriber 0.2.25 ANSI escape log
-    # injection. Fix in 0.3.20+. Sentrix uses tracing-subscriber 0.3.x
-    # directly (in main.rs / sentrix-rpc/etc.); the 0.2.25 entry is
-    # pulled exclusively by ark-relations 0.5.1 → ark-r1cs-std →
-    # ark-bn254 → revm-precompile 34.0.0. Arkworks is the zk-circuit
-    # framework; revm pulls it for BN254/BLS12-381 EC precompiles.
-    # ark-relations doesn't subscribe its own logs to user input, so
-    # the practical exploit surface is nil. Drop when arkworks ships
-    # a release that bumps tracing-subscriber to 0.3.x.
-    "RUSTSEC-2025-0055",
+    # 2026-05-07 sweep — RUSTSEC-2026-0118 / -0119 (hickory-proto) and
+    # RUSTSEC-2025-0055 (tracing-subscriber 0.2) no longer match any
+    # in-tree crate version (cargo-deny `advisory-not-detected`); the
+    # advisories were either resolved upstream or the affected versions
+    # rotated out of the dep tree. Removed from the ignore list.
 ]
 
 # ── Licenses ────────────────────────────────────────────────
@@ -115,8 +89,7 @@ skip = [
     # thiserror 1.x held by older deps, 2.x held by newer ones. Both safe.
     { name = "thiserror" },
     { name = "thiserror-impl" },
-    # axum 0.8 → tower 0.5, tower-http 0.6 → tower 0.4. Transitive via axum stack.
-    { name = "tower" },
+    # 2026-05-07: tower de-duplicated upstream — single version now.
     # libp2p transitive; 0.7 + 0.8 coexist until libp2p unifies.
     { name = "unsigned-varint" },
     # windows-sys: 0.52, 0.60, 0.61 all in-tree via Windows-only deps that
@@ -128,6 +101,41 @@ skip = [
     # the 0.13 variant) — already covered by RUSTSEC-2026-0097 +
     # GHSA-vxx9-2994-q338 ignores. Drops when libp2p-yamux 0.48 ships.
     { name = "yamux" },
+
+    # 2026-05-07 sweep — RustCrypto + arkworks ecosystem split.
+    # The crypto traits crate (`digest`) bumped 0.10 → 0.11 in late
+    # 2025; revm 38 + sha2/3 0.11 use the new traits, but arkworks
+    # 0.5 (revm-precompile → ark-bn254 → ark-ff) and a few libp2p
+    # transitive deps still depend on `digest 0.10` / `0.9`. The
+    # following crates each appear at two versions because of that
+    # split. They drop simultaneously when arkworks ships a release
+    # that bumps to digest 0.11+.
+    { name = "block-buffer" },
+    { name = "const-oid" },
+    { name = "crypto-common" },
+    { name = "digest" },
+    { name = "hmac" },
+    { name = "keccak" },
+    { name = "sha2" },
+    { name = "sha3" },
+
+    # foldhash + hashlink: pulled by `hashbrown` and `mdbx-sys`
+    # respectively at slightly-different points in their version
+    # history. Tiny crates, no security surface.
+    { name = "foldhash" },
+    { name = "hashlink" },
+
+    # hashbrown: 0.12 / 0.14 / 0.15 / 0.16 / 0.17 all in-tree via
+    # different consumers (older revm vs alloy vs reqwest dep
+    # families). Drops to 1-2 versions once the ecosystem realigns.
+    { name = "hashbrown" },
+
+    # toml_datetime / toml_edit / winnow: cargo-deny + cargo-audit
+    # use newer toml stack while a few transitive build-deps stay on
+    # older toml_edit. Build-time only, no runtime impact.
+    { name = "toml_datetime" },
+    { name = "toml_edit" },
+    { name = "winnow" },
 ]
 
 # ── Sources ──────────────────────────────────────────────────


### PR DESCRIPTION
## Why
cargo-deny was emitting 14 \`[bans] multiple-versions = "warn"\` entries on every CI run — all transitive crypto / hashing / asn1 ecosystem splits we can't unilaterally fix until upstream realigns. Plus 3 advisory ignores went stale (no longer match any in-tree crate version).

## What changed
\`deny.toml\` skip list extended with:

| Family | Crates | Why |
|---|---|---|
| RustCrypto traits split | \`block-buffer\`, \`const-oid\`, \`crypto-common\`, \`digest\`, \`hmac\`, \`keccak\`, \`sha2\`, \`sha3\` | revm 38 / sha2 0.11 use new \`digest\` 0.11 traits; arkworks 0.5 still on 0.10 / 0.9 |
| hashbrown family | \`foldhash\`, \`hashlink\`, \`hashbrown\` | hashbrown has 5 versions across older revm vs alloy vs reqwest dep families |
| toml stack | \`toml_datetime\`, \`toml_edit\`, \`winnow\` | cargo-deny + cargo-audit use newer toml; build-deps lag |

Plus dropped:
- \`tower\` skip (de-duplicated upstream — single version now)
- RUSTSEC-2026-0118 / -0119 (hickory-proto) ignores — \`advisory-not-detected\`
- RUSTSEC-2025-0055 (tracing-subscriber 0.2) ignore — \`advisory-not-detected\`

\`ci.yml\` \`cargo audit --ignore\` list updated to mirror.

## State / consensus impact
None. Pure CI noise reduction.

## Test plan
- [x] \`cargo deny check\` reports \`advisories ok, bans ok, licenses ok, sources ok\` with zero warnings
- [ ] CI green