### PR TITLE
chore: release v2.1.82 (EXTENDED_TOUCH_LIST_HEIGHT activated mainnet)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "bincode",
  "hex",
@@ -5042,7 +5042,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5072,7 +5072,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "anyhow",
  "axum",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5148,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "anyhow",
  "axum",
@@ -5171,14 +5171,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "hex",
  "proptest",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5223,14 +5223,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "bincode",
  "blake3",
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.81"
+version = "2.1.82"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.81"
+version = "2.1.82"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
v2.1.82 = v2.1.81 + PR #537 (extended touch list). Built `rust:1.94-bullseye`, sha256 `a4c4acbab77b6e797894134db418111e3da550ba4a3e26808bb180c97967dbd3`. Deployed cluster-wide on halt-7 recovery cycle; mainnet `EXTENDED_TOUCH_LIST_HEIGHT=1651601` set in all 4 env files. Activation lead time ~10 minutes from deploy.