### PR TITLE
fix(v2.1.85): engine-init reads last_signed + watchdog HEIGHT_STALL env-var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "bincode",
  "hex",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5074,7 +5074,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5089,7 +5089,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "anyhow",
  "axum",
@@ -5110,7 +5110,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "anyhow",
  "axum",
@@ -5174,14 +5174,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "hex",
  "proptest",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5226,14 +5226,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "bincode",
  "blake3",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.84"
+version = "2.1.85"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1490,8 +1490,20 @@ async fn cmd_start(
             // restart; missed-detection cost is operator-triggered
             // SIGKILL → MDBX_CORRUPTED → forced rsync recovery (today's
             // failure mode that motivated this watchdog).
-            const HEIGHT_STALL_THRESHOLD: Duration = Duration::from_secs(90);
-            const HEIGHT_WARN_THRESHOLD: Duration = Duration::from_secs(30);
+            // v2.1.85: env-var override. Default 90s is fine for steady-state
+            // 1s-block production but kills validators mid-recovery (round-skip
+            // cycles can take >90s when the cluster is converging from a halt).
+            // Operators in recovery scenarios can set
+            // HEIGHT_STALL_THRESHOLD_SEC=600 to give BFT room to finish round
+            // transitions. Pre-v2.1.85 was hardcoded 90s; see v44 incident
+            // 2026-05-07 for the failure mode this override addresses.
+            let height_stall_secs: u64 = std::env::var("HEIGHT_STALL_THRESHOLD_SEC")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(90);
+            let height_stall_threshold = Duration::from_secs(height_stall_secs);
+            let height_warn_threshold =
+                Duration::from_secs(height_stall_secs.saturating_mul(1).max(30) / 3);
             const TICK: Duration = Duration::from_secs(5);
             const CHANNEL_GAUGE_TICK: Duration = Duration::from_secs(30);
             const CHANNEL_PRESSURE_PCT: usize = 25;
@@ -1552,7 +1564,7 @@ async fn cmd_start(
                     last_height_changed = tokio::time::Instant::now();
                 } else {
                     let stale = last_height_changed.elapsed();
-                    if stale >= HEIGHT_STALL_THRESHOLD {
+                    if stale >= height_stall_threshold {
                         tracing::error!(
                             target: "validator_watchdog",
                             "FATAL: chain height stuck at {} for {}s — BFT can't finalize. \
@@ -1561,12 +1573,12 @@ async fn cmd_start(
                             current_height, stale.as_secs(),
                         );
                         std::process::abort();
-                    } else if stale >= HEIGHT_WARN_THRESHOLD {
+                    } else if stale >= height_warn_threshold {
                         tracing::warn!(
                             target: "validator_watchdog",
                             "chain height stuck at {} for {}s — abort threshold {}s",
                             current_height, stale.as_secs(),
-                            HEIGHT_STALL_THRESHOLD.as_secs(),
+                            height_stall_threshold.as_secs(),
                         );
                     }
                 }
@@ -2268,6 +2280,33 @@ async fn cmd_start(
 
                     let mut bft =
                         BftEngine::new(next_height, wallet.address.clone(), total_active_stake);
+
+                    // v2.1.85: resume at the correct round if we previously
+                    // signed at this height pre-crash. Without this the v2.1.84
+                    // LastSignBytes guard correctly refuses any sign at-or-below
+                    // last_signed (h=N, r=R_prev, *), but the engine initialises
+                    // at round 0, so the next sign is at (N, 0, Proposal) which
+                    // is rejected as a double-vote attempt. Result: chicken-egg
+                    // halt where chain can't advance until operator manually
+                    // clears /var/lib/sentrix/last-sign.json. See v44 incident
+                    // 2026-05-07 for the failure mode.
+                    if let Some(state) = sentrix_bft::last_sign_guard::current_state() {
+                        if state.height == next_height && state.round > 0 {
+                            let target_round = state.round.saturating_add(1);
+                            // BftEngine::advance_round bumps round + resets the
+                            // vote collector + phase_start. Apply N times to
+                            // skip the prior in-progress round.
+                            for _ in 0..target_round {
+                                bft.advance_round();
+                            }
+                            tracing::info!(
+                                "BFT engine resume: prior sign at (h={}, r={}, s={}) — \
+                                 advanced engine to round {} to bypass guard refusal",
+                                state.height, state.round, state.step, target_round,
+                            );
+                        }
+                    }
+
                     proposed_block = None;
                     // #1d: reset rebroadcast tracking on new height.
                     proposal_broadcast_at = None;

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -2290,21 +2290,22 @@ async fn cmd_start(
                     // halt where chain can't advance until operator manually
                     // clears /var/lib/sentrix/last-sign.json. See v44 incident
                     // 2026-05-07 for the failure mode.
-                    if let Some(state) = sentrix_bft::last_sign_guard::current_state() {
-                        if state.height == next_height && state.round > 0 {
-                            let target_round = state.round.saturating_add(1);
-                            // BftEngine::advance_round bumps round + resets the
-                            // vote collector + phase_start. Apply N times to
-                            // skip the prior in-progress round.
-                            for _ in 0..target_round {
-                                bft.advance_round();
-                            }
-                            tracing::info!(
-                                "BFT engine resume: prior sign at (h={}, r={}, s={}) — \
-                                 advanced engine to round {} to bypass guard refusal",
-                                state.height, state.round, state.step, target_round,
-                            );
+                    if let Some(state) = sentrix_bft::last_sign_guard::current_state()
+                        && state.height == next_height
+                        && state.round > 0
+                    {
+                        let target_round = state.round.saturating_add(1);
+                        // BftEngine::advance_round bumps round + resets the
+                        // vote collector + phase_start. Apply N times to
+                        // skip the prior in-progress round.
+                        for _ in 0..target_round {
+                            bft.advance_round();
                         }
+                        tracing::info!(
+                            "BFT engine resume: prior sign at (h={}, r={}, s={}) — \
+                             advanced engine to round {} to bypass guard refusal",
+                            state.height, state.round, state.step, target_round,
+                        );
                     }
 
                     proposed_block = None;

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/src/last_sign_guard.rs
+++ b/crates/sentrix-bft/src/last_sign_guard.rs
@@ -92,6 +92,21 @@ pub fn init(path: PathBuf) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Read the persisted last-signed state. Returns None if the guard
+/// hasn't been initialised (operator opted out via unset env var).
+///
+/// Added in v2.1.85 so the BFT engine init path can resume at
+/// `last_signed.round + 1` for the same height after a mid-round
+/// crash, instead of restarting at round 0 and getting refused by
+/// the guard. See `bin/sentrix/src/main.rs` validator-loop for the
+/// caller; without this the v2.1.84 guard caused chicken-egg halts
+/// where post-restart engine couldn't make progress.
+pub fn current_state() -> Option<LastSignState> {
+    let g = GUARD.get()?;
+    let st = g.state.lock().ok()?;
+    Some(st.clone())
+}
+
 /// Check + record a sign-attempt. Returns Ok(()) if the guard isn't
 /// initialised (legacy behaviour) OR if `(height, round, step)` strictly
 /// exceeds the persisted last-signed tuple. Returns Err if the request

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.84"
+version = "2.1.85"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Two follow-ups from v2.1.84's LastSignBytes guard release.

### (1) BFT engine init reads last_signed at boot

v2.1.84's guard correctly refuses any sign at-or-below last_signed, but the engine restarts at round 0 on every new height. If a validator was at (h=N, r=R_prev) pre-crash, post-restart it tries to sign at (N, 0, Proposal) which the guard refuses. Result: chicken-egg halt where chain can't advance until operator manually clears `/var/lib/sentrix/last-sign.json`.

This PR adds `last_sign_guard::current_state() -> Option<LastSignState>` and uses it in the validator-loop's "need_new_round" branch. After `BftEngine::new`, if persisted state has `height == next_height && round > 0`, advance the engine to `round + 1` via existing `advance_round()`. Engine resume = correct round = guard allows next sign = chain advances.

### (2) Watchdog HEIGHT_STALL_THRESHOLD env-var override

Hardcoded 90s is fine for steady-state 1s-block production but kills validators mid-round-skip cycles during recovery (round timeouts can take >90s when converging from a halt). Operators can now set `HEIGHT_STALL_THRESHOLD_SEC=600` to give BFT room.

Default unchanged (90) so production behaviour is bit-identical until operators opt in. Warn threshold scales (stall/3, 30s minimum).

## Why this matters

v44 incident on 2026-05-07 demonstrated both bugs in the same recovery cycle. v2.1.84 was deployed but had to be env-disabled (`LAST_SIGN_GUARD_PATH` commented out) to get the chain to advance at all. With v2.1.85 the guard can be re-enabled cluster-wide without operator-driven workarounds.

## Test plan

- [x] `cargo test -p sentrix-bft --lib` — 97/97
- [x] `cargo check --workspace` — clean
- [x] Docker bullseye release build — clean (binary built locally for staging)
- [ ] Workspace test pass via CI
- [ ] Smoke deploy to a single mainnet host with `LAST_SIGN_GUARD_PATH` set + `HEIGHT_STALL_THRESHOLD_SEC=600`, restart mid-round, verify "BFT engine resume: prior sign at ..." log + chain advance.
- [ ] Per-host rollout one at a time with 5-min observation gap.

## Activation order (post-merge)

1. v2.1.85 binary on all 4 hosts.
2. Confirm 30-min halt-free at v2.1.85 with `LAST_SIGN_GUARD_PATH` still env-disabled.
3. Set `HEIGHT_STALL_THRESHOLD_SEC=600` per host.
4. Set `LAST_SIGN_GUARD_PATH=/var/lib/sentrix/last-sign.json` per host.
5. Recreate (down + up) per host, one at a time.
6. After all 4 healthy, schedule re-activation of `STRICT_JUSTIFICATION_HEIGHT`.