### PR TITLE
fix(runtime+bft): no self-kill, drop eager nil-vote in catch_up_round

### DIFF
--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -515,6 +515,55 @@ impl LibP2pNode {
     }
 }
 
+// ── Swarm watchdog action policy ─────────────────────────
+//
+// The swarm-task watchdog (spawned inside run_swarm) detects silent-thread-
+// death by polling SWARM_TICK. When it fires, the action is configurable so
+// we can run a "warn" experiment on testnet to isolate whether the hard kill
+// itself contributes to mesh churn vs actually catching real wedges.
+//
+// Default is `Abort` — zero behaviour change without the env set.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SwarmWatchdogAction {
+    /// Log only. No process termination. Resets the stall baseline so we
+    /// don't re-fire every TICK. Used on testnet for diagnostic bakes.
+    WarnOnly,
+    /// `std::process::exit(1)` — graceful (runs destructors).
+    Exit,
+    /// `std::process::abort()` — current production behaviour. Drops the
+    /// process immediately so systemd/docker `restart=unless-stopped` cycles
+    /// it cleanly without giving the libp2p task time to do anything weird.
+    Abort,
+}
+
+/// Parse `SENTRIX_SWARM_WATCHDOG_MODE`. Recognised values (case-insensitive):
+/// `abort`, `exit`, `warn`. Anything else (or unset) returns `Abort`. Invalid
+/// values log a warning so an operator typo on testnet doesn't silently fall
+/// back to a different behaviour than they expected.
+pub(crate) fn parse_watchdog_mode(value: Option<&str>) -> SwarmWatchdogAction {
+    let raw = match value {
+        Some(s) => s.trim(),
+        None => return SwarmWatchdogAction::Abort,
+    };
+    if raw.is_empty() {
+        return SwarmWatchdogAction::Abort;
+    }
+    match raw.to_ascii_lowercase().as_str() {
+        "abort" => SwarmWatchdogAction::Abort,
+        "exit" => SwarmWatchdogAction::Exit,
+        "warn" => SwarmWatchdogAction::WarnOnly,
+        other => {
+            tracing::warn!(
+                target: "swarm_watchdog",
+                "Unrecognised SENTRIX_SWARM_WATCHDOG_MODE='{}' — falling back to default (abort).",
+                other,
+            );
+            SwarmWatchdogAction::Abort
+        }
+    }
+}
+
 // ── Swarm event loop ─────────────────────────────────────
 
 // large_futures: the Swarm owns SentrixBehaviour which has internal caches;
@@ -604,9 +653,19 @@ async fn run_swarm(
     // 2026-05-05 v2.1.66: spawn the swarm-task watchdog. It reads
     // SWARM_TICK every 5 s; if the counter stays still for ≥30 s past
     // the startup grace, the swarm select! loop has wedged and we
-    // abort. sync_interval (30 s) and kad_interval (60 s) ticks alone
-    // keep SWARM_TICK incrementing during quiet periods so we don't
-    // false-positive on a chain with no traffic.
+    // act per SENTRIX_SWARM_WATCHDOG_MODE. sync_interval (30 s) and
+    // kad_interval (60 s) ticks alone keep SWARM_TICK incrementing
+    // during quiet periods so we don't false-positive on a chain with
+    // no traffic.
+    //
+    // 2026-05-10: the kill action is now configurable via env so we
+    // can run a "warn" experiment on testnet to isolate whether the
+    // hard kill itself is contributing to mesh churn vs catching a
+    // real silent-thread-death. Default stays "abort" — zero behaviour
+    // change without the env set.
+    let watchdog_mode = parse_watchdog_mode(
+        std::env::var("SENTRIX_SWARM_WATCHDOG_MODE").ok().as_deref(),
+    );
     tokio::spawn(async move {
         use tokio::time::{Duration, Instant as TokioInstant, sleep};
         const STALL_THRESHOLD: Duration = Duration::from_secs(30);
@@ -633,14 +692,22 @@ async fn run_swarm(
             } else if last_changed.elapsed() >= STALL_THRESHOLD {
                 tracing::error!(
                     target: "swarm_watchdog",
-                    "FATAL: libp2p swarm task stalled — no select!-loop progress \
-                     for {}s (counter={}). Aborting cleanly so systemd restarts \
-                     (closes silent-thread-death class at h=1392113 / h=1398998 \
-                     where libp2p went unresponsive while validator main loop \
-                     kept ticking).",
-                    last_changed.elapsed().as_secs(), current,
+                    "libp2p swarm task stalled — no select!-loop progress \
+                     for {}s (counter={}, mode={:?}). Silent-thread-death \
+                     class at h=1392113 / h=1398998 was where libp2p went \
+                     unresponsive while validator main loop kept ticking.",
+                    last_changed.elapsed().as_secs(), current, watchdog_mode,
                 );
-                std::process::abort();
+                match watchdog_mode {
+                    SwarmWatchdogAction::Abort => std::process::abort(),
+                    SwarmWatchdogAction::Exit => std::process::exit(1),
+                    SwarmWatchdogAction::WarnOnly => {
+                        // Reset baseline so we don't re-fire every tick;
+                        // the operator wanted only a warning, not a kill.
+                        last_seen = current;
+                        last_changed = TokioInstant::now();
+                    }
+                }
             }
         }
     });
