### PR TITLE
fix(bft): LastSignBytes guard same-bytes-replay — close v2.1.85 rebroadcast bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.86] — 2026-05-08 — LastSignBytes guard same-bytes-replay exemption
+
+Closes the rebroadcast bug class that kept `LAST_SIGN_GUARD_PATH` env-disabled cluster-wide since v2.1.84/v2.1.85.
+
+**The bug**: BFT engine's proposal/prevote/precommit rebroadcast loop (see `bin/sentrix/src/main.rs::proposal_rebroadcast_count`) constructs a fresh struct with `signature: vec![]` each cycle and calls `.sign()` again. With the LastSignBytes guard ON, the second cycle saw `(h, r, step) <= last_signed` and refused — leaving signature empty, peers reject via `verify_sig`, validator silent → halt.
+
+**The fix**: same-bytes-replay exemption. New `check_and_record_with_bytes(h, r, step, payload_bytes)` differentiates legitimate rebroadcast (same tuple AND same bytes → return Ok, signature regenerated identically) from real double-vote (same tuple, different bytes → still refuses).
+
+The `last_sign_bytes_hex` field on `LastSignState` (reserved-but-unused since v2.1.84) now persists `sha256(signing_payload)`. Backwards-compatible: legacy `check_and_record(h, r, step)` still exists, behaves bit-identically to v2.1.85 (strict, no replay).
+
+Effect on operations: `LAST_SIGN_GUARD_PATH=/var/lib/sentrix/last-sign.json` can be re-enabled cluster-wide. Restart cycles that previously left validators silent now resume signing the legitimate rebroadcast on the same (h, r, step). Double-vote with different bytes still refused (the guard's actual purpose preserved).
+
+Tests: 5 new pure tests cover the replay decision rule; SHA-256 roundtrip; legacy callsite parity. All 13 last_sign_guard tests + 103 sentrix-bft suite pass. Workspace builds clean.
+
+Files: `crates/sentrix-bft/src/last_sign_guard.rs` (+143 lines), `crates/sentrix-bft/src/messages.rs` (3 sign-site callers updated), `crates/sentrix-bft/Cargo.toml` (+`hex = "0.4"`).
+
 ## [2.1.81] — 2026-05-07 — state-fingerprint debug trace
 
 Single-purpose release: ships PR #534's `emit_state_fingerprint` in the apply path, gated on `SENTRIX_STATE_FINGERPRINT=1`. When enabled, every block-apply emits a deterministic SHA-256 of AccountDB content (sorted balances, nonces, code-hashes, storage, plus `total_burned` + `total_minted`) as `[STATE-FP] h=<height> acc=<hex8> fp=<hex8>` to stderr. Default-off — zero overhead when env var unset.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "bincode",
  "hex",
@@ -5036,7 +5036,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "bincode",
  "hex",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "anyhow",
  "axum",
@@ -5111,7 +5111,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5133,7 +5133,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "anyhow",
  "axum",
@@ -5175,14 +5175,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "hex",
  "proptest",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5227,14 +5227,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "bincode",
  "blake3",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.85"
+version = "2.1.86"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5021,6 +5021,7 @@ name = "sentrix-bft"
 version = "2.1.85"
 dependencies = [
  "bincode",
+ "hex",
  "secp256k1 0.31.1",
  "sentrix-primitives",
  "sentrix-staking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 secp256k1 = { version = "0.31", features = ["rand", "recovery", "serde"] }
 sha2 = "0.11"
+hex = "0.4"
 sha3 = "0.11"
 tracing = "0.1"
 

--- a/crates/sentrix-bft/src/last_sign_guard.rs
+++ b/crates/sentrix-bft/src/last_sign_guard.rs
@@ -115,7 +115,46 @@ pub fn current_state() -> Option<LastSignState> {
 ///
 /// On Ok, the new tuple is fsync'd to disk BEFORE returning, so a
 /// post-broadcast crash leaves the on-disk state already advanced.
+///
+/// **Legacy entry point** — preserved for backwards compatibility. Callers
+/// that don't supply payload bytes get the strict check (any
+/// `(h,r,s) <= last_signed` is rejected, no replay exemption).
+///
+/// New callers that need legitimate-rebroadcast support should use
+/// [`check_and_record_with_bytes`] instead.
 pub fn check_and_record(height: u64, round: u32, step: VoteStep) -> Result<(), DoubleSignAttempt> {
+    check_and_record_with_bytes(height, round, step, &[])
+}
+
+/// Check + record a sign-attempt with the signing payload bytes.
+///
+/// Adds a same-bytes-replay exemption: if the (h, r, step) equals the
+/// persisted last-signed tuple AND `payload_bytes` hashes to the same
+/// value as the persisted hash, the call returns Ok(()) without
+/// re-persisting. This is a legitimate rebroadcast of an already-signed
+/// message (BFT engine retransmitting on round timeout) — re-emitting
+/// the same signature is NOT a double-vote.
+///
+/// Behaviour:
+/// - Guard not initialised → Ok (legacy bypass)
+/// - `step == Other` → Ok (non-consensus messages aren't guarded)
+/// - new `(h,r,s)` strictly > last_signed → record + persist + Ok
+/// - same `(h,r,s)` AND `hash(payload) == last_persisted_hash` → Ok (replay)
+/// - same `(h,r,s)` AND hash differs → Err (real double-vote)
+/// - new `(h,r,s)` < last_signed → Err (rollback attempt)
+///
+/// Closes the v2.1.85 rebroadcast bug class: pre-fix, BFT engine's
+/// proposal/prevote/precommit rebroadcast loop (see
+/// `bin/sentrix/src/main.rs::proposal_rebroadcast_count`) constructs a
+/// fresh struct with `signature: vec![]` each cycle and calls `.sign()`,
+/// which the strict guard rejected as double-vote, leaving signature
+/// empty → peers reject → validator silent → halt.
+pub fn check_and_record_with_bytes(
+    height: u64,
+    round: u32,
+    step: VoteStep,
+    payload_bytes: &[u8],
+) -> Result<(), DoubleSignAttempt> {
     let g = match GUARD.get() {
         Some(g) => g,
         None => return Ok(()),
@@ -127,6 +166,29 @@ pub fn check_and_record(height: u64, round: u32, step: VoteStep) -> Result<(), D
     let new_step_ord = step as u32;
     let cur_tuple = (st.height, st.round, st.step);
     let new_tuple = (height, round, new_step_ord);
+
+    // Same-bytes-replay exemption: if the requested tuple equals the
+    // persisted tuple AND the payload bytes match, this is a legitimate
+    // rebroadcast — return Ok without re-persisting (already on disk).
+    // Empty payload_bytes (legacy callers via `check_and_record`) skips
+    // the replay path so old behaviour is preserved bit-identically.
+    if new_tuple == cur_tuple && !payload_bytes.is_empty() {
+        let new_hash = hash_payload(payload_bytes);
+        if !st.last_sign_bytes_hex.is_empty() && st.last_sign_bytes_hex == new_hash {
+            tracing::debug!(
+                target: "sentrix_bft::last_sign_guard",
+                "rebroadcast replay exempt: h={} r={} step={:?}",
+                height, round, step
+            );
+            return Ok(());
+        }
+        // Same tuple, different bytes — real equivocation attempt.
+        return Err(DoubleSignAttempt {
+            attempted: new_tuple,
+            last_signed: cur_tuple,
+        });
+    }
+
     if new_tuple <= cur_tuple {
         return Err(DoubleSignAttempt {
             attempted: new_tuple,
@@ -136,6 +198,11 @@ pub fn check_and_record(height: u64, round: u32, step: VoteStep) -> Result<(), D
     st.height = height;
     st.round = round;
     st.step = new_step_ord;
+    if !payload_bytes.is_empty() {
+        st.last_sign_bytes_hex = hash_payload(payload_bytes);
+    } else {
+        st.last_sign_bytes_hex.clear();
+    }
     let snapshot = st.clone();
     drop(st);
     if let Err(e) = write_atomic(&g.path, &snapshot) {
@@ -151,6 +218,16 @@ pub fn check_and_record(height: u64, round: u32, step: VoteStep) -> Result<(), D
         });
     }
     Ok(())
+}
+
+/// Hash signing payload bytes to a stable hex digest stored in the
+/// last-sign state file. Uses SHA-256 — matches the rest of the chain's
+/// canonical hashing convention.
+fn hash_payload(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
 }
 
 /// Atomic write: writes to a `<path>.tmp` file, fsyncs, then renames.
@@ -268,4 +345,83 @@ mod tests {
     // already-recorded tuples). Algorithm coverage above is enough; the
     // glue (init → state file → mutex → check_and_record) is exercised
     // by the validator binary at startup.
+
+    // ── Same-bytes-replay exemption (v2.1.86 rebroadcast fix) ──
+    //
+    // Pure tests for the replay logic. Can't use the global GUARD (singleton
+    // poisoning), so test the decision rule in isolation.
+    fn check_replay_pure(
+        cur: (u64, u32, u32),
+        cur_hash: &str,
+        new: (u64, u32, u32),
+        new_hash: &str,
+    ) -> Result<(), &'static str> {
+        if new == cur && !new_hash.is_empty() {
+            if !cur_hash.is_empty() && cur_hash == new_hash {
+                return Ok(()); // legitimate rebroadcast replay
+            }
+            return Err("same tuple, different bytes — equivocation");
+        }
+        if new <= cur {
+            return Err("rollback");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn replay_same_bytes_same_tuple_allowed() {
+        // Validator already prevoted at h=10 r=0 with hash "abc".
+        // Rebroadcast cycle calls sign() again with same payload.
+        let cur = (10, 0, VoteStep::Prevote as u32);
+        assert!(check_replay_pure(cur, "abc", cur, "abc").is_ok());
+    }
+
+    #[test]
+    fn replay_different_bytes_same_tuple_rejected() {
+        // Validator already prevoted at h=10 r=0 with hash "abc".
+        // New attempt at same tuple but DIFFERENT block hash = real
+        // double-vote. Must be refused.
+        let cur = (10, 0, VoteStep::Prevote as u32);
+        assert!(check_replay_pure(cur, "abc", cur, "xyz").is_err());
+    }
+
+    #[test]
+    fn replay_legacy_no_hash_allows_strict_check() {
+        // Legacy callers via `check_and_record` (no payload) get the
+        // pre-fix behaviour: same tuple = always reject.
+        let cur = (10, 0, VoteStep::Prevote as u32);
+        // Empty new_hash bypasses the replay path and falls into the
+        // strict tuple check.
+        assert!(check_replay_pure(cur, "abc", cur, "").is_err());
+    }
+
+    #[test]
+    fn replay_higher_tuple_always_advances() {
+        // New tuple > last_signed always advances regardless of hash.
+        let cur = (10, 0, VoteStep::Prevote as u32);
+        let new = (10, 0, VoteStep::Precommit as u32);
+        assert!(check_replay_pure(cur, "abc", new, "different").is_ok());
+    }
+
+    #[test]
+    fn replay_curfile_no_hash_falls_through_to_strict() {
+        // Edge case: persisted state file has no hash (state from v2.1.85
+        // pre-fix), new sign comes in with hash. Same tuple, but cur_hash
+        // is empty. The replay path requires BOTH non-empty to allow.
+        // Falls through to strict tuple check, which says "same tuple = err".
+        // This is correct: without a way to match the old signature, refuse.
+        let cur = (10, 0, VoteStep::Prevote as u32);
+        assert!(check_replay_pure(cur, "", cur, "abc").is_err());
+    }
+
+    #[test]
+    fn hash_payload_deterministic() {
+        let h1 = hash_payload(b"test-prevote-payload-h10-r0");
+        let h2 = hash_payload(b"test-prevote-payload-h10-r0");
+        let h3 = hash_payload(b"different");
+        assert_eq!(h1, h2);
+        assert_ne!(h1, h3);
+        // SHA-256 hex output is 64 chars.
+        assert_eq!(h1.len(), 64);
+    }
 }

--- a/crates/sentrix-bft/src/last_sign_guard.rs
+++ b/crates/sentrix-bft/src/last_sign_guard.rs
@@ -424,4 +424,64 @@ mod tests {
         // SHA-256 hex output is 64 chars.
         assert_eq!(h1.len(), 64);
     }
+
+    // Walks every branch of `check_and_record_with_bytes` through the
+    // global GUARD. Only ONE test in this module touches the singleton —
+    // this one — so cross-test poisoning isn't a concern.
+    #[test]
+    fn full_guard_lifecycle_through_global() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("last-sign.json");
+
+        // Pre-init: every call is a no-op pass.
+        assert!(check_and_record_with_bytes(1, 0, VoteStep::Prevote, b"any").is_ok());
+        assert!(check_and_record(1, 0, VoteStep::Prevote).is_ok());
+        assert!(current_state().is_none());
+
+        init(path).unwrap();
+
+        // VoteStep::Other is never guarded — passes regardless of (h, r).
+        assert!(check_and_record_with_bytes(0, 0, VoteStep::Other, b"x").is_ok());
+        assert!(check_and_record_with_bytes(u64::MAX, u32::MAX, VoteStep::Other, b"x").is_ok());
+
+        // New tuple > cur → Ok + persist + hash recorded.
+        let p1 = b"prevote-payload-h10-r0";
+        assert!(check_and_record_with_bytes(10, 0, VoteStep::Prevote, p1).is_ok());
+        let st = current_state().unwrap();
+        assert_eq!((st.height, st.round, st.step), (10, 0, VoteStep::Prevote as u32));
+        assert_eq!(st.last_sign_bytes_hex.len(), 64);
+
+        // Same tuple + same bytes → replay exempt (Ok, no error).
+        assert!(check_and_record_with_bytes(10, 0, VoteStep::Prevote, p1).is_ok());
+
+        // Same tuple + different bytes → real equivocation (Err).
+        let err = check_and_record_with_bytes(10, 0, VoteStep::Prevote, b"DIFFERENT").unwrap_err();
+        assert_eq!(err.attempted, (10, 0, VoteStep::Prevote as u32));
+        assert_eq!(err.last_signed, (10, 0, VoteStep::Prevote as u32));
+        // Display impl renders the tuple
+        let s = format!("{}", err);
+        assert!(s.contains("DoubleSignAttempt"));
+        assert!(s.contains("h=10"));
+
+        // Advance step (Prevote → Precommit) at same h/r → Ok.
+        assert!(check_and_record_with_bytes(10, 0, VoteStep::Precommit, b"precommit-bytes").is_ok());
+
+        // Rollback attempt → Err (legacy strict path, empty payload).
+        assert!(check_and_record(10, 0, VoteStep::Prevote).is_err());
+
+        // Legacy callers (no payload bytes) advance forward fine and clear hash.
+        assert!(check_and_record(11, 0, VoteStep::Prevote).is_ok());
+        let st = current_state().unwrap();
+        assert_eq!(st.height, 11);
+        assert!(st.last_sign_bytes_hex.is_empty());
+
+        // After legacy advance, replay-exempt path with the now-empty cur_hash
+        // falls through to strict check → same tuple = Err.
+        assert!(check_and_record_with_bytes(11, 0, VoteStep::Prevote, b"new-bytes").is_err());
+
+        // init() is idempotent — second call when GUARD already set is no-op.
+        init(dir.path().join("ignored.json")).unwrap();
+        let st = current_state().unwrap();
+        assert_eq!(st.height, 11); // unchanged
+    }
 }

--- a/crates/sentrix-bft/src/last_sign_guard.rs
+++ b/crates/sentrix-bft/src/last_sign_guard.rs
@@ -425,63 +425,10 @@ mod tests {
         assert_eq!(h1.len(), 64);
     }
 
-    // Walks every branch of `check_and_record_with_bytes` through the
-    // global GUARD. Only ONE test in this module touches the singleton —
-    // this one — so cross-test poisoning isn't a concern.
-    #[test]
-    fn full_guard_lifecycle_through_global() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("last-sign.json");
-
-        // Pre-init: every call is a no-op pass.
-        assert!(check_and_record_with_bytes(1, 0, VoteStep::Prevote, b"any").is_ok());
-        assert!(check_and_record(1, 0, VoteStep::Prevote).is_ok());
-        assert!(current_state().is_none());
-
-        init(path).unwrap();
-
-        // VoteStep::Other is never guarded — passes regardless of (h, r).
-        assert!(check_and_record_with_bytes(0, 0, VoteStep::Other, b"x").is_ok());
-        assert!(check_and_record_with_bytes(u64::MAX, u32::MAX, VoteStep::Other, b"x").is_ok());
-
-        // New tuple > cur → Ok + persist + hash recorded.
-        let p1 = b"prevote-payload-h10-r0";
-        assert!(check_and_record_with_bytes(10, 0, VoteStep::Prevote, p1).is_ok());
-        let st = current_state().unwrap();
-        assert_eq!((st.height, st.round, st.step), (10, 0, VoteStep::Prevote as u32));
-        assert_eq!(st.last_sign_bytes_hex.len(), 64);
-
-        // Same tuple + same bytes → replay exempt (Ok, no error).
-        assert!(check_and_record_with_bytes(10, 0, VoteStep::Prevote, p1).is_ok());
-
-        // Same tuple + different bytes → real equivocation (Err).
-        let err = check_and_record_with_bytes(10, 0, VoteStep::Prevote, b"DIFFERENT").unwrap_err();
-        assert_eq!(err.attempted, (10, 0, VoteStep::Prevote as u32));
-        assert_eq!(err.last_signed, (10, 0, VoteStep::Prevote as u32));
-        // Display impl renders the tuple
-        let s = format!("{}", err);
-        assert!(s.contains("DoubleSignAttempt"));
-        assert!(s.contains("h=10"));
-
-        // Advance step (Prevote → Precommit) at same h/r → Ok.
-        assert!(check_and_record_with_bytes(10, 0, VoteStep::Precommit, b"precommit-bytes").is_ok());
-
-        // Rollback attempt → Err (legacy strict path, empty payload).
-        assert!(check_and_record(10, 0, VoteStep::Prevote).is_err());
-
-        // Legacy callers (no payload bytes) advance forward fine and clear hash.
-        assert!(check_and_record(11, 0, VoteStep::Prevote).is_ok());
-        let st = current_state().unwrap();
-        assert_eq!(st.height, 11);
-        assert!(st.last_sign_bytes_hex.is_empty());
-
-        // After legacy advance, replay-exempt path with the now-empty cur_hash
-        // falls through to strict check → same tuple = Err.
-        assert!(check_and_record_with_bytes(11, 0, VoteStep::Prevote, b"new-bytes").is_err());
-
-        // init() is idempotent — second call when GUARD already set is no-op.
-        init(dir.path().join("ignored.json")).unwrap();
-        let st = current_state().unwrap();
-        assert_eq!(st.height, 11); // unchanged
-    }
+    // The end-to-end test that walks every branch of
+    // `check_and_record_with_bytes` through the global singleton GUARD lives
+    // in `tests/last_sign_guard_integration.rs`. Integration tests get their
+    // own test binary, so the OnceLock initialisation can't poison sibling
+    // unit tests in `messages.rs` that exercise `Proposal::sign` /
+    // `Prevote::sign` / `Precommit::sign` via the same singleton.
 }

--- a/crates/sentrix-bft/src/messages.rs
+++ b/crates/sentrix-bft/src/messages.rs
@@ -445,10 +445,12 @@ impl Prevote {
     /// `InvalidSignature`. With the guard uninitialised the call is
     /// the legacy unconditional sign.
     pub fn sign(&mut self, secret_key: &SecretKey) {
-        if let Err(e) = crate::last_sign_guard::check_and_record(
+        let payload = Self::signing_payload(self.height, self.round, &self.block_hash);
+        if let Err(e) = crate::last_sign_guard::check_and_record_with_bytes(
             self.height,
             self.round,
             crate::last_sign_guard::VoteStep::Prevote,
+            &payload,
         ) {
             tracing::error!(
                 target: "sentrix_bft::sign",
@@ -457,7 +459,6 @@ impl Prevote {
             );
             return; // signature stays empty — peer-side verify_sig rejects
         }
-        let payload = Self::signing_payload(self.height, self.round, &self.block_hash);
         self.signature = sign_payload(&payload, secret_key);
     }
 
@@ -472,10 +473,12 @@ impl Precommit {
     /// Sign this precommit with the given secret key, filling the signature field.
     /// See `Prevote::sign` for the LastSignBytes guard semantics.
     pub fn sign(&mut self, secret_key: &SecretKey) {
-        if let Err(e) = crate::last_sign_guard::check_and_record(
+        let payload = Self::signing_payload(self.height, self.round, &self.block_hash);
+        if let Err(e) = crate::last_sign_guard::check_and_record_with_bytes(
             self.height,
             self.round,
             crate::last_sign_guard::VoteStep::Precommit,
+            &payload,
         ) {
             tracing::error!(
                 target: "sentrix_bft::sign",
@@ -484,7 +487,6 @@ impl Precommit {
             );
             return;
         }
-        let payload = Self::signing_payload(self.height, self.round, &self.block_hash);
         self.signature = sign_payload(&payload, secret_key);
     }
 
@@ -499,10 +501,12 @@ impl Proposal {
     /// Sign this proposal with the given secret key.
     /// See `Prevote::sign` for the LastSignBytes guard semantics.
     pub fn sign(&mut self, secret_key: &SecretKey) {
-        if let Err(e) = crate::last_sign_guard::check_and_record(
+        let payload = Self::signing_payload(self.height, self.round, &self.block_hash);
+        if let Err(e) = crate::last_sign_guard::check_and_record_with_bytes(
             self.height,
             self.round,
             crate::last_sign_guard::VoteStep::Proposal,
+            &payload,
         ) {
             tracing::error!(
                 target: "sentrix_bft::sign",
@@ -511,7 +515,6 @@ impl Proposal {
             );
             return;
         }
-        let payload = Self::signing_payload(self.height, self.round, &self.block_hash);
         self.signature = sign_payload(&payload, secret_key);
     }
 

--- a/crates/sentrix-bft/tests/last_sign_guard_integration.rs
+++ b/crates/sentrix-bft/tests/last_sign_guard_integration.rs
@@ -1,0 +1,73 @@
+//! End-to-end test for the `last_sign_guard` module's global singleton.
+//!
+//! Lives as an integration test (not a `#[cfg(test)] mod tests`) so its
+//! `OnceLock` init doesn't poison the unit-test binary, where
+//! `messages::tests::test_proposal_sign_verify` (and friends) exercise
+//! `Proposal::sign` / `Prevote::sign` / `Precommit::sign` through the same
+//! singleton and rely on the guard being uninitialised.
+//!
+//! Walks every branch of `check_and_record_with_bytes` end-to-end through
+//! the live GUARD: legacy bypass, Other step, advance + persist, replay
+//! exemption (same bytes → Ok), equivocation (different bytes → Err),
+//! rollback rejection, legacy clear-hash advance, idempotent init.
+
+use sentrix_bft::last_sign_guard::{
+    check_and_record, check_and_record_with_bytes, current_state, init, VoteStep,
+};
+
+#[test]
+fn full_guard_lifecycle_through_global() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("last-sign.json");
+
+    // Pre-init: every call is a no-op pass; current_state returns None.
+    assert!(check_and_record_with_bytes(1, 0, VoteStep::Prevote, b"any").is_ok());
+    assert!(check_and_record(1, 0, VoteStep::Prevote).is_ok());
+    assert!(current_state().is_none());
+
+    init(path).unwrap();
+
+    // VoteStep::Other is never guarded — passes regardless of (h, r).
+    assert!(check_and_record_with_bytes(0, 0, VoteStep::Other, b"x").is_ok());
+    assert!(check_and_record_with_bytes(u64::MAX, u32::MAX, VoteStep::Other, b"x").is_ok());
+
+    // New tuple > cur → Ok + persist + hash recorded.
+    let p1 = b"prevote-payload-h10-r0";
+    assert!(check_and_record_with_bytes(10, 0, VoteStep::Prevote, p1).is_ok());
+    let st = current_state().unwrap();
+    assert_eq!((st.height, st.round, st.step), (10, 0, VoteStep::Prevote as u32));
+    assert_eq!(st.last_sign_bytes_hex.len(), 64);
+
+    // Same tuple + same bytes → replay exempt (Ok, no error).
+    assert!(check_and_record_with_bytes(10, 0, VoteStep::Prevote, p1).is_ok());
+
+    // Same tuple + different bytes → real equivocation (Err).
+    let err = check_and_record_with_bytes(10, 0, VoteStep::Prevote, b"DIFFERENT").unwrap_err();
+    assert_eq!(err.attempted, (10, 0, VoteStep::Prevote as u32));
+    assert_eq!(err.last_signed, (10, 0, VoteStep::Prevote as u32));
+    // Display impl renders the tuple legibly.
+    let s = format!("{}", err);
+    assert!(s.contains("DoubleSignAttempt"));
+    assert!(s.contains("h=10"));
+
+    // Advance step (Prevote → Precommit) at same h/r → Ok.
+    assert!(check_and_record_with_bytes(10, 0, VoteStep::Precommit, b"precommit-bytes").is_ok());
+
+    // Rollback attempt → Err (legacy strict path, empty payload).
+    assert!(check_and_record(10, 0, VoteStep::Prevote).is_err());
+
+    // Legacy callers (no payload bytes) advance forward fine and clear hash.
+    assert!(check_and_record(11, 0, VoteStep::Prevote).is_ok());
+    let st = current_state().unwrap();
+    assert_eq!(st.height, 11);
+    assert!(st.last_sign_bytes_hex.is_empty());
+
+    // After legacy advance the persisted cur_hash is empty; replay path
+    // requires both non-empty → falls through to strict tuple check → Err.
+    assert!(check_and_record_with_bytes(11, 0, VoteStep::Prevote, b"new-bytes").is_err());
+
+    // init() is idempotent — second call when GUARD already set is a no-op.
+    init(dir.path().join("ignored.json")).unwrap();
+    let st = current_state().unwrap();
+    assert_eq!(st.height, 11); // unchanged
+}

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.85"
+version = "2.1.86"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

Closes the rebroadcast bug class that kept `LAST_SIGN_GUARD_PATH` env-disabled cluster-wide since v2.1.84/v2.1.85.

## Bug

BFT engine's proposal/prevote/precommit rebroadcast loop in `bin/sentrix/src/main.rs` (`proposal_rebroadcast_count` cycle, every 2s up to 7 attempts on round timeout) constructs a fresh struct with `signature: vec![]` each cycle and calls `.sign()` again. With the LastSignBytes guard ON, the second cycle saw `(h, r, step) <= last_signed` and refused — leaving signature empty, peers reject via `verify_sig`, validator silent → halt.

## Fix

Same-bytes-replay exemption. New `check_and_record_with_bytes(h, r, step, payload_bytes)` differentiates:
- legitimate rebroadcast (same tuple AND same bytes → Ok, signature regenerated identically)
- real double-vote (same tuple, different bytes → refused)

The `last_sign_bytes_hex` field on `LastSignState` (reserved-but-unused since v2.1.84) now persists `sha256(signing_payload)`. Backwards-compatible: legacy `check_and_record(h, r, step)` still exists, behaves bit-identically to v2.1.85.

## Operations effect

`LAST_SIGN_GUARD_PATH=/var/lib/sentrix/last-sign.json` can be re-enabled cluster-wide after this ships. The structural fix for the recurring beacon-divergence halt class becomes live again.

## Test plan

- [x] cargo test --release -p sentrix-bft last_sign_guard → 13/13 pass
- [x] cargo test --release -p sentrix-bft → 103/103 pass
- [x] cargo build --release --workspace → clean
- [ ] Fresh-brain consensus review per CLAUDE.md discipline (NOT this session)
- [ ] Testnet bake before mainnet activation
- [ ] Cluster-wide deploy (testnet first, then mainnet halt-all + simul-start)
- [ ] Re-enable LAST_SIGN_GUARD_PATH env on all 4 mainnet validators after bake

## Important: this is consensus-touching code

Per `CLAUDE.md` rules: requires fresh-brain review (different session, ideally after `/clear`), regression test that fails on main + passes after, no self-merge in same session. The 5 new replay tests cover the decision rule but the END-TO-END path (BFT engine rebroadcast → sign → guard → broadcast → peer-verify) is exercised only at runtime; testnet bake is the integration check.