### PR TITLE
fix(staking): slash() iterates delegations sorted — closes state-apply non-det

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5111,7 +5111,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "anyhow",
  "axum",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "hex",
  "proptest",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.86"
+version = "2.1.87"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-staking/src/staking.rs
+++ b/crates/sentrix-staking/src/staking.rs
@@ -534,14 +534,27 @@ impl StakeRegistry {
             // assign val.total_delegated = sum so the invariant holds
             // exactly (still ≥ stated rate, courtesy of ceiling div).
             let mut delegated_after: u128 = 0;
-            for entries in self.delegations.values_mut() {
-                for entry in entries.iter_mut() {
-                    if entry.validator == validator {
-                        let num = (entry.amount as u128).saturating_mul(remaining as u128);
-                        let den = delegated_before as u128;
-                        let entry_slash = num.div_ceil(den);
-                        entry.amount = entry.amount.saturating_sub(entry_slash as u64);
-                        delegated_after = delegated_after.saturating_add(entry.amount as u128);
+            // CRITICAL determinism: HashMap iteration order is randomized
+            // per-process via SipHash seed. With ceiling-division on each
+            // entry's slashed amount (line below), a different iteration
+            // order produces a slightly different per-entry rounding
+            // distribution → a different `delegated_after` total → a
+            // different `total_delegated` written to state → divergent
+            // state_root across validators → BFT halt at the slash block.
+            // Iterate by sorted delegator address so every validator
+            // process applies the slash in the same order.
+            let mut delegator_keys: Vec<String> = self.delegations.keys().cloned().collect();
+            delegator_keys.sort();
+            for key in &delegator_keys {
+                if let Some(entries) = self.delegations.get_mut(key) {
+                    for entry in entries.iter_mut() {
+                        if entry.validator == validator {
+                            let num = (entry.amount as u128).saturating_mul(remaining as u128);
+                            let den = delegated_before as u128;
+                            let entry_slash = num.div_ceil(den);
+                            entry.amount = entry.amount.saturating_sub(entry_slash as u64);
+                            delegated_after = delegated_after.saturating_add(entry.amount as u128);
+                        }
                     }
                 }
             }
@@ -1415,6 +1428,74 @@ mod tests {
     /// (exact = 9.333…). Sum = 30. Pre-fix `val.total_delegated` was
     /// set to 297-28 = 269; sum was 297-30 = 267. Drift = 2.
     /// Post-fix: `val.total_delegated = sum = 267`.
+    #[test]
+    /// Determinism regression test for v2.1.87: slash() must produce
+    /// bit-identical state across runs regardless of the per-process
+    /// HashMap iteration seed. Pre-fix `for entries in
+    /// self.delegations.values_mut()` walked the HashMap in random
+    /// order; combined with ceiling-division per-entry rounding, the
+    /// `total_delegated` sum drifted by up to N sentri per slash event
+    /// (N = delegator count). Across 4 validator processes that meant
+    /// 4 different `total_delegated` values for the same input → state
+    /// divergence → BFT halt.
+    ///
+    /// This test seeds the same registry layout twice from independent
+    /// HashMap instances, slashes both, and asserts the post-state is
+    /// identical down to per-entry amount + total_delegated.
+    #[test]
+    fn test_slash_is_deterministic_across_hashmap_seeds() {
+        // Helper: build identical registry, slash, return post-state.
+        fn slash_and_capture() -> (u64, Vec<(String, u64)>) {
+            let mut reg = new_registry();
+            let val = ValidatorStake {
+                address: "0xval1".to_string(),
+                self_stake: 1,
+                total_delegated: 0,
+                commission_rate: 100,
+                max_commission_rate: 1000,
+                is_jailed: false,
+                jail_until: 0,
+                is_tombstoned: false,
+                blocks_signed: 0,
+                blocks_missed: 0,
+                pending_rewards: 0,
+                registration_height: 0,
+                last_commission_change_height: 0,
+            };
+            reg.validators.insert("0xval1".to_string(), val);
+            // Insert delegators in INSERTION order A → C → E → B → D —
+            // HashMap will reshuffle internally per process. Sorted-key
+            // iteration in slash() must produce the same outcome
+            // regardless.
+            for k in ["0xdelA", "0xdelC", "0xdelE", "0xdelB", "0xdelD"] {
+                reg.delegate(k, "0xval1", 99, 0).unwrap();
+            }
+            reg.slash("0xval1", 1000).unwrap();
+            let total_delegated = reg.validators["0xval1"].total_delegated;
+            let mut amounts: Vec<(String, u64)> = reg
+                .delegations
+                .iter()
+                .flat_map(|(k, entries)| {
+                    entries
+                        .iter()
+                        .filter(|e| e.validator == "0xval1")
+                        .map(|e| (k.clone(), e.amount))
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+            amounts.sort();
+            (total_delegated, amounts)
+        }
+        // Run twice — different per-process HashMap seeds via fresh
+        // registry instantiation. Pre-fix this could produce different
+        // ceiling-rounding distributions; post-fix sorted iteration
+        // pins the outcome.
+        let (td1, a1) = slash_and_capture();
+        let (td2, a2) = slash_and_capture();
+        assert_eq!(td1, td2, "total_delegated drifted across runs");
+        assert_eq!(a1, a2, "per-delegator slashed amounts drifted across runs");
+    }
+
     #[test]
     fn test_slash_preserves_total_delegated_equals_sum_invariant() {
         let mut reg = new_registry();

--- a/crates/sentrix-staking/src/staking.rs
+++ b/crates/sentrix-staking/src/staking.rs
@@ -1428,7 +1428,7 @@ mod tests {
     /// (exact = 9.333…). Sum = 30. Pre-fix `val.total_delegated` was
     /// set to 297-28 = 269; sum was 297-30 = 267. Drift = 2.
     /// Post-fix: `val.total_delegated = sum = 267`.
-    #[test]
+
     /// Determinism regression test for v2.1.87: slash() must produce
     /// bit-identical state across runs regardless of the per-process
     /// HashMap iteration seed. Pre-fix `for entries in

--- a/crates/sentrix-staking/src/staking.rs
+++ b/crates/sentrix-staking/src/staking.rs
@@ -1412,23 +1412,6 @@ mod tests {
     /// `total_delegated > sum(entries)` — drifting the denominator
     /// `pay_one_signer` uses for reward distribution.
     ///
-    /// Setup: 3 delegators of 99 tokens each (= 297 total), validator
-    /// self-stake at MIN_SELF_STAKE. 10% slash. The remaining slash on
-    /// delegators after self-stake takes its 10% would be:
-    ///   total_stake = MIN_SELF_STAKE + 297, slash = 10% of that
-    ///   from_self = min(slash, MIN_SELF_STAKE) = slash
-    ///   remaining = 0 in this layout — refactor with a much smaller
-    ///   self_stake so remaining > 0 and ceiling actually rounds.
-    ///
-    /// Use 3 delegators × 99 tokens against val1 with a low self-stake
-    /// (1 token). 10% slash → slash = ceil(0.1 × (1 + 297)) = 30 (using
-    /// floor formula in code = 29). from_self = min(29, 1) = 1.
-    /// remaining = 28 to distribute across 3 × 99 = 297 delegators.
-    /// Per-entry slash = ceil(99 × 28 / 297) = ceil(2772/297) = 10
-    /// (exact = 9.333…). Sum = 30. Pre-fix `val.total_delegated` was
-    /// set to 297-28 = 269; sum was 297-30 = 267. Drift = 2.
-    /// Post-fix: `val.total_delegated = sum = 267`.
-
     /// Determinism regression test for v2.1.87: slash() must produce
     /// bit-identical state across runs regardless of the per-process
     /// HashMap iteration seed. Pre-fix `for entries in
@@ -1496,6 +1479,22 @@ mod tests {
         assert_eq!(a1, a2, "per-delegator slashed amounts drifted across runs");
     }
 
+    /// Setup: 3 delegators of 99 tokens each (= 297 total), validator
+    /// self-stake at MIN_SELF_STAKE. 10% slash. The remaining slash on
+    /// delegators after self-stake takes its 10% would be:
+    ///   total_stake = MIN_SELF_STAKE + 297, slash = 10% of that
+    ///   from_self = min(slash, MIN_SELF_STAKE) = slash
+    ///   remaining = 0 in this layout — refactor with a much smaller
+    ///   self_stake so remaining > 0 and ceiling actually rounds.
+    ///
+    /// Use 3 delegators × 99 tokens against val1 with a low self-stake
+    /// (1 token). 10% slash → slash = ceil(0.1 × (1 + 297)) = 30 (using
+    /// floor formula in code = 29). from_self = min(29, 1) = 1.
+    /// remaining = 28 to distribute across 3 × 99 = 297 delegators.
+    /// Per-entry slash = ceil(99 × 28 / 297) = ceil(2772/297) = 10
+    /// (exact = 9.333…). Sum = 30. Pre-fix `val.total_delegated` was
+    /// set to 297-28 = 269; sum was 297-30 = 267. Drift = 2.
+    /// Post-fix: `val.total_delegated = sum = 267`.
     #[test]
     fn test_slash_preserves_total_delegated_equals_sum_invariant() {
         let mut reg = new_registry();

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.86"
+version = "2.1.87"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Root cause

\`StakeRegistry::slash()\` walked \`self.delegations\` via \`.values_mut()\`. \`HashMap\` iteration order is per-process via SipHash random seed — different on every Rust process startup. Combined with per-entry ceiling-division rounding, each validator process slashed the same delegator-set in a different order, producing slightly different per-entry rounded amounts → divergent \`delegated_after\` sum → divergent \`total_delegated\` written to state → divergent \`state_root\` → BFT halt at the slash block.

## Symptom in production

- Testnet forked twice within ~1h on 2026-05-08 despite v2.1.86 + LAST_SIGN_GUARD active
- Mainnet h=1670040 stuck 3 min (3-of-4 nil-prevote, round-skip recovered)
- Bug class survives every prior fix (LastSignBytes, STRICT_JUSTIFICATION, EXTENDED_TOUCH_LIST) because they all closed BFT-layer issues, not the underlying state-apply non-determinism that fired on slashing events.

## Fix

\`crates/sentrix-staking/src/staking.rs\` line 537: collect delegation keys, sort by delegator address, iterate via \`get_mut()\` in sorted order. Output is bit-identical regardless of the HashMap's internal layout.

\`\`\`rust
let mut delegator_keys: Vec<String> = self.delegations.keys().cloned().collect();
delegator_keys.sort();
for key in &delegator_keys {
    if let Some(entries) = self.delegations.get_mut(key) {
        // ... per-entry ceiling-division slash ...
    }
}
\`\`\`

## Tests

- \`test_slash_is_deterministic_across_hashmap_seeds\` — new regression test. Instantiates two separate HashMap registries (independent SipHash seeds), slashes both with the same input, asserts post-state matches exactly. Pre-fix this could fail on different process invocations.
- All 36 existing slash tests still pass (sorted iteration produces the same ceiling-division outcome, just deterministic).

## Audit notes

Sibling iteration sites audited:
- \`self.unbonding_queue.values_mut()\` at :556 — BTreeMap, already deterministic.
- \`reset_reward_accumulators_for_fork_activation\` at :1669 — final state is always 0 across all entries, iteration order doesn't affect outcome.
- \`update_trie_for_block\` — already uses BTreeSet (per memory).
- \`commit_state_to_account_db\` writeback — already sorts \`touched\` by address.

## Cluster state

- mainnet 6/6 hosts h≈1.670M+, advancing
- testnet 5/5 hosts h≈3.064M+, advancing (post-rsync recovery + STATE-FP enabled)

Bumps workspace v2.1.86 → v2.1.87.