### PR TITLE
fix(consensus): STRICT_JUSTIFICATION_HEIGHT — close peer-fork class (halt #9 RCA)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -222,12 +222,95 @@ impl Blockchain {
                 .filter_map(|a| self.stake_registry.get_validator(a))
                 .map(|v| v.total_stake())
                 .sum();
-            // total_active_stake==0 means the registry hasn't been
-            // initialised on this node yet (cold-start syncing from
-            // genesis before staking state has been replayed). Skip
-            // rather than reject — the apply path for staking ops
-            // earlier in the catch-up sequence brings the registry up.
-            if total_active_stake > 0 && !j.has_supermajority(total_active_stake) {
+
+            // Strict justification verification (audit halt #9 fix,
+            // 2026-05-07). Pre-fork the gate verified ONLY the
+            // arithmetic of stake-weight (peer-supplied number summed
+            // against receiver's threshold). Signatures themselves
+            // were never recovered — a peer with drifted active-set
+            // view (post-halt-recovery, simul-start race) could ship
+            // a block whose precommits were signed by the wrong
+            // keys or weighted from a different registry snapshot;
+            // receiver would accept silently → fork. Halt #9 was
+            // exactly this. Post-fork: recover every precommit's
+            // signer via `Precommit::signing_payload_for_height` +
+            // `recover_signer`, match against claimed validator,
+            // sum verified-stake using the RECEIVER's own registry,
+            // reject if threshold not met.
+            if Self::is_strict_justification_height(expected_index) {
+                use sentrix_bft::messages::{Precommit, recover_signer};
+                let mut verified_stake: u64 = 0;
+                let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+                for p in &j.precommits {
+                    // Reject duplicate validators in the justification —
+                    // pre-fix the dedup was implicit via the stake-weight
+                    // sum but now we tally per validator.
+                    if !seen.insert(p.validator.as_str()) {
+                        return Err(SentrixError::InvalidBlock(format!(
+                            "block {} justification has duplicate precommit from {}",
+                            expected_index, p.validator,
+                        )));
+                    }
+                    // Validator must be in our active set.
+                    let val = match self.stake_registry.get_validator(&p.validator) {
+                        Some(v) => v,
+                        None => {
+                            return Err(SentrixError::InvalidBlock(format!(
+                                "block {} justification cites validator {} not in our active \
+                                 set — peer-finalised view diverges, refusing to apply",
+                                expected_index, p.validator,
+                            )));
+                        }
+                    };
+                    // Recover signer + match against claimed validator.
+                    let payload = Precommit::signing_payload_for_height(
+                        j.height,
+                        j.round,
+                        &Some(j.block_hash.clone()),
+                        self.chain_id,
+                    );
+                    let recovered = match recover_signer(&payload, &p.signature) {
+                        Ok(addr) => addr,
+                        Err(_) => {
+                            return Err(SentrixError::InvalidBlock(format!(
+                                "block {} precommit from {} has invalid signature",
+                                expected_index, p.validator,
+                            )));
+                        }
+                    };
+                    if recovered.to_lowercase() != p.validator.to_lowercase() {
+                        return Err(SentrixError::InvalidBlock(format!(
+                            "block {} precommit from {} signed by different key (recovered={})",
+                            expected_index, p.validator, recovered,
+                        )));
+                    }
+                    verified_stake = verified_stake.saturating_add(val.total_stake());
+                }
+                if total_active_stake == 0 {
+                    return Err(SentrixError::InvalidBlock(format!(
+                        "block {} arrived during cold-start (total_active_stake=0); strict-\
+                         justification fork active so we refuse to bypass — bypass_authz \
+                         replay should be used to catch up",
+                        expected_index,
+                    )));
+                }
+                let threshold = sentrix_primitives::supermajority_threshold(total_active_stake);
+                if verified_stake < threshold {
+                    return Err(SentrixError::InvalidBlock(format!(
+                        "block {} verified-stake {} < threshold {} (total_active_stake={}, \
+                         signers={}) — peer-finalised view diverges from ours, refusing \
+                         to apply",
+                        expected_index,
+                        verified_stake,
+                        threshold,
+                        total_active_stake,
+                        j.signer_count(),
+                    )));
+                }
+            } else if total_active_stake > 0 && !j.has_supermajority(total_active_stake) {
+                // Pre-fork legacy gate (stake-weight arithmetic only).
+                // total_active_stake==0 cold-start bypass preserved for
+                // bit-identical chain history.
                 return Err(SentrixError::InvalidBlock(format!(
                     "block {} justification stake {} is below the local supermajority \
                      threshold {} (total_active_stake={}, signers={}) — peer-finalised \

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -340,6 +340,36 @@ pub fn get_extended_touch_list_height() -> u64 {
         .unwrap_or(EXTENDED_TOUCH_LIST_HEIGHT_DEFAULT)
 }
 
+/// Strict-justification fork (2026-05-07, post-halt #9 RCA): pre-fork
+/// the peer-justification gate verified only stake-weight ARITHMETIC —
+/// it summed the `stake_weight` field on each `SignedPrecommit` (sender-
+/// supplied number) and checked that against the receiver's local
+/// `total_active_stake` threshold. The signatures themselves were never
+/// recovered or matched against the claimed validator. A peer with a
+/// drifted active-set view could send a block whose precommits were
+/// either unsigned, signed by the wrong key, or weighted from a
+/// different registry snapshot, and the receiver would accept the block
+/// silently — applied a fork. Plus the `total_active_stake==0` branch
+/// at simul-start COMPLETELY bypassed the gate, accepting any
+/// justification during the cold-start window.
+///
+/// Post-fork: every precommit signature is recovered with
+/// `Precommit::signing_payload_for_height` + `recover_signer` and
+/// matched against the claimed validator address. Verified-stake is
+/// summed using the receiver's OWN `stake_registry.get_validator(...)`,
+/// not the sender's `stake_weight` field. Threshold gate uses the
+/// receiver's active set; if `total_active_stake==0` post-fork the
+/// gate REJECTS instead of bypassing (cold-start nodes catch up via
+/// `bypass_authz` replay anyway). Default `u64::MAX` preserves
+/// legacy behaviour bit-identically.
+const STRICT_JUSTIFICATION_HEIGHT_DEFAULT: u64 = u64::MAX;
+pub fn get_strict_justification_height() -> u64 {
+    std::env::var("STRICT_JUSTIFICATION_HEIGHT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(STRICT_JUSTIFICATION_HEIGHT_DEFAULT)
+}
+
 /// Read chain_id from SENTRIX_CHAIN_ID env var, fallback to 7119.
 pub fn get_chain_id() -> u64 {
     std::env::var("SENTRIX_CHAIN_ID")
@@ -1011,6 +1041,17 @@ impl Blockchain {
     /// CALL trie-vs-AccountDB divergence class.
     pub fn is_extended_touch_list_height(height: u64) -> bool {
         let fork = get_extended_touch_list_height();
+        fork != u64::MAX && height >= fork
+    }
+
+    /// Strict justification verification — true once
+    /// `STRICT_JUSTIFICATION_HEIGHT` activates. Post-fork every
+    /// peer-supplied block runs full crypto verification on its
+    /// justification precommits (recover signer, match against
+    /// claimed validator, sum verified stake from receiver's own
+    /// registry). Closes the chain-fork class identified by halt #9.
+    pub fn is_strict_justification_height(height: u64) -> bool {
+        let fork = get_strict_justification_height();
         fork != u64::MAX && height >= fork
     }
 


### PR DESCRIPTION
## Root cause (from tonight's halt #9 RCA + parallel reference research)

\`block_executor.rs:213-241\` peer-justification gate verified only stake-weight ARITHMETIC. Sender's \`SignedPrecommit.stake_weight\` field summed against receiver's threshold; signatures were NEVER recovered or matched against claimed validators. Plus \`total_active_stake==0\` cold-start bypass let ANY justification through during the simul-start window.

A peer with a drifted active-set view (post-halt-recovery, simul-start race) could ship a block whose precommits were:
- unsigned
- signed by wrong key
- weighted from a different registry snapshot

Receiver would accept silently → fork. Tonight's halt #9 was EXACTLY this:
- vps2/vps3 produced blocks with their 58-account registry view
- vps1/vps5 received them; stake-weight-only check passed against their 43-account registry
- Blocks applied → 15 EVM-CREATE'd contracts silently mirrored from vps2's view
- Trie roots diverged at h=1,652,000

## Fix

Post-fork: every precommit fully verified —
1. \`Precommit::signing_payload_for_height(j.height, j.round, &Some(j.block_hash), self.chain_id)\` recreates canonical signing bytes
2. \`recover_signer(&payload, &p.signature)\` recovers signer address
3. Match recovered against \`p.validator\` claim
4. Sum stake using receiver's OWN \`stake_registry.get_validator(...).total_stake()\` — not sender's claimed weight
5. Reject if duplicate validator in justification, validator not in receiver's active set, signature invalid, recovered ≠ claimed, or verified-stake < 2/3+1 threshold
6. Cold-start bypass REJECTED post-fork (catch-up uses \`bypass_authz\` replay)

Default \`STRICT_JUSTIFICATION_HEIGHT=u64::MAX\` preserves legacy bit-identical chain history.

## Why this matches CometBFT canonical pattern

Per parallel research agent: every CommitSig signature is verified individually before state apply. Embedding LastCommit in N+1 + verify-on-apply is the canonical Tendermint pattern. Sentrix was missing the per-signature verification loop entirely.

## Activation playbook

Same pattern as STATE_ROOT_V2 + EXTENDED_TOUCH_LIST activations:
1. Halt-all + canonical chain.db rsync (align state pre-flip)
2. Pick activation_height = current_tip + 600 (~10 min lead)
3. Add \`STRICT_JUSTIFICATION_HEIGHT=<h>\` to each \`/etc/<svc>/<svc>.env\`
4. Deploy v2.1.83 binary cluster-wide
5. Simul-start
6. Watch activation moment for halt-or-pass

## Test plan
- [x] cargo check -p sentrix-core
- [x] cargo clippy --workspace --tests -- -D warnings
- [x] cargo test --workspace --tests (all green)
- [ ] CI green
- [ ] Mainnet activation pass

Halt #9 forensic data preserved at \`/home/sentriscloud/state-investigation/halt9/\` for retrospective.