@@ -2201,5 +2268,72 @@ mod tests {
         let block =
             sentrix_primitives::block::Block::new(0, "0".to_string(), vec![], "v1".to_string());
         node.broadcast_block(&block).await; // must not panic
+    }
+
+    // ── Swarm watchdog mode parsing ────────────────────────────────
+
+    #[test]
+    fn watchdog_mode_default_is_abort_when_unset() {
+        assert_eq!(parse_watchdog_mode(None), SwarmWatchdogAction::Abort);
+    }
+
+    #[test]
+    fn watchdog_mode_recognises_abort_exit_warn() {
+        assert_eq!(parse_watchdog_mode(Some("abort")), SwarmWatchdogAction::Abort);
+        assert_eq!(parse_watchdog_mode(Some("exit")), SwarmWatchdogAction::Exit);
+        assert_eq!(parse_watchdog_mode(Some("warn")), SwarmWatchdogAction::WarnOnly);
+    }
+
+    #[test]
+    fn watchdog_mode_is_case_insensitive() {
+        assert_eq!(parse_watchdog_mode(Some("ABORT")), SwarmWatchdogAction::Abort);
+        assert_eq!(parse_watchdog_mode(Some("Exit")), SwarmWatchdogAction::Exit);
+        assert_eq!(parse_watchdog_mode(Some("WARN")), SwarmWatchdogAction::WarnOnly);
+        assert_eq!(parse_watchdog_mode(Some("Warn")), SwarmWatchdogAction::WarnOnly);
+    }
+
+    #[test]
+    fn watchdog_mode_trims_whitespace() {
+        assert_eq!(parse_watchdog_mode(Some("  warn  ")), SwarmWatchdogAction::WarnOnly);
+        assert_eq!(parse_watchdog_mode(Some("\texit\n")), SwarmWatchdogAction::Exit);
+    }
+
+    #[test]
+    fn watchdog_mode_invalid_falls_back_to_abort() {
+        // Typo / unknown value → safe default, not panic.
+        assert_eq!(parse_watchdog_mode(Some("nuke")), SwarmWatchdogAction::Abort);
+        assert_eq!(parse_watchdog_mode(Some("disable")), SwarmWatchdogAction::Abort);
+        assert_eq!(parse_watchdog_mode(Some("123")), SwarmWatchdogAction::Abort);
+    }
+
+    #[test]
+    fn watchdog_mode_empty_string_falls_back_to_abort() {
+        assert_eq!(parse_watchdog_mode(Some("")), SwarmWatchdogAction::Abort);
+        assert_eq!(parse_watchdog_mode(Some("   ")), SwarmWatchdogAction::Abort);
+    }
+
+    #[test]
+    fn watchdog_mode_warn_does_not_terminate_process() {
+        // The whole point of the experiment: warn mode must NOT request
+        // termination. We verify by matching on the enum variant — the
+        // runtime side only calls process::abort/exit on the kill variants.
+        let action = parse_watchdog_mode(Some("warn"));
+        let terminates = matches!(
+            action,
+            SwarmWatchdogAction::Abort | SwarmWatchdogAction::Exit
+        );
+        assert!(!terminates, "warn mode must not request process termination");
+    }
+
+    #[test]
+    fn watchdog_mode_kill_variants_request_termination() {
+        for v in ["abort", "exit"] {
+            let action = parse_watchdog_mode(Some(v));
+            let terminates = matches!(
+                action,
+                SwarmWatchdogAction::Abort | SwarmWatchdogAction::Exit
+            );
+            assert!(terminates, "{} mode must request process termination", v);
+        }
     }
 }


