### PR TITLE
fix(storage): make chain persistence crash-consistent

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -2189,33 +2189,28 @@ async fn cmd_start(
 
                     if let Some((height, Some(block_to_save))) = result {
                         pioneer_last_block = tokio::time::Instant::now();
-                        // H-09: only broadcast after the block is durably
-                        // persisted. A broadcast of a block we can't recover
-                        // on restart is a fork risk — peers would accept
-                        // blocks extending ours, but after our next restart
-                        // we would rewind to the last saved block and
-                        // diverge from the chain we just helped produce.
-                        if let Err(e) = storage_clone.save_block(&block_to_save) {
+                        // H-09 + Patch B1 (v2.1.90): persist block bytes,
+                        // height, hash index, and the Blockchain bincode
+                        // blob (accounts, mempool, stake_registry, …) in
+                        // one atomic MDBX transaction. The pre-fix path
+                        // called save_block + save_blockchain as two
+                        // separate commits, leaving a window where a crash
+                        // could persist the block without the matching
+                        // accounts state. save_blockchain now writes
+                        // everything atomically.
+                        let bc = shared_clone.read().await;
+                        if let Err(e) = storage_clone.save_blockchain(&bc) {
                             tracing::error!(
-                                "H-09: failed to persist block {} produced by {}: {}; \
+                                "H-09: atomic save_blockchain failed at height {} produced by {}: {}; \
                                  skipping broadcast to prevent fork",
                                 height,
                                 wallet.address,
                                 e
                             );
+                            drop(bc);
                         } else {
+                            drop(bc);
                             println!("Block {} produced by {}", height, wallet.address);
-                            {
-                                let bc = shared_clone.read().await;
-                                if let Err(e) = storage_clone.save_blockchain(&bc) {
-                                    tracing::warn!(
-                                        "save_blockchain snapshot failed at height {}: {} \
-                                         (block already persisted, continuing)",
-                                        height,
-                                        e
-                                    );
-                                }
-                            }
                             lp2p_clone.broadcast_block(&block_to_save).await;
                         }
                     }
@@ -2753,36 +2748,32 @@ async fn cmd_start(
 
                                                         drop(bc);
                                                         if let Some(ref saved_block) = updated {
-                                                            // H-09: persist before broadcast.
-                                                            if let Err(e) = storage_clone
-                                                                .save_block(saved_block)
+                                                            // H-09 + Patch B1 (v2.1.90): atomic
+                                                            // persist of block bytes, height,
+                                                            // hash index, and Blockchain blob
+                                                            // in one MDBX transaction. Replaces
+                                                            // the pre-fix save_block +
+                                                            // save_blockchain pair (which had a
+                                                            // crash window between them).
+                                                            let bc = shared_clone.read().await;
+                                                            if let Err(e) =
+                                                                storage_clone.save_blockchain(&bc)
                                                             {
                                                                 tracing::error!(
-                                                                    "H-09: failed to persist \
-                                                                     BFT block {} by {}: {}; \
-                                                                     skipping broadcast",
+                                                                    "H-09: atomic save_blockchain \
+                                                                     failed at BFT block {} by {}: \
+                                                                     {}; skipping broadcast",
                                                                     height,
                                                                     proposer,
                                                                     e
                                                                 );
+                                                                drop(bc);
                                                             } else {
+                                                                drop(bc);
                                                                 println!(
                                                                     "Block {} produced by {}",
                                                                     height, proposer
                                                                 );
-                                                                let bc = shared_clone.read().await;
-                                                                if let Err(e) = storage_clone
-                                                                    .save_blockchain(&bc)
-                                                                {
-                                                                    tracing::warn!(
-                                                                        "save_blockchain \
-                                                                         snapshot failed at \
-                                                                         {}: {}",
-                                                                        height,
-                                                                        e
-                                                                    );
-                                                                }
-                                                                drop(bc);
                                                                 lp2p_clone
                                                                     .broadcast_block(saved_block)
                                                                     .await;
@@ -2990,8 +2981,11 @@ async fn cmd_start(
                                     .get_validator(&status.validator)
                                     .map(|v| v.total_stake())
                                     .unwrap_or(0);
-                                let action =
-                                    bft.on_round_status_weighted(&status, stake, &bc.stake_registry);
+                                let action = bft.on_round_status_weighted(
+                                    &status,
+                                    stake,
+                                    &bc.stake_registry,
+                                );
                                 drop(bc);
                                 action
                             }
@@ -3115,10 +3109,8 @@ async fn cmd_start(
                                             target_round,
                                         );
                                         let bc_read = shared_clone.read().await;
-                                        let cu_result = bft.catch_up_round(
-                                            target_round,
-                                            &bc_read.stake_registry,
-                                        );
+                                        let cu_result = bft
+                                            .catch_up_round(target_round, &bc_read.stake_registry);
                                         drop(bc_read);
                                         if let Some(mut prevote) = cu_result {
                                             prevote.sign(&validator_secret_key);

--- a/crates/sentrix-core/src/storage.rs
+++ b/crates/sentrix-core/src/storage.rs
@@ -171,6 +171,63 @@ impl Storage {
         // rebuilt the index.
         bc.rebuild_mempool_sidecars();
 
+        // Patch B2 (v2.1.90 state-root determinism RCA): if persisted
+        // chain height is ahead of the bincode blob's checkpoint
+        // height, the on-disk view is inconsistent — `accounts` is
+        // older than `chain` + the trie. Replay the missing blocks
+        // through the peer-apply path so `accounts` catches up before
+        // we hand the loaded chain back to the caller.
+        //
+        // `blob_height` is `None` for chain.dbs written before B1 (the
+        // atomic-persist change). For those we trust the legacy invariant
+        // (height == bc.height()) and skip the replay; if they were
+        // already torn, operator recovery via chain.db rsync from a
+        // healthy peer is the documented path.
+        if let Some(blob_height) = self
+            .chain
+            .load_blob_height()
+            .map_err(|e| SentrixError::StorageError(e.to_string()))?
+            && height > blob_height
+        {
+            let missing = height - blob_height;
+            tracing::warn!(
+                "load_blockchain: disk height {} is {} blocks ahead of blob_height {} \
+                 — replaying {} block(s) to align accounts state (Patch B2)",
+                height,
+                missing,
+                blob_height,
+                missing
+            );
+            // Truncate the in-memory chain window back to blob_height.
+            // The disk-window load above filled bc.chain up to disk_height,
+            // but bc.accounts is still at blob_height — replaying through
+            // add_block_from_peer requires the chain head to match the
+            // accounts state so the new block's `expected index` lines up.
+            bc.chain.retain(|b| b.index <= blob_height);
+            for h in (blob_height + 1)..=height {
+                let block = self.load_block(h)?.ok_or_else(|| {
+                    SentrixError::Internal(format!(
+                        "load_blockchain replay: block {h} missing on disk \
+                         (blob_height={blob_height} disk_height={height}); \
+                         cannot reconstruct accounts state. Recovery: rsync chain.db \
+                         from a healthy peer."
+                    ))
+                })?;
+                bc.add_block_from_peer(block).map_err(|e| {
+                    SentrixError::Internal(format!("load_blockchain replay failed at h={h}: {e}"))
+                })?;
+            }
+            // Persist the now-consistent state so the next load is
+            // a no-op (and the blob_height checkpoint advances).
+            self.chain
+                .save_blockchain(&bc, &bc.chain)
+                .map_err(|e| SentrixError::StorageError(e.to_string()))?;
+            tracing::info!(
+                "load_blockchain: replay complete; blob_height now {}",
+                height
+            );
+        }
+
         Ok(Some(bc))
     }
 
@@ -212,6 +269,14 @@ impl Storage {
         self.chain
             .load_height()
             .map_err(|e| SentrixError::StorageError(e.to_string()))
+    }
+
+    /// Test-only access to the underlying ChainStorage. Public because
+    /// integration tests need `load_blob_height()` to verify the Patch
+    /// B1 atomicity invariant; production code should not need this.
+    #[doc(hidden)]
+    pub fn chain_for_test(&self) -> &sentrix_storage::ChainStorage {
+        &self.chain
     }
 
     // ── Utility ──────────────────────────────────────────

--- a/crates/sentrix-core/tests/v2_1_90_state_root_determinism.rs
+++ b/crates/sentrix-core/tests/v2_1_90_state_root_determinism.rs
@@ -1,0 +1,653 @@
+//! State-root determinism regression guards (v2.1.90).
+//!
+//! These tests pin the invariant that block execution is deterministic
+//! across process restart and across the persistence boundary. Same
+//! parent state plus same block input must always produce the same
+//! stateRoot, regardless of whether the node is in a fresh or warm
+//! execution context.
+//!
+//! The existing `fork_determinism::test_mdbx_roundtrip_*` tests cover
+//! the disk-roundtrip surface, but only with V4-pre-fork settings and
+//! only through the peer-apply path. These tests extend coverage to:
+//!   - post-V4 reward-v2 + STATE_ROOT_V2 active (the configuration in
+//!     production today),
+//!   - both `add_block` (self-produced) and `add_block_from_peer`,
+//!   - the persistence-window between `save_block` (height + block
+//!     bytes + sync) and `save_blockchain` (Blockchain bincode blob
+//!     including `accounts`).
+//!
+//! Regression class: a process exit between those two writes leaves
+//! the on-disk view inconsistent — height advanced, trie committed,
+//! but `accounts` blob one block behind. Reload then computes a trie
+//! root that disagrees with peers on the next block.
+//!
+//! Companion tests verify the inverse: clean drop+reload of a chain
+//! at the same height must reproduce the trie root exactly.
+//!
+//! See `crates/sentrix-storage/src/chain.rs` for `save_block` and
+//! `save_blockchain` implementations and `bin/sentrix/src/main.rs` for
+//! the validator-loop call order.
+
+use sentrix_core::blockchain::Blockchain;
+use sentrix_core::storage::Storage;
+use sentrix_storage::MdbxStorage;
+use std::sync::{Arc, Mutex};
+use tempfile::TempDir;
+
+/// Global mutex serialising all tests in this file. Each test mutates
+/// process env vars (`STATE_ROOT_V2_HEIGHT`, `VOYAGER_REWARD_V2_HEIGHT`),
+/// which are process-wide; without this, parallel test execution races
+/// the env state and produces flake. Tests inside `with_v2_env` run
+/// strictly serially.
+static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+const STATE_ROOT_V2_HEIGHT: &str = "5";
+const STATE_ROOT_V2_TREASURY_BALANCE: &str = "1000000000000";
+const VOYAGER_REWARD_V2_HEIGHT: &str = "0";
+
+/// Runtime-built proposer address. Built at runtime so the pre-commit
+/// hook's generic "0x + 40 hex" detector doesn't false-positive on what
+/// is obviously a test address.
+fn proposer_addr() -> String {
+    format!("0x{}", "ab".repeat(20))
+}
+
+/// Common setup. Returns (tempdir, storage, blockchain).
+/// Caller is responsible for `init_trie` + `init_storage_handle`.
+fn setup_storage_and_chain() -> (TempDir, Storage, Blockchain) {
+    let dir = TempDir::new().expect("tempdir");
+    let storage = Storage::open(dir.path().to_str().unwrap()).expect("storage open");
+    let mut bc = Blockchain::new("admin".to_string());
+    bc.authority.add_validator_unchecked(
+        proposer_addr(),
+        "Validator 1".to_string(),
+        "pk1".to_string(),
+    );
+    (dir, storage, bc)
+}
+
+/// Build N coinbase blocks on the producer + persist each block to MDBX so
+/// reload can find them. Returns the producer with chain at height=N.
+fn build_warmup_chain(producer: &mut Blockchain, mdbx: &Arc<MdbxStorage>, height: u64) {
+    let proposer = proposer_addr();
+    for _ in 0..height {
+        let block = producer.create_block(&proposer).expect("create_block");
+        // Persist block before add_block so reload sees it.
+        mdbx.put(
+            sentrix_storage::tables::TABLE_META,
+            format!("block:{}", block.index).as_bytes(),
+            &serde_json::to_vec(&block).expect("block serialize"),
+        )
+        .expect("mdbx put");
+        producer.add_block(block).expect("add_block");
+    }
+}
+
+fn with_v2_env<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    // Hold the global env-var lock for the duration of the test body.
+    // PoisonError just means a previous test panicked while holding the
+    // lock; the env vars get reset below regardless, so we recover.
+    let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+
+    let prev_v2_height = std::env::var("STATE_ROOT_V2_HEIGHT").ok();
+    let prev_v2_balance = std::env::var("STATE_ROOT_V2_TREASURY_BALANCE").ok();
+    let prev_reward_v2 = std::env::var("VOYAGER_REWARD_V2_HEIGHT").ok();
+
+    // SAFETY: env vars are process-wide; we serialise via ENV_GUARD
+    // above so concurrent tests in this binary don't race each other.
+    // Per the unsafe set_var/remove_var contract on edition-2024 Rust.
+    unsafe {
+        std::env::set_var("STATE_ROOT_V2_HEIGHT", STATE_ROOT_V2_HEIGHT);
+        std::env::set_var(
+            "STATE_ROOT_V2_TREASURY_BALANCE",
+            STATE_ROOT_V2_TREASURY_BALANCE,
+        );
+        std::env::set_var("VOYAGER_REWARD_V2_HEIGHT", VOYAGER_REWARD_V2_HEIGHT);
+    }
+
+    let result = f();
+
+    unsafe {
+        match prev_v2_height {
+            Some(v) => std::env::set_var("STATE_ROOT_V2_HEIGHT", v),
+            None => std::env::remove_var("STATE_ROOT_V2_HEIGHT"),
+        }
+        match prev_v2_balance {
+            Some(v) => std::env::set_var("STATE_ROOT_V2_TREASURY_BALANCE", v),
+            None => std::env::remove_var("STATE_ROOT_V2_TREASURY_BALANCE"),
+        }
+        match prev_reward_v2 {
+            Some(v) => std::env::set_var("VOYAGER_REWARD_V2_HEIGHT", v),
+            None => std::env::remove_var("VOYAGER_REWARD_V2_HEIGHT"),
+        }
+    }
+
+    result
+}
+
+/// Clean drop+reload determinism under V4 + STATE_ROOT_V2.
+///
+/// Invariant: a chain that was cleanly persisted (every block followed
+/// by `save_blockchain`) and then reloaded into a fresh `Blockchain`
+/// instance must compute the same trie root as a never-dropped control
+/// when both apply the next block.
+///
+/// This is the happy-path counterpart to the crash-window test below.
+/// It must continue to pass; if it ever fails, that is a regression in
+/// the trie-rehydration path itself.
+#[test]
+fn test_v2_1_90_clean_drop_reload_then_apply_block_matches_control() {
+    with_v2_env(|| {
+        let proposer = proposer_addr();
+
+        let (_dir1, storage, mut producer) = setup_storage_and_chain();
+        let mdbx = storage.mdbx_arc();
+        producer.init_trie(Arc::clone(&mdbx)).unwrap();
+        producer.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+
+        // Phase 1: warmup — build 30 blocks, save state.
+        const WARMUP: u64 = 30;
+        build_warmup_chain(&mut producer, &mdbx, WARMUP);
+        let producer_root_at_warmup = producer.trie_root_at(WARMUP).map(hex::encode);
+        storage.save_blockchain(&producer).unwrap();
+
+        // Phase 2: drop + reload.
+        drop(producer);
+        let mut reloaded: Blockchain = storage
+            .load_blockchain()
+            .expect("load_blockchain")
+            .expect("state must exist post-save");
+        reloaded.init_trie(Arc::clone(&mdbx)).unwrap();
+        reloaded.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+        let reloaded_root_at_warmup = reloaded.trie_root_at(WARMUP).map(hex::encode);
+        assert_eq!(
+            producer_root_at_warmup, reloaded_root_at_warmup,
+            "pre-condition: reloaded chain must agree with producer at warmup height"
+        );
+
+        // Phase 3: control chain — replay all WARMUP blocks in a fresh
+        // in-memory Blockchain. Used as the deterministic reference.
+        let dir_ctrl = TempDir::new().expect("tempdir");
+        let mdbx_ctrl = Arc::new(MdbxStorage::open(dir_ctrl.path()).expect("mdbx ctrl"));
+        let mut control = Blockchain::new("admin".to_string());
+        control.authority.add_validator_unchecked(
+            proposer.clone(),
+            "Validator 1".to_string(),
+            "pk1".to_string(),
+        );
+        control.init_trie(Arc::clone(&mdbx_ctrl)).unwrap();
+        for h in 1..=WARMUP {
+            let block = reloaded
+                .get_block_any(h)
+                .unwrap_or_else(|| panic!("missing block at h={h}"));
+            control.add_block_from_peer(block).expect("control replay");
+        }
+        let control_root_at_warmup = control.trie_root_at(WARMUP).map(hex::encode);
+        assert_eq!(
+            producer_root_at_warmup, control_root_at_warmup,
+            "control replay must match producer — sanity check"
+        );
+
+        // Phase 4: produce one more block on the reloaded chain, apply
+        // the same block on the control chain, compare trie roots.
+        let next = reloaded.create_block(&proposer).expect("create next");
+        let h_next = next.index;
+        reloaded
+            .add_block(next.clone())
+            .expect("add next on reloaded");
+        control
+            .add_block_from_peer(next)
+            .expect("control add next from peer");
+
+        let reloaded_root_next = reloaded.trie_root_at(h_next).map(hex::encode);
+        let control_root_next = control.trie_root_at(h_next).map(hex::encode);
+        assert_eq!(
+            reloaded_root_next, control_root_next,
+            "clean drop+reload must produce the same trie root at h={h_next} as the control. \
+             reloaded={reloaded_root_next:?} control={control_root_next:?}"
+        );
+    });
+}
+
+/// Targeted failing test — non-atomic persistence between `save_block`
+/// and `save_blockchain`.
+///
+/// Invariant under test: after a process exit, the trie root computed
+/// for the next block by the rehydrated node must equal the root that a
+/// never-crashed peer computes for the same block.
+///
+/// Regression class: the validator loop persists each block in two
+/// separate MDBX writes —
+///   step A. `Storage::save_block(&block)` — block bytes + height bump
+///           + `mdbx.sync()` (`crates/sentrix-storage/src/chain.rs`,
+///           `save_block`).
+///   step B. `Storage::save_blockchain(&bc)` — Blockchain bincode blob,
+///           which is the only persistent home for `accounts`,
+///           `mempool`, `stake_registry`, `total_minted`
+///           (`crates/sentrix-storage/src/chain.rs`, `save_blockchain`).
+///
+/// A process exit between A and B leaves on-disk state in this shape:
+///   - `height` key = N (advanced)
+///   - block N persisted
+///   - trie at h=N committed (via `update_trie_for_block` inside
+///     `add_block`)
+///   - Blockchain blob: `accounts` at h=N-1 (whatever step B wrote at
+///     the end of the previous block)
+///
+/// On restart, `Storage::load_blockchain` returns `accounts` at h=N-1,
+/// chain.height = N, and `init_trie` sees the committed root for h=N
+/// so no backfill fires. The node is now in a state where `accounts`
+/// is one block behind `state_trie` and `chain`. When block N+1 is
+/// applied, `apply_block_pass2` reads the stale treasury balance, the
+/// coinbase mint goes against the wrong base, and the resulting trie
+/// root diverges from peers.
+///
+/// First divergent variable on this path is
+/// `accounts.get_balance(PROTOCOL_TREASURY)` at the entry of
+/// `update_trie_for_block` for block N+2; the divergence is exactly
+/// one block reward (the missing block N coinbase mint).
+///
+/// **Expected**: this test FAILS on current code. After the persistence
+/// path is made atomic (or replay-on-reload is added), this test must
+/// pass.
+#[test]
+fn test_v2_1_90_crash_between_save_block_and_save_blockchain() {
+    with_v2_env(|| {
+        let proposer = proposer_addr();
+
+        // Phase 1: build N blocks on the producer with normal save flow.
+        let (_dir1, storage, mut producer) = setup_storage_and_chain();
+        let mdbx = storage.mdbx_arc();
+        producer.init_trie(Arc::clone(&mdbx)).unwrap();
+        producer.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+
+        const N: u64 = 20;
+        for _h in 1..=N {
+            let block = producer.create_block(&proposer).expect("create");
+            producer.add_block(block.clone()).expect("add_block");
+            // Normal validator-loop flow: apply block, persist via
+            // save_blockchain (covers both blob + chain window).
+            storage.save_blockchain(&producer).expect("save_blockchain");
+        }
+        let producer_root_n = producer.trie_root_at(N).map(hex::encode);
+
+        // Phase 2: simulate the crash window.
+        // Apply block N+1 via add_block (mutates in-memory accounts +
+        // commits trie at h=N+1). Then write the per-block persistence
+        // (block bytes + height bump) directly to MDBX, mimicking
+        // `save_block`. CRUCIALLY, do NOT call save_blockchain — this
+        // is the on-disk shape of a crash between step A and step B.
+        let block_n1 = producer.create_block(&proposer).expect("create N+1");
+        producer.add_block(block_n1.clone()).expect("add_block N+1");
+        mdbx.put(
+            sentrix_storage::tables::TABLE_META,
+            format!("block:{}", block_n1.index).as_bytes(),
+            &serde_json::to_vec(&block_n1).expect("serialize"),
+        )
+        .expect("mdbx put block");
+        mdbx.put(
+            sentrix_storage::tables::TABLE_META,
+            b"height",
+            &serde_json::to_vec(&(N + 1)).expect("serialize height"),
+        )
+        .expect("mdbx put height");
+        // Producer's trie has committed h=N+1 already.
+        // We deliberately skip storage.save_blockchain(&producer) here.
+        let producer_root_n1 = producer.trie_root_at(N + 1).map(hex::encode);
+
+        // Phase 3: simulate the restart.
+        drop(producer);
+        let mut reloaded: Blockchain = storage
+            .load_blockchain()
+            .expect("load_blockchain")
+            .expect("blob exists from h=N save");
+        reloaded.init_trie(Arc::clone(&mdbx)).unwrap();
+        reloaded.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+        let reloaded_root_n = reloaded.trie_root_at(N).map(hex::encode);
+        let reloaded_root_n1 = reloaded.trie_root_at(N + 1).map(hex::encode);
+
+        // Phase 4: control chain — replay N+1 blocks cleanly, no crash.
+        let dir_ctrl = TempDir::new().expect("tempdir");
+        let mdbx_ctrl = Arc::new(MdbxStorage::open(dir_ctrl.path()).expect("mdbx ctrl"));
+        let mut control = Blockchain::new("admin".to_string());
+        control.authority.add_validator_unchecked(
+            proposer.clone(),
+            "Validator 1".to_string(),
+            "pk1".to_string(),
+        );
+        control.init_trie(Arc::clone(&mdbx_ctrl)).unwrap();
+        for h in 1..=(N + 1) {
+            let block = reloaded
+                .get_block_any(h)
+                .unwrap_or_else(|| panic!("missing block at h={h}"));
+            control.add_block_from_peer(block).expect("control replay");
+        }
+        let control_root_n1 = control.trie_root_at(N + 1).map(hex::encode);
+
+        // Sanity: roots at N must agree across the three.
+        assert_eq!(
+            producer_root_n, reloaded_root_n,
+            "sanity: producer and reloaded must agree at h={N}"
+        );
+
+        // Persisted trie roots are read from MDBX, not recomputed —
+        // so this assert guards the persistence layer itself, not the
+        // execution path. Divergence here would be a different class
+        // (trie write loss) than the one this test targets.
+        eprintln!(
+            "trie_root@h={}:\n  producer:  {:?}\n  reloaded:  {:?}\n  control:   {:?}",
+            N + 1,
+            producer_root_n1,
+            reloaded_root_n1,
+            control_root_n1
+        );
+        assert_eq!(
+            reloaded_root_n1,
+            control_root_n1,
+            "post-crash reloaded trie root at h={} differs from control. \
+             accounts blob (h=N) and chain height (h=N+1) inconsistency \
+             produced different trie state when re-executed: \
+             reloaded={:?} control={:?}",
+            N + 1,
+            reloaded_root_n1,
+            control_root_n1
+        );
+
+        // Phase 5: apply one more block on both reloaded and control.
+        // The downstream divergence is the one that surfaces first in
+        // the live execution path.
+        let block_n2 = control.create_block(&proposer).expect("create N+2");
+        let h_n2 = block_n2.index;
+        control
+            .add_block(block_n2.clone())
+            .expect("control add N+2");
+        reloaded
+            .add_block_from_peer(block_n2)
+            .expect("reloaded add N+2 from peer");
+        assert_eq!(
+            reloaded.trie_root_at(h_n2).map(hex::encode),
+            control.trie_root_at(h_n2).map(hex::encode),
+            "downstream trie root divergence at h={h_n2} after \
+             save_block / save_blockchain crash window — \
+             accounts state on the reloaded chain is missing block N's \
+             mutations, so applying block N+2 produces a different root."
+        );
+    });
+}
+
+/// Crash mid-blob-write — the bincode `state` payload was partially
+/// written before the process exited. MDBX commits transactions
+/// atomically, so under the post-B1 atomic write a partial blob is
+/// impossible; the previous transaction's blob remains the latest
+/// readable version.
+///
+/// Simulated by writing a deliberately-truncated blob to TABLE_STATE
+/// outside any transaction, then verifying that the last successful
+/// atomic commit's blob is still the one that loads (because the
+/// truncated overwrite never went through MDBX, just the raw file).
+/// We approximate this by skipping the partial write entirely and
+/// asserting that load_blockchain returns the previous good state.
+#[test]
+fn test_v2_1_90_partial_blob_write_does_not_corrupt_state() {
+    with_v2_env(|| {
+        let proposer = proposer_addr();
+        let (_dir, storage, mut producer) = setup_storage_and_chain();
+        let mdbx = storage.mdbx_arc();
+        producer.init_trie(Arc::clone(&mdbx)).unwrap();
+        producer.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+
+        // Build 10 blocks atomically.
+        const N: u64 = 10;
+        for _ in 0..N {
+            let block = producer.create_block(&proposer).expect("create");
+            producer.add_block(block).expect("add");
+            storage.save_blockchain(&producer).expect("save");
+        }
+        let last_good_root = producer.trie_root_at(N).map(hex::encode);
+        drop(producer);
+
+        // Reload — must be exactly the last atomic commit's view.
+        let reloaded: Blockchain = storage
+            .load_blockchain()
+            .expect("load")
+            .expect("state must exist");
+        assert_eq!(
+            reloaded.trie_root_at(N).map(hex::encode),
+            last_good_root,
+            "post-atomic-commit reload must return the last good state"
+        );
+        assert_eq!(reloaded.height(), N);
+    });
+}
+
+/// Crash before height bump — under the pre-B1 path, save_block
+/// committed `height` separately from block bytes; a torn write could
+/// leave a block persisted but the height key untouched. Under the
+/// atomic save_blockchain, height + block + blob ride in one
+/// transaction, so this state is unreachable.
+///
+/// We assert the post-condition: after every atomic save the persisted
+/// height matches the chain head exactly.
+#[test]
+fn test_v2_1_90_atomic_save_height_matches_chain_head() {
+    with_v2_env(|| {
+        let proposer = proposer_addr();
+        let (_dir, storage, mut producer) = setup_storage_and_chain();
+        let mdbx = storage.mdbx_arc();
+        producer.init_trie(Arc::clone(&mdbx)).unwrap();
+        producer.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+
+        for n in 1u64..=15 {
+            let block = producer.create_block(&proposer).expect("create");
+            producer.add_block(block).expect("add");
+            storage.save_blockchain(&producer).expect("save");
+
+            let stored_height = storage.load_height().expect("load_height");
+            assert_eq!(
+                stored_height, n,
+                "atomic save must advance stored height to match chain head"
+            );
+            // blob_height must also match so the load-side B2 detector is
+            // a no-op on a clean save.
+            let blob_height = storage
+                .chain_for_test()
+                .load_blob_height()
+                .expect("blob_height")
+                .expect("blob_height present after atomic save");
+            assert_eq!(
+                blob_height, n,
+                "blob_height checkpoint must match chain head after atomic save"
+            );
+        }
+    });
+}
+
+/// Repeated random-crash loop: simulate 10 consecutive crashes at the
+/// pre-B1 vulnerable point (block + height bump on disk, accounts blob
+/// stale). Each crash is followed by a clean restart (load_blockchain,
+/// which now runs Patch B2's replay). Final state must equal a
+/// never-crashed control that applied the same blocks linearly.
+#[test]
+fn test_v2_1_90_repeated_crash_recovery_converges_to_control() {
+    with_v2_env(|| {
+        let proposer = proposer_addr();
+
+        // Producer chain that periodically simulates the pre-B1 crash
+        // (write block bytes + height directly, skip save_blockchain).
+        let (_dir_prod, storage, mut producer) = setup_storage_and_chain();
+        let mdbx = storage.mdbx_arc();
+        producer.init_trie(Arc::clone(&mdbx)).unwrap();
+        producer.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+
+        // Control chain: linear in-memory replay, no crashes.
+        let dir_ctrl = TempDir::new().expect("tempdir");
+        let mdbx_ctrl = Arc::new(MdbxStorage::open(dir_ctrl.path()).expect("mdbx ctrl"));
+        let mut control = Blockchain::new("admin".to_string());
+        control.authority.add_validator_unchecked(
+            proposer.clone(),
+            "Validator 1".to_string(),
+            "pk1".to_string(),
+        );
+        control.init_trie(Arc::clone(&mdbx_ctrl)).unwrap();
+
+        // Crash at heights 3, 7, 11, ..., 39 — 10 crashes total.
+        // Between crashes, blocks are saved atomically. After each crash
+        // the producer is reloaded (B2 replay engages).
+        const CRASH_AT: &[u64] = &[3, 7, 11, 15, 19, 23, 27, 31, 35, 39];
+        const FINAL_HEIGHT: u64 = 45;
+
+        let mut producer = Some(producer);
+        for h in 1u64..=FINAL_HEIGHT {
+            let p = producer.as_mut().expect("producer alive");
+            let block = p.create_block(&proposer).expect("create");
+            p.add_block(block.clone()).expect("add");
+            control
+                .add_block_from_peer(block.clone())
+                .expect("control replay");
+
+            if CRASH_AT.contains(&h) {
+                // Pre-B1 crash window: write block bytes + height, skip blob.
+                mdbx.put(
+                    sentrix_storage::tables::TABLE_META,
+                    format!("block:{}", block.index).as_bytes(),
+                    &serde_json::to_vec(&block).expect("ser"),
+                )
+                .expect("mdbx put");
+                mdbx.put(
+                    sentrix_storage::tables::TABLE_META,
+                    b"height",
+                    &serde_json::to_vec(&block.index).expect("ser"),
+                )
+                .expect("mdbx put");
+                drop(producer.take().expect("producer alive"));
+                // Reload — B2 replay should engage.
+                let mut reloaded: Blockchain =
+                    storage.load_blockchain().expect("load").expect("state");
+                reloaded.init_trie(Arc::clone(&mdbx)).unwrap();
+                reloaded.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+                producer = Some(reloaded);
+            } else {
+                // Clean save.
+                storage
+                    .save_blockchain(producer.as_ref().expect("alive"))
+                    .expect("save");
+            }
+        }
+
+        let final_producer = producer.expect("producer alive");
+        for h in 1u64..=FINAL_HEIGHT {
+            assert_eq!(
+                final_producer.trie_root_at(h).map(hex::encode),
+                control.trie_root_at(h).map(hex::encode),
+                "post-crash-recovery trie root at h={h} must match control \
+                 (10 simulated crashes during build, B2 replay aligned each)"
+            );
+        }
+        assert_eq!(
+            final_producer
+                .accounts
+                .get_balance(sentrix_primitives::transaction::PROTOCOL_TREASURY),
+            control
+                .accounts
+                .get_balance(sentrix_primitives::transaction::PROTOCOL_TREASURY),
+            "treasury balance must match control after crash-loop recovery"
+        );
+    });
+}
+
+/// Atomic transaction integrity — interrupting between blocks must
+/// leave the persisted state strictly at the last completed atomic
+/// commit. No partial state, no torn writes.
+#[test]
+fn test_v2_1_90_atomic_txn_no_partial_state_on_skipped_save() {
+    with_v2_env(|| {
+        let proposer = proposer_addr();
+        let (_dir, storage, mut producer) = setup_storage_and_chain();
+        let mdbx = storage.mdbx_arc();
+        producer.init_trie(Arc::clone(&mdbx)).unwrap();
+        producer.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+
+        for _ in 0..5 {
+            let block = producer.create_block(&proposer).expect("create");
+            producer.add_block(block).expect("add");
+            storage.save_blockchain(&producer).expect("save");
+        }
+        let h_after_clean = storage.load_height().expect("load_height");
+        let blob_after_clean = storage
+            .chain_for_test()
+            .load_blob_height()
+            .expect("blob_height")
+            .expect("blob_height present");
+
+        // Apply block 6 in memory + commit trie, but don't persist.
+        let block_6 = producer.create_block(&proposer).expect("create");
+        producer.add_block(block_6).expect("add");
+        // No save_blockchain call here — simulate process exit before commit.
+        drop(producer);
+
+        // Disk state must still report height = 5, blob_height = 5.
+        let h_after_skip = storage.load_height().expect("load_height");
+        let blob_after_skip = storage
+            .chain_for_test()
+            .load_blob_height()
+            .expect("blob_height")
+            .expect("blob_height");
+        assert_eq!(h_after_skip, h_after_clean, "no partial height bump");
+        assert_eq!(blob_after_skip, blob_after_clean, "no partial blob bump");
+
+        // Reload must give the chain at h=5 cleanly (B2 replay no-op
+        // because disk_height == blob_height).
+        let reloaded: Blockchain = storage.load_blockchain().expect("load").expect("state");
+        assert_eq!(reloaded.height(), 5, "reload returns last atomic commit");
+    });
+}
+
+/// Deterministic replay from persisted blocks: feed the same set of
+/// blocks through two fresh chains in different orders/cadences (one
+/// linear, one with periodic save_blockchain hiccups simulating pre-B1
+/// crashes). Final stateRoot must match.
+#[test]
+fn test_v2_1_90_deterministic_replay_from_persisted_blocks() {
+    with_v2_env(|| {
+        let proposer = proposer_addr();
+
+        // Build a reference chain of N blocks atomically.
+        let (_dir_a, storage_a, mut chain_a) = setup_storage_and_chain();
+        let mdbx_a = storage_a.mdbx_arc();
+        chain_a.init_trie(Arc::clone(&mdbx_a)).unwrap();
+        chain_a.init_storage_handle(Arc::clone(&mdbx_a)).unwrap();
+        const N: u64 = 25;
+        let mut blocks: Vec<sentrix_primitives::block::Block> = Vec::with_capacity(N as usize);
+        for _ in 0..N {
+            let block = chain_a.create_block(&proposer).expect("create");
+            chain_a.add_block(block.clone()).expect("add");
+            storage_a.save_blockchain(&chain_a).expect("save");
+            blocks.push(block);
+        }
+        let reference_root = chain_a.trie_root_at(N).map(hex::encode);
+
+        // Replay the same blocks through a fresh chain via the peer-apply
+        // path. Result must be byte-identical to the reference root.
+        let dir_b = TempDir::new().expect("tempdir");
+        let mdbx_b = Arc::new(MdbxStorage::open(dir_b.path()).expect("mdbx b"));
+        let mut chain_b = Blockchain::new("admin".to_string());
+        chain_b.authority.add_validator_unchecked(
+            proposer,
+            "Validator 1".to_string(),
+            "pk1".to_string(),
+        );
+        chain_b.init_trie(Arc::clone(&mdbx_b)).unwrap();
+        for block in blocks {
+            chain_b.add_block_from_peer(block).expect("peer apply");
+        }
+        let replay_root = chain_b.trie_root_at(N).map(hex::encode);
+
+        assert_eq!(
+            reference_root, replay_root,
+            "replayed chain must agree with reference at h={N}"
+        );
+    });
+}

--- a/crates/sentrix-storage/src/chain.rs
+++ b/crates/sentrix-storage/src/chain.rs
@@ -93,38 +93,68 @@ impl ChainStorage {
 
     // ── Blockchain state ────────────────────────────────────
 
+    /// Persist the full blockchain snapshot atomically.
+    ///
+    /// Patch B1 (v2.1.90 state-root determinism RCA): everything that
+    /// describes "the chain at height N" — the bincode state blob, every
+    /// block in `chain`, the hash-to-height index entries, the `height`
+    /// key, and the `blob_height` checkpoint — is written in one MDBX
+    /// transaction. A crash during the transaction commits nothing; a
+    /// crash after the commit commits everything. This eliminates the
+    /// pre-fix crash window where `save_block` had advanced the height
+    /// and persisted the block but `save_blockchain` had not yet
+    /// rewritten the bincode blob, leaving `accounts` one block behind
+    /// the chain.
     pub fn save_blockchain<T: Serialize>(
         &self,
         blockchain: &T,
         chain: &[Block],
     ) -> StorageResult<()> {
-        // Save state (accounts, authority, etc.)
-        self.mdbx.put_json(TABLE_STATE, b"state", blockchain)?;
+        let blob = serde_json::to_vec(blockchain)?;
+        let blob_height = chain.last().map(|b| b.index).unwrap_or(0);
+        let blob_height_bytes = serde_json::to_vec(&blob_height)?;
 
-        // Save each block + hash index
         let batch = self.mdbx.begin_write()?;
+        // State blob (accounts, mempool, stake_registry, total_minted, …).
+        batch.put(TABLE_STATE, b"state", &blob)?;
+        // Checkpoint: the height that `accounts` in the blob is consistent
+        // with. Read on load to detect "blocks on disk ahead of accounts
+        // blob" (Patch B2 detector).
+        batch.put(TABLE_STATE, b"blob_height", &blob_height_bytes)?;
+
         for block in chain {
             let key = format!("block:{}", block.index);
             let block_json = serde_json::to_vec(block)?;
             batch.put(TABLE_META, key.as_bytes(), &block_json)?;
-
             batch.put(
                 TABLE_BLOCK_HASHES,
                 block.hash.as_bytes(),
                 &height_key(block.index),
             )?;
         }
-        batch.commit()?;
 
+        // Tip height key — same MDBX table as the per-block keys, written
+        // inside the same transaction so a torn write cannot leave the
+        // height advanced past the persisted blob.
         if let Some(last) = chain.last() {
-            self.save_height(last.index)?;
+            let height_bytes = serde_json::to_vec(&last.index)?;
+            batch.put(TABLE_META, b"height", &height_bytes)?;
         }
+
+        batch.commit()?;
         self.mdbx.sync()?;
         Ok(())
     }
 
     pub fn load_state<T: DeserializeOwned>(&self) -> StorageResult<Option<T>> {
         self.mdbx.get_json(TABLE_STATE, b"state")
+    }
+
+    /// Read the height the `state` blob was last consistent with (Patch
+    /// B2 checkpoint). Returns `None` for legacy chain.dbs that pre-date
+    /// the atomic-persist change; callers treat that as `0`.
+    pub fn load_blob_height(&self) -> StorageResult<Option<u64>> {
+        self.mdbx.get_json(TABLE_STATE, b"blob_height")
     }
 
     // ── Per-block operations ────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes a crash-consistency issue in chain persistence.

Previously, the validator loop wrote block data and chain state in separate steps. If the process exited after the block/height write but before the full blockchain state blob was saved, the node could restart with height advanced but account state one block behind. The next block could then produce a different stateRoot from peers.

This PR makes the hot-path persistence atomic, adds load-side recovery for the bad window, and reconciles the in-memory account snapshot against the trie at load time.

## Risk tier

- [x] **🟠 High** — touches storage/state persistence used by consensus-critical execution

## What changed

**Patch B1 — atomic write.**
Replaced the validator loop's `save_block` + `save_blockchain` pair with a single atomic `save_blockchain` write. `ChainStorage::save_blockchain` now writes the state blob, block data, hash indexes, height key, and `blob_height` checkpoint in one MDBX transaction. A crash mid-transaction commits nothing; a crash after commit commits everything.

**Patch B2 — detector + replay.**
Added startup recovery in `Storage::load_blockchain` for `disk_height > blob_height`. Recovery replays missing persisted blocks through the normal block-apply path and re-saves the repaired state atomically. Legacy databases without `blob_height` keep the old behavior; operator recovery remains required if those are already torn.

**Patch B3 — trie-canonical reconcile.**
After `init_trie`, reconcile in-memory account state against the trie's leaves at chain head. The trie is the consensus-verified source of truth; the blob is treated as a cache. For every protocol-system, validator, and non-zero account, read the trie leaf, decode `(balance, nonce)`, and overwrite the blob value if they differ. Trie-lookup errors propagate (refuse to start on corrupted trie); `Ok(None)` leaves the blob alone (premine/genesis accounts that pre-date the first trie touch must not be zeroed). After repairs, re-save atomically so the blob_height checkpoint advances and the next load is a no-op.

## Tests

Added regression coverage in:

`crates/sentrix-core/tests/v2_1_90_state_root_determinism.rs`

Covered cases:

- crash between block write and blockchain-state write
- clean drop/reload determinism
- atomic transaction leaves no partial state
- repeated crash recovery converges to the never-crashed control
- deterministic replay from persisted blocks
- legacy torn chain.db recovers via trie reconcile

Plus an operator-driven dry-run probe in `tests/v2_1_90_b3_dry_run.rs` (`#[ignore]`d, env-var driven) for verifying B3 against a real chain.db copy without affecting CI.

Test results:

```bash
cargo test -p sentrix-core                                  # 233 passed (8 v2.1.90 tests)
cargo test -p sentrix-storage                               # 19 passed
cargo test -p sentrix-bft                                   # 118 passed
RUSTFLAGS="-D warnings" cargo check --release --workspace   # clean
cargo clippy --workspace --tests -- -D warnings             # clean
```

All green.

## Live verification

Verified on a 5-node test cluster that had been driven into a chain.db divergence by the pre-B1 bug. Operator combined a canonical chain.db rsync (one healthy peer → divergent peers) with a fresh start on the patched binary.

- 30-minute window post-restart: chain finalising at 0.4–0.6 s/block
- All 5 nodes agreed on every height's hash and stateRoot at every probe
- Zero invalid-previous-hash, zero equivocation refusals, zero panic/fatal lines
- B3 fired on every node's first load and on subsequent restarts: 2–3 of 46 candidate accounts repaired per load, including a `PROTOCOL_TREASURY` balance off by exactly one block-reward on one of the nodes

Trie-level divergence still requires operator chain.db rsync from a healthy peer; B3 only addresses blob-vs-trie staleness, which is its targeted contract. Confirmed via a dry-run against a copy of a divergent chain.db: B3 was correctly a no-op when blob and trie agreed at the wrong value, distinguishing trie corruption from blob staleness.