### PR TITLE
fix(runtime+bft): no self-kill + drop eager nil-vote in catch_up_round

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -18,6 +18,38 @@ use tokio::sync::RwLock;
 
 const DEFAULT_API_PORT: u16 = 8545;
 
+// 2026-05-10: validator-runtime liveness metrics. See also
+// `crates/sentrix-network/src/libp2p_node.rs::SWARM_STALL_TOTAL` and the
+// runtime self-kill removal note in docs/operations/guardian.md.
+//
+// These counters and flags replace the in-process abort behaviour that
+// previously fired on heartbeat-stall and chain-height-stall. External
+// supervisors (sentrix-guardian / systemd / docker) consume these to
+// decide whether to restart the process — that decision no longer
+// belongs inside the validator runtime itself.
+
+/// Cumulative count of validator-loop heartbeat stalls. Each increment
+/// = one `HEARTBEAT_STALL_THRESHOLD` window where the heartbeat counter
+/// did not advance.
+pub static VALIDATOR_HEARTBEAT_STALL_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Age in seconds of the last observed heartbeat advance. 0 means the
+/// counter advanced on this tick.
+pub static VALIDATOR_HEARTBEAT_AGE_SECONDS: AtomicU64 = AtomicU64::new(0);
+
+/// Cumulative count of chain-height stalls observed. Each increment =
+/// one `height_stall_threshold` window where bc.height() did not change.
+pub static BFT_HEIGHT_STALL_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Age in seconds of the last observed height advance. 0 means a block
+/// finalized on this tick.
+pub static BFT_HEIGHT_STALL_SECONDS: AtomicU64 = AtomicU64::new(0);
+
+/// Health flag — true while either the heartbeat or chain-height
+/// stall window is active. Cleared automatically when progress resumes.
+/// Read by `/sentrix_status_extended` and external supervisors.
+pub static BFT_LIVENESS_DEGRADED: AtomicBool = AtomicBool::new(false);
+
 fn get_api_port() -> u16 {
     std::env::var("SENTRIX_API_PORT")
         .ok()
@@ -1534,7 +1566,18 @@ async fn cmd_start(
                 }
 
                 // ── Heartbeat watchdog (loop-stop) ──
+                //
+                // 2026-05-10: this used to call std::process::abort() at
+                // HEARTBEAT_STALL_THRESHOLD. The hard-kill was removed
+                // because (a) the 6h warn-mode bake on testnet showed the
+                // kill was hiding a deeper BFT/libp2p round-cascade
+                // liveness issue, and (b) restart authority belongs to an
+                // external supervisor that can decide based on observed
+                // health flags + counters, not on a fixed timer inside
+                // the validator runtime. See docs/operations/guardian.md.
                 let current = heartbeat.load(Ordering::Acquire);
+                let hb_age = last_changed.elapsed().as_secs();
+                VALIDATOR_HEARTBEAT_AGE_SECONDS.store(hb_age, Ordering::Release);
                 if current != last_seen {
                     last_seen = current;
                     last_changed = tokio::time::Instant::now();
@@ -1545,49 +1588,74 @@ async fn cmd_start(
                             event_tx_for_watchdog.max_capacity() - event_tx_for_watchdog.capacity();
                         let bft_depth =
                             bft_tx_for_watchdog.max_capacity() - bft_tx_for_watchdog.capacity();
-                        tracing::error!(
+                        VALIDATOR_HEARTBEAT_STALL_TOTAL.fetch_add(1, Ordering::Relaxed);
+                        BFT_LIVENESS_DEGRADED.store(true, Ordering::Release);
+                        tracing::warn!(
                             target: "validator_watchdog",
-                            "FATAL: validator loop heartbeat stale for {}s (counter={}, \
-                             event_tx_depth={}/{}, bft_tx_depth={}/{}) \
-                             — BFT engine wedged. Aborting so systemd restarts cleanly.",
+                            "validator loop heartbeat stale for {}s (counter={}, \
+                             event_tx_depth={}/{}, bft_tx_depth={}/{}, stall_total={}) \
+                             — BFT engine may be wedged. External supervisor can \
+                             restart based on bft_liveness_degraded + heartbeat_stall_total. \
+                             Runtime will not self-kill.",
                             stale.as_secs(), current,
                             event_depth, event_tx_for_watchdog.max_capacity(),
                             bft_depth, bft_tx_for_watchdog.max_capacity(),
+                            VALIDATOR_HEARTBEAT_STALL_TOTAL.load(Ordering::Relaxed),
                         );
-                        std::process::abort();
+                        // Reset the baseline so we don't re-warn on every
+                        // 5s tick while the stall persists. The health
+                        // flag stays set until the heartbeat actually
+                        // advances (cleared above on counter-change).
+                        last_seen = current;
+                        last_changed = tokio::time::Instant::now();
                     } else if stale >= HEARTBEAT_WARN_THRESHOLD {
                         tracing::warn!(
                             target: "validator_watchdog",
                             "validator loop heartbeat stale for {}s (counter={}) — \
-                             abort threshold {}s",
+                             stall threshold {}s",
                             stale.as_secs(), current, HEARTBEAT_STALL_THRESHOLD.as_secs(),
                         );
                     }
                 }
 
                 // ── Chain-height watchdog (BFT-stuck) ──
+                //
+                // Same 2026-05-10 change: hard-kill removed, replaced
+                // with metrics + warn + degraded health flag. The BFT
+                // round-cascade pattern that the kill was masking is
+                // documented in docs/debugging/bft-liveness.md.
                 let current_height = {
                     let bc = shared_for_watchdog.read().await;
                     bc.height()
                 };
+                let height_age = last_height_changed.elapsed().as_secs();
+                BFT_HEIGHT_STALL_SECONDS.store(height_age, Ordering::Release);
                 if current_height != last_height {
                     last_height = current_height;
                     last_height_changed = tokio::time::Instant::now();
+                    // Resumed progress — both watchdogs agree health is
+                    // restored only when both heartbeat AND height
+                    // advance, but this side just clears its slice.
+                    BFT_LIVENESS_DEGRADED.store(false, Ordering::Release);
                 } else {
                     let stale = last_height_changed.elapsed();
                     if stale >= height_stall_threshold {
-                        tracing::error!(
+                        BFT_HEIGHT_STALL_TOTAL.fetch_add(1, Ordering::Relaxed);
+                        BFT_LIVENESS_DEGRADED.store(true, Ordering::Release);
+                        tracing::warn!(
                             target: "validator_watchdog",
-                            "FATAL: chain height stuck at {} for {}s — BFT can't finalize. \
-                             Aborting cleanly so systemd restarts (avoids operator SIGKILL \
-                             window that has corrupted MDBX in past incidents).",
+                            "chain height stuck at {} for {}s — BFT not finalizing. \
+                             height_stall_total={}, bft_liveness_degraded=true. \
+                             Runtime will not self-kill — external supervisor decides.",
                             current_height, stale.as_secs(),
+                            BFT_HEIGHT_STALL_TOTAL.load(Ordering::Relaxed),
                         );
-                        std::process::abort();
+                        // Reset baseline so we don't re-warn every tick.
+                        last_height_changed = tokio::time::Instant::now();
                     } else if stale >= height_warn_threshold {
                         tracing::warn!(
                             target: "validator_watchdog",
-                            "chain height stuck at {} for {}s — abort threshold {}s",
+                            "chain height stuck at {} for {}s — stall threshold {}s",
                             current_height, stale.as_secs(),
                             height_stall_threshold.as_secs(),
                         );

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -168,14 +168,42 @@ impl BftEngine {
         }
         self.phase_start = Instant::now();
 
-        // 2026-05-09 finalization-dead fix: if we are the proposer for
-        // the caught-up round, do NOT enter the Prevote/nil-cast path.
-        // The validator-loop will detect the proposer slot via
-        // `is_proposer(...)`, build a proposal, and rely on
-        // `on_own_proposal -> accept_proposal -> BroadcastPrevote` to
-        // emit our yes-prevote. That path requires `phase == Propose`
-        // and `our_prevote_cast == false`, both of which `advance_round`
-        // already established above.
+        // 2026-05-10 nil-cascade fix: leave the engine in `phase=Propose`
+        // with `our_prevote_cast=false` regardless of whether we are the
+        // round's proposer. This applies to both proposer and non-proposer
+        // catch-up paths.
+        //
+        // Why we used to nil-prevote eagerly (Issue #133):
+        // gossipsub is fire-and-forget — if we missed round-N's proposal
+        // during a libp2p hiccup, it would never be re-delivered, and the
+        // engine would wait forever in Propose. The eager nil-vote let us
+        // contribute to quorum immediately so the round could either reach
+        // a 3/4 nil-precommit majority and skip, or finalize off our 3/4
+        // block-prevote without us.
+        //
+        // Why that backfired in observed testnet cascades:
+        // when round-N's proposal DID arrive after catch_up_round had
+        // already entered Prevote with nil, `on_proposal` returned Wait
+        // because `phase != Propose`. The nil-vote stuck for the whole
+        // round. Same pattern firing on every catch_up across a slow
+        // libp2p mesh produced the round 5 / 8 / 11+ cascades we saw on
+        // 2026-05-10 testnet.
+        //
+        // Why staying in Propose is safe:
+        // `on_timeout` already nil-prevotes from Propose phase if no
+        // proposal arrives within `propose_timeout(round)` (20s + 1s/round,
+        // capped at 30s). The validator-loop calls `is_timed_out()` every
+        // tick, so the nil-vote fallback is reliable. The original
+        // "wait forever" risk from #133 doesn't apply once on_timeout is
+        // wired correctly — and it has been since v2.1.60's heartbeat
+        // watchdog, which made the validator-loop tick rate observable.
+        //
+        // The trade-off:
+        // we contribute to quorum ~20s later in the worst case (proposal
+        // never arrives) but actually accept late-but-valid proposals,
+        // which the eager-nil path made impossible. The 20s delay is
+        // already absorbed by propose_timeout — net effect on cascade-free
+        // rounds is zero, and the cascade case improves dramatically.
         if stake_registry
             .weighted_proposer(self.state.height, self.state.round)
             .as_deref()
@@ -183,25 +211,19 @@ impl BftEngine {
         {
             tracing::debug!(
                 target: "bft_catch_up",
-                "catch_up_round: we are proposer at h={} r={} — skip nil-prevote, leave phase=Propose",
+                "catch_up_round: we are proposer at h={} r={} — leave phase=Propose, validator-loop will build the block",
                 self.state.height,
                 self.state.round,
             );
-            return None;
+        } else {
+            tracing::debug!(
+                target: "bft_catch_up",
+                "catch_up_round: non-proposer at h={} r={} — leave phase=Propose so a late-but-valid proposal can still be accepted; on_timeout will nil-prevote after propose_timeout if it never arrives",
+                self.state.height,
+                self.state.round,
+            );
         }
-
-        // Non-proposer path (Issue #133): enter Prevote with nil vote
-        // so we contribute to quorum immediately instead of waiting
-        // (forever) for a proposal that gossipsub will not re-deliver.
-        self.state.phase = BftPhase::Prevote;
-        self.state.our_prevote_cast = true;
-        Some(Prevote {
-            height: self.state.height,
-            round: self.state.round,
-            block_hash: None,
-            validator: self.our_address.clone(),
-            signature: vec![], // caller signs before broadcast
-        })
+        None
     }
 
     /// Are we the proposer for current height+round?
@@ -1593,11 +1615,13 @@ mod tests {
         // RoundStatus triggers catch-up to peer_round - 1 when peer is 2+ ahead.
         // This prevents the round desync stall without causing leapfrog.
         //
-        // Issue #133: after catch_up, the engine now emits a nil prevote
-        // (BftAction::BroadcastPrevote with block_hash = None) so peers
-        // observe our participation in the caught-up round — otherwise
-        // a restarted validator sits silent and 4-of-4 quorum drops to
-        // 3-of-4.
+        // 2026-05-10: catch_up_round no longer emits an eager nil-prevote.
+        // It advances the round and leaves the engine in `BftPhase::Propose`
+        // with `our_prevote_cast = false`, ready to accept a late-but-valid
+        // proposal. If no proposal arrives within `propose_timeout(round)`
+        // the validator-loop's `on_timeout` call still emits the nil-vote
+        // fallback, so the original Issue #133 "wait forever" risk is
+        // preserved through that path. See the comment in `catch_up_round`.
         let (mut engine, reg) = setup();
         assert_eq!(engine.round(), 0);
 
@@ -1609,23 +1633,30 @@ mod tests {
             signature: Vec::new(),
         };
         let action = engine.on_round_status(&status, &reg);
-        match action {
-            BftAction::BroadcastPrevote(p) => {
-                assert_eq!(p.round, 4, "prevote must be for caught-up round");
-                assert_eq!(
-                    p.block_hash, None,
-                    "must be nil prevote — we have no proposal"
-                );
-            }
-            other => panic!("expected BroadcastPrevote(nil), got {other:?}"),
-        }
+        assert!(
+            matches!(action, BftAction::Wait),
+            "catch_up no longer eager-nil-votes; got {action:?}"
+        );
         assert_eq!(engine.round(), 4); // caught up to peer - 1
+        assert_eq!(
+            engine.state.phase,
+            BftPhase::Propose,
+            "stay in Propose so a late proposal can be accepted"
+        );
+        assert!(
+            !engine.state.our_prevote_cast,
+            "our_prevote_cast stays false after catch_up so late proposal can drive a real prevote"
+        );
     }
 
-    // Issue #133: after catch_up, our_prevote_cast must be set so a late
-    // proposal for this round does NOT trigger a double-vote.
+    // 2026-05-10: catch_up no longer pre-empts the prevote, so the original
+    // "double-vote prevention via our_prevote_cast" intent of this test no
+    // longer applies. The test now pins the new contract: catch_up leaves
+    // the engine ready to accept a late proposal, and the actual
+    // double-vote protection lives in the LastSignBytes guard at the
+    // signing layer (PR #541), not in the engine state machine.
     #[test]
-    fn test_133_catch_up_sets_our_prevote_cast_prevents_double_vote() {
+    fn test_133_catch_up_does_not_block_late_proposal() {
         let (mut engine, reg) = setup();
         let status = RoundStatus {
             height: 100,
@@ -1635,18 +1666,28 @@ mod tests {
         };
         let _ = engine.on_round_status(&status, &reg);
         assert!(
-            engine.state.our_prevote_cast,
-            "catch_up must mark our prevote cast"
+            !engine.state.our_prevote_cast,
+            "catch_up must NOT mark our prevote cast — late proposal still needs to be accepted"
         );
-        assert_eq!(engine.state.phase, BftPhase::Prevote);
+        assert_eq!(engine.state.phase, BftPhase::Propose);
+        assert_eq!(engine.round(), 4);
 
-        // Late proposal for the same round must NOT cause a second prevote.
+        // Late proposal for the same round → engine accepts and emits a
+        // real prevote for the block. (Double-vote prevention happens at
+        // the signing layer via LastSignBytes guard, not here.)
         let proposer = reg.weighted_proposer(engine.height(), 4).unwrap();
         let action = engine.on_proposal("late_hash", &proposer, &reg);
-        assert!(
-            matches!(action, BftAction::Wait),
-            "late proposal must not trigger second prevote when our_prevote_cast is set; got {action:?}"
-        );
+        match action {
+            BftAction::BroadcastPrevote(p) => {
+                assert_eq!(p.round, 4, "prevote is for the caught-up round");
+                assert_eq!(
+                    p.block_hash.as_deref(),
+                    Some("late_hash"),
+                    "engine must vote for the late proposal, not nil"
+                );
+            }
+            other => panic!("expected BroadcastPrevote for late proposal, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1942,6 +1983,10 @@ mod tests {
     fn test_143_f_plus_one_peers_at_same_round_triggers_catch_up() {
         // 2 of 4 peers at round 1 → f+1 (2 peers × 250 stake = 500 > 334).
         // Our round is 0, so we should catch up to round 1.
+        //
+        // 2026-05-10: catch_up no longer eager-nil-votes (see catch_up_round
+        // comment). Engine still advances to round 1 but stays in Propose
+        // so a late-but-valid proposal can drive a real prevote.
         let (mut engine, reg) = setup_143();
         assert_eq!(engine.round(), 0);
 
@@ -1949,12 +1994,13 @@ mod tests {
         let action = engine.on_round_status_weighted(&status("0xb", 1), 250, &reg);
 
         assert!(
-            matches!(action, BftAction::BroadcastPrevote(ref p) if p.round == 1 && p.block_hash.is_none()),
-            "expected nil prevote at round 1 after f+1 peers reported, got {:?}",
+            matches!(action, BftAction::Wait),
+            "f+1 catch-up advances the round but no longer eager-nil-votes; got {:?}",
             action,
         );
         assert_eq!(engine.round(), 1);
-        assert!(engine.state.our_prevote_cast);
+        assert_eq!(engine.state.phase, BftPhase::Propose);
+        assert!(!engine.state.our_prevote_cast);
     }
 
     #[test]
@@ -1985,15 +2031,16 @@ mod tests {
         assert!(matches!(a1, BftAction::Wait), "a1 = {:?}", a1);
         // Second report: 2 peers at round 3 → cumulative 500 stake, crosses
         // the 334 threshold, so we jump to round 3.
-        assert!(
-            matches!(a2, BftAction::BroadcastPrevote(ref p) if p.round == 3),
-            "expected catch-up to round 3 at a2, got {:?}",
-            a2,
-        );
+        //
+        // 2026-05-10: catch_up returns Wait (no eager nil-vote). Round is
+        // still bumped via the underlying advance_round.
+        assert!(matches!(a2, BftAction::Wait), "a2 = {:?}", a2);
         // Third report: one peer at round 5 is below threshold on its own,
         // so we stay at round 3. This is the anti-single-liar property.
         assert!(matches!(a3, BftAction::Wait), "a3 = {:?}", a3);
         assert_eq!(engine.round(), 3);
+        assert_eq!(engine.state.phase, BftPhase::Propose);
+        assert!(!engine.state.our_prevote_cast);
     }
 
     #[test]
@@ -2031,13 +2078,16 @@ mod tests {
         assert!(matches!(action, BftAction::Wait));
 
         // Peer 0xa reports again, this time with their actual 250 stake.
+        // 2026-05-10: catch_up returns Wait; round still advances.
         let action = engine.on_round_status_weighted(&status("0xa", 1), 250, &reg);
         assert!(
-            matches!(action, BftAction::BroadcastPrevote(ref p) if p.round == 1),
-            "stake refresh should unlock the skip, got {:?}",
+            matches!(action, BftAction::Wait),
+            "stake refresh advances round but no eager nil-vote; got {:?}",
             action,
         );
         assert_eq!(engine.round(), 1);
+        assert_eq!(engine.state.phase, BftPhase::Propose);
+        assert!(!engine.state.our_prevote_cast);
     }
 
     #[test]
@@ -2080,13 +2130,15 @@ mod tests {
         // The back-compat `on_round_status` wrapper preserves the pre-#143
         // single-peer "2+ rounds ahead" trigger for any call site that
         // hasn't migrated to the weighted API yet.
+        //
+        // 2026-05-10: catch_up returns Wait now (no eager nil-vote).
+        // Round still advances to peer_round - 1.
         let (mut engine, reg) = setup_143();
         let action = engine.on_round_status(&status("0xa", 2), &reg);
-        assert!(
-            matches!(action, BftAction::BroadcastPrevote(ref p) if p.round == 1),
-            "legacy path should catch up to peer_round - 1, got {:?}",
-            action,
-        );
+        assert!(matches!(action, BftAction::Wait), "got {:?}", action);
+        assert_eq!(engine.round(), 1, "legacy path catches up to peer_round - 1");
+        assert_eq!(engine.state.phase, BftPhase::Propose);
+        assert!(!engine.state.our_prevote_cast);
     }
 
     /// V3 regression: `on_proposal` must reject a proposal whose
@@ -2448,10 +2500,17 @@ mod tests {
         (reg, total)
     }
 
-    /// Test 1 — Non-proposer catch_up_round still returns nil prevote and
-    /// sets `our_prevote_cast = true`. Issue #133 path preserved.
+    /// Test 1 — Non-proposer catch_up_round leaves the engine ready to
+    /// accept a late proposal: round bumped, phase=Propose,
+    /// our_prevote_cast=false, no nil-vote emitted.
+    ///
+    /// 2026-05-10: changed from the previous "must emit nil-prevote"
+    /// contract. The eager nil-vote was producing nil-precommit cascades
+    /// when a late-but-valid proposal arrived shortly after catch-up.
+    /// Nil-vote fallback now happens via `on_timeout` after
+    /// `propose_timeout(round)` if no proposal arrives.
     #[test]
-    fn test_finalization_dead_fix_non_proposer_emits_nil_prevote() {
+    fn test_finalization_dead_fix_non_proposer_does_not_eager_nil_vote() {
         let (reg, total_stake) = setup_4val();
         // round 1 proposer is 0xval002; we are 0xval001 (NOT proposer)
         let mut engine = BftEngine::new(100, "0xval001".into(), total_stake);
@@ -2459,21 +2518,18 @@ mod tests {
         let pv = engine.catch_up_round(1, &reg);
 
         assert!(
-            pv.is_some(),
-            "non-proposer must emit a nil-prevote for the caught-up round"
+            pv.is_none(),
+            "non-proposer no longer eager-nil-votes on catch-up"
         );
-        let pv = pv.unwrap();
-        assert_eq!(pv.height, 100);
-        assert_eq!(pv.round, 1);
-        assert!(
-            pv.block_hash.is_none(),
-            "catch-up prevote must be nil (no block to vote for yet)"
+        assert_eq!(engine.state.round, 1, "round counter still advances");
+        assert_eq!(
+            engine.state.phase,
+            BftPhase::Propose,
+            "stay in Propose so a late proposal can drive a real prevote"
         );
-        assert_eq!(engine.state.round, 1);
-        assert_eq!(engine.state.phase, BftPhase::Prevote);
         assert!(
-            engine.state.our_prevote_cast,
-            "non-proposer path MUST set our_prevote_cast so we don't double-vote when the proposal arrives later in the same round"
+            !engine.state.our_prevote_cast,
+            "our_prevote_cast stays false until a real proposal (or timeout) drives the vote"
         );
     }
 
@@ -2614,12 +2670,15 @@ mod tests {
         assert_eq!(engine.state.phase, BftPhase::Precommit);
     }
 
-    /// Test 6 — Regression pin for Issue #133. Non-proposer that misses
-    /// the original proposal (gossipsub doesn't replay it) must still
-    /// emit a nil-prevote on catch-up so it contributes to round quorum
-    /// instead of stalling in `BftPhase::Propose` forever.
+    /// Test 6 — Issue #133 fallback now lives in `on_timeout`, not in
+    /// catch_up_round. After catch_up the engine sits in Propose; if no
+    /// proposal arrives within `propose_timeout(round)`, the validator-
+    /// loop's regular `is_timed_out + on_timeout` cycle emits the nil-
+    /// vote. The "wait forever" risk from #133 is therefore handled
+    /// without paying the eager-nil cascade cost when proposals do
+    /// arrive late.
     #[test]
-    fn test_finalization_dead_fix_issue_133_non_proposer_regression() {
+    fn test_finalization_dead_fix_issue_133_timeout_fallback_emits_nil() {
         let (reg, total_stake) = setup_4val();
         // Round 2 proposer is 0xval003; we are 0xval001 (NOT proposer at r=2)
         let mut engine = BftEngine::new(100, "0xval001".into(), total_stake);
@@ -2628,23 +2687,36 @@ mod tests {
         assert_eq!(engine.state.round, 0);
 
         let pv = engine.catch_up_round(2, &reg);
-
-        assert!(
-            pv.is_some(),
-            "Issue #133: a non-proposer that catches up MUST emit a nil-prevote so the round can reach quorum without re-presenting the proposal"
-        );
-        let pv = pv.unwrap();
-        assert_eq!(pv.round, 2);
-        assert!(
-            pv.block_hash.is_none(),
-            "catch-up prevote is nil (we have no proposal bytes to vote on)"
-        );
+        assert!(pv.is_none(), "no eager nil-vote on catch-up");
         assert_eq!(engine.state.round, 2);
+        assert_eq!(engine.state.phase, BftPhase::Propose);
+
+        // Force the propose-phase timeout by rewinding `phase_start` past
+        // `propose_timeout(round=2)` (the engine uses Instant::now under
+        // the hood; we approximate by calling on_timeout directly with a
+        // pre-aged phase_start).
+        engine.phase_start = Instant::now()
+            .checked_sub(propose_timeout(engine.state.round))
+            .expect("Instant arithmetic")
+            .checked_sub(Duration::from_secs(1))
+            .expect("Instant arithmetic");
+
+        let action = engine.on_timeout();
+        match action {
+            BftAction::BroadcastPrevote(p) => {
+                assert_eq!(p.round, 2);
+                assert!(
+                    p.block_hash.is_none(),
+                    "fallback nil-vote emitted by on_timeout when no proposal arrived"
+                );
+            }
+            other => panic!(
+                "expected BroadcastPrevote(nil) from on_timeout fallback, got {:?}",
+                other
+            ),
+        }
         assert_eq!(engine.state.phase, BftPhase::Prevote);
-        assert!(
-            engine.state.our_prevote_cast,
-            "must be set so a later on_proposal in the same round won't double-vote"
-        );
+        assert!(engine.state.our_prevote_cast);
     }
 
     /// v2.1.91 regression target: if the caller fails to enqueue the
@@ -2902,7 +2974,10 @@ mod tests {
 
         let caught_up = engine.catch_up_round(2, &reg);
 
-        assert!(caught_up.is_some());
+        // 2026-05-10: catch_up_round no longer eager-nil-votes, so the
+        // returned Option<Prevote> is None. The pending-vote-clearing
+        // contract this test pins still holds.
+        assert!(caught_up.is_none());
         assert!(engine.pending_prevote.is_none());
         assert!(engine.pending_precommit.is_none());
         assert_eq!(engine.state.round, 2);

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -42,23 +42,40 @@ pub static EVENT_TX_DROPPED: AtomicU64 = AtomicU64::new(0);
 
 /// 2026-05-05 v2.1.66: swarm-task progress counter. Incremented on
 /// every iteration of the run_swarm select! loop. Read by a separate
-/// watchdog tokio task — if the counter stays still for ≥30 s, the
-/// swarm task is wedged (most likely on `event_tx.send().await` if
-/// the validator-loop consumer is stuck, or on internal libp2p
-/// state-machine deadlock) and we trigger `std::process::abort()` so
-/// systemd `Restart=always` cycles cleanly without MDBX corruption.
+/// watchdog tokio task to detect silent-thread-death (counter stays
+/// still while validator main loop keeps ticking).
 ///
-/// Same pattern as the v2.1.60 heartbeat watchdog and v2.1.62 chain-
-/// height watchdog. Closes the silent-thread-death class observed at
-/// h=1392113 (2026-05-05 morning) and h=1398998 (2026-05-05 afternoon)
-/// where vps1's libp2p went unresponsive while the validator main
-/// loop kept ticking — peers' BFT prevote/precommit/proposal/round-
-/// status all timed out outbound to vps1 (`outbound failure to
-/// 12D3KooWSZ...JJE: Timeout while waiting for a response`) and the
-/// cluster lost a voter without any local signal that vps1 should
-/// restart. With this watchdog vps1 will self-abort + cycle back via
-/// systemd before the cluster crosses the quorum threshold.
+/// Closes the silent-thread-death class observed at h=1392113 and
+/// h=1398998 (both 2026-05-05) where vps1's libp2p went unresponsive
+/// while the validator main loop kept ticking — peers' BFT prevote/
+/// precommit/proposal/round-status all timed out outbound to vps1.
+///
+/// 2026-05-10: the action on stall is no longer process::abort by
+/// default. See `SwarmWatchdogAction` and `SWARM_STALL_TOTAL` /
+/// `SWARM_STALLED` below. Default action is WarnOnly so external
+/// supervisors (sentrix-guardian / systemd / docker `unless-stopped`)
+/// can decide whether and how to restart. In-process self-kill was
+/// hiding deeper liveness issues — see docs/debugging/bft-liveness.md.
 pub static SWARM_TICK: AtomicU64 = AtomicU64::new(0);
+
+/// 2026-05-10: cumulative count of swarm-task stall detections. Each
+/// increment corresponds to a `STALL_THRESHOLD` window where SWARM_TICK
+/// did not advance. Exposed as `sentrix_swarm_stall_total` for external
+/// monitoring. Replaces the hard-kill signal — restart decisions move
+/// to an external guardian.
+pub static SWARM_STALL_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// 2026-05-10: age in seconds of the last observed SWARM_TICK change.
+/// 0 means the counter advanced this tick. Exposed as
+/// `sentrix_swarm_last_tick_age_seconds`.
+pub static SWARM_LAST_TICK_AGE_SECONDS: AtomicU64 = AtomicU64::new(0);
+
+/// 2026-05-10: health flag — true while the swarm task is currently
+/// considered stalled (no SWARM_TICK progress for ≥ STALL_THRESHOLD).
+/// Cleared automatically when progress resumes. Read by the
+/// `/sentrix_status_extended` health endpoint.
+pub static SWARM_STALLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 /// 2026-05-05 v2.1.65: cumulative count of broadcasts dropped because
 /// the swarm cmd_tx channel was full (try_send → TrySendError::Full).
@@ -518,36 +535,52 @@ impl LibP2pNode {
 // ── Swarm watchdog action policy ─────────────────────────
 //
 // The swarm-task watchdog (spawned inside run_swarm) detects silent-thread-
-// death by polling SWARM_TICK. When it fires, the action is configurable so
-// we can run a "warn" experiment on testnet to isolate whether the hard kill
-// itself contributes to mesh churn vs actually catching real wedges.
+// death by polling SWARM_TICK. The action on detection is configurable.
 //
-// Default is `Abort` — zero behaviour change without the env set.
+// 2026-05-10: default changed from Abort → WarnOnly. The 6h warn-mode
+// testnet bake confirmed that:
+//   1. Hard-kill restart cycles were the dominant restart-churn source
+//      (74 cumulative restarts in 6h on abort-mode vs 0 on warn-mode).
+//   2. Removing the kill exposed a deeper BFT/libp2p round-cascade
+//      liveness issue that the kill had been masking via mesh reset.
+//
+// In-process self-kill is the wrong answer to liveness because it hides
+// the underlying cascade and produces false confidence. External
+// supervisors (sentrix-guardian / systemd / docker `unless-stopped`)
+// can still restart unhealthy nodes — the difference is they decide
+// based on observed health flags + stall counters, not on a black-box
+// 30s timer inside the process.
+//
+// `Abort` and `Exit` modes are kept available behind the env so
+// operators who knowingly want the historical kill behaviour can opt
+// in, but the default is now non-fatal.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SwarmWatchdogAction {
-    /// Log only. No process termination. Resets the stall baseline so we
-    /// don't re-fire every TICK. Used on testnet for diagnostic bakes.
+    /// Log only — increment SWARM_STALL_TOTAL, set SWARM_STALLED, reset
+    /// the stall baseline so we don't re-fire every TICK. Default since
+    /// 2026-05-10.
     WarnOnly,
-    /// `std::process::exit(1)` — graceful (runs destructors).
+    /// `std::process::exit(1)` — graceful (runs destructors). Opt-in.
     Exit,
-    /// `std::process::abort()` — current production behaviour. Drops the
-    /// process immediately so systemd/docker `restart=unless-stopped` cycles
-    /// it cleanly without giving the libp2p task time to do anything weird.
+    /// `std::process::abort()` — drops the process immediately so an
+    /// external supervisor cycles it. Opt-in; the historical default
+    /// pre-2026-05-10. Use only when you specifically want the kill
+    /// behaviour.
     Abort,
 }
 
 /// Parse `SENTRIX_SWARM_WATCHDOG_MODE`. Recognised values (case-insensitive):
-/// `abort`, `exit`, `warn`. Anything else (or unset) returns `Abort`. Invalid
-/// values log a warning so an operator typo on testnet doesn't silently fall
-/// back to a different behaviour than they expected.
+/// `abort`, `exit`, `warn`. Anything else (or unset) returns the default
+/// `WarnOnly`. Invalid values log a warning so an operator typo doesn't
+/// silently fall back to a different behaviour than they expected.
 pub(crate) fn parse_watchdog_mode(value: Option<&str>) -> SwarmWatchdogAction {
     let raw = match value {
         Some(s) => s.trim(),
-        None => return SwarmWatchdogAction::Abort,
+        None => return SwarmWatchdogAction::WarnOnly,
     };
     if raw.is_empty() {
-        return SwarmWatchdogAction::Abort;
+        return SwarmWatchdogAction::WarnOnly;
     }
     match raw.to_ascii_lowercase().as_str() {
         "abort" => SwarmWatchdogAction::Abort,
@@ -556,10 +589,10 @@ pub(crate) fn parse_watchdog_mode(value: Option<&str>) -> SwarmWatchdogAction {
         other => {
             tracing::warn!(
                 target: "swarm_watchdog",
-                "Unrecognised SENTRIX_SWARM_WATCHDOG_MODE='{}' — falling back to default (abort).",
+                "Unrecognised SENTRIX_SWARM_WATCHDOG_MODE='{}' — falling back to default (warn).",
                 other,
             );
-            SwarmWatchdogAction::Abort
+            SwarmWatchdogAction::WarnOnly
         }
     }
 }
@@ -686,24 +719,43 @@ async fn run_swarm(
                 continue;
             }
             let current = SWARM_TICK.load(Ordering::Acquire);
+            // Update tick-age gauge regardless of stall state so external
+            // monitors can see how stale the loop is in real time.
+            let age = last_changed.elapsed().as_secs();
+            SWARM_LAST_TICK_AGE_SECONDS.store(age, Ordering::Release);
             if current != last_seen {
                 last_seen = current;
                 last_changed = TokioInstant::now();
+                // Resumed progress — clear the health flag.
+                SWARM_STALLED.store(false, std::sync::atomic::Ordering::Release);
             } else if last_changed.elapsed() >= STALL_THRESHOLD {
-                tracing::error!(
+                // Always increment the cumulative counter and set the
+                // health flag — these are the signals an external
+                // supervisor consumes regardless of mode.
+                SWARM_STALL_TOTAL.fetch_add(1, Ordering::Relaxed);
+                SWARM_STALLED.store(true, std::sync::atomic::Ordering::Release);
+
+                tracing::warn!(
                     target: "swarm_watchdog",
                     "libp2p swarm task stalled — no select!-loop progress \
-                     for {}s (counter={}, mode={:?}). Silent-thread-death \
-                     class at h=1392113 / h=1398998 was where libp2p went \
-                     unresponsive while validator main loop kept ticking.",
-                    last_changed.elapsed().as_secs(), current, watchdog_mode,
+                     for {}s (counter={}, mode={:?}, stall_total={}). \
+                     Silent-thread-death class at h=1392113 / h=1398998 \
+                     was where libp2p went unresponsive while validator \
+                     main loop kept ticking. External supervisor can \
+                     decide whether to restart based on swarm_stalled + \
+                     stall_total.",
+                    last_changed.elapsed().as_secs(),
+                    current,
+                    watchdog_mode,
+                    SWARM_STALL_TOTAL.load(Ordering::Relaxed),
                 );
                 match watchdog_mode {
                     SwarmWatchdogAction::Abort => std::process::abort(),
                     SwarmWatchdogAction::Exit => std::process::exit(1),
                     SwarmWatchdogAction::WarnOnly => {
-                        // Reset baseline so we don't re-fire every tick;
-                        // the operator wanted only a warning, not a kill.
+                        // Reset the stall baseline so we don't re-fire
+                        // every tick. Health flag stays set until the
+                        // counter actually advances again (cleared above).
                         last_seen = current;
                         last_changed = TokioInstant::now();
                     }
@@ -2273,8 +2325,11 @@ mod tests {
     // ── Swarm watchdog mode parsing ────────────────────────────────
 
     #[test]
-    fn watchdog_mode_default_is_abort_when_unset() {
-        assert_eq!(parse_watchdog_mode(None), SwarmWatchdogAction::Abort);
+    fn watchdog_mode_default_is_warn_when_unset() {
+        // 2026-05-10: default flipped from Abort → WarnOnly. Validator
+        // runtime no longer self-kills on swarm stall; restart decisions
+        // move to an external supervisor.
+        assert_eq!(parse_watchdog_mode(None), SwarmWatchdogAction::WarnOnly);
     }
 
     #[test]
@@ -2299,22 +2354,22 @@ mod tests {
     }
 
     #[test]
-    fn watchdog_mode_invalid_falls_back_to_abort() {
-        // Typo / unknown value → safe default, not panic.
-        assert_eq!(parse_watchdog_mode(Some("nuke")), SwarmWatchdogAction::Abort);
-        assert_eq!(parse_watchdog_mode(Some("disable")), SwarmWatchdogAction::Abort);
-        assert_eq!(parse_watchdog_mode(Some("123")), SwarmWatchdogAction::Abort);
+    fn watchdog_mode_invalid_falls_back_to_default() {
+        // Typo / unknown value → safe default (warn), not panic.
+        assert_eq!(parse_watchdog_mode(Some("nuke")), SwarmWatchdogAction::WarnOnly);
+        assert_eq!(parse_watchdog_mode(Some("disable")), SwarmWatchdogAction::WarnOnly);
+        assert_eq!(parse_watchdog_mode(Some("123")), SwarmWatchdogAction::WarnOnly);
     }
 
     #[test]
-    fn watchdog_mode_empty_string_falls_back_to_abort() {
-        assert_eq!(parse_watchdog_mode(Some("")), SwarmWatchdogAction::Abort);
-        assert_eq!(parse_watchdog_mode(Some("   ")), SwarmWatchdogAction::Abort);
+    fn watchdog_mode_empty_string_falls_back_to_default() {
+        assert_eq!(parse_watchdog_mode(Some("")), SwarmWatchdogAction::WarnOnly);
+        assert_eq!(parse_watchdog_mode(Some("   ")), SwarmWatchdogAction::WarnOnly);
     }
 
     #[test]
     fn watchdog_mode_warn_does_not_terminate_process() {
-        // The whole point of the experiment: warn mode must NOT request
+        // The whole point of warn mode: it must NOT request process
         // termination. We verify by matching on the enum variant — the
         // runtime side only calls process::abort/exit on the kill variants.
         let action = parse_watchdog_mode(Some("warn"));
@@ -2323,6 +2378,19 @@ mod tests {
             SwarmWatchdogAction::Abort | SwarmWatchdogAction::Exit
         );
         assert!(!terminates, "warn mode must not request process termination");
+    }
+
+    #[test]
+    fn watchdog_default_does_not_terminate_process() {
+        // Strong invariant for mission requirement #1: default behaviour
+        // (no env set) must not self-kill. External supervisors are the
+        // only correct restart authority.
+        let action = parse_watchdog_mode(None);
+        let terminates = matches!(
+            action,
+            SwarmWatchdogAction::Abort | SwarmWatchdogAction::Exit
+        );
+        assert!(!terminates, "default watchdog mode must not request process termination");
     }
 
     #[test]

--- a/docs/debugging/bft-liveness.md
+++ b/docs/debugging/bft-liveness.md
@@ -1,0 +1,136 @@
+# Diagnosing BFT liveness stalls
+
+## What "liveness stall" looks like
+
+A Sentrix validator stuck in a BFT liveness stall has these symptoms:
+
+- `bc.height()` is unchanged for minutes.
+- Logs show BFT round numbers climbing: `round=0` → `round=1` → … →
+  `round=10+`.
+- `BFT skip round` and `BFT timeout — advanced to round N` messages
+  fire repeatedly.
+- Many round transitions end with a precommit nil-majority:
+  `BFT #1d: precommit nil-majority skip … precommit_tally=[nil=4500B]`.
+- Chain may eventually resume (round cascade resolves) or stay stuck
+  until an external restart.
+
+This is **not** a halt-class safety violation — no double-finalize,
+no equivocation. It is a liveness issue: the engine cannot reach
+quorum on a block.
+
+## What the engine does at each round
+
+For a 4-validator chain (3 / 4 stake quorum):
+
+1. Proposer for `(height, round)` builds a block and gossips a
+   `Proposal` over libp2p.
+2. Each validator receives the proposal, validates, and casts a signed
+   prevote for the proposed hash (or nil if locked on a different hash
+   or the proposal didn't arrive).
+3. Once a validator sees a 3 / 4 stake-weighted prevote supermajority
+   for a non-nil hash, it casts a precommit for that hash.
+4. Once a validator sees a 3 / 4 stake-weighted precommit
+   supermajority, it finalizes the block.
+5. If the round timer fires before quorum, the engine advances to the
+   next round (skip-round). If a 3 / 4 stake-weighted nil precommit
+   majority forms, same thing.
+
+## Why nil-majority cascades happen
+
+The dominant cause observed on testnet 2026-05-10 was libp2p **proposal
+delivery jitter**:
+
+- Round timeouts at the validator side fire ~13 s after the round
+  starts.
+- On a healthy mesh the proposal reaches all 4 validators within a
+  few tens of milliseconds.
+- Under jitter (gossipsub mesh stuck on a slow peer, libp2p select!
+  loop briefly stalled, OS scheduler latency), the proposal arrives
+  at some validators only after they have already prevoted nil on
+  timeout.
+- Once 2 / 4 validators have prevoted nil, the round can no longer
+  reach 3 / 4 prevote supermajority for the block — even if the
+  remaining 2 validators successfully receive the proposal and prevote
+  for it.
+- The engine then sees a nil-precommit majority and skips to the next
+  round. Same proposer pattern, same race, same outcome — a cascade
+  of nil rounds at one height while libp2p mesh is degraded.
+
+There are other failure modes (locked-without-bytes livelock, real
+network partition, real fork) but the common observed mode at
+~16 s/blk testnet baseline is jitter-driven nil cascade.
+
+## How to confirm it's liveness, not safety
+
+Before declaring "this is a liveness issue", rule out:
+
+```bash
+# Any divergent state across validators at the same height?
+journalctl -u sentrix-node --since "10 min ago" | grep STATE-FP | tail -30
+# Any double-finalize / equivocation events?
+docker logs --since 10m sentrix-testnet-val1 \
+  | grep -E 'invalid previous|equivocation|double.sign' \
+  | head -10
+```
+
+If both are clean (and `STATE-FP` fingerprints agree across hosts at
+the same heights), it is a liveness issue.
+
+## Logs to collect at a stall
+
+```bash
+# Per-validator BFT activity over the stall window.
+docker logs --since 10m sentrix-testnet-val1 \
+  | grep -E 'BFT (round|timeout|skip|finalized|prevote|precommit|proposal)' \
+  | tail -100
+# Round-skip and nil-majority counts.
+docker logs --since 10m sentrix-testnet-val1 \
+  | grep -cE 'BFT skip round|nil-majority'
+docker logs --since 10m sentrix-testnet-val1 \
+  | grep -cE 'BFT timeout'
+# libp2p connection events (handshake errors, dropped peers).
+docker logs --since 10m sentrix-testnet-val1 \
+  | grep -E 'Handshake failed|outgoing connection error|outbound failure|Connection reset' \
+  | head -20
+# Health flags — confirm runtime is in degraded state.
+curl -s http://127.0.0.1:9545/sentrix_status_extended | jq '.health'
+```
+
+## What `bft_liveness_degraded=true` means at runtime
+
+The validator runtime sets this flag when either:
+
+- the validator-loop heartbeat counter has not advanced for
+  `HEARTBEAT_STALL_THRESHOLD` (60 s by default), or
+- `bc.height()` has not advanced for `height_stall_threshold` (90 s
+  by default; tunable via `HEIGHT_STALL_THRESHOLD_SEC`).
+
+The flag is **cleared automatically** as soon as either side resumes
+progress. An external supervisor should treat the flag as a
+"page-the-operator" signal, not as a "kill the process now" signal.
+
+A degraded flag for 30 s during a libp2p mesh hiccup is normal under
+the current testnet conditions. A degraded flag held for > 5 min is a
+real incident — collect logs (above), then restart the unit.
+
+## Distinguishing the failure modes
+
+| Pattern                                                              | Likely cause                              | Action                                         |
+| -------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------- |
+| Round 0 → 1 → 2 → … → 10+; nil-majority each time; no peer errors    | libp2p proposal delivery jitter           | Wait — usually self-recovers in 1–3 min.       |
+| Round 0 → 1 → 2 + many `outgoing connection error`                   | libp2p mesh partial partition             | Inspect peer connectivity; restart if stuck.   |
+| Locked-on-different-hash + persistent nil prevote                    | Locked-without-bytes livelock             | Stale-lock relax should clear after gap; restart if not. |
+| `STATE-FP` divergence at same height                                 | Real consensus / safety bug               | Halt cluster + STATE-FP RCA. Do NOT just restart. |
+| `swarm_stalled=true` for >2 min, no log activity in swarm            | libp2p select! loop wedged                | Restart the unit (warn mode logs the stall but does not kill). |
+
+## Reference: relevant code paths
+
+- `crates/sentrix-bft/src/engine.rs::accept_proposal` — proposal-arrival
+  prevote logic and lock-conflict nil-vote.
+- `crates/sentrix-bft/src/engine.rs::on_prevote_weighted` — prevote
+  supermajority detection and lock acquisition.
+- `crates/sentrix-bft/src/engine.rs::on_timeout` — round-skip on timer.
+- `crates/sentrix-network/src/libp2p_node.rs::SwarmWatchdogAction` —
+  swarm-stall policy (default warn-only).
+- `bin/sentrix/src/main.rs` validator-loop watchdog block — heartbeat
+  and chain-height stall detection (warn-only since 2026-05-10).

--- a/docs/operations/guardian.md
+++ b/docs/operations/guardian.md
@@ -1,0 +1,127 @@
+# Validator restart authority — guardian model
+
+## Summary
+
+The Sentrix validator runtime does **not** call `process::abort()` or
+`process::exit()` to recover from liveness stalls. Restart authority
+lives **outside** the validator process, in an external supervisor:
+
+- `systemd` with `Restart=always` on the production validator units, or
+- `docker` with `restart: unless-stopped` on the testnet docker stack, or
+- a dedicated `sentrix-guardian` daemon for richer policy
+
+The runtime emits health flags and counters; the supervisor reads them
+and decides whether to restart.
+
+## Why this changed (2026-05-10)
+
+Before this change, three watchdogs inside the validator process called
+`std::process::abort()` on stall:
+
+- **Swarm-task watchdog** (libp2p select-loop progress) — 30 s threshold
+- **Validator-loop heartbeat watchdog** — 60 s threshold
+- **Chain-height watchdog** — 90 s default threshold (env-tunable)
+
+The 6 h testnet bake on 2026-05-10 demonstrated that these aborts were
+**masking** a deeper BFT/libp2p round-cascade liveness issue rather than
+fixing it. Each abort cycle reset the libp2p mesh, which incidentally
+broke validators out of nil-precommit cascades — but it produced false
+confidence: the underlying bug was never visible in production logs
+because the kills always cleared it before it persisted.
+
+When the kills were disabled (`SENTRIX_SWARM_WATCHDOG_MODE=warn`):
+
+- Restart count dropped from 74 / 6 h → 0
+- BFT round cascades became visible (round 5, 8, 11, 18+)
+- Block-time degraded from 0.82 s/blk avg → 2.83 s/blk avg
+- 0 safety regressions (no double-finalize, no equivocation, no
+  invalid-prev)
+
+The conclusion: in-process self-kill is the **wrong tool** for
+recovering from a consensus-layer liveness issue. It hides the bug and
+makes it harder to diagnose. The right tool is a metric and an
+external supervisor.
+
+## What the runtime exposes
+
+### Counters (cumulative, never decrement)
+
+| Metric                             | Source                          | Meaning                                                |
+| ---------------------------------- | ------------------------------- | ------------------------------------------------------ |
+| `sentrix_swarm_stall_total`        | `sentrix-network::libp2p_node`  | Each `STALL_THRESHOLD` (30 s) window with no progress. |
+| `sentrix_heartbeat_stall_total`    | `bin/sentrix::main`             | Each `HEARTBEAT_STALL_THRESHOLD` (60 s) window.        |
+| `sentrix_bft_height_stall_total`   | `bin/sentrix::main`             | Each `height_stall_threshold` (90 s default) window.   |
+
+### Gauges (current state)
+
+| Metric                                | Meaning                                                              |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| `sentrix_swarm_last_tick_age_seconds` | Seconds since the libp2p select! loop last advanced.                 |
+| `sentrix_validator_heartbeat_age`     | Seconds since the validator loop heartbeat last advanced.            |
+| `sentrix_bft_height_stall_seconds`    | Seconds since `bc.height()` last advanced.                           |
+
+### Health flags (boolean)
+
+| Flag                       | Meaning                                                                      |
+| -------------------------- | ---------------------------------------------------------------------------- |
+| `swarm_stalled`            | `true` while the swarm task has been stuck > `STALL_THRESHOLD`.              |
+| `bft_liveness_degraded`    | `true` while heartbeat or height stall is currently active.                  |
+
+Flags are **automatically cleared** when the underlying counter advances
+again — no operator intervention needed to reset them. They are exposed
+via the `/sentrix_status_extended` RPC endpoint.
+
+## Recommended supervisor policy
+
+These are starting thresholds. Tune for your deployment.
+
+| Severity   | Condition                                                              | Action                                       |
+| ---------- | ---------------------------------------------------------------------- | -------------------------------------------- |
+| `warn`     | `bft_height_stall_seconds > 120`                                       | Page on-call, collect logs.                  |
+| `critical` | `bft_height_stall_seconds > 300` AND BFT round > 10                    | Collect logs, then restart the unit.         |
+| `critical` | `swarm_stalled` is true AND `swarm_stall_total` increased twice in 5 m | Collect logs, then restart the unit.         |
+
+**Always collect logs before restart.** The whole point of removing
+the in-process kill was to keep the failure mode observable. A blind
+auto-restart loses the diagnostic value.
+
+A minimal log-collection step:
+
+```bash
+# Capture the last 5 minutes of validator + system logs before bouncing.
+journalctl -u sentrix-node --since "5 min ago" > /tmp/stall-evidence-$(date +%s).log
+```
+
+For docker stacks:
+
+```bash
+docker logs --since 5m sentrix-testnet-val1 \
+  > /tmp/val1-stall-$(date +%s).log
+```
+
+Restart only after the log is on disk.
+
+## Opting back in to in-process kill (not recommended)
+
+If a deployment really needs the historical kill behaviour (single-host
+homelab, no external supervisor available), set:
+
+```
+SENTRIX_SWARM_WATCHDOG_MODE=abort
+```
+
+This restores `std::process::abort()` on the libp2p stall path. The
+heartbeat and chain-height watchdogs in the validator runtime no longer
+have an env-flag for kill mode — they are warn-only by design. If you
+want them to terminate the process, your external supervisor should
+enforce that based on the published health flags.
+
+## What guardian is **not**
+
+- Not a consensus participant. Guardian only restarts processes; it
+  never touches BFT state, votes, or chain.db.
+- Not a fork resolver. Forks are handled by the BFT engine + state-fp
+  trace + chain.db rsync from canonical, all upstream of guardian.
+- Not a substitute for fixing the underlying BFT/libp2p liveness
+  issues. Guardian is a band-aid that makes operations sustainable
+  while the deeper fixes are in flight.


### PR DESCRIPTION
Two fixes for testnet liveness stalls. Continuation of PR #559 (which shipped the env-gating but kept defaults unchanged).

## Patch A continuation (commit `0071bbf`)

Removes the in-process `process::abort()` calls that survived PR #559:
- Default `SwarmWatchdogAction` flipped from `Abort` to `WarnOnly`. `Abort` and `Exit` modes still available via `SENTRIX_SWARM_WATCHDOG_MODE`.
- Validator-loop heartbeat watchdog and chain-height watchdog in `bin/sentrix/main.rs` no longer abort. They warn, increment counters, set `BFT_LIVENESS_DEGRADED`.
- New metrics: `SWARM_STALL_TOTAL`, `SWARM_LAST_TICK_AGE_SECONDS`, `SWARM_STALLED`, `VALIDATOR_HEARTBEAT_STALL_TOTAL`, `BFT_HEIGHT_STALL_TOTAL`.
- Catastrophic-bug paths (panic hook + genesis credit failure) kept on purpose.
- Docs: `docs/operations/guardian.md`, `docs/debugging/bft-liveness.md`.

The 6h `WARN`-mode bake on 2026-05-10 morning showed each abort cycle was hiding a deeper BFT round-cascade bug, not fixing it. Removing the kill exposed the cascade — see Patch B.

## Patch B (commit `4ca279f`)

`catch_up_round` no longer emits an eager nil-prevote. Pre-fix: when a non-proposer caught up via f+1 RoundStatus, it pre-emptively cast a nil prevote and entered Prevote phase. If the round-N proposal then arrived, `on_proposal` saw `phase != Propose` and returned Wait — the nil-vote stuck for the whole round. Same pattern firing on every catch-up across a slow mesh = round 5 / 8 / 11+ cascades.

Now: catch_up advances the round but leaves the engine in `Propose` with `our_prevote_cast=false`, returns `None`. Late-but-valid proposal drives a real prevote. If nothing arrives within `propose_timeout`, `on_timeout` emits the nil-vote fallback — same protection #133 needed, just without the cascade cost.

Updated 9 unit tests to pin the new contract. Double-vote prevention is in the LastSignBytes guard (PR #541), not in engine state.

## Test plan

- [x] 125/125 sentrix-bft tests pass
- [x] 41/41 sentrix-network tests pass
- [x] clippy + check `-D warnings` clean across bft / network / node
- [x] glibc-compat binary (max 2.30, sha `43248b89…`)
- [x] Testnet redeploy: chain unstuck from h=3,134,002 cascade in <30 s, advancing 0.46–1.62 s/blk at round=0
- [ ] 1 h bake (in flight)