### PR TITLE
fix(bft): always refresh peer stake on RoundStatus (audit M7)

### DIFF
--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -656,16 +656,25 @@ impl BftEngine {
         if status.height < self.state.height {
             return BftAction::Wait;
         }
-        // Track peer's highest-seen round. Keep the max round; refresh the
-        // stake snapshot on every update (the peer's stake can change across
-        // epoch boundaries).
+        // Track peer's highest-seen round.
+        //
+        // Audit M7 (2026-05-06): pre-fix the stake refresh was gated on
+        // `status.round >= entry.0` — same condition as the round
+        // update. When a peer crossed an epoch boundary (stake delta)
+        // but stayed at the same round number, the cached stake stayed
+        // at the pre-epoch value. `f_plus_one_round`'s stake-weighted
+        // threshold then summed pre-epoch stakes for a peer set whose
+        // active stakes had moved, producing the wrong catch-up trigger.
+        // Now: always refresh stake; only gate the round update on the
+        // `>=` check so we still preserve the "highest seen round"
+        // monotonicity invariant.
         let entry = self
             .peer_rounds
             .entry(status.validator.clone())
             .or_insert((0, stake));
+        entry.1 = stake;
         if status.round >= entry.0 {
             entry.0 = status.round;
-            entry.1 = stake;
         }
 
         if let Some(target) = self.f_plus_one_round()


### PR DESCRIPTION
## Why
Pre-fix \`on_round_status_weighted\` refreshed both the round and stake snapshot only when \`status.round >= entry.0\`. When a peer crossed an epoch boundary (stake delta) but stayed at the same round number, the cached stake remained pre-epoch. \`f_plus_one_round\` summed stale stakes → wrong stake-weighted catch-up threshold.

## What changed
Always update \`entry.1 = stake\` on every \`on_round_status_weighted\` call; only gate the round update on the \`>=\` check so the "highest seen round" monotonicity invariant is preserved.

## State / consensus impact
Only matters at epoch boundaries where a peer's stake actually changed without their reported round advancing. The faulty branch produced misleading f+1 round triggers; post-fix uses current-epoch stakes.

## Test plan
- [x] cargo clippy -p sentrix-bft --tests -- -D warnings
- [x] cargo test -p sentrix-bft --lib (90 passed)
- [ ] CI green