### PR TITLE
fix(storage): make chain persistence crash-consistent

### DIFF
--- a/crates/sentrix-core/src/storage.rs
+++ b/crates/sentrix-core/src/storage.rs
@@ -3,7 +3,10 @@
 use crate::blockchain::{Blockchain, CHAIN_WINDOW_SIZE};
 use sentrix_primitives::block::Block;
 use sentrix_primitives::error::{SentrixError, SentrixResult};
+use sentrix_primitives::transaction::PROTOCOL_TREASURY;
 use sentrix_storage::{ChainStorage, MdbxStorage};
+use sentrix_trie::{account_value_decode, address_to_key};
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 pub struct Storage {
@@ -171,6 +174,49 @@ impl Storage {
         // rebuilt the index.
         bc.rebuild_mempool_sidecars();
 
+        // Patch B3 — trie-canonical reconciliation on load.
+        //
+        // The bincode `state` blob carries a snapshot of `accounts`,
+        // but under the pre-B1 non-atomic save flow (or any chain.db
+        // repaired with `state` and trie out of sync) the in-memory
+        // balances can drift from what the trie commits. The trie root
+        // is consensus-verified, so the trie is the source of truth;
+        // the blob is treated as a cache.
+        //
+        // For every protocol-system, validator, stake-related, and
+        // any-non-zero account, read the trie leaf at the loaded
+        // height, decode (balance, nonce), and overwrite the blob's
+        // value if they differ. Accounts with no trie leaf are left
+        // alone (covers the genesis/premine path that was never
+        // touched by `update_trie_for_block`).
+        //
+        // Errors propagate: a trie-lookup failure during reconcile
+        // means the trie is unreadable, not just that an account is
+        // absent — refuse to start so an operator surfaces it instead
+        // of silently running on inconsistent state.
+        let (checked, repaired) = Self::reconcile_accounts_from_trie(&mut bc)?;
+        if repaired > 0 {
+            tracing::warn!(
+                "load_blockchain B3: reconciled {}/{} accounts from trie at height {} \
+                 (blob was stale; trie is canonical)",
+                repaired,
+                checked,
+                bc.height()
+            );
+            // Persist the repaired state via the atomic B1 path so the
+            // next load is a no-op + the blob_height checkpoint advances.
+            self.chain
+                .save_blockchain(&bc, &bc.chain)
+                .map_err(|e| SentrixError::StorageError(e.to_string()))?;
+        } else {
+            tracing::debug!(
+                "load_blockchain B3: {}/{} accounts checked, none required reconcile at height {}",
+                repaired,
+                checked,
+                bc.height()
+            );
+        }
+
         // Patch B2 (v2.1.90 state-root determinism RCA): if persisted
         // chain height is ahead of the bincode blob's checkpoint
         // height, the on-disk view is inconsistent — `accounts` is
@@ -277,6 +323,125 @@ impl Storage {
     #[doc(hidden)]
     pub fn chain_for_test(&self) -> &sentrix_storage::ChainStorage {
         &self.chain
+    }
+
+    /// Patch B3 — reconcile in-memory `accounts` against the trie
+    /// leaves at the loaded height. Returns (checked, repaired).
+    ///
+    /// The trie at `bc.height()` is the consensus-verified source of
+    /// truth; the blob's `accounts` is a cache that can drift if a
+    /// previous save was non-atomic. For every account we expect the
+    /// trie to know about — protocol-system addresses, validators in
+    /// `stake_registry`, and any address with non-zero balance/nonce
+    /// in the blob — read the trie leaf and overwrite the blob's
+    /// (balance, nonce) if they differ.
+    ///
+    /// Addresses with no trie leaf (`Ok(None)`) are skipped: the trie
+    /// only stores accounts that have been touched by
+    /// `update_trie_for_block`, while `bc.accounts` may also carry
+    /// premine / genesis accounts that pre-date the first trie touch.
+    /// We must not zero those out.
+    ///
+    /// Trie-lookup errors (`Err(_)`) propagate: a corrupted trie is a
+    /// hard-fail, not silent fallback.
+    fn reconcile_accounts_from_trie(bc: &mut Blockchain) -> SentrixResult<(usize, usize)> {
+        // Build the candidate address set first — sorted + deduped so
+        // the reconcile order is deterministic across runs (helps debug
+        // logs and makes tests stable).
+        let mut addrs: BTreeSet<String> = BTreeSet::new();
+
+        // 1. Protocol-system sentinel.
+        addrs.insert(PROTOCOL_TREASURY.to_string());
+
+        // 2. Validators in stake_registry — both the active set and
+        //    the full validator map (so jailed/unbonding entries get
+        //    reconciled too if they have a trie leaf).
+        for addr in bc.stake_registry.active_set.iter() {
+            addrs.insert(addr.clone());
+        }
+        for addr in bc.stake_registry.validators.keys() {
+            addrs.insert(addr.clone());
+        }
+
+        // 3. Any account in the blob with non-zero balance or nonce.
+        //    Catches user accounts that have been touched at some point
+        //    in chain history; misses purely-zero accounts but those
+        //    have no state to drift on.
+        for (addr, acct) in bc.accounts.accounts.iter() {
+            if acct.balance > 0 || acct.nonce > 0 {
+                addrs.insert(addr.clone());
+            }
+        }
+
+        // Split-borrow: we need `&mut bc.state_trie` for `trie.get`
+        // (which mutates the cache) and `&mut bc.accounts` to apply
+        // any repairs. The struct fields are independent, so this
+        // satisfies the borrow checker.
+        let trie = bc.state_trie.as_mut().ok_or_else(|| {
+            SentrixError::Internal(
+                "B3 reconcile: state_trie is None — init_trie must run before reconcile"
+                    .to_string(),
+            )
+        })?;
+
+        // Phase 1: read all trie leaves into a buffer. This avoids
+        // holding the trie borrow while we mutate accounts in phase 2.
+        let mut trie_values: Vec<(String, Option<(u64, u64)>)> = Vec::with_capacity(addrs.len());
+        for addr in &addrs {
+            let key = address_to_key(addr);
+            let leaf = trie.get(&key).map_err(|e| {
+                SentrixError::Internal(format!(
+                    "B3 reconcile: trie lookup for {addr} failed at h={}: {e}",
+                    bc.chain.last().map(|b| b.index).unwrap_or(0)
+                ))
+            })?;
+            let decoded = leaf.and_then(|bytes| account_value_decode(&bytes));
+            trie_values.push((addr.clone(), decoded));
+        }
+
+        // Phase 2: apply repairs.
+        let height = bc.chain.last().map(|b| b.index).unwrap_or(0);
+        let mut checked = 0usize;
+        let mut repaired = 0usize;
+        for (addr, trie_view) in trie_values {
+            checked += 1;
+            let Some((trie_balance, trie_nonce)) = trie_view else {
+                // No trie leaf for this address — skip. Either it's a
+                // premine account that has never been touched, or it
+                // has zero state at this height. Either way, the blob
+                // is the only source of truth for it, so we leave it.
+                continue;
+            };
+            let (blob_balance, blob_nonce) = bc
+                .accounts
+                .accounts
+                .get(&addr)
+                .map(|a| (a.balance, a.nonce))
+                .unwrap_or((0, 0));
+            if trie_balance != blob_balance || trie_nonce != blob_nonce {
+                tracing::warn!(
+                    "B3 reconcile: account {} blob=(bal={},nonce={}) != trie=(bal={},nonce={}) \
+                     at h={} — overwriting blob from trie (canonical)",
+                    addr,
+                    blob_balance,
+                    blob_nonce,
+                    trie_balance,
+                    trie_nonce,
+                    height
+                );
+                let acct = bc.accounts.get_or_create(&addr);
+                acct.balance = trie_balance;
+                acct.nonce = trie_nonce;
+                repaired += 1;
+            }
+        }
+
+        // The reconcile path mutates `accounts.touched_in_block` as a
+        // side effect of `get_or_create`. Clear it so the next
+        // `apply_block_pass2` doesn't pick up a stale touch list.
+        bc.accounts.clear_touched_in_block();
+
+        Ok((checked, repaired))
     }
 
     // ── Utility ──────────────────────────────────────────

--- a/crates/sentrix-core/tests/v2_1_90_b3_dry_run.rs
+++ b/crates/sentrix-core/tests/v2_1_90_b3_dry_run.rs
@@ -1,0 +1,168 @@
+//! v2.1.90 Patch B3 — operator-driven dry-run against a real chain.db.
+//!
+//! Loads the chain.db at the path in env var `SENTRIX_B3_DRYRUN_PATH`
+//! through `Storage::load_blockchain` (which now includes the B3
+//! trie-canonical reconcile pass) and prints what the reconcile saw
+//! and repaired. Intended for one-shot operator probes against a
+//! sandbox copy of a torn chain.db; never run in CI.
+//!
+//! Run with:
+//!   SENTRIX_B3_DRYRUN_PATH=/path/to/sandbox \
+//!     cargo test -p sentrix-core --test v2_1_90_b3_dry_run \
+//!     -- --ignored --nocapture
+//!
+//! Reads the underlying `Blockchain.accounts.PROTOCOL_TREASURY` value
+//! before and after the reconcile and prints both, plus the trie's
+//! committed value, so the operator can verify whether B3 fixed the
+//! divergence on this specific chain.db.
+
+use sentrix_core::storage::Storage;
+use sentrix_primitives::transaction::PROTOCOL_TREASURY;
+use sentrix_storage::tables::TABLE_STATE;
+use std::sync::Arc;
+
+#[test]
+#[ignore = "operator-driven; needs SENTRIX_B3_DRYRUN_PATH"]
+fn b3_dry_run_against_real_chain_db() {
+    let path = match std::env::var("SENTRIX_B3_DRYRUN_PATH") {
+        Ok(p) => p,
+        Err(_) => panic!("SENTRIX_B3_DRYRUN_PATH not set"),
+    };
+
+    println!();
+    println!("═══ B3 dry-run on chain.db at {} ═══", path);
+
+    // SAFETY: env vars are process-wide. This test is operator-run,
+    // single-threaded by design (cargo test --test ... runs one binary).
+    unsafe {
+        std::env::set_var("SENTRIX_ALLOW_UNENCRYPTED_DISK", "true");
+    }
+
+    // Step 1: read the current blob's PROTOCOL_TREASURY balance + nonce
+    // BEFORE letting load_blockchain run, by opening MDBX directly.
+    let mdbx_pre = Arc::new(
+        sentrix_storage::MdbxStorage::open(std::path::Path::new(&path)).expect("open mdbx (pre)"),
+    );
+    let raw_blob: Vec<u8> = mdbx_pre
+        .get(TABLE_STATE, b"state")
+        .expect("read state")
+        .expect("state present in chain.db");
+    let bc_blob: serde_json::Value = serde_json::from_slice(&raw_blob).expect("parse state");
+
+    let pre_treasury_balance = bc_blob
+        .pointer(&format!("/accounts/accounts/{}/balance", PROTOCOL_TREASURY))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(u64::MAX);
+    let pre_treasury_nonce = bc_blob
+        .pointer(&format!("/accounts/accounts/{}/nonce", PROTOCOL_TREASURY))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(u64::MAX);
+
+    let blob_height_before: Option<u64> = match mdbx_pre
+        .get(TABLE_STATE, b"blob_height")
+        .expect("read blob_height")
+    {
+        Some(b) => serde_json::from_slice(&b).ok(),
+        None => None,
+    };
+
+    let height_key_before: Option<u64> = match mdbx_pre
+        .get(sentrix_storage::tables::TABLE_META, b"height")
+        .expect("read height")
+    {
+        Some(b) => serde_json::from_slice(&b).ok(),
+        None => None,
+    };
+
+    println!("PRE-RECONCILE:");
+    println!("  height key       = {:?}", height_key_before);
+    println!("  blob_height key  = {:?}", blob_height_before);
+    println!(
+        "  blob treasury    = balance={} nonce={}",
+        pre_treasury_balance, pre_treasury_nonce
+    );
+
+    // Drop our direct MDBX handle so Storage::open can claim the lock.
+    drop(mdbx_pre);
+
+    // Step 2: run Storage::load_blockchain (B3 reconciles inside).
+    let storage = Storage::open(&path).expect("Storage::open");
+    let bc = storage
+        .load_blockchain()
+        .expect("load_blockchain ok")
+        .expect("blockchain state present");
+
+    let post_treasury_balance = bc.accounts.get_balance(PROTOCOL_TREASURY);
+    let post_treasury_nonce = bc.accounts.get_nonce(PROTOCOL_TREASURY);
+    let height_after = bc.height();
+
+    // Re-open MDBX to read the post-reconcile blob_height.
+    drop(bc);
+    drop(storage);
+    let mdbx_post =
+        sentrix_storage::MdbxStorage::open(std::path::Path::new(&path)).expect("open mdbx (post)");
+    let blob_height_after: Option<u64> = match mdbx_post
+        .get(TABLE_STATE, b"blob_height")
+        .expect("read blob_height post")
+    {
+        Some(b) => serde_json::from_slice(&b).ok(),
+        None => None,
+    };
+
+    let raw_blob_post: Vec<u8> = mdbx_post
+        .get(TABLE_STATE, b"state")
+        .expect("read state post")
+        .expect("state present");
+    let bc_blob_post: serde_json::Value =
+        serde_json::from_slice(&raw_blob_post).expect("parse state post");
+    let blob_treasury_post = bc_blob_post
+        .pointer(&format!("/accounts/accounts/{}/balance", PROTOCOL_TREASURY))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(u64::MAX);
+
+    println!();
+    println!("POST-RECONCILE:");
+    println!("  bc.height()          = {}", height_after);
+    println!("  blob_height key      = {:?}", blob_height_after);
+    println!(
+        "  in-memory treasury   = balance={} nonce={}",
+        post_treasury_balance, post_treasury_nonce
+    );
+    println!("  on-disk blob treasury = balance={}", blob_treasury_post);
+
+    let delta_balance = post_treasury_balance.abs_diff(pre_treasury_balance);
+    let direction = if post_treasury_balance >= pre_treasury_balance {
+        "+"
+    } else {
+        "-"
+    };
+
+    println!();
+    println!("DELTA:");
+    println!(
+        "  balance change       = {}{} sentri ({}{} block-rewards × 100M)",
+        direction,
+        delta_balance,
+        direction,
+        delta_balance / 100_000_000
+    );
+    println!(
+        "  blob_height transition: {:?} -> {:?}",
+        blob_height_before, blob_height_after
+    );
+    println!();
+    println!("VERDICT:");
+    if pre_treasury_balance == post_treasury_balance && pre_treasury_nonce == post_treasury_nonce {
+        println!("  No reconcile fired for PROTOCOL_TREASURY — blob already matched trie.");
+        println!("  This chain.db is internally consistent (blob == trie). B3 is a no-op for it.");
+        println!("  Cross-validator divergence (if any) is at the trie level itself and");
+        println!("  requires chain.db rsync from a healthy peer.");
+    } else {
+        println!("  B3 RECONCILED PROTOCOL_TREASURY:");
+        println!("    blob (before) = {}", pre_treasury_balance);
+        println!("    trie / blob (after) = {}", post_treasury_balance);
+        println!("    delta = {}{}", direction, delta_balance);
+        println!("  This chain.db can be unblocked by a B3-aware restart without rsync.");
+    }
+    println!();
+}

--- a/crates/sentrix-core/tests/v2_1_90_state_root_determinism.rs
+++ b/crates/sentrix-core/tests/v2_1_90_state_root_determinism.rs
@@ -605,6 +605,143 @@ fn test_v2_1_90_atomic_txn_no_partial_state_on_skipped_save() {
     });
 }
 
+/// Patch B3 — trie-canonical reconciliation on load.
+///
+/// Scenario: a chain.db that was torn under the pre-B1 non-atomic
+/// persistence path. The on-disk view has block bytes + height +
+/// trie data consistent with chain head h=N, but the bincode `state`
+/// blob's `accounts` map is stale because one or more historical
+/// `save_blockchain` calls didn't fire after their preceding
+/// `save_block`. The blob also has no `blob_height` key (it pre-dates
+/// the B1 atomic-save change), so the B2 detector treats it as legacy
+/// and skips replay.
+///
+/// Without B3, applying block N+1 reads the stale `accounts` value and
+/// produces a different trie root than peers — the same bug class that
+/// caused split-brain on the live cluster.
+///
+/// With B3, `Storage::load_blockchain` reconciles in-memory account
+/// state against the trie's leaves at h=N before returning, so the
+/// next `apply_block_pass2` reads canonical balances regardless of
+/// blob staleness.
+#[test]
+fn test_v2_1_90_legacy_torn_chain_db_recovers_via_trie_reconcile() {
+    with_v2_env(|| {
+        let proposer = proposer_addr();
+
+        // Phase 1: build N blocks atomically (post-B1).
+        let (_dir, storage, mut producer) = setup_storage_and_chain();
+        let mdbx = storage.mdbx_arc();
+        producer.init_trie(Arc::clone(&mdbx)).unwrap();
+        producer.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+        const N: u64 = 10;
+        for _ in 0..N {
+            let block = producer.create_block(&proposer).expect("create");
+            producer.add_block(block).expect("add");
+            storage.save_blockchain(&producer).expect("save");
+        }
+        let producer_root_n = producer.trie_root_at(N).map(hex::encode);
+        let canonical_treasury = producer
+            .accounts
+            .get_balance(sentrix_primitives::transaction::PROTOCOL_TREASURY);
+        drop(producer);
+
+        // Phase 2: corrupt the persisted blob — decrement
+        // PROTOCOL_TREASURY balance by K block-rewards, simulating a
+        // chain.db where K save_blockchain calls were skipped after
+        // their save_block under the pre-B1 non-atomic path.
+        const K: u64 = 5;
+        const BLOCK_REWARD: u64 = 100_000_000;
+        let drop_amount = K * BLOCK_REWARD;
+
+        let raw = mdbx
+            .get(sentrix_storage::tables::TABLE_STATE, b"state")
+            .expect("read state")
+            .expect("state present");
+        let mut bc_blob: Blockchain = serde_json::from_slice(&raw).expect("decode state");
+        let acct = bc_blob
+            .accounts
+            .accounts
+            .get_mut(sentrix_primitives::transaction::PROTOCOL_TREASURY)
+            .expect("treasury entry present in blob");
+        let pre = acct.balance;
+        assert!(pre >= drop_amount, "test setup: blob treasury too small");
+        acct.balance = pre - drop_amount;
+        let corrupt = serde_json::to_vec(&bc_blob).expect("encode state");
+        mdbx.put(sentrix_storage::tables::TABLE_STATE, b"state", &corrupt)
+            .expect("write corrupt state");
+
+        // Delete blob_height to simulate a chain.db that pre-dates the
+        // B1 atomic-save change. With the key absent, the B2 detector's
+        // `load_blob_height` returns None and the detector skips replay,
+        // leaving B3 reconciliation as the only repair path.
+        let _ = mdbx
+            .delete(sentrix_storage::tables::TABLE_STATE, b"blob_height")
+            .expect("delete blob_height");
+
+        // Phase 3: reload and apply block N+1.
+        let mut reloaded: Blockchain = storage
+            .load_blockchain()
+            .expect("load_blockchain")
+            .expect("state present");
+        reloaded.init_trie(Arc::clone(&mdbx)).unwrap();
+        reloaded.init_storage_handle(Arc::clone(&mdbx)).unwrap();
+
+        // After B3, the reconciler must have repaired the treasury
+        // balance from the trie. Sanity-check it matches the canonical
+        // pre-corruption value.
+        let post_reload_treasury = reloaded
+            .accounts
+            .get_balance(sentrix_primitives::transaction::PROTOCOL_TREASURY);
+        assert_eq!(
+            post_reload_treasury, canonical_treasury,
+            "B3 reconciliation must restore PROTOCOL_TREASURY from trie. \
+             Expected {canonical_treasury}, got {post_reload_treasury}. \
+             Pre-fix delta = {drop_amount} (K={K} block rewards)."
+        );
+
+        // Phase 4: control chain — never corrupted, replay all N blocks.
+        let dir_ctrl = TempDir::new().expect("tempdir");
+        let mdbx_ctrl = Arc::new(MdbxStorage::open(dir_ctrl.path()).expect("mdbx ctrl"));
+        let mut control = Blockchain::new("admin".to_string());
+        control.authority.add_validator_unchecked(
+            proposer.clone(),
+            "Validator 1".to_string(),
+            "pk1".to_string(),
+        );
+        control.init_trie(Arc::clone(&mdbx_ctrl)).unwrap();
+        for h in 1..=N {
+            let block = reloaded
+                .get_block_any(h)
+                .unwrap_or_else(|| panic!("missing block at h={h}"));
+            control.add_block_from_peer(block).expect("control replay");
+        }
+        // Sanity: control trie root at N matches producer's snapshot.
+        assert_eq!(
+            control.trie_root_at(N).map(hex::encode),
+            producer_root_n,
+            "control replay must match producer at h={N}"
+        );
+
+        // Phase 5: apply block N+1 on both sides; trie roots must match.
+        let block_n1 = control.create_block(&proposer).expect("create N+1");
+        let h_n1 = block_n1.index;
+        control
+            .add_block(block_n1.clone())
+            .expect("control add N+1");
+        reloaded
+            .add_block_from_peer(block_n1)
+            .expect("reloaded add N+1");
+
+        assert_eq!(
+            reloaded.trie_root_at(h_n1).map(hex::encode),
+            control.trie_root_at(h_n1).map(hex::encode),
+            "post-reconcile trie root at h={h_n1} must match control. \
+             B3 should have restored treasury from trie at load time."
+        );
+    });
+}
+
 /// Deterministic replay from persisted blocks: feed the same set of
 /// blocks through two fresh chains in different orders/cadences (one
 /// linear, one with periodic save_blockchain hiccups simulating pre-B1


### PR DESCRIPTION
## Summary

Fixes a crash-consistency issue in chain persistence.

Before this change, block data and chain state could be persisted in separate steps. If the process exited in between, a node could restart with height/block metadata ahead of the account state. That could later produce a different stateRoot from peers.

This PR makes the hot-path persistence atomic and adds startup recovery for stale cached account state.

## Risk tier

- [x] **🟠 High** — touches storage/state persistence used by consensus-critical execution

## What changed

- Replaced the validator loop’s `save_block` + `save_blockchain` sequence with a single atomic persistence path.
- `ChainStorage::save_blockchain` now writes the state blob, block data, hash indexes, height key, and `blob_height` checkpoint in one MDBX transaction.
- Added startup recovery for `disk_height > blob_height`.
- Added trie-based reconciliation for account blob drift on load.
- Legacy or already-forked chain databases still require operator recovery from a healthy peer.

## Tests

Added regression coverage in:

`crates/sentrix-core/tests/v2_1_90_state_root_determinism.rs`

Covered cases:

- crash between block persistence and chain-state persistence
- clean drop/reload determinism
- atomic transaction no-partial-state behavior
- repeated crash recovery converging to the never-crashed control
- deterministic replay from persisted blocks
- blob-vs-trie account reconciliation on load

Local checks passed:

```bash
cargo test -p sentrix-core
cargo test -p sentrix-bft
cargo test -p sentrix-storage
RUSTFLAGS="-D warnings" cargo check --release --workspace
cargo clippy --workspace --tests -- -D warnings