### PR TITLE
chore: release v2.1.80

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5043,7 +5043,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "bincode",
  "hex",
@@ -5052,7 +5052,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "anyhow",
  "axum",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5140,7 +5140,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5158,7 +5158,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "anyhow",
  "axum",
@@ -5181,14 +5181,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "hex",
  "proptest",
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5233,14 +5233,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "bincode",
  "blake3",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5300,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.79"
+version = "2.1.80"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.79"
+version = "2.1.80"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Workspace bump to 2.1.80 — covers tonight's audit batch (PR #511 / #512 / #515 / #516 / #517 / #518 / #519 / #520 / #522 / #524 / #525 + e2e harness fill + auto-merge workflow).

Built via \`docker run rust:1.94-bullseye\` for glibc 2.30 baseline (vps1+vps2 on 2.35, vps3+vps5 on 2.39 — all compatible). sha256 \`6304381a96cd04a2819bff390630201e6d25e3024731f0fdde85ce79053760bb\`, 4-of-4 mainnet live + advancing post deploy.