### PR TITLE
fix(bft): rebroadcast prevote + precommit, bump to 2.1.91

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5111,7 +5111,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "anyhow",
  "axum",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "hex",
  "proptest",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.89"
+version = "2.1.91"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -13,42 +13,10 @@ use sentrix::storage::db::Storage;
 use sentrix::wallet::keystore::Keystore;
 use sentrix::wallet::wallet::Wallet;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::RwLock;
 
 const DEFAULT_API_PORT: u16 = 8545;
-
-// 2026-05-10: validator-runtime liveness metrics. See also
-// `crates/sentrix-network/src/libp2p_node.rs::SWARM_STALL_TOTAL` and the
-// runtime self-kill removal note in docs/operations/guardian.md.
-//
-// These counters and flags replace the in-process abort behaviour that
-// previously fired on heartbeat-stall and chain-height-stall. External
-// supervisors (sentrix-guardian / systemd / docker) consume these to
-// decide whether to restart the process — that decision no longer
-// belongs inside the validator runtime itself.
-
-/// Cumulative count of validator-loop heartbeat stalls. Each increment
-/// = one `HEARTBEAT_STALL_THRESHOLD` window where the heartbeat counter
-/// did not advance.
-pub static VALIDATOR_HEARTBEAT_STALL_TOTAL: AtomicU64 = AtomicU64::new(0);
-
-/// Age in seconds of the last observed heartbeat advance. 0 means the
-/// counter advanced on this tick.
-pub static VALIDATOR_HEARTBEAT_AGE_SECONDS: AtomicU64 = AtomicU64::new(0);
-
-/// Cumulative count of chain-height stalls observed. Each increment =
-/// one `height_stall_threshold` window where bc.height() did not change.
-pub static BFT_HEIGHT_STALL_TOTAL: AtomicU64 = AtomicU64::new(0);
-
-/// Age in seconds of the last observed height advance. 0 means a block
-/// finalized on this tick.
-pub static BFT_HEIGHT_STALL_SECONDS: AtomicU64 = AtomicU64::new(0);
-
-/// Health flag — true while either the heartbeat or chain-height
-/// stall window is active. Cleared automatically when progress resumes.
-/// Read by `/sentrix_status_extended` and external supervisors.
-pub static BFT_LIVENESS_DEGRADED: AtomicBool = AtomicBool::new(false);
 
 fn get_api_port() -> u16 {
     std::env::var("SENTRIX_API_PORT")
@@ -1479,216 +1447,20 @@ async fn cmd_start(
         }
     }
 
-    // BFT engine watchdog — heartbeat counter incremented at the top of
-    // every validator-loop iteration; a separate task panics + aborts
-    // the process if the counter stays stale for STALL_THRESHOLD seconds.
+    // 2026-05-10: in-process validator-loop watchdog removed.
     //
-    // Closes the silent-thread-death class (2026-05-04 incident series):
-    // a tokio task gets wedged on a lock or channel send, the validator
-    // loop stops iterating but the process stays alive (panic supervisor
-    // doesn't fire because nothing panicked). BFT engine emits no logs,
-    // chain stalls cluster-wide because a non-voting validator drops the
-    // others below quorum. The fix-without-RCA pattern: detect liveness
-    // at the loop level + abort on stall + let systemd Restart=always
-    // cycle the process. The next peer-gossip from a healthy validator
-    // re-syncs us via the libp2p add-block path.
+    // Production blockchains (Tendermint/CometBFT, Geth, Cosmos SDK
+    // app chains) don't ship in-process self-kill watchdogs. Restart
+    // authority belongs to an external supervisor (systemd, docker,
+    // sentrix-guardian) that can decide based on observed metrics —
+    // /sentrix_status_extended exposes the chain head, peer count,
+    // channel-drop counters, and the supervisor consumes those.
     //
