### PR TITLE
fix(channel): bft_tx + event_tx capacity 4096 → 16384 (closes BFT split-brain under load)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5111,7 +5111,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "anyhow",
  "axum",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "hex",
  "proptest",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.87"
+version = "2.1.88"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1305,7 +1305,13 @@ async fn cmd_start(
     // validator-loop pause without losing the await-based send semantics
     // that BFT requires (dropped votes destabilise consensus more than
     // backpressure does).
-    let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<NodeEvent>(4096);
+    // 2026-05-08 v2.1.88: bumped 4096 → 16384 after testnet observed 8671
+    // bft_tx FULL drops in 30 min on a fullnode under catch-up sync, which
+    // produced BFT split-brain at h=3066004 (validators received proposals
+    // at different rounds → 2-2 fork → halt). Channel back-pressure is
+    // worse for consensus stability than the extra ~2 MB RAM cost of
+    // deeper buffering.
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<NodeEvent>(16384);
 
     // ── P2P: libp2p TCP + Noise + Yamux ─────────────────
     println!("P2P transport: libp2p (Noise encrypted)");
@@ -1373,15 +1379,16 @@ async fn cmd_start(
     let shutdown_flag = Arc::new(AtomicBool::new(false));
 
     // BFT event channel — forwards P2P BFT votes from event handler to validator loop
-    // Same 4096 capacity rationale as event_tx above. This is the
-    // event-handler → validator-loop hop; when validator pauses (e.g.
-    // long write lock during epoch boundary processing), incoming BFT
-    // messages buffer here. 256 slots was tight enough that a slow
-    // finalize would stall the event handler trying to forward;
-    // 4096 gives enough margin that the validator's heartbeat watchdog
-    // catches a truly stuck loop before this channel saturates.
+    // Capacity history: 256 → 4096 (v2.1.65) → 16384 (v2.1.88).
+    // 2026-05-08 v2.1.88: bumped 4096 → 16384 after testnet halt at
+    // h=3066004 traced to BFT split-brain caused by upstream channel
+    // back-pressure. fullnode-1 logged 8671 bft_tx FULL drops in 30 min
+    // under catch-up sync; under that pressure validators received
+    // proposals at different rounds → 2-2 fork → halt. Deeper buffer
+    // gives the main loop time to drain MDBX-write backlogs before
+    // dropping consensus messages. Cost: ~3 MB extra RAM per validator.
     let (bft_tx, bft_rx) =
-        tokio::sync::mpsc::channel::<sentrix::core::bft_messages::BftMessage>(4096);
+        tokio::sync::mpsc::channel::<sentrix::core::bft_messages::BftMessage>(16384);
 
     // 2026-05-05 v2.1.68: cumulative count of BFT messages dropped because
     // bft_tx was full when the event-handler tokio task tried to forward

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.87"
+version = "2.1.88"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Symptom

Testnet halted at h=3066004 (2026-05-08 ~22:30 CEST) via BFT split-brain 2-2 fork:
- val1 + val3: hash=75026034
- val4 (alone, ahead): h=3066005 hash=c1bfda75
- val2 (alone, behind): h=3066003

STATE-FP traces showed cross-validator state determinism (PR #551 slash() fix in v2.1.87 confirmed working). Divergence was at the BFT **consensus** layer, not state-apply.

## Root cause

fullnode-1 logs:
\`\`\`
ERROR bft_tx_drop: bft_tx FULL (4096/4096) — DROPPED inbound BftPrevote
(total drops since boot: 8671)
\`\`\`

8671 dropped messages in 30 min under catch-up sync. Channel saturation = inbound BFT messages lost at network boundary → validator main loop sees stale BFT view → votes on wrong round → 2-2 split-brain → halt.

## Fix

Bump both channel capacities to 16384 (4× headroom):
- \`event_tx\` (libp2p → handler) at bin/sentrix/src/main.rs:1308
- \`bft_tx\` (handler → validator loop) at bin/sentrix/src/main.rs:1384

Capacity history: 256 → 4096 (v2.1.65) → 16384 (v2.1.88).

## Cost vs benefit

- Cost: ~3 MB extra RAM per validator (negligible vs 8 GB+ allocated)
- Benefit: drains MDBX-write backlogs before dropping consensus messages

## Cluster state at PR creation

- Mainnet 6/6 v2.1.87, h≈1.671M+, advancing
- Testnet 5/5 v2.1.87 (just recovered from this halt via halt-rsync), h=3.066M+

Bumps workspace v2.1.87 → v2.1.88.