### PR TITLE
docs: bump revm 37 → 38

### DIFF
--- a/docs-site/src/components/HomepageFeatures/index.tsx
+++ b/docs-site/src/components/HomepageFeatures/index.tsx
@@ -54,7 +54,7 @@ const FeatureList: FeatureItem[] = [
     icon: Pillar,
     description: (
       <>
-        EVM-native L1 with Solidity smart contracts (revm 37). EIP-1559 fee
+        EVM-native L1 with Solidity smart contracts (revm 38). EIP-1559 fee
         market, ERC-20 / ERC-721 / SRC-721 token standards, MetaMask + Hardhat
         + ethers.js ready out of the box.
       </>

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-Sentrix is a Layer-1 blockchain written in Rust. **Voyager DPoS+BFT consensus** (live since 2026-04-25; Pioneer PoA round-robin was bootstrap consensus through h=579046), account-based model (like Ethereum), custom Binary Sparse Merkle Tree for state proofs, EVM execution via revm 37.
+Sentrix is a Layer-1 blockchain written in Rust. **Voyager DPoS+BFT consensus** (live since 2026-04-25; Pioneer PoA round-robin was bootstrap consensus through h=579046), account-based model (like Ethereum), custom Binary Sparse Merkle Tree for state proofs, EVM execution via revm 38.
 
 ## Components
 
@@ -32,7 +32,7 @@ crates/sentrix-wire/            Wire-protocol message types
 crates/sentrix-wallet/          Keygen, Argon2id keystore
 crates/sentrix-trie/            256-level Binary Sparse Merkle Tree
 crates/sentrix-staking/         DPoS, epoch rotation, slashing
-crates/sentrix-evm/             revm 37 adapter
+crates/sentrix-evm/             revm 38 adapter
 crates/sentrix-precompiles/     EVM precompiles
 crates/sentrix-bft/             BFT consensus (timeout-only round advance)
 crates/sentrix-core/            Blockchain, authority, executor, mempool,

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -27,7 +27,7 @@ Sentrix is an open-source, EVM-compatible Layer-1 built in Rust. Real chain, rea
 | **Testnet** | Chain ID `7120` · `https://testnet-rpc.sentrixchain.com/rpc` |
 | **Block Time** | 1 second |
 | **Consensus** | Voyager DPoS+BFT (live since April 2026) |
-| **Execution** | EVM-native (revm 37) |
+| **Execution** | EVM-native (revm 38) |
 | **Max Supply** | 315M SRX (post tokenomics-v2 fork) |
 | **Premine** | 20% of cap |
 | **Halving** | Every 126M blocks (~4 years, Bitcoin-parity) |

--- a/docs/operations/SMART_CONTRACT_GUIDE.md
+++ b/docs/operations/SMART_CONTRACT_GUIDE.md
@@ -1,6 +1,6 @@
 # Deploying Smart Contracts to Sentrix
 
-Sentrix runs an EVM (revm 37) on both mainnet and testnet, and accepts standard Ethereum tooling. This guide walks through deploying a Solidity contract via Remix in under 5 minutes.
+Sentrix runs an EVM (revm 38) on both mainnet and testnet, and accepts standard Ethereum tooling. This guide walks through deploying a Solidity contract via Remix in under 5 minutes.
 
 > **Network choice:** Use **testnet** (chain ID 7120) for development — get free SRX from the [faucet](https://faucet.sentrixchain.com). Use **mainnet** (chain ID 7119) for production deployments. EVM has been live on mainnet since the 2026-04-25 Voyager activation.
 

--- a/docs/roadmap/PHASE2.md
+++ b/docs/roadmap/PHASE2.md
@@ -1,6 +1,6 @@
 # Voyager — DPoS + BFT + EVM (LIVE on mainnet)
 
-> **Status: ACTIVE on mainnet since 2026-04-25 (h=579047).** Both networks (mainnet chain_id 7119, testnet chain_id 7120) run Voyager DPoS+BFT with EVM (revm 37) enabled.
+> **Status: ACTIVE on mainnet since 2026-04-25 (h=579047).** Both networks (mainnet chain_id 7119, testnet chain_id 7120) run Voyager DPoS+BFT with EVM (revm 38) enabled.
 
 Voyager succeeded Pioneer (PoA round-robin, blocks 0…579046 on mainnet) as the consensus + execution engine. The transition was a hard-fork at h=579047 — `voyager_activated=true` flag set on chain.db, all 4 mainnet validators migrated together via parallel restart with the L2 cold-start gate ensuring mesh-stable BFT entry.
 
@@ -29,9 +29,9 @@ After a proposer drafts a block, all active validators vote in two phases (Tende
 
 For a 4-validator mesh, supermajority threshold = 3 of 4 (75%). Mainnet routinely finalizes round-0 at 1 block/sec under nominal load.
 
-### 3. EVM via revm 37
+### 3. EVM via revm 38
 
-Solidity smart contracts via [revm](https://github.com/bluealloy/revm) (Paradigm's EVM, used by Reth/Erigon). Pure Rust, battle-tested, currently on revm 37.
+Solidity smart contracts via [revm](https://github.com/bluealloy/revm) (Paradigm's EVM, used by Reth/Erigon). Pure Rust, battle-tested, currently on revm 38.
 
 - **Activation:** `evm_activated=true` set 2026-04-25 in the same window as Voyager activation (h=579060).
 - **Gas pricing:** 0.1 sentri/gas; block gas limit 30M; basic transfer ≈ 0.000021 SRX.


### PR DESCRIPTION
Tracks workspace runtime EVM (crates/sentrix-evm/Cargo.toml).

Historical changelog entry for the h=579047 activation left at revm 37 — that was the version live at that height.