-    // Threshold pick: 60s. BFT round-step timeout is in the seconds, a
-    // healthy iteration runs many times per second, so 60s of zero
-    // increments is unambiguously wedged. False-positive cost is one
-    // restart (~30s of downtime) which is dominated by the cost of
-    // letting a stalled validator sit indefinitely (cluster halt).
-    let validator_heartbeat = Arc::new(AtomicU64::new(0));
-    if validator.is_some() {
-        let heartbeat = validator_heartbeat.clone();
-        let shutdown = shutdown_flag.clone();
-        // Capture sender handles so the watchdog can also surface channel
-        // depth — `Sender::capacity()` returns free slots, max - free =
-        // depth.
-        let event_tx_for_watchdog = event_tx.clone();
-        let bft_tx_for_watchdog = bft_tx.clone();
-        // Chain-height-stale watchdog needs a Blockchain handle to read
-        // the latest finalized height. Read-only; takes the read lock
-        // for ~microseconds per tick.
-        let shared_for_watchdog = shared.clone();
-        tokio::spawn(async move {
-            use tokio::time::{Duration, sleep};
-            // Heartbeat watchdog — catches validator loop totally stopped
-            // iterating (silent thread death class). Loop iterates many
-            // times per second when healthy, so 60 s of zero increments
-            // is unambiguously wedged.
-            const HEARTBEAT_STALL_THRESHOLD: Duration = Duration::from_secs(60);
-            const HEARTBEAT_WARN_THRESHOLD: Duration = Duration::from_secs(20);
-            // Chain-height watchdog — catches the case where the loop IS
-            // iterating (heartbeat advances) but BFT can't reach finality
-            // (round-step rebroadcast cycle without finalize). Today's
-            // 2026-05-04 incident pattern: process alive + emitting
-            // libp2p outbound-failure logs every 2 s but height didn't
-            // move for 30+ min. Operator force-stopped, systemd
-            // SIGKILL'd, MDBX corrupted mid-write.
-            //
-            // 90 s threshold is generous: a healthy 4-validator BFT
-            // produces a block every 1 s, so 90 s of no-finalize = 90
-            // missed slots = real stall. False-positive cost is one
-            // restart; missed-detection cost is operator-triggered
-            // SIGKILL → MDBX_CORRUPTED → forced rsync recovery (today's
-            // failure mode that motivated this watchdog).
-            // v2.1.85: env-var override. Default 90s is fine for steady-state
-            // 1s-block production but kills validators mid-recovery (round-skip
-            // cycles can take >90s when the cluster is converging from a halt).
-            // Operators in recovery scenarios can set
-            // HEIGHT_STALL_THRESHOLD_SEC=600 to give BFT room to finish round
-            // transitions. Pre-v2.1.85 was hardcoded 90s; see v44 incident
-            // 2026-05-07 for the failure mode this override addresses.
-            let height_stall_secs: u64 = std::env::var("HEIGHT_STALL_THRESHOLD_SEC")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(90);
-            let height_stall_threshold = Duration::from_secs(height_stall_secs);
-            let height_warn_threshold =
-                Duration::from_secs(height_stall_secs.saturating_mul(1).max(30) / 3);
-            const TICK: Duration = Duration::from_secs(5);
-            const CHANNEL_GAUGE_TICK: Duration = Duration::from_secs(30);
-            const CHANNEL_PRESSURE_PCT: usize = 25;
-
-            let mut last_seen = heartbeat.load(Ordering::Acquire);
-            let mut last_changed = tokio::time::Instant::now();
-            let mut last_height: u64 = {
-                let bc = shared_for_watchdog.read().await;
-                bc.height()
-            };
-            let mut last_height_changed = tokio::time::Instant::now();
-            let mut last_gauge = tokio::time::Instant::now();
-            loop {
-                sleep(TICK).await;
-                if shutdown.load(Ordering::Acquire) {
-                    return;
-                }
-
-                // ── Heartbeat watchdog (loop-stop) ──
-                //
-                // 2026-05-10: this used to call std::process::abort() at
-                // HEARTBEAT_STALL_THRESHOLD. The hard-kill was removed
-                // because (a) the 6h warn-mode bake on testnet showed the
-                // kill was hiding a deeper BFT/libp2p round-cascade
-                // liveness issue, and (b) restart authority belongs to an
-                // external supervisor that can decide based on observed
-                // health flags + counters, not on a fixed timer inside
-                // the validator runtime. See docs/operations/guardian.md.
-                let current = heartbeat.load(Ordering::Acquire);
-                let hb_age = last_changed.elapsed().as_secs();
-                VALIDATOR_HEARTBEAT_AGE_SECONDS.store(hb_age, Ordering::Release);
-                if current != last_seen {
-                    last_seen = current;
-                    last_changed = tokio::time::Instant::now();
-                } else {
-                    let stale = last_changed.elapsed();
-                    if stale >= HEARTBEAT_STALL_THRESHOLD {
-                        let event_depth =
-                            event_tx_for_watchdog.max_capacity() - event_tx_for_watchdog.capacity();
-                        let bft_depth =
-                            bft_tx_for_watchdog.max_capacity() - bft_tx_for_watchdog.capacity();
-                        VALIDATOR_HEARTBEAT_STALL_TOTAL.fetch_add(1, Ordering::Relaxed);
-                        BFT_LIVENESS_DEGRADED.store(true, Ordering::Release);
-                        tracing::warn!(
-                            target: "validator_watchdog",
-                            "validator loop heartbeat stale for {}s (counter={}, \
-                             event_tx_depth={}/{}, bft_tx_depth={}/{}, stall_total={}) \
-                             — BFT engine may be wedged. External supervisor can \
-                             restart based on bft_liveness_degraded + heartbeat_stall_total. \
-                             Runtime will not self-kill.",
-                            stale.as_secs(), current,
-                            event_depth, event_tx_for_watchdog.max_capacity(),
-                            bft_depth, bft_tx_for_watchdog.max_capacity(),
-                            VALIDATOR_HEARTBEAT_STALL_TOTAL.load(Ordering::Relaxed),
-                        );
-                        // Reset the baseline so we don't re-warn on every
-                        // 5s tick while the stall persists. The health
-                        // flag stays set until the heartbeat actually
-                        // advances (cleared above on counter-change).
-                        last_seen = current;
-                        last_changed = tokio::time::Instant::now();
-                    } else if stale >= HEARTBEAT_WARN_THRESHOLD {
-                        tracing::warn!(
-                            target: "validator_watchdog",
-                            "validator loop heartbeat stale for {}s (counter={}) — \
-                             stall threshold {}s",
-                            stale.as_secs(), current, HEARTBEAT_STALL_THRESHOLD.as_secs(),
-                        );
-                    }
-                }
-
-                // ── Chain-height watchdog (BFT-stuck) ──
-                //
-                // Same 2026-05-10 change: hard-kill removed, replaced
-                // with metrics + warn + degraded health flag. The BFT
-                // round-cascade pattern that the kill was masking is
-                // documented in docs/debugging/bft-liveness.md.
-                let current_height = {
-                    let bc = shared_for_watchdog.read().await;
-                    bc.height()
-                };
-                let height_age = last_height_changed.elapsed().as_secs();
-                BFT_HEIGHT_STALL_SECONDS.store(height_age, Ordering::Release);
-                if current_height != last_height {
-                    last_height = current_height;
-                    last_height_changed = tokio::time::Instant::now();
-                    // Resumed progress — both watchdogs agree health is
-                    // restored only when both heartbeat AND height
-                    // advance, but this side just clears its slice.
-                    BFT_LIVENESS_DEGRADED.store(false, Ordering::Release);
-                } else {
-                    let stale = last_height_changed.elapsed();
-                    if stale >= height_stall_threshold {
-                        BFT_HEIGHT_STALL_TOTAL.fetch_add(1, Ordering::Relaxed);
-                        BFT_LIVENESS_DEGRADED.store(true, Ordering::Release);
-                        tracing::warn!(
-                            target: "validator_watchdog",
-                            "chain height stuck at {} for {}s — BFT not finalizing. \
-                             height_stall_total={}, bft_liveness_degraded=true. \
-                             Runtime will not self-kill — external supervisor decides.",
-                            current_height, stale.as_secs(),
-                            BFT_HEIGHT_STALL_TOTAL.load(Ordering::Relaxed),
-                        );
-                        // Reset baseline so we don't re-warn every tick.
-                        last_height_changed = tokio::time::Instant::now();
-                    } else if stale >= height_warn_threshold {
-                        tracing::warn!(
-                            target: "validator_watchdog",
-                            "chain height stuck at {} for {}s — stall threshold {}s",
-                            current_height, stale.as_secs(),
-                            height_stall_threshold.as_secs(),
-                        );
-                    }
-                }
-
-                // ── Channel-depth gauge ──
-                if last_gauge.elapsed() >= CHANNEL_GAUGE_TICK {
-                    last_gauge = tokio::time::Instant::now();
-                    let event_max = event_tx_for_watchdog.max_capacity();
-                    let bft_max = bft_tx_for_watchdog.max_capacity();
-                    let event_depth = event_max - event_tx_for_watchdog.capacity();
-                    let bft_depth = bft_max - bft_tx_for_watchdog.capacity();
-                    let event_pct = event_depth * 100 / event_max.max(1);
-                    let bft_pct = bft_depth * 100 / bft_max.max(1);
-                    if event_pct >= CHANNEL_PRESSURE_PCT || bft_pct >= CHANNEL_PRESSURE_PCT {
-                        tracing::warn!(
-                            target: "channel_depth",
-                            "backpressure: event_tx={}% ({}/{}) bft_tx={}% ({}/{})",
-                            event_pct, event_depth, event_max,
-                            bft_pct, bft_depth, bft_max,
-                        );
-                    } else {
-                        tracing::debug!(
-                            target: "channel_depth",
-                            "event_tx={}/{} bft_tx={}/{}",
-                            event_depth, event_max, bft_depth, bft_max,
-                        );
-                    }
-                }
-            }
-        });
-    }
+    // The earlier in-process watchdog was added during incident
+    // response and worked, but it hid the underlying BFT/libp2p
+    // liveness issues by short-cycling the process. See PR #561 +
+    // docs/operations/guardian.md for the full reasoning and the
+    // recommended supervisor policy.
 
     // Validator loop — capture the JoinHandle so the graceful-shutdown
     // path (C-08) can await the task's exit before save_blockchain
