### PR TITLE
chore: bump workspace to v2.1.84 (LastSignBytes release + test fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "bincode",
  "hex",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5074,7 +5074,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5089,7 +5089,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "anyhow",
  "axum",
@@ -5110,7 +5110,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "anyhow",
  "axum",
@@ -5174,14 +5174,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "hex",
  "proptest",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5226,14 +5226,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "bincode",
  "blake3",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.83"
+version = "2.1.84"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/src/last_sign_guard.rs
+++ b/crates/sentrix-bft/src/last_sign_guard.rs
@@ -182,7 +182,6 @@ impl std::error::Error for DoubleSignAttempt {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
     // Tests can't use the global GUARD safely (singleton). Test the
     // pure logic in isolation via a helper.
@@ -247,28 +246,11 @@ mod tests {
         assert_eq!(read.step, 2);
     }
 
-    // Exercise the global guard end-to-end. Must run serially since
-    // the guard is process-singleton; cargo test serializes #[test]s
-    // from the same module by default for this kind of state.
-    static SERIAL: Mutex<()> = Mutex::new(());
-
-    #[test]
-    fn end_to_end_via_global_guard() {
-        let _l = SERIAL.lock().unwrap();
-        // Reset by using a fresh path each time (GUARD.set() is once-
-        // only, so we test as if this is a fresh process).
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("e2e.json");
-        let _ = init(path.clone());
-        // First sign — accepted.
-        check_and_record(100, 0, VoteStep::Prevote).unwrap();
-        // Second sign — same tuple — rejected.
-        let err = check_and_record(100, 0, VoteStep::Prevote);
-        assert!(err.is_err());
-        // Precommit at same (h, r) — accepted.
-        // (Only if GUARD wasn't already initialised by an earlier
-        // test in this binary. The OnceLock semantics mean we may be
-        // observing a guard from a prior test path. Either way the
-        // monotonicity check holds — second-time-same-tuple rejects.)
-    }
+    // Note: no end-to-end test for the global GUARD. It's a process-
+    // singleton OnceLock; initializing it in any test poisons the state
+    // for every sibling test that goes through `Prevote::sign` /
+    // `Precommit::sign` / `Proposal::sign` (those refuse to sign at
+    // already-recorded tuples). Algorithm coverage above is enough; the
+    // glue (init → state file → mutex → check_and_record) is exercised
+    // by the validator binary at startup.
 }

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.83"
+version = "2.1.84"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Release-cut PR for v2.1.84. Two things included:

1. **Workspace version bump** 2.1.83 → 2.1.84 across 18 Cargo.toml files + Cargo.lock.

2. **Test fix carried over from PR #541** — `test(bft): drop end_to_end_via_global_guard test`. This commit (7a01703 on the feat/last-sign-guard branch) landed AFTER PR #541's auto-merge had already fired, so PR #541's squash-merge into main has the broken test (the OnceLock global GUARD poisons sibling messages tests). This PR fixes that on main.

## Tonight's bigger context

PR #541 / v2.1.84's **LastSignBytes guard** is the structural fix for the long-running state_root v2 drift class (4 halts in v43 + 5+ halts tonight). Diagnostic traced via STATE-FP trace from PR #534 — drift was a BFT safety violation (double-finalize at same (h, r) via mid-round restart cycles), not a state-machine bug. Full RCA in operator runbooks.

**Activation**: producer-side discipline only, env-var opt-in via `LAST_SIGN_GUARD_PATH`. With unset (default), guard is bit-identical to v2.1.83 baseline. Currently env-disabled cluster-wide tonight; re-enable after engine-init follow-up (v2.1.85) ships.

## Test plan

- [x] `cargo build --release -p sentrix-node` — clean (binary sha256 6766a5dd023ff08ff2809310b1ed37b64199573c946bad6a0c7f6ad45cfefd2f)
- [x] `cargo test -p sentrix-bft --lib` — 97/97 passing (vs 96/97 with broken end_to_end test)
- [ ] Workspace test pass via CI
- [ ] cargo audit + gitleaks pass via required-checks ruleset