### PR TITLE
docs: align mainnet name + RPC URLs to chainlist registry

### DIFF
--- a/docs/operations/METAMASK.md
+++ b/docs/operations/METAMASK.md
@@ -2,30 +2,30 @@
 
 Sentrix is fully MetaMask-compatible on both networks. Mainnet (chain ID 7119) and Testnet (chain ID 7120) both run Voyager DPoS+BFT consensus with EVM enabled — MetaMask reads balances, signs transactions, and deploys Solidity contracts on either network.
 
-## Add Sentrix Testnet to MetaMask
+## Add Sentrix Chain (mainnet) to MetaMask
 
 1. Open MetaMask → Settings → Networks → Add a network → Add a network manually
 2. Fill in:
 
    | Field | Value |
    |-------|-------|
-   | **Network Name** | Sentrix Testnet |
-   | **New RPC URL** | `https://testnet-rpc.sentrixchain.com/rpc` |
-   | **Chain ID** | `7120` |
-   | **Currency Symbol** | `SRX` |
-   | **Block Explorer URL** | `https://scan.sentrixchain.com` |
-
-3. Save. Switch to "Sentrix Testnet" in the network dropdown.
-
-## Add Sentrix Mainnet
-
-   | Field | Value |
-   |-------|-------|
-   | **Network Name** | Sentrix |
+   | **Network Name** | Sentrix Chain |
    | **New RPC URL** | `https://rpc.sentrixchain.com` |
    | **Chain ID** | `7119` |
    | **Currency Symbol** | `SRX` |
    | **Block Explorer URL** | `https://scan.sentrixchain.com` |
+
+3. Save. Switch to "Sentrix Chain" in the network dropdown.
+
+## Add Sentrix Testnet to MetaMask
+
+   | Field | Value |
+   |-------|-------|
+   | **Network Name** | Sentrix Testnet |
+   | **New RPC URL** | `https://testnet-rpc.sentrixchain.com` |
+   | **Chain ID** | `7120` |
+   | **Currency Symbol** | `SRX` |
+   | **Block Explorer URL** | `https://scan-testnet.sentrixchain.com` |
 
 Mainnet supports `eth_sendRawTransaction` and Solidity contract deployment since the 2026-04-25 Voyager activation. Use mainnet for production deployments and testnet for development.
 
@@ -54,12 +54,12 @@ The contract address appears in Remix and is queryable via `eth_getCode`.
 
 ```bash
 # Get deployed contract code
-curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
+curl -X POST https://testnet-rpc.sentrixchain.com \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xCONTRACT_ADDR","latest"],"id":1}'
 
 # Call a function (example: totalSupply() = 0x18160ddd)
-curl -X POST https://testnet-rpc.sentrixchain.com/rpc \
+curl -X POST https://testnet-rpc.sentrixchain.com \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xCONTRACT_ADDR","data":"0x18160ddd"},"latest"],"id":1}'
 ```

--- a/genesis/mainnet.toml
+++ b/genesis/mainnet.toml
@@ -14,7 +14,7 @@
 
 [chain]
 chain_id = 7119
-name = "Sentrix Mainnet"
+name = "Sentrix Chain"
 
 [genesis]
 # 2024-04-09 00:00:00 UTC — the timestamp baked into the live chain's block 0.


### PR DESCRIPTION
## Summary

Two doc / config files were the loudest outliers vs. the chainlist registry submission ([ethereum-lists/chains#8266](https://github.com/ethereum-lists/chains/pull/8266)) and the frontend chain configs (Sentriscloud/frontend#49):

- `genesis/mainnet.toml` had `name = "Sentrix Mainnet"`. Every frontend now uses `Sentrix Chain`. The genesis hash invariants are timestamp / parent_hash / coinbase tx (per the file header) — `name` is metadata, not consensus, so changing it does not fork the chain. Boot logs now print `Sentrix Chain` instead of `Sentrix Mainnet`.
- `docs/operations/METAMASK.md` had the mainnet network name as bare `"Sentrix"` (the only file in the codebase doing that), and a stray `/rpc` suffix in the testnet table while the mainnet table was bare. Now all four user-facing fields (mainnet name, both RPC URLs, testnet block explorer) match the chainlist values:

  | | Mainnet | Testnet |
  |---|---|---|
  | Network Name | `Sentrix Chain` | `Sentrix Testnet` |
  | RPC URL | `https://rpc.sentrixchain.com` | `https://testnet-rpc.sentrixchain.com` |
  | Symbol | `SRX` | `SRX` |
  | Explorer | `https://scan.sentrixchain.com` | `https://scan-testnet.sentrixchain.com` |

Mainnet section also moved above testnet since it's the default user path now.

## Out of scope (follow-up)

`crates/sentrix-rpc/src/routes/ops.rs` (the `/` self-describe endpoint) and `docs/operations/API_REFERENCE.md` still hardcode `"name": "Sentrix"` — that surface is not consumed by chainlist or wallet-add flows. Worth standardising in a separate change because the right fix is to read `[chain].name` from the loaded genesis (so testnet self-describes as `Sentrix Testnet`), not to hardcode another string.

## Test plan

- [ ] `cargo build --release` (genesis change is parsed by serde, no schema change)
- [ ] `cargo test test_mainnet_genesis_block_hash_matches_hardcoded` still passes (block hash is independent of `name`)
- [ ] On a fresh node, boot log line reads `loaded genesis: Sentrix Chain (chain_id 7119)` not `Sentrix Mainnet`
- [ ] Walk through METAMASK.md mainnet steps in a fresh MetaMask install — network shows up as "Sentrix Chain"