@@ -1888,18 +1660,7 @@ async fn cmd_start(
             const ADVERT_BROADCAST_INTERVAL: tokio::time::Duration =
                 tokio::time::Duration::from_secs(600); // 10 minutes
 
-            // Move heartbeat counter into the spawned task so the watchdog
-            // task can observe liveness without sharing the validator's
-            // internal state.
-            let heartbeat = validator_heartbeat.clone();
             loop {
-                // Watchdog liveness signal — incremented every iteration.
-                // The watchdog task spawned earlier panics + aborts if this
-                // counter stays still for >60s, catching any wedge that
-                // would otherwise let the process drift on while BFT goes
-                // silent (the silent-thread-death pattern from 2026-05-04).
-                heartbeat.fetch_add(1, Ordering::Release);
-
                 if shutdown_flag_clone.load(Ordering::Acquire) {
                     tracing::info!("Validator loop: shutdown flag set — exiting");
                     break;

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1615,6 +1615,24 @@ async fn cmd_start(
             // enough peers have acked, without spamming the network.
             let mut proposal_broadcast_at: Option<std::time::Instant> = None;
             let mut proposal_rebroadcast_count: u32 = 0;
+            // 2026-05-10: vote rebroadcast tracking. Mirrors the proposal
+            // rebroadcast above. Earlier we found cascade rounds where one
+            // peer's prevote never reached one of the four validators
+            // (single-attempt request-response delivery, no built-in retry
+            // beyond the proposer's proposal rebroadcast). The receiver hit
+            // prevote_timeout without seeing the supermajority and nil-
+            // precommitted, then everyone cascaded.
+            //
+            // Re-broadcasting the SAME signed Prevote / Precommit at a
+            // periodic tick during their respective phases gives a missed
+            // peer ~6 more chances inside the 12 s phase budget. Same bytes
+            // = same signature, no double-vote risk.
+            let mut prevote_broadcast_at: Option<std::time::Instant> = None;
+            let mut prevote_rebroadcast_count: u32 = 0;
+            let mut last_prevote_round: (u64, u32) = (0, 0);
+            let mut precommit_broadcast_at: Option<std::time::Instant> = None;
+            let mut precommit_rebroadcast_count: u32 = 0;
+            let mut last_precommit_round: (u64, u32) = (0, 0);
             // v2.1.89: stash the originally-signed Proposal struct so the
             // #1d rebroadcast tick replays byte-identical bytes instead of
             // rebuilding + re-signing. Pre-fix, the rebroadcast path called
@@ -3283,6 +3301,72 @@ async fn cmd_start(
                             proposal_rebroadcast_count,
                             MAX_REBROADCASTS
                         );
+                    }
+
+                    // 2026-05-10: prevote / precommit rebroadcast (same
+                    // 2 s × 7 attempts pattern as proposal). Closes the
+                    // single-attempt RR delivery gap that produced
+                    // round-cascades when one peer's vote didn't reach
+                    // one of the four validators. Reset tracking when the
+                    // engine moves to a new (height, round).
+                    let cur_hr = (bft.height(), bft.round());
+                    if last_prevote_round != cur_hr {
+                        last_prevote_round = cur_hr;
+                        prevote_broadcast_at = None;
+                        prevote_rebroadcast_count = 0;
+                    }
+                    if last_precommit_round != cur_hr {
+                        last_precommit_round = cur_hr;
+                        precommit_broadcast_at = None;
+                        precommit_rebroadcast_count = 0;
+                    }
+                    if let Some(pv) = bft.pending_prevote()
+                        && pv.height == bft.height()
+                        && pv.round == bft.round()
+                        && matches!(bft.phase(), BftPhase::Prevote)
+                        && prevote_rebroadcast_count < MAX_REBROADCASTS
+                    {
+                        let due = match prevote_broadcast_at {
+                            None => true,
+                            Some(t) => t.elapsed() >= REBROADCAST_INTERVAL,
+                        };
+                        if due {
+                            lp2p_clone.broadcast_bft_prevote(pv).await;
+                            prevote_broadcast_at = Some(std::time::Instant::now());
+                            prevote_rebroadcast_count += 1;
+                            tracing::debug!(
+                                target: "bft_vote_rebroadcast",
+                                "rebroadcast prevote at height={} round={} attempt={}/{}",
+                                bft.height(),
+                                bft.round(),
+                                prevote_rebroadcast_count,
+                                MAX_REBROADCASTS
+                            );
+                        }
+                    }
+                    if let Some(pc) = bft.pending_precommit()
+                        && pc.height == bft.height()
+                        && pc.round == bft.round()
+                        && matches!(bft.phase(), BftPhase::Precommit)
+                        && precommit_rebroadcast_count < MAX_REBROADCASTS
+                    {
+                        let due = match precommit_broadcast_at {
+                            None => true,
+                            Some(t) => t.elapsed() >= REBROADCAST_INTERVAL,
+                        };
+                        if due {
+                            lp2p_clone.broadcast_bft_precommit(pc).await;
+                            precommit_broadcast_at = Some(std::time::Instant::now());
+                            precommit_rebroadcast_count += 1;
+                            tracing::debug!(
+                                target: "bft_vote_rebroadcast",
+                                "rebroadcast precommit at height={} round={} attempt={}/{}",
+                                bft.height(),
+                                bft.round(),
+                                precommit_rebroadcast_count,
+                                MAX_REBROADCASTS
+                            );
+                        }
                     }
 
                     // Check for BFT timeouts

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -85,6 +85,18 @@ impl BftEngine {
         }
     }
 
+    /// 2026-05-10: accessor for the validator-loop's vote-rebroadcast tick.
+    /// Mirror of the proposal rebroadcast logic — periodically re-issues
+    /// our last cast vote so peers that missed the initial RR delivery
+    /// see it. Same bytes = same signature, no double-vote risk.
+    pub fn pending_prevote(&self) -> Option<&Prevote> {
+        self.pending_prevote.as_ref()
+    }
+
+    pub fn pending_precommit(&self) -> Option<&Precommit> {
+        self.pending_precommit.as_ref()
+    }
+
     /// Reset for a new height
     pub fn new_height(&mut self, height: u64, total_active_stake: u64) {
         self.state.advance_height(height, total_active_stake);

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -40,42 +40,15 @@ static SYNC_SKIPPED_TOTAL: AtomicU64 = AtomicU64::new(0);
 /// locks, RPC handler blocking).
 pub static EVENT_TX_DROPPED: AtomicU64 = AtomicU64::new(0);
 
-/// 2026-05-05 v2.1.66: swarm-task progress counter. Incremented on
-/// every iteration of the run_swarm select! loop. Read by a separate
-/// watchdog tokio task to detect silent-thread-death (counter stays
-/// still while validator main loop keeps ticking).
+/// Swarm-task progress counter. Incremented on every iteration of the
+/// run_swarm select! loop. Exposed as `sentrix_swarm_tick` so an
+/// external supervisor can compute a tick-age gauge if it wants to.
 ///
-/// Closes the silent-thread-death class observed at h=1392113 and
-/// h=1398998 (both 2026-05-05) where vps1's libp2p went unresponsive
-/// while the validator main loop kept ticking — peers' BFT prevote/
-/// precommit/proposal/round-status all timed out outbound to vps1.
-///
-/// 2026-05-10: the action on stall is no longer process::abort by
-/// default. See `SwarmWatchdogAction` and `SWARM_STALL_TOTAL` /
-/// `SWARM_STALLED` below. Default action is WarnOnly so external
-/// supervisors (sentrix-guardian / systemd / docker `unless-stopped`)
-/// can decide whether and how to restart. In-process self-kill was
-/// hiding deeper liveness issues — see docs/debugging/bft-liveness.md.
+/// We don't ship an in-process watchdog any more — production chains
+/// (Tendermint/CometBFT, Geth, Cosmos SDK) leave restart authority to
+/// the supervisor (systemd, docker, k8s, sentrix-guardian). See
+/// docs/operations/guardian.md for the rationale.
 pub static SWARM_TICK: AtomicU64 = AtomicU64::new(0);
-
-/// 2026-05-10: cumulative count of swarm-task stall detections. Each
-/// increment corresponds to a `STALL_THRESHOLD` window where SWARM_TICK
-/// did not advance. Exposed as `sentrix_swarm_stall_total` for external
-/// monitoring. Replaces the hard-kill signal — restart decisions move
-/// to an external guardian.
-pub static SWARM_STALL_TOTAL: AtomicU64 = AtomicU64::new(0);
-
-/// 2026-05-10: age in seconds of the last observed SWARM_TICK change.
-/// 0 means the counter advanced this tick. Exposed as
-/// `sentrix_swarm_last_tick_age_seconds`.
-pub static SWARM_LAST_TICK_AGE_SECONDS: AtomicU64 = AtomicU64::new(0);
-
-/// 2026-05-10: health flag — true while the swarm task is currently
-/// considered stalled (no SWARM_TICK progress for ≥ STALL_THRESHOLD).
-/// Cleared automatically when progress resumes. Read by the
-/// `/sentrix_status_extended` health endpoint.
-pub static SWARM_STALLED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
 
 /// 2026-05-05 v2.1.65: cumulative count of broadcasts dropped because
 /// the swarm cmd_tx channel was full (try_send → TrySendError::Full).
@@ -532,71 +505,6 @@ impl LibP2pNode {
     }
 }
 
-// ── Swarm watchdog action policy ─────────────────────────
-//
-// The swarm-task watchdog (spawned inside run_swarm) detects silent-thread-
-// death by polling SWARM_TICK. The action on detection is configurable.
-//
-// 2026-05-10: default changed from Abort → WarnOnly. The 6h warn-mode
-// testnet bake confirmed that:
-//   1. Hard-kill restart cycles were the dominant restart-churn source
-//      (74 cumulative restarts in 6h on abort-mode vs 0 on warn-mode).
-//   2. Removing the kill exposed a deeper BFT/libp2p round-cascade
-//      liveness issue that the kill had been masking via mesh reset.
-//
-// In-process self-kill is the wrong answer to liveness because it hides
-// the underlying cascade and produces false confidence. External
-// supervisors (sentrix-guardian / systemd / docker `unless-stopped`)
-// can still restart unhealthy nodes — the difference is they decide
-// based on observed health flags + stall counters, not on a black-box
-// 30s timer inside the process.
-//
-// `Abort` and `Exit` modes are kept available behind the env so
-// operators who knowingly want the historical kill behaviour can opt
-// in, but the default is now non-fatal.
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SwarmWatchdogAction {
-    /// Log only — increment SWARM_STALL_TOTAL, set SWARM_STALLED, reset
-    /// the stall baseline so we don't re-fire every TICK. Default since
-    /// 2026-05-10.
-    WarnOnly,
-    /// `std::process::exit(1)` — graceful (runs destructors). Opt-in.
-    Exit,
-    /// `std::process::abort()` — drops the process immediately so an
-    /// external supervisor cycles it. Opt-in; the historical default
-    /// pre-2026-05-10. Use only when you specifically want the kill
-    /// behaviour.
-    Abort,
-}
-
-/// Parse `SENTRIX_SWARM_WATCHDOG_MODE`. Recognised values (case-insensitive):
-/// `abort`, `exit`, `warn`. Anything else (or unset) returns the default
-/// `WarnOnly`. Invalid values log a warning so an operator typo doesn't
-/// silently fall back to a different behaviour than they expected.
-pub(crate) fn parse_watchdog_mode(value: Option<&str>) -> SwarmWatchdogAction {
-    let raw = match value {
-        Some(s) => s.trim(),
-        None => return SwarmWatchdogAction::WarnOnly,
-    };
-    if raw.is_empty() {
-        return SwarmWatchdogAction::WarnOnly;
-    }
-    match raw.to_ascii_lowercase().as_str() {
-        "abort" => SwarmWatchdogAction::Abort,
-        "exit" => SwarmWatchdogAction::Exit,
-        "warn" => SwarmWatchdogAction::WarnOnly,
-        other => {
-            tracing::warn!(
-                target: "swarm_watchdog",
-                "Unrecognised SENTRIX_SWARM_WATCHDOG_MODE='{}' — falling back to default (warn).",
-                other,
-            );
-            SwarmWatchdogAction::WarnOnly
-        }
-    }
-}
-
 // ── Swarm event loop ─────────────────────────────────────
 
 // large_futures: the Swarm owns SentrixBehaviour which has internal caches;
@@ -683,86 +591,10 @@ async fn run_swarm(
     let mut inbound_watchdog_interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
     const INBOUND_SILENCE_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(30);
 
-    // 2026-05-05 v2.1.66: spawn the swarm-task watchdog. It reads
-    // SWARM_TICK every 5 s; if the counter stays still for ≥30 s past
-    // the startup grace, the swarm select! loop has wedged and we
-    // act per SENTRIX_SWARM_WATCHDOG_MODE. sync_interval (30 s) and
-    // kad_interval (60 s) ticks alone keep SWARM_TICK incrementing
-    // during quiet periods so we don't false-positive on a chain with
-    // no traffic.
-    //
-    // 2026-05-10: the kill action is now configurable via env so we
-    // can run a "warn" experiment on testnet to isolate whether the
-    // hard kill itself is contributing to mesh churn vs catching a
-    // real silent-thread-death. Default stays "abort" — zero behaviour
-    // change without the env set.
-    let watchdog_mode = parse_watchdog_mode(
-        std::env::var("SENTRIX_SWARM_WATCHDOG_MODE").ok().as_deref(),
-    );
-    tokio::spawn(async move {
-        use tokio::time::{Duration, Instant as TokioInstant, sleep};
-        const STALL_THRESHOLD: Duration = Duration::from_secs(30);
-        const STARTUP_GRACE: Duration = Duration::from_secs(60);
-        const TICK: Duration = Duration::from_secs(5);
-
-        let started = TokioInstant::now();
-        let mut last_seen = SWARM_TICK.load(Ordering::Acquire);
-        let mut last_changed = TokioInstant::now();
-        loop {
-            sleep(TICK).await;
-            // Honour startup grace — peer mesh + identify handshakes +
-            // initial gossipsub mesh formation can take >30 s on cold
-            // start. Reset the baseline during this window.
-            if started.elapsed() < STARTUP_GRACE {
-                last_seen = SWARM_TICK.load(Ordering::Acquire);
-                last_changed = TokioInstant::now();
-                continue;
-            }
-            let current = SWARM_TICK.load(Ordering::Acquire);
-            // Update tick-age gauge regardless of stall state so external
-            // monitors can see how stale the loop is in real time.
-            let age = last_changed.elapsed().as_secs();
-            SWARM_LAST_TICK_AGE_SECONDS.store(age, Ordering::Release);
-            if current != last_seen {
-                last_seen = current;
-                last_changed = TokioInstant::now();
-                // Resumed progress — clear the health flag.
-                SWARM_STALLED.store(false, std::sync::atomic::Ordering::Release);
-            } else if last_changed.elapsed() >= STALL_THRESHOLD {
-                // Always increment the cumulative counter and set the
-                // health flag — these are the signals an external
-                // supervisor consumes regardless of mode.
-                SWARM_STALL_TOTAL.fetch_add(1, Ordering::Relaxed);
-                SWARM_STALLED.store(true, std::sync::atomic::Ordering::Release);
-
-                tracing::warn!(
-                    target: "swarm_watchdog",
-                    "libp2p swarm task stalled — no select!-loop progress \
-                     for {}s (counter={}, mode={:?}, stall_total={}). \
-                     Silent-thread-death class at h=1392113 / h=1398998 \
-                     was where libp2p went unresponsive while validator \
-                     main loop kept ticking. External supervisor can \
-                     decide whether to restart based on swarm_stalled + \
-                     stall_total.",
-                    last_changed.elapsed().as_secs(),
-                    current,
-                    watchdog_mode,
-                    SWARM_STALL_TOTAL.load(Ordering::Relaxed),
-                );
-                match watchdog_mode {
-                    SwarmWatchdogAction::Abort => std::process::abort(),
-                    SwarmWatchdogAction::Exit => std::process::exit(1),
-                    SwarmWatchdogAction::WarnOnly => {
-                        // Reset the stall baseline so we don't re-fire
-                        // every tick. Health flag stays set until the
-                        // counter actually advances again (cleared above).
-                        last_seen = current;
-                        last_changed = TokioInstant::now();
-                    }
-                }
-            }
-        }
-    });
+    // 2026-05-10: in-process swarm-task watchdog removed. Restart
+    // authority belongs to the external supervisor, same as Geth /
+    // Tendermint / Cosmos SDK. SWARM_TICK still ticks on every select!
+    // iteration so external monitors can observe loop progress.
 
     loop {
         tokio::select! {
@@ -2322,86 +2154,4 @@ mod tests {
         node.broadcast_block(&block).await; // must not panic
     }
 
-    // ── Swarm watchdog mode parsing ────────────────────────────────
-
-    #[test]
-    fn watchdog_mode_default_is_warn_when_unset() {
-        // 2026-05-10: default flipped from Abort → WarnOnly. Validator
-        // runtime no longer self-kills on swarm stall; restart decisions
-        // move to an external supervisor.
-        assert_eq!(parse_watchdog_mode(None), SwarmWatchdogAction::WarnOnly);
-    }
-
-    #[test]
-    fn watchdog_mode_recognises_abort_exit_warn() {
-        assert_eq!(parse_watchdog_mode(Some("abort")), SwarmWatchdogAction::Abort);
-        assert_eq!(parse_watchdog_mode(Some("exit")), SwarmWatchdogAction::Exit);
-        assert_eq!(parse_watchdog_mode(Some("warn")), SwarmWatchdogAction::WarnOnly);
-    }
-
-    #[test]
-    fn watchdog_mode_is_case_insensitive() {
-        assert_eq!(parse_watchdog_mode(Some("ABORT")), SwarmWatchdogAction::Abort);
-        assert_eq!(parse_watchdog_mode(Some("Exit")), SwarmWatchdogAction::Exit);
-        assert_eq!(parse_watchdog_mode(Some("WARN")), SwarmWatchdogAction::WarnOnly);
-        assert_eq!(parse_watchdog_mode(Some("Warn")), SwarmWatchdogAction::WarnOnly);
-    }
-
-    #[test]
-    fn watchdog_mode_trims_whitespace() {
-        assert_eq!(parse_watchdog_mode(Some("  warn  ")), SwarmWatchdogAction::WarnOnly);
-        assert_eq!(parse_watchdog_mode(Some("\texit\n")), SwarmWatchdogAction::Exit);
-    }
-
-    #[test]
-    fn watchdog_mode_invalid_falls_back_to_default() {
-        // Typo / unknown value → safe default (warn), not panic.
-        assert_eq!(parse_watchdog_mode(Some("nuke")), SwarmWatchdogAction::WarnOnly);
-        assert_eq!(parse_watchdog_mode(Some("disable")), SwarmWatchdogAction::WarnOnly);
-        assert_eq!(parse_watchdog_mode(Some("123")), SwarmWatchdogAction::WarnOnly);
-    }
-
-    #[test]
-    fn watchdog_mode_empty_string_falls_back_to_default() {
-        assert_eq!(parse_watchdog_mode(Some("")), SwarmWatchdogAction::WarnOnly);
-        assert_eq!(parse_watchdog_mode(Some("   ")), SwarmWatchdogAction::WarnOnly);
-    }
-
-    #[test]
-    fn watchdog_mode_warn_does_not_terminate_process() {
-        // The whole point of warn mode: it must NOT request process
-        // termination. We verify by matching on the enum variant — the
-        // runtime side only calls process::abort/exit on the kill variants.
-        let action = parse_watchdog_mode(Some("warn"));
-        let terminates = matches!(
-            action,
-            SwarmWatchdogAction::Abort | SwarmWatchdogAction::Exit
-        );
-        assert!(!terminates, "warn mode must not request process termination");
-    }
-
-    #[test]
-    fn watchdog_default_does_not_terminate_process() {
-        // Strong invariant for mission requirement #1: default behaviour
-        // (no env set) must not self-kill. External supervisors are the
-        // only correct restart authority.
-        let action = parse_watchdog_mode(None);
-        let terminates = matches!(
-            action,
-            SwarmWatchdogAction::Abort | SwarmWatchdogAction::Exit
-        );
-        assert!(!terminates, "default watchdog mode must not request process termination");
-    }
-
-    #[test]
-    fn watchdog_mode_kill_variants_request_termination() {
-        for v in ["abort", "exit"] {
-            let action = parse_watchdog_mode(Some(v));
-            let terminates = matches!(
-                action,
-                SwarmWatchdogAction::Abort | SwarmWatchdogAction::Exit
-            );
-            assert!(terminates, "{} mode must request process termination", v);
-        }
-    }
 }

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.89"
+version = "2.1.91"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."

--- a/docs/operations/guardian.md
+++ b/docs/operations/guardian.md
@@ -1,89 +1,86 @@
-# Validator restart authority — guardian model
+# Validator restart authority — external supervisor model
 
 ## Summary
 
-The Sentrix validator runtime does **not** call `process::abort()` or
-`process::exit()` to recover from liveness stalls. Restart authority
-lives **outside** the validator process, in an external supervisor:
+The Sentrix validator runtime does **not** ship an in-process watchdog
+that can kill the process on liveness stalls. Restart authority lives
+**outside** the validator process, in an external supervisor:
 
 - `systemd` with `Restart=always` on the production validator units, or
 - `docker` with `restart: unless-stopped` on the testnet docker stack, or
 - a dedicated `sentrix-guardian` daemon for richer policy
 
-The runtime emits health flags and counters; the supervisor reads them
-and decides whether to restart.
-
-## Why this changed (2026-05-10)
-
-Before this change, three watchdogs inside the validator process called
-`std::process::abort()` on stall:
-
-- **Swarm-task watchdog** (libp2p select-loop progress) — 30 s threshold
-- **Validator-loop heartbeat watchdog** — 60 s threshold
-- **Chain-height watchdog** — 90 s default threshold (env-tunable)
-
-The 6 h testnet bake on 2026-05-10 demonstrated that these aborts were
-**masking** a deeper BFT/libp2p round-cascade liveness issue rather than
-fixing it. Each abort cycle reset the libp2p mesh, which incidentally
-broke validators out of nil-precommit cascades — but it produced false
-confidence: the underlying bug was never visible in production logs
-because the kills always cleared it before it persisted.
-
-When the kills were disabled (`SENTRIX_SWARM_WATCHDOG_MODE=warn`):
-
-- Restart count dropped from 74 / 6 h → 0
-- BFT round cascades became visible (round 5, 8, 11, 18+)
-- Block-time degraded from 0.82 s/blk avg → 2.83 s/blk avg
-- 0 safety regressions (no double-finalize, no equivocation, no
-  invalid-prev)
-
-The conclusion: in-process self-kill is the **wrong tool** for
-recovering from a consensus-layer liveness issue. It hides the bug and
-makes it harder to diagnose. The right tool is a metric and an
-external supervisor.
+This matches the pattern used by Tendermint / CometBFT, Geth, and
+Cosmos SDK app chains. The runtime's job is to expose health metrics;
+the supervisor's job is to decide when to restart.
 
 ## What the runtime exposes
 
-### Counters (cumulative, never decrement)
+The chain head, peer count, channel-drop counters, and similar gauges
+are available through `/sentrix_status_extended`. An external monitor
+polls that endpoint and decides when to act.
 
-| Metric                             | Source                          | Meaning                                                |
-| ---------------------------------- | ------------------------------- | ------------------------------------------------------ |
-| `sentrix_swarm_stall_total`        | `sentrix-network::libp2p_node`  | Each `STALL_THRESHOLD` (30 s) window with no progress. |
-| `sentrix_heartbeat_stall_total`    | `bin/sentrix::main`             | Each `HEARTBEAT_STALL_THRESHOLD` (60 s) window.        |
-| `sentrix_bft_height_stall_total`   | `bin/sentrix::main`             | Each `height_stall_threshold` (90 s default) window.   |
+The most useful raw signals:
 
-### Gauges (current state)
+- `latest_height` — chain tip from this node's view.
+- `peer_count` — verified libp2p peers.
+- `EVENT_TX_DROPPED`, `BFT_TX_DROPPED`, `DROPPED_BFT_BROADCASTS` —
+  cumulative back-pressure drops at the network/BFT boundary.
+- `INBOUND_SILENCE_DISCONNECTS` — peers force-disconnected by the
+  inbound-silence detector (libp2p peer management, not self-kill).
+- `SWARM_TICK` — incremented every iteration of the libp2p select!
+  loop. An external supervisor can compute "tick age" by subtracting
+  successive values and comparing against wall-clock.
 
-| Metric                                | Meaning                                                              |
-| ------------------------------------- | -------------------------------------------------------------------- |
-| `sentrix_swarm_last_tick_age_seconds` | Seconds since the libp2p select! loop last advanced.                 |
-| `sentrix_validator_heartbeat_age`     | Seconds since the validator loop heartbeat last advanced.            |
-| `sentrix_bft_height_stall_seconds`    | Seconds since `bc.height()` last advanced.                           |
+## What used to be in the runtime, and why it isn't any more
 
-### Health flags (boolean)
+There were three in-process watchdogs at one point:
 
-| Flag                       | Meaning                                                                      |
-| -------------------------- | ---------------------------------------------------------------------------- |
-| `swarm_stalled`            | `true` while the swarm task has been stuck > `STALL_THRESHOLD`.              |
-| `bft_liveness_degraded`    | `true` while heartbeat or height stall is currently active.                  |
+- libp2p swarm-task watchdog — fired `process::abort()` if SWARM_TICK
+  stayed still for ~30 s.
+- Validator-loop heartbeat watchdog — same, but on a per-iteration
+  counter inside the validator main loop.
+- Chain-height watchdog — same, but on `bc.height()`.
 
-Flags are **automatically cleared** when the underlying counter advances
-again — no operator intervention needed to reset them. They are exposed
-via the `/sentrix_status_extended` RPC endpoint.
+Operationally they worked: each kill cycle let `systemd Restart=always`
+bring the process back, the libp2p mesh re-handshook, and the chain
+broke out of whatever stuck state it was in. They were added during
+real incidents and stopped real halts.
+
+But two things were wrong with them:
+
+1. They short-cycled the process every time consensus had a bad
+   minute. That hid the underlying bugs — operators kept seeing
+   "validator restarted, chain is fine" instead of seeing the actual
+   nil-cascade or libp2p mesh stall in production logs. The fix
+   was to remove the kill so the bugs become visible (PR #559 →
+   PR #561).
+2. No production blockchain ships in-process self-kill. The right
+   tool for "process is unhealthy, please restart" is the supervisor
+   layer (systemd, docker, k8s, sentrix-guardian). Putting it in the
+   chain code is mixing concerns.
+
+The 6 h `SENTRIX_SWARM_WATCHDOG_MODE=warn` testnet bake on 2026-05-10
+proved the analysis: with kills disabled, restart count dropped from
+74 / 6 h to 0, no safety regression, but the BFT round-cascade pattern
+became immediately visible. That cascade was then fixed properly in
+the engine (PR #561 Patch B — `catch_up_round` no longer eager-nil-votes).
+
+After that, the watchdogs themselves were removed (this commit).
 
 ## Recommended supervisor policy
 
 These are starting thresholds. Tune for your deployment.
 
-| Severity   | Condition                                                              | Action                                       |
-| ---------- | ---------------------------------------------------------------------- | -------------------------------------------- |
-| `warn`     | `bft_height_stall_seconds > 120`                                       | Page on-call, collect logs.                  |
-| `critical` | `bft_height_stall_seconds > 300` AND BFT round > 10                    | Collect logs, then restart the unit.         |
-| `critical` | `swarm_stalled` is true AND `swarm_stall_total` increased twice in 5 m | Collect logs, then restart the unit.         |
+| Severity   | Condition                                                      | Action                                  |
+| ---------- | -------------------------------------------------------------- | --------------------------------------- |
+| `warn`     | `latest_height` unchanged for > 120 s                          | Page on-call, collect logs.             |
+| `critical` | `latest_height` unchanged for > 300 s                          | Collect logs, then restart the unit.    |
+| `critical` | `EVENT_TX_DROPPED` increases by >1000 in 5 min                 | Collect logs, then restart the unit.    |
+| `critical` | `peer_count` drops to 0 and stays there > 60 s                 | Collect logs, then restart the unit.    |
 
-**Always collect logs before restart.** The whole point of removing
-the in-process kill was to keep the failure mode observable. A blind
-auto-restart loses the diagnostic value.
+**Always collect logs before restart.** Auto-restart loops without log
+capture is the failure mode that produced the original problem.
 
 A minimal log-collection step:
 
@@ -101,27 +98,26 @@ docker logs --since 5m sentrix-testnet-val1 \
 
 Restart only after the log is on disk.
 
-## Opting back in to in-process kill (not recommended)
+## What stays in the runtime
 
-If a deployment really needs the historical kill behaviour (single-host
-homelab, no external supervisor available), set:
+The runtime still does panic-on-bug — a Rust panic in any tokio task
+hits a process-level panic hook that prints the panic + backtrace and
+aborts. That is **not** a watchdog. It signals corrupted state /
+broken invariant, the same way `panic!` works in Tendermint or any
+other Rust/Go chain. The supervisor cycles the process the same way
+it would for any other crash.
 
-```
-SENTRIX_SWARM_WATCHDOG_MODE=abort
-```
-
-This restores `std::process::abort()` on the libp2p stall path. The
-heartbeat and chain-height watchdogs in the validator runtime no longer
-have an env-flag for kill mode — they are warn-only by design. If you
-want them to terminate the process, your external supervisor should
-enforce that based on the published health flags.
+Genesis-init failure (e.g. premine credit overflow on cold-start)
+still calls `process::exit(1)`. That is also not a watchdog — it's
+"can't even reach a chain that's possible to run, stop now". The
+supervisor will retry on its own schedule.
 
 ## What guardian is **not**
 
 - Not a consensus participant. Guardian only restarts processes; it
   never touches BFT state, votes, or chain.db.
-- Not a fork resolver. Forks are handled by the BFT engine + state-fp
+- Not a fork resolver. Forks are handled by the BFT engine + STATE-FP
   trace + chain.db rsync from canonical, all upstream of guardian.
-- Not a substitute for fixing the underlying BFT/libp2p liveness
-  issues. Guardian is a band-aid that makes operations sustainable
-  while the deeper fixes are in flight.
+- Not a substitute for fixing real BFT/libp2p liveness issues.
+  Guardian's job is to make sure the runtime stays running; making
+  the runtime *stop needing to be restarted* is engineering work.


### PR DESCRIPTION
The proposer rebroadcasts its proposal every 2 s × 7 attempts. Prevote and precommit go out exactly once each. Per-peer request-response delivery is single-attempt — if the RR to one validator fails, that vote is lost and the receiver never sees supermajority.

## Concrete evidence

Trace from testnet h=3,141,278 round=0 on 2026-05-10:

- val2 (proposer) prevotes block, all peers see it
- val3 prevotes block, val2 + val1 see it
- val1 prevotes block, val2 sees it, **val3 doesn't**
- val4 misses round entirely
- val3's local view = 2 of 4 prevotes for block, below 3-of-4 threshold
- val3 nil-precommits at prevote_timeout
- cluster cascades into round 1, 2, 3...

Drop counters were 0, libp2p connection errors were 0, but the cascade fired anyway. The pattern is consistent with libp2p RR per-peer single-attempt delivery flakiness.

## Fix

Mirror the proposal rebroadcast pattern for prevote and precommit. 2 s × 7 attempts inside the 12 s prevote / precommit phase budget. Same bytes = same signature = no double-vote risk.

- New `pending_prevote()` / `pending_precommit()` accessors on `BftEngine`.
- Validator-loop tracks last `(height, round)` pair for each phase, resets the rebroadcast counter on transition, and re-issues the cached vote at the same 2 s cadence used for proposal.

Also bumps workspace version `2.1.89 → 2.1.91` so `/sentrix_status` matches the operational name. PR #555 was 2.1.89, #556+#557 was 2.1.90, #558 + Patch A/B + watchdog removal is 2.1.91.

## Test plan

- [x] `cargo test -p sentrix-bft --release` — 125/125 pass
- [x] `cargo test -p sentrix-network --release` — 32/32 pass
- [x] `RUSTFLAGS="-D warnings" cargo check` clean across bft / network / node
- [x] Build glibc-compatible binary — sha `7c16e567…`, max GLIBC 2.30
- [ ] Testnet bake — confirm `prevote_tally=[nil=…]` cascade pattern stops