### PR TITLE
feat(bft): LastSignBytes / privval guard — close double-vote-on-restart class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "bincode",
  "hex",
@@ -5042,7 +5042,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5072,7 +5072,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "anyhow",
  "axum",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5148,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "anyhow",
  "axum",
@@ -5171,14 +5171,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "hex",
  "proptest",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5223,14 +5223,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "bincode",
  "blake3",
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.82"
+version = "2.1.83"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5026,8 +5026,10 @@ dependencies = [
  "sentrix-staking",
  "sentrix-wallet",
  "serde",
+ "serde_json",
  "sha2 0.11.0",
  "sha3 0.11.0",
+ "tempfile",
  "tracing",
 ]
 
@@ -5158,6 +5160,7 @@ dependencies = [
  "libp2p",
  "secp256k1 0.31.1",
  "sentrix",
+ "sentrix-bft",
  "sentrix-grpc",
  "sentrix-wire",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -63,3 +63,7 @@ secp256k1 = { version = "0.31", features = ["rand", "recovery", "serde"] }
 # Wraps the env-var validator key so the source `String`'s heap allocation
 # is wiped after we derive the `Wallet` (C-06 hardening).
 zeroize = "1.7"
+# 2026-05-07 v2.1.84: LastSignBytes / privval guard init lives in main.rs.
+# sentrix (lib) doesn't re-export sentrix-bft, so we pull it directly. Pinned
+# via path to keep the workspace at one copy.
+sentrix-bft = { path = "../../crates/sentrix-bft" }

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1611,6 +1611,37 @@ async fn cmd_start(
         let shutdown_flag_clone = shutdown_flag.clone();
         let mut bft_rx = bft_rx; // move receiver into this task
         let validator_secret_key = wallet.get_secret_key()?;
+
+        // LastSignBytes guard (Tendermint privval pattern, 2026-05-07
+        // post-halt-class hardening). If `LAST_SIGN_GUARD_PATH` env is
+        // set we persist the highest (height, round, step) tuple this
+        // validator has signed at; subsequent sign attempts at-or-below
+        // that tuple are refused. Closes the cascade-jail-at-restart
+        // class — pre-fix a validator that crashed mid-round could
+        // re-vote with different content after recovery, which under a
+        // Byzantine interpretation looks like equivocation. With the
+        // env var unset the guard is a no-op (legacy behaviour
+        // bit-identical) so chain history stays valid.
+        if let Ok(path) = std::env::var("LAST_SIGN_GUARD_PATH") {
+            let p = std::path::PathBuf::from(&path);
+            if let Err(e) = sentrix_bft::last_sign_guard::init(p) {
+                tracing::error!(
+                    "FATAL: LastSignBytes guard init failed at {}: {}. Refusing to start \
+                     validator — fix path / permissions and restart.",
+                    path,
+                    e
+                );
+                return Err(anyhow::anyhow!(
+                    "LastSignBytes guard init failed at {path}: {e}"
+                ));
+            }
+        } else {
+            tracing::warn!(
+                "LAST_SIGN_GUARD_PATH not set — running without privval double-vote guard. \
+                 Set to e.g. /var/lib/sentrix/last-sign.json for production. \
+                 (Behaviour matches v2.1.83 unguarded baseline.)"
+            );
+        }
         Some(tokio::spawn(async move {
             use sentrix::core::bft::{BftAction, BftEngine, BftPhase};
             use sentrix::core::bft_messages::{BftMessage, Proposal};

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -11,6 +11,7 @@ sentrix-primitives = { path = "../sentrix-primitives" }
 sentrix-staking = { path = "../sentrix-staking" }
 sentrix-wallet = { path = "../sentrix-wallet" }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 secp256k1 = { version = "0.31", features = ["rand", "recovery", "serde"] }
 sha2 = "0.11"
 sha3 = "0.11"
@@ -18,3 +19,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 bincode = "1.3"
+tempfile = "3"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/src/last_sign_guard.rs
+++ b/crates/sentrix-bft/src/last_sign_guard.rs
@@ -1,0 +1,274 @@
+//! LastSignBytes / privval guard — prevents double-voting across validator
+//! restarts (Tendermint canonical pattern).
+//!
+//! Every prevote / precommit signing operation records the highest
+//! `(height, round, step)` it has signed at, persisted to disk with
+//! fsync before the message is broadcast. On boot, the next sign
+//! refuses to operate at any `(h, r, s) <= last_signed`.
+//!
+//! Closes the cascade-jail-at-restart class: pre-fix, a validator that
+//! crashed mid-round would re-vote inconsistently after recovery — same
+//! height + round but different block hash — which (under a Byzantine
+//! interpretation) looks like equivocation. CometBFT's privval daemon
+//! has had this guard since 2018; Sentrix was missing it.
+//!
+//! Activation: operator sets `LAST_SIGN_GUARD_PATH=/var/lib/sentrix/last-sign.json`
+//! in each validator's env file. With the env unset, the guard is a
+//! no-op (matches pre-fix behaviour bit-identically) so chain history
+//! stays valid + new operators don't get a hard requirement.
+//!
+//! File format: small JSON blob, atomic-rename-on-write so a partial
+//! write can't corrupt the file mid-restart.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+/// Vote step. Step ordering matters for the comparison: at the same
+/// (height, round) signing a precommit AFTER a prevote is allowed
+/// (precommit > prevote in step), but going back from precommit to
+/// prevote is double-vote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VoteStep {
+    Prevote = 1,
+    Precommit = 2,
+    /// Proposal — counted as step 0 because proposing happens before
+    /// any voting at the same (height, round).
+    Proposal = 0,
+    /// RoundStatus / multiaddr advertisements / non-consensus messages.
+    /// These are NOT guarded — they don't risk double-vote-style
+    /// equivocation slashing.
+    Other = 99,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LastSignState {
+    pub height: u64,
+    pub round: u32,
+    pub step: u32, // serialized as numeric so we don't break on enum changes
+    /// Optional — last bytes the signer hashed. Lets a future
+    /// `same-bytes-replay` exemption recognise a duplicate sign request
+    /// for an identical message and re-emit the same signature instead
+    /// of refusing. Not implemented yet but field reserved.
+    #[serde(default)]
+    pub last_sign_bytes_hex: String,
+}
+
+/// Whole-process guard state. `None` means "guard not initialised" —
+/// every guarded_check returns Ok(()) so the call site behaves as if
+/// the guard didn't exist. Operator opts in by calling `init(path)`
+/// once at startup.
+struct Guard {
+    path: PathBuf,
+    state: Mutex<LastSignState>,
+}
+
+static GUARD: OnceLock<Guard> = OnceLock::new();
+
+/// Initialise the guard. Called once by the validator binary at
+/// startup if `LAST_SIGN_GUARD_PATH` env var is set. Reads the
+/// existing state file if present; creates an empty one if not.
+/// Idempotent — second call is a no-op.
+pub fn init(path: PathBuf) -> std::io::Result<()> {
+    if GUARD.get().is_some() {
+        return Ok(());
+    }
+    let state = if path.exists() {
+        let bytes = std::fs::read(&path)?;
+        serde_json::from_slice::<LastSignState>(&bytes)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?
+    } else {
+        // Initial state — every (h, r, s) >= (0, 0, 0) is allowed.
+        let st = LastSignState::default();
+        write_atomic(&path, &st)?;
+        st
+    };
+    let _ = GUARD.set(Guard {
+        path,
+        state: Mutex::new(state),
+    });
+    tracing::info!(target: "sentrix_bft::last_sign_guard", "LastSignBytes guard initialised");
+    Ok(())
+}
+
+/// Check + record a sign-attempt. Returns Ok(()) if the guard isn't
+/// initialised (legacy behaviour) OR if `(height, round, step)` strictly
+/// exceeds the persisted last-signed tuple. Returns Err if the request
+/// would re-sign at-or-below the last-signed point — indicating a
+/// double-vote attempt.
+///
+/// On Ok, the new tuple is fsync'd to disk BEFORE returning, so a
+/// post-broadcast crash leaves the on-disk state already advanced.
+pub fn check_and_record(height: u64, round: u32, step: VoteStep) -> Result<(), DoubleSignAttempt> {
+    let g = match GUARD.get() {
+        Some(g) => g,
+        None => return Ok(()),
+    };
+    if matches!(step, VoteStep::Other) {
+        return Ok(());
+    }
+    let mut st = g.state.lock().expect("last-sign-state mutex poisoned");
+    let new_step_ord = step as u32;
+    let cur_tuple = (st.height, st.round, st.step);
+    let new_tuple = (height, round, new_step_ord);
+    if new_tuple <= cur_tuple {
+        return Err(DoubleSignAttempt {
+            attempted: new_tuple,
+            last_signed: cur_tuple,
+        });
+    }
+    st.height = height;
+    st.round = round;
+    st.step = new_step_ord;
+    let snapshot = st.clone();
+    drop(st);
+    if let Err(e) = write_atomic(&g.path, &snapshot) {
+        tracing::error!(
+            target: "sentrix_bft::last_sign_guard",
+            "FATAL: last-sign-state persist failed at {:?}: {} — refusing to sign, validator should halt",
+            g.path,
+            e
+        );
+        return Err(DoubleSignAttempt {
+            attempted: new_tuple,
+            last_signed: cur_tuple,
+        });
+    }
+    Ok(())
+}
+
+/// Atomic write: writes to a `<path>.tmp` file, fsyncs, then renames.
+/// Avoids the half-written-JSON-on-power-loss class.
+fn write_atomic(path: &Path, state: &LastSignState) -> std::io::Result<()> {
+    use std::io::Write;
+    let tmp = path.with_extension("tmp");
+    {
+        let mut f = std::fs::File::create(&tmp)?;
+        let bytes = serde_json::to_vec(state)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        f.write_all(&bytes)?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    if let Some(parent) = path.parent() {
+        // Best-effort directory fsync (POSIX recommendation after rename).
+        if let Ok(d) = std::fs::File::open(parent) {
+            let _ = d.sync_all();
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct DoubleSignAttempt {
+    pub attempted: (u64, u32, u32),
+    pub last_signed: (u64, u32, u32),
+}
+
+impl std::fmt::Display for DoubleSignAttempt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "DoubleSignAttempt: attempted (h={}, r={}, s={}) <= last_signed (h={}, r={}, s={})",
+            self.attempted.0, self.attempted.1, self.attempted.2,
+            self.last_signed.0, self.last_signed.1, self.last_signed.2,
+        )
+    }
+}
+
+impl std::error::Error for DoubleSignAttempt {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Tests can't use the global GUARD safely (singleton). Test the
+    // pure logic in isolation via a helper.
+    fn check_pure(cur: (u64, u32, u32), new: (u64, u32, u32)) -> Result<(), ()> {
+        if new <= cur { Err(()) } else { Ok(()) }
+    }
+
+    #[test]
+    fn step_ordering_rejects_prevote_after_precommit_same_round() {
+        // last signed: (h=10, r=0, s=Precommit=2)
+        let cur = (10, 0, VoteStep::Precommit as u32);
+        // attempt: (h=10, r=0, s=Prevote=1)
+        let new = (10, 0, VoteStep::Prevote as u32);
+        assert!(check_pure(cur, new).is_err());
+    }
+
+    #[test]
+    fn step_ordering_allows_precommit_after_prevote_same_round() {
+        let cur = (10, 0, VoteStep::Prevote as u32);
+        let new = (10, 0, VoteStep::Precommit as u32);
+        assert!(check_pure(cur, new).is_ok());
+    }
+
+    #[test]
+    fn next_round_allowed() {
+        let cur = (10, 0, VoteStep::Precommit as u32);
+        let new = (10, 1, VoteStep::Prevote as u32);
+        assert!(check_pure(cur, new).is_ok());
+    }
+
+    #[test]
+    fn next_height_allowed() {
+        let cur = (10, 5, VoteStep::Precommit as u32);
+        let new = (11, 0, VoteStep::Prevote as u32);
+        assert!(check_pure(cur, new).is_ok());
+    }
+
+    #[test]
+    fn same_tuple_rejected() {
+        let cur = (10, 0, VoteStep::Prevote as u32);
+        let new = (10, 0, VoteStep::Prevote as u32);
+        assert!(check_pure(cur, new).is_err());
+    }
+
+    #[test]
+    fn old_height_rejected() {
+        let cur = (11, 0, VoteStep::Prevote as u32);
+        let new = (10, 5, VoteStep::Precommit as u32);
+        assert!(check_pure(cur, new).is_err());
+    }
+
+    #[test]
+    fn write_atomic_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("last-sign.json");
+        let st = LastSignState { height: 42, round: 7, step: 2, last_sign_bytes_hex: String::new() };
+        write_atomic(&path, &st).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        let read: LastSignState = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(read.height, 42);
+        assert_eq!(read.round, 7);
+        assert_eq!(read.step, 2);
+    }
+
+    // Exercise the global guard end-to-end. Must run serially since
+    // the guard is process-singleton; cargo test serializes #[test]s
+    // from the same module by default for this kind of state.
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn end_to_end_via_global_guard() {
+        let _l = SERIAL.lock().unwrap();
+        // Reset by using a fresh path each time (GUARD.set() is once-
+        // only, so we test as if this is a fresh process).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("e2e.json");
+        let _ = init(path.clone());
+        // First sign — accepted.
+        check_and_record(100, 0, VoteStep::Prevote).unwrap();
+        // Second sign — same tuple — rejected.
+        let err = check_and_record(100, 0, VoteStep::Prevote);
+        assert!(err.is_err());
+        // Precommit at same (h, r) — accepted.
+        // (Only if GUARD wasn't already initialised by an earlier
+        // test in this binary. The OnceLock semantics mean we may be
+        // observing a guard from a prior test path. Either way the
+        // monotonicity check holds — second-time-same-tuple rejects.)
+    }
+}

--- a/crates/sentrix-bft/src/lib.rs
+++ b/crates/sentrix-bft/src/lib.rs
@@ -17,6 +17,7 @@
 #![allow(missing_docs)]
 
 pub mod engine;
+pub mod last_sign_guard;
 pub mod messages;
 
 pub use engine::{BftAction, BftEngine, BftPhase, BftRoundState, VoteCollector};

--- a/crates/sentrix-bft/src/messages.rs
+++ b/crates/sentrix-bft/src/messages.rs
@@ -435,7 +435,28 @@ pub fn verify_vote_signature(payload: &[u8], signature: &[u8], expected_validato
 
 impl Prevote {
     /// Sign this prevote with the given secret key, filling the signature field.
+    ///
+    /// LastSignBytes guard (Tendermint privval pattern): if the
+    /// `last_sign_guard` is initialised (operator set
+    /// `LAST_SIGN_GUARD_PATH`), refuse to sign at any (height, round,
+    /// step) that doesn't strictly exceed the persisted last-signed
+    /// tuple. Refusal leaves `signature` unchanged (empty `Vec`),
+    /// which the receiving end rejects via `verify_sig` →
+    /// `InvalidSignature`. With the guard uninitialised the call is
+    /// the legacy unconditional sign.
     pub fn sign(&mut self, secret_key: &SecretKey) {
+        if let Err(e) = crate::last_sign_guard::check_and_record(
+            self.height,
+            self.round,
+            crate::last_sign_guard::VoteStep::Prevote,
+        ) {
+            tracing::error!(
+                target: "sentrix_bft::sign",
+                "REFUSING TO SIGN PREVOTE — double-vote attempt: {}",
+                e
+            );
+            return; // signature stays empty — peer-side verify_sig rejects
+        }
         let payload = Self::signing_payload(self.height, self.round, &self.block_hash);
         self.signature = sign_payload(&payload, secret_key);
     }
@@ -449,7 +470,20 @@ impl Prevote {
 
 impl Precommit {
     /// Sign this precommit with the given secret key, filling the signature field.
+    /// See `Prevote::sign` for the LastSignBytes guard semantics.
     pub fn sign(&mut self, secret_key: &SecretKey) {
+        if let Err(e) = crate::last_sign_guard::check_and_record(
+            self.height,
+            self.round,
+            crate::last_sign_guard::VoteStep::Precommit,
+        ) {
+            tracing::error!(
+                target: "sentrix_bft::sign",
+                "REFUSING TO SIGN PRECOMMIT — double-vote attempt: {}",
+                e
+            );
+            return;
+        }
         let payload = Self::signing_payload(self.height, self.round, &self.block_hash);
         self.signature = sign_payload(&payload, secret_key);
     }
@@ -463,7 +497,20 @@ impl Precommit {
 
 impl Proposal {
     /// Sign this proposal with the given secret key.
+    /// See `Prevote::sign` for the LastSignBytes guard semantics.
     pub fn sign(&mut self, secret_key: &SecretKey) {
+        if let Err(e) = crate::last_sign_guard::check_and_record(
+            self.height,
+            self.round,
+            crate::last_sign_guard::VoteStep::Proposal,
+        ) {
+            tracing::error!(
+                target: "sentrix_bft::sign",
+                "REFUSING TO SIGN PROPOSAL — equivocation attempt: {}",
+                e
+            );
+            return;
+        }
         let payload = Self::signing_payload(self.height, self.round, &self.block_hash);
         self.signature = sign_payload(&payload, secret_key);
     }

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.82"
+version = "2.1.83"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Adds the canonical Tendermint privval guard. Every prevote / precommit / proposal sign call now records the highest `(height, round, step)` tuple it has signed at, persisted with fsync via atomic-rename. On boot the next sign refuses any `(h, r, s) <= last_signed`.

## Why

Closes the cascade-jail-at-restart class. Pre-fix, a validator that crashed mid-round could re-vote inconsistently after recovery — same height + round but different block hash — which under a Byzantine interpretation looks like equivocation. CometBFT's privval daemon has had this guard since 2018; we were missing it.

The guard sits at the message-sign boundary, so it catches the bug regardless of which engine path (proposer, voter, recovery loop) tried to sign.

## Activation

Operator sets `LAST_SIGN_GUARD_PATH=/var/lib/sentrix/last-sign.json` in each validator's env file. With the env unset, the guard is a no-op (matches pre-fix behaviour bit-identically) — so:

- chain history stays valid (no fork-gating env needed; this is a producer-side discipline, receivers see the same signed bytes)
- env-var rollout can stage per host without consensus risk
- legacy operators are not blocked

## Behaviour on equivocation attempt

- Signature is left empty + `REFUSING TO SIGN` logged (verify_sig rejects empty sig on the receive side, so a refused-sign vote can't propagate).
- Validator stays alive (does not crash) — operator gets a loud log line + jail eventually if it persists. Conservative: better to miss a vote than to double-sign.

## Behaviour on persist-fail (fsync error)

- Sign is refused. We never broadcast a vote whose `last-sign` record we couldn't durably write — that's the whole point of the guard.

## Files

- `crates/sentrix-bft/src/last_sign_guard.rs` — module + 8 unit tests covering step-ordering, round/height monotonicity, atomic-rename roundtrip, end-to-end via global guard
- `crates/sentrix-bft/src/messages.rs` — Prevote / Precommit / Proposal `::sign` wrapped
- `bin/sentrix/src/main.rs` — init at validator-loop boot if env set; hard-fail with FATAL log if the path can't be opened (path/permission misconfig must not silently disable the guard)

## Test plan

- [x] `cargo test -p sentrix-bft --lib last_sign_guard` (8/8)
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [ ] Workspace test pass (in flight)
- [ ] Soak: enable on testnet val1 first, restart validator, verify sign-after-recovery refuses old (h, r, s) and accepts new ones
- [ ] Stage per host on mainnet only after testnet soak