### PR DESCRIPTION
Two related fixes for the testnet liveness stalls.

## Patch A — no in-process self-kill (commit 22e5342)

Three watchdogs called `process::abort()` on stall: libp2p swarm-task, validator-loop heartbeat, chain-height. The 6h warn-mode bake on 2026-05-10 showed each abort cycle was incidentally clearing libp2p mesh stalls and hiding a deeper BFT round-cascade bug.

- libp2p swarm watchdog default flipped `Abort → WarnOnly`. `Abort` and `Exit` modes still available via `SENTRIX_SWARM_WATCHDOG_MODE`.
- Heartbeat + chain-height watchdogs in main.rs no longer abort. They warn, increment a counter, set `BFT_LIVENESS_DEGRADED`.
- New metrics: `SWARM_STALL_TOTAL`, `SWARM_LAST_TICK_AGE_SECONDS`, `SWARM_STALLED`, `VALIDATOR_HEARTBEAT_STALL_TOTAL`, `BFT_HEIGHT_STALL_TOTAL`, `BFT_LIVENESS_DEGRADED`.
- Catastrophic-bug paths (panic hook + genesis credit failure) kept on purpose.
- Docs: `docs/operations/guardian.md`, `docs/debugging/bft-liveness.md`.

## Patch B — drop eager nil-vote in `catch_up_round` (commit a60c09b)

Removing the kills exposed the cascade Patch A was meant to find. Root cause: when a non-proposer caught up via f+1 RoundStatus, the engine pre-emptively cast a nil prevote and entered Prevote phase. If the round-N proposal then arrived, `on_proposal` saw `phase != Propose` and returned Wait — the nil-vote stuck for the whole round. Same pattern firing on every catch-up across a slow mesh = round 5/8/11+ cascades.

`catch_up_round` now leaves the engine in `Propose` with `our_prevote_cast=false`, returns `None`. Late-but-valid proposal drives a real prevote. If nothing arrives within `propose_timeout`, `on_timeout` emits the nil-vote fallback (same protection #133 needed, just without the cascade cost).

Updated 9 unit tests to pin the new contract:
- `test_finalization_dead_fix_non_proposer_does_not_eager_nil_vote`
- `test_finalization_dead_fix_issue_133_timeout_fallback_emits_nil` (uses phase_start rewind to drive on_timeout)
- `test_133_catch_up_does_not_block_late_proposal`
- 6 others updated to assert new (round, phase=Propose, our_prevote_cast=false) contract.

Double-vote prevention is in the LastSignBytes guard (PR #541), not in engine state.

## Test plan

- [x] 125/125 sentrix-bft tests pass (incl. 9 updated)
- [x] sentrix-network 41/41 pass (incl. 9 watchdog-mode parsing tests with new default)
- [x] clippy + check `-D warnings` clean across bft/network/node
- [x] Build glibc-compatible binary (max GLIBC 2.30, sha `43248b89…`)
- [x] Testnet deploy: chain unstuck from h=3,134,002 cascade in <30s, advancing 0.36s/blk at round=0
- [ ] 1h+ bake (in flight)