### PR TITLE
fix(node): speculative pre-build of next proposal (Fix C)

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1627,12 +1627,11 @@ async fn cmd_start(
             // periodic tick during their respective phases gives a missed
             // peer ~6 more chances inside the 12 s phase budget. Same bytes
             // = same signature, no double-vote risk.
-            let mut prevote_broadcast_at: Option<std::time::Instant> = None;
-            let mut prevote_rebroadcast_count: u32 = 0;
-            let mut last_prevote_round: (u64, u32) = (0, 0);
-            let mut precommit_broadcast_at: Option<std::time::Instant> = None;
-            let mut precommit_rebroadcast_count: u32 = 0;
-            let mut last_precommit_round: (u64, u32) = (0, 0);
+            // Vote rebroadcast state used to live here (REBROADCAST_INTERVAL
+            // 0.5s × 6 attempts, mirrored for prevote + precommit). Dropped
+            // 2026-05-10 with the gossipsub-for-BFT switch: gossipsub mesh
+            // already retransmits missed votes via IHAVE/IWANT, so the
+            // validator-side tick became double work.
             // v2.1.89: stash the originally-signed Proposal struct so the
             // #1d rebroadcast tick replays byte-identical bytes instead of
             // rebuilding + re-signing. Pre-fix, the rebroadcast path called
@@ -3303,71 +3302,11 @@ async fn cmd_start(
                         );
                     }
 
-                    // 2026-05-10: prevote / precommit rebroadcast (same
-                    // 2 s × 7 attempts pattern as proposal). Closes the
-                    // single-attempt RR delivery gap that produced
-                    // round-cascades when one peer's vote didn't reach
-                    // one of the four validators. Reset tracking when the
-                    // engine moves to a new (height, round).
-                    let cur_hr = (bft.height(), bft.round());
-                    if last_prevote_round != cur_hr {
-                        last_prevote_round = cur_hr;
-                        prevote_broadcast_at = None;
-                        prevote_rebroadcast_count = 0;
-                    }
-                    if last_precommit_round != cur_hr {
-                        last_precommit_round = cur_hr;
-                        precommit_broadcast_at = None;
-                        precommit_rebroadcast_count = 0;
-                    }
-                    if let Some(pv) = bft.pending_prevote()
-                        && pv.height == bft.height()
-                        && pv.round == bft.round()
-                        && matches!(bft.phase(), BftPhase::Prevote)
-                        && prevote_rebroadcast_count < MAX_REBROADCASTS
-                    {
-                        let due = match prevote_broadcast_at {
-                            None => true,
-                            Some(t) => t.elapsed() >= REBROADCAST_INTERVAL,
-                        };
-                        if due {
-                            lp2p_clone.broadcast_bft_prevote(pv).await;
-                            prevote_broadcast_at = Some(std::time::Instant::now());
-                            prevote_rebroadcast_count += 1;
-                            tracing::debug!(
-                                target: "bft_vote_rebroadcast",
-                                "rebroadcast prevote at height={} round={} attempt={}/{}",
-                                bft.height(),
-                                bft.round(),
-                                prevote_rebroadcast_count,
-                                MAX_REBROADCASTS
-                            );
-                        }
-                    }
-                    if let Some(pc) = bft.pending_precommit()
-                        && pc.height == bft.height()
-                        && pc.round == bft.round()
-                        && matches!(bft.phase(), BftPhase::Precommit)
-                        && precommit_rebroadcast_count < MAX_REBROADCASTS
-                    {
-                        let due = match precommit_broadcast_at {
-                            None => true,
-                            Some(t) => t.elapsed() >= REBROADCAST_INTERVAL,
-                        };
-                        if due {
-                            lp2p_clone.broadcast_bft_precommit(pc).await;
-                            precommit_broadcast_at = Some(std::time::Instant::now());
-                            precommit_rebroadcast_count += 1;
-                            tracing::debug!(
-                                target: "bft_vote_rebroadcast",
-                                "rebroadcast precommit at height={} round={} attempt={}/{}",
-                                bft.height(),
-                                bft.round(),
-                                precommit_rebroadcast_count,
-                                MAX_REBROADCASTS
-                            );
-                        }
-                    }
+                    // Vote rebroadcast tick (prevote + precommit) lived here
+                    // until 2026-05-10. Removed when BFT votes moved from
+                    // request-response to gossipsub — the mesh handles
+                    // retransmission via IHAVE/IWANT and there's no point
+                    // double-publishing from the validator loop.
 
                     // Check for BFT timeouts
                     if bft.is_timed_out() {

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1462,6 +1462,56 @@ async fn cmd_start(
     // docs/operations/guardian.md for the full reasoning and the
     // recommended supervisor policy.
 
+    // Fix A (2026-05-10) — async chain.db save off the BFT critical path.
+    // Pre-fix: validator-loop blocked on storage.save_blockchain inside the
+    // FinalizeBlock arm. With a ~5 GB mainnet chain.db that fsync + JSON
+    // serialise was 500 ms-1 s and held up the next round. Now we ship
+    // every finalized height onto a save_tx channel and a dedicated writer
+    // task drains it serially. Crash safety is preserved by the existing
+    // B2 load-replay path (PR #556): if we die between in-memory commit
+    // and the disk save, restart replays the missing block(s).
+    let save_buffer: usize = std::env::var("SENTRIX_SAVE_QUEUE_DEPTH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(64);
+    let (save_tx, mut save_rx) = tokio::sync::mpsc::channel::<u64>(save_buffer);
+    {
+        let writer_storage = storage.clone();
+        let writer_shared = shared.clone();
+        tokio::spawn(async move {
+            while let Some(target_height) = save_rx.recv().await {
+                // Drain coalesced heights: if the writer is behind, multiple
+                // FinalizeBlock pushes can stack up. One snapshot covers all
+                // of them since save_blockchain writes the full state blob.
+                let mut latest = target_height;
+                while let Ok(h) = save_rx.try_recv() {
+                    latest = h;
+                }
+                let bc = writer_shared.read().await;
+                let height_at_save = bc.height();
+                match writer_storage.save_blockchain(&bc) {
+                    Ok(()) => {
+                        tracing::debug!(
+                            target: "save_writer",
+                            "background save_blockchain ok queued_for=h{} caught_up_to=h{}",
+                            latest,
+                            height_at_save,
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            target: "save_writer",
+                            "background save_blockchain failed queued_for=h{} caught_up_to=h{}: {}",
+                            latest, height_at_save, e,
+                        );
+                    }
+                }
+                drop(bc);
+            }
+            tracing::info!(target: "save_writer", "save channel closed; writer exiting");
+        });
+    }
+
     // Validator loop — capture the JoinHandle so the graceful-shutdown
     // path (C-08) can await the task's exit before save_blockchain
     // snapshots state. Without the handle the process could exit mid
@@ -1470,6 +1520,7 @@ async fn cmd_start(
         println!("Validator mode: {}", wallet.address);
         let shared_clone = shared.clone();
         let storage_clone = storage.clone();
+        let save_tx_clone = save_tx.clone();
         let lp2p_clone = lp2p.clone();
         let shutdown_flag_clone = shutdown_flag.clone();
         let mut bft_rx = bft_rx; // move receiver into this task
@@ -2594,36 +2645,26 @@ async fn cmd_start(
 
                                                         drop(bc);
                                                         if let Some(ref saved_block) = updated {
-                                                            // H-09 + Patch B1 (v2.1.90): atomic
-                                                            // persist of block bytes, height,
-                                                            // hash index, and Blockchain blob
-                                                            // in one MDBX transaction. Replaces
-                                                            // the pre-fix save_block +
-                                                            // save_blockchain pair (which had a
-                                                            // crash window between them).
-                                                            let bc = shared_clone.read().await;
-                                                            if let Err(e) =
-                                                                storage_clone.save_blockchain(&bc)
-                                                            {
-                                                                tracing::error!(
-                                                                    "H-09: atomic save_blockchain \
-                                                                     failed at BFT block {} by {}: \
-                                                                     {}; skipping broadcast",
+                                                            // Fix A: queue the disk save on the
+                                                            // writer task instead of fsync-blocking
+                                                            // here. B2 load-replay recovers if we
+                                                            // crash between in-memory commit and
+                                                            // the queued save.
+                                                            if save_tx_clone.try_send(height).is_err() {
+                                                                tracing::warn!(
+                                                                    target: "save_writer",
+                                                                    "save queue full at h={}; \
+                                                                     B2 load-replay will catch up",
                                                                     height,
-                                                                    proposer,
-                                                                    e
                                                                 );
-                                                                drop(bc);
-                                                            } else {
-                                                                drop(bc);
-                                                                println!(
-                                                                    "Block {} produced by {}",
-                                                                    height, proposer
-                                                                );
-                                                                lp2p_clone
-                                                                    .broadcast_block(saved_block)
-                                                                    .await;
                                                             }
+                                                            println!(
+                                                                "Block {} produced by {}",
+                                                                height, proposer
+                                                            );
+                                                            lp2p_clone
+                                                                .broadcast_block(saved_block)
+                                                                .await;
                                                         }
                                                     }
                                                     Err(e) => tracing::warn!(
@@ -3124,7 +3165,11 @@ async fn cmd_start(
 
                                                 drop(bc);
                                                 if let Some(ref saved_block) = updated {
-                                                    // H-09: persist before broadcast.
+                                                    // H-09: persist block bytes before broadcast
+                                                    // (small write, kept sync). The expensive full
+                                                    // state snapshot moves to the writer queue
+                                                    // (Fix A); B2 load-replay covers a crash
+                                                    // between this point and the queued save.
                                                     if let Err(e) =
                                                         storage_clone.save_block(saved_block)
                                                     {
@@ -3140,18 +3185,14 @@ async fn cmd_start(
                                                             "Block {} produced by {}",
                                                             height, proposer
                                                         );
-                                                        let bc = shared_clone.read().await;
-                                                        if let Err(e) =
-                                                            storage_clone.save_blockchain(&bc)
-                                                        {
+                                                        if save_tx_clone.try_send(height).is_err() {
                                                             tracing::warn!(
-                                                                "save_blockchain snapshot \
-                                                                 failed at {}: {}",
+                                                                target: "save_writer",
+                                                                "save queue full at h={}; \
+                                                                 B2 load-replay will catch up",
                                                                 height,
-                                                                e
                                                             );
                                                         }
-                                                        drop(bc);
                                                         lp2p_clone
                                                             .broadcast_block(saved_block)
                                                             .await;

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1695,6 +1695,15 @@ async fn cmd_start(
             // is the correct invariant: a rebroadcast is the same message,
             // not a new one.
             let mut last_signed_proposal: Option<Proposal> = None;
+            // Fix C (speculative block-build) — after we finalize block N
+            // and apply its state, if we're the deterministic proposer for
+            // N+1 round 0 we pre-build the next block + sign its proposal
+            // inside the same write-lock cycle. The validator-loop's next
+            // round_start handler consumes this stash and skips the
+            // ~100-200 ms build step. Stale stashes (round != 0, height
+            // mismatch, post-epoch-boundary) fall back to the normal
+            // build_or_reuse_proposal path. Tuple: (height, block, proposal).
+            let mut speculative_proposal: Option<(u64, Block, Proposal)> = None;
             // Pioneer mode: track last block time for a fine-grained poll loop.
             // Poll every PIONEER_TICK, but only attempt to build a block when
             // at least BLOCK_TIME_SECS has elapsed since the last one. Gives
@@ -2254,14 +2263,36 @@ async fn cmd_start(
                         // and re-broadcasts the cached block if we're locked, which is
                         // what unsticks the chain when an earlier round's prevote
                         // supermajority didn't precommit.
+                        //
+                        // Fix C: consume the speculative pre-built proposal from the
+                        // prior FinalizeBlock arm if it matches (height, round=0,
+                        // not locked at a different hash). Saves the create_block_voyager
+                        // + bincode::serialize + sign roundtrip that otherwise lives
+                        // on the BFT critical path.
                         let mut bc = shared_clone.write().await;
-                        match build_or_reuse_proposal(
-                            &bft,
-                            &mut bc,
-                            &wallet.address,
-                            &validator_secret_key,
-                            next_height,
-                        ) {
+                        let stash = speculative_proposal.take().filter(|(h, _, _)| {
+                            *h == next_height
+                                && bft.round() == 0
+                                && bft.locked_proposal_bytes().is_none()
+                        });
+                        let built = match stash {
+                            Some((_, block, proposal)) => {
+                                tracing::info!(
+                                    target: "speculative_build",
+                                    "consumed pre-built proposal h={} (skipped build)",
+                                    next_height,
+                                );
+                                Some((block, proposal))
+                            }
+                            None => build_or_reuse_proposal(
+                                &bft,
+                                &mut bc,
+                                &wallet.address,
+                                &validator_secret_key,
+                                next_height,
+                            ),
+                        };
+                        match built {
                             Some((block, proposal)) => {
                                 let block_hash = block.hash.clone();
                                 let block_data = proposal.block_data.clone();
@@ -2642,6 +2673,49 @@ async fn cmd_start(
                                                             height,
                                                             round
                                                         );
+
+                                                        // Fix C: speculative block-build for N+1.
+                                                        // State is at height N here (just applied),
+                                                        // active_set has been re-derived if this was
+                                                        // an epoch boundary, so weighted_proposer for
+                                                        // N+1 round 0 is now stable. If it's us, pre-
+                                                        // build the proposal so the next round_start
+                                                        // can skip the ~100-200 ms build step.
+                                                        let next_h = bc.height().saturating_add(1);
+                                                        let we_next = bc
+                                                            .stake_registry
+                                                            .weighted_proposer(next_h, 0)
+                                                            .as_deref()
+                                                            == Some(wallet.address.as_str());
+                                                        if we_next {
+                                                            match bc.create_block_voyager(&wallet.address) {
+                                                                Ok(block) => {
+                                                                    let block_hash = block.hash.clone();
+                                                                    let block_data = bincode::serialize(&block).unwrap_or_default();
+                                                                    let mut prop = Proposal {
+                                                                        height: next_h,
+                                                                        round: 0,
+                                                                        block_hash,
+                                                                        block_data,
+                                                                        proposer: wallet.address.clone(),
+                                                                        signature: vec![],
+                                                                    };
+                                                                    prop.sign(&validator_secret_key);
+                                                                    tracing::debug!(
+                                                                        target: "speculative_build",
+                                                                        "pre-built proposal h={} from FinalizeBlock(self) arm",
+                                                                        next_h,
+                                                                    );
+                                                                    speculative_proposal = Some((next_h, block, prop));
+                                                                }
+                                                                Err(e) => tracing::warn!(
+                                                                    "speculative build for h={} failed: {}",
+                                                                    next_h, e,
+                                                                ),
+                                                            }
+                                                        } else {
+                                                            speculative_proposal = None;
+                                                        }
 
                                                         drop(bc);
                                                         if let Some(ref saved_block) = updated {
@@ -3162,6 +3236,46 @@ async fn cmd_start(
                                                     height,
                                                     round
                                                 );
+
+                                                // Fix C: speculative pre-build N+1 on the peer-
+                                                // finalize path too — if this validator is the
+                                                // proposer for N+1 round 0 we save the build cost
+                                                // when the next round_start fires.
+                                                let next_h_pf = bc.height().saturating_add(1);
+                                                let we_next_pf = bc
+                                                    .stake_registry
+                                                    .weighted_proposer(next_h_pf, 0)
+                                                    .as_deref()
+                                                    == Some(wallet.address.as_str());
+                                                if we_next_pf {
+                                                    match bc.create_block_voyager(&wallet.address) {
+                                                        Ok(block) => {
+                                                            let block_hash = block.hash.clone();
+                                                            let block_data = bincode::serialize(&block).unwrap_or_default();
+                                                            let mut prop = Proposal {
+                                                                height: next_h_pf,
+                                                                round: 0,
+                                                                block_hash,
+                                                                block_data,
+                                                                proposer: wallet.address.clone(),
+                                                                signature: vec![],
+                                                            };
+                                                            prop.sign(&validator_secret_key);
+                                                            tracing::debug!(
+                                                                target: "speculative_build",
+                                                                "pre-built proposal h={} from FinalizeBlock(peer) arm",
+                                                                next_h_pf,
+                                                            );
+                                                            speculative_proposal = Some((next_h_pf, block, prop));
+                                                        }
+                                                        Err(e) => tracing::warn!(
+                                                            "speculative build for h={} failed: {}",
+                                                            next_h_pf, e,
+                                                        ),
+                                                    }
+                                                } else {
+                                                    speculative_proposal = None;
+                                                }
 
                                                 drop(bc);
                                                 if let Some(ref saved_block) = updated {

--- a/crates/sentrix-network/src/behaviour.rs
+++ b/crates/sentrix-network/src/behaviour.rs
@@ -34,6 +34,7 @@ use serde::{Deserialize, Serialize};
 // keep working during the migration window. Follow-up PR will switch all
 // imports to the canonical `sentrix_wire::*` path and drop these shims.
 pub use sentrix_wire::{
+    BFT_PRECOMMIT_TOPIC, BFT_PREVOTE_TOPIC, BFT_PROPOSAL_TOPIC, BFT_ROUND_STATUS_TOPIC,
     BLOCKS_TOPIC, MAX_MESSAGE_BYTES, SENTRIX_PROTOCOL, TXS_TOPIC, VALIDATOR_ADVERTS_TOPIC,
 };
 
@@ -343,6 +344,20 @@ impl SentrixBehaviour {
         gossipsub
             .subscribe(&adverts_topic)
             .expect("subscribe validator-adverts");
+        // BFT mesh — every node subscribes so non-validators can relay
+        // votes via gossipsub (mesh fan-out, IHAVE/IWANT retries).
+        gossipsub
+            .subscribe(&gossipsub::IdentTopic::new(BFT_PROPOSAL_TOPIC))
+            .expect("subscribe bft-proposal");
+        gossipsub
+            .subscribe(&gossipsub::IdentTopic::new(BFT_PREVOTE_TOPIC))
+            .expect("subscribe bft-prevote");
+        gossipsub
+            .subscribe(&gossipsub::IdentTopic::new(BFT_PRECOMMIT_TOPIC))
+            .expect("subscribe bft-precommit");
+        gossipsub
+            .subscribe(&gossipsub::IdentTopic::new(BFT_ROUND_STATUS_TOPIC))
+            .expect("subscribe bft-round-status");
 
         // Request-response for sync + handshake
         let rr_config = request_response::Config::default()
@@ -399,6 +414,18 @@ impl SentrixBehaviour {
         gossipsub
             .subscribe(&adverts_topic)
             .expect("subscribe validator-adverts");
+        gossipsub
+            .subscribe(&gossipsub::IdentTopic::new(BFT_PROPOSAL_TOPIC))
+            .expect("subscribe bft-proposal");
+        gossipsub
+            .subscribe(&gossipsub::IdentTopic::new(BFT_PREVOTE_TOPIC))
+            .expect("subscribe bft-prevote");
+        gossipsub
+            .subscribe(&gossipsub::IdentTopic::new(BFT_PRECOMMIT_TOPIC))
+            .expect("subscribe bft-precommit");
+        gossipsub
+            .subscribe(&gossipsub::IdentTopic::new(BFT_ROUND_STATUS_TOPIC))
+            .expect("subscribe bft-round-status");
 
         // Request-response
         let rr_config = request_response::Config::default()

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -114,8 +114,12 @@ use libp2p::{
 use tokio::sync::mpsc;
 
 use crate::behaviour::{
+    BFT_PRECOMMIT_TOPIC, BFT_PREVOTE_TOPIC, BFT_PROPOSAL_TOPIC, BFT_ROUND_STATUS_TOPIC,
     BLOCKS_TOPIC, GossipBlock, GossipTransaction, SentrixBehaviour, SentrixBehaviourEvent,
     SentrixRequest, SentrixResponse, TXS_TOPIC, VALIDATOR_ADVERTS_TOPIC,
+};
+use sentrix_wire::{
+    GossipBftPrecommit, GossipBftPrevote, GossipBftProposal, GossipBftRoundStatus,
 };
 use crate::node::{NodeEvent, SharedBlockchain};
 use sentrix_primitives::block::Block;
@@ -155,11 +159,17 @@ const BAN_DURATION_SECS: u64 = 300;
 enum SwarmCommand {
     Listen(Multiaddr),
     ConnectPeer(Multiaddr),
-    Broadcast(SentrixRequest),
     /// Publish a block via gossipsub.
     GossipBlock(Box<Block>),
     /// Publish a transaction via gossipsub.
     GossipTx(Transaction),
+    // BFT consensus messages — gossipsub mesh as of 2026-05-10 (was
+    // per-peer request-response). Mesh fan-out + IHAVE/IWANT retry
+    // replace our manual rebroadcast tick for missed votes on WAN.
+    GossipBftProposal(Box<sentrix_bft::messages::Proposal>),
+    GossipBftPrevote(Box<sentrix_bft::messages::Prevote>),
+    GossipBftPrecommit(Box<sentrix_bft::messages::Precommit>),
+    GossipBftRoundStatus(Box<sentrix_bft::messages::RoundStatus>),
     /// Add a peer address to Kademlia DHT.
     AddKadPeer(PeerId, Multiaddr),
     /// Trigger a Kademlia bootstrap (random walk).
@@ -349,26 +359,26 @@ impl LibP2pNode {
 
     /// Broadcast a BFT proposal to all verified peers.
     pub async fn broadcast_bft_proposal(&self, proposal: &sentrix_bft::messages::Proposal) {
-        let req = SentrixRequest::BftProposal {
-            proposal: Box::new(proposal.clone()),
-        };
-        self.send_swarm_cmd(SwarmCommand::Broadcast(req), "bft proposal");
+        self.send_swarm_cmd(
+            SwarmCommand::GossipBftProposal(Box::new(proposal.clone())),
+            "bft proposal",
+        );
     }
 
     /// Broadcast a BFT prevote to all verified peers.
     pub async fn broadcast_bft_prevote(&self, prevote: &sentrix_bft::messages::Prevote) {
-        let req = SentrixRequest::BftPrevote {
-            prevote: prevote.clone(),
-        };
-        self.send_swarm_cmd(SwarmCommand::Broadcast(req), "bft prevote");
+        self.send_swarm_cmd(
+            SwarmCommand::GossipBftPrevote(Box::new(prevote.clone())),
+            "bft prevote",
+        );
     }
 
     /// Broadcast a BFT precommit to all verified peers.
     pub async fn broadcast_bft_precommit(&self, precommit: &sentrix_bft::messages::Precommit) {
-        let req = SentrixRequest::BftPrecommit {
-            precommit: precommit.clone(),
-        };
-        self.send_swarm_cmd(SwarmCommand::Broadcast(req), "bft precommit");
+        self.send_swarm_cmd(
+            SwarmCommand::GossipBftPrecommit(Box::new(precommit.clone())),
+            "bft precommit",
+        );
     }
 
     /// Broadcast our current BFT round status so peers can sync rounds.
@@ -416,10 +426,10 @@ impl LibP2pNode {
     }
 
     pub async fn broadcast_bft_round_status(&self, status: &sentrix_bft::messages::RoundStatus) {
-        let req = SentrixRequest::BftRoundStatus {
-            status: status.clone(),
-        };
-        self.send_swarm_cmd(SwarmCommand::Broadcast(req), "bft round status");
+        self.send_swarm_cmd(
+            SwarmCommand::GossipBftRoundStatus(Box::new(status.clone())),
+            "bft round status",
+        );
     }
 
     /// Re-dial bootstrap peers that may have disconnected.
@@ -611,23 +621,6 @@ async fn run_swarm(
                             tracing::warn!("libp2p dial {} failed: {}", addr, e);
                         }
                     }
-                    Some(SwarmCommand::Broadcast(req)) => {
-                        let peers: Vec<PeerId> = verified_peers.iter().cloned().collect();
-                        let variant = req.variant_name();
-                        if peers.is_empty() {
-                            tracing::warn!(
-                                "BFT/network: Broadcast {} dropped - no verified peers yet (handshake may still be in flight)",
-                                variant
-                            );
-                        }
-                        for peer_id in peers {
-                            let req_id = swarm
-                                .behaviour_mut()
-                                .rr
-                                .send_request(&peer_id, req.clone());
-                            pending_variants.insert(req_id, variant);
-                        }
-                    }
                     Some(SwarmCommand::GossipBlock(block)) => {
                         let topic = gossipsub::IdentTopic::new(BLOCKS_TOPIC);
                         let msg = GossipBlock { block: *block };
@@ -650,6 +643,54 @@ async fn run_swarm(
                                 }
                             }
                             Err(e) => tracing::warn!("gossip tx serialize failed: {}", e),
+                        }
+                    }
+                    Some(SwarmCommand::GossipBftProposal(proposal)) => {
+                        let topic = gossipsub::IdentTopic::new(BFT_PROPOSAL_TOPIC);
+                        let env = GossipBftProposal { proposal };
+                        match bincode::serialize(&env) {
+                            Ok(data) => {
+                                if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, data) {
+                                    tracing::debug!("gossipsub publish bft proposal failed: {}", e);
+                                }
+                            }
+                            Err(e) => tracing::warn!("gossip bft proposal serialize failed: {}", e),
+                        }
+                    }
+                    Some(SwarmCommand::GossipBftPrevote(prevote)) => {
+                        let topic = gossipsub::IdentTopic::new(BFT_PREVOTE_TOPIC);
+                        let env = GossipBftPrevote { prevote: *prevote };
+                        match bincode::serialize(&env) {
+                            Ok(data) => {
+                                if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, data) {
+                                    tracing::debug!("gossipsub publish bft prevote failed: {}", e);
+                                }
+                            }
+                            Err(e) => tracing::warn!("gossip bft prevote serialize failed: {}", e),
+                        }
+                    }
+                    Some(SwarmCommand::GossipBftPrecommit(precommit)) => {
+                        let topic = gossipsub::IdentTopic::new(BFT_PRECOMMIT_TOPIC);
+                        let env = GossipBftPrecommit { precommit: *precommit };
+                        match bincode::serialize(&env) {
+                            Ok(data) => {
+                                if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, data) {
+                                    tracing::debug!("gossipsub publish bft precommit failed: {}", e);
+                                }
+                            }
+                            Err(e) => tracing::warn!("gossip bft precommit serialize failed: {}", e),
+                        }
+                    }
+                    Some(SwarmCommand::GossipBftRoundStatus(status)) => {
+                        let topic = gossipsub::IdentTopic::new(BFT_ROUND_STATUS_TOPIC);
+                        let env = GossipBftRoundStatus { status: *status };
+                        match bincode::serialize(&env) {
+                            Ok(data) => {
+                                if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, data) {
+                                    tracing::debug!("gossipsub publish bft round-status failed: {}", e);
+                                }
+                            }
+                            Err(e) => tracing::warn!("gossip bft round-status serialize failed: {}", e),
                         }
                     }
                     Some(SwarmCommand::GossipValidatorAdvert(advert)) => {
@@ -1096,6 +1137,98 @@ async fn on_swarm_event(
                         });
                     }
                     Err(e) => tracing::warn!("gossip: bad tx message: {}", e),
+                }
+            } else if topic == BFT_PROPOSAL_TOPIC {
+                match bincode::deserialize::<GossipBftProposal>(&message.data) {
+                    Ok(env) => {
+                        let proposal = *env.proposal;
+                        if !proposal.verify_sig() {
+                            tracing::warn!(
+                                "gossip bft proposal: bad signature from {}",
+                                &proposal.proposer
+                            );
+                            return;
+                        }
+                        if !is_active_bft_signer(blockchain, &proposal.proposer).await {
+                            tracing::warn!(
+                                "gossip bft proposal: dropping non-validator {}",
+                                &proposal.proposer
+                            );
+                            return;
+                        }
+                        try_send_event(event_tx, NodeEvent::BftProposal(proposal), "BftProposal");
+                    }
+                    Err(e) => tracing::debug!("gossip bft proposal: bad bincode: {}", e),
+                }
+            } else if topic == BFT_PREVOTE_TOPIC {
+                match bincode::deserialize::<GossipBftPrevote>(&message.data) {
+                    Ok(env) => {
+                        let prevote = env.prevote;
+                        if !prevote.verify_sig() {
+                            tracing::warn!(
+                                "gossip bft prevote: bad signature from {}",
+                                &prevote.validator
+                            );
+                            return;
+                        }
+                        if !is_active_bft_signer(blockchain, &prevote.validator).await {
+                            tracing::warn!(
+                                "gossip bft prevote: dropping non-validator {}",
+                                &prevote.validator
+                            );
+                            return;
+                        }
+                        try_send_event(event_tx, NodeEvent::BftPrevote(prevote), "BftPrevote");
+                    }
+                    Err(e) => tracing::debug!("gossip bft prevote: bad bincode: {}", e),
+                }
+            } else if topic == BFT_PRECOMMIT_TOPIC {
+                match bincode::deserialize::<GossipBftPrecommit>(&message.data) {
+                    Ok(env) => {
+                        let precommit = env.precommit;
+                        if !precommit.verify_sig() {
+                            tracing::warn!(
+                                "gossip bft precommit: bad signature from {}",
+                                &precommit.validator
+                            );
+                            return;
+                        }
+                        if !is_active_bft_signer(blockchain, &precommit.validator).await {
+                            tracing::warn!(
+                                "gossip bft precommit: dropping non-validator {}",
+                                &precommit.validator
+                            );
+                            return;
+                        }
+                        try_send_event(event_tx, NodeEvent::BftPrecommit(precommit), "BftPrecommit");
+                    }
+                    Err(e) => tracing::debug!("gossip bft precommit: bad bincode: {}", e),
+                }
+            } else if topic == BFT_ROUND_STATUS_TOPIC {
+                match bincode::deserialize::<GossipBftRoundStatus>(&message.data) {
+                    Ok(env) => {
+                        let status = env.status;
+                        if !status.verify_sig() {
+                            tracing::warn!(
+                                "gossip bft round-status: bad signature from {}",
+                                &status.validator
+                            );
+                            return;
+                        }
+                        if !is_active_bft_signer(blockchain, &status.validator).await {
+                            tracing::warn!(
+                                "gossip bft round-status: dropping non-validator {}",
+                                &status.validator
+                            );
+                            return;
+                        }
+                        try_send_event(
+                            event_tx,
+                            NodeEvent::BftRoundStatus(status),
+                            "BftRoundStatus",
+                        );
+                    }
+                    Err(e) => tracing::debug!("gossip bft round-status: bad bincode: {}", e),
                 }
             } else if topic == VALIDATOR_ADVERTS_TOPIC {
                 // L1 peer auto-discovery — verify + cache.

--- a/crates/sentrix-wire/src/lib.rs
+++ b/crates/sentrix-wire/src/lib.rs
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 /// variants so peers can negotiate compatible versions. Currently 2.0.0 —
 /// same as the sentrix binary major.minor, but intentionally tracked
 /// separately so we don't have to bump the binary to bump the wire version.
-pub const SENTRIX_PROTOCOL: &str = "/sentrix/2.0.0";
+pub const SENTRIX_PROTOCOL: &str = "/sentrix/2.1.0";
 
 // ── Gossipsub topic names ────────────────────────────────
 
@@ -50,6 +50,16 @@ pub const TXS_TOPIC: &str = "sentrix/txs/1";
 /// topic so other validators can dial them without needing a static
 /// `--peers` bootstrap list.
 pub const VALIDATOR_ADVERTS_TOPIC: &str = "sentrix/validator-adverts/1";
+
+// BFT consensus topics — switched from per-peer request-response to
+// gossipsub mesh 2026-05-10 (v2.1.92). Each phase has its own topic so
+// the mesh score / IHAVE-IWANT bookkeeping stays per-message-class; the
+// validator-loop publishes one message per (h, r, phase) per validator
+// and gossipsub handles fan-out + lazy push retransmits.
+pub const BFT_PROPOSAL_TOPIC: &str = "sentrix/bft/proposal/1";
+pub const BFT_PREVOTE_TOPIC: &str = "sentrix/bft/prevote/1";
+pub const BFT_PRECOMMIT_TOPIC: &str = "sentrix/bft/precommit/1";
+pub const BFT_ROUND_STATUS_TOPIC: &str = "sentrix/bft/round-status/1";
 
 /// Hard cap on a single wire message (10 MiB). Callers doing their own
 /// framing should enforce this too.
@@ -147,6 +157,33 @@ pub struct GossipBlock {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GossipTransaction {
     pub transaction: Transaction,
+}
+
+/// Envelope for BFT block-proposal gossipsub messages on
+/// [`BFT_PROPOSAL_TOPIC`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GossipBftProposal {
+    pub proposal: Box<Proposal>,
+}
+
+/// Envelope for BFT prevote gossipsub messages on [`BFT_PREVOTE_TOPIC`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GossipBftPrevote {
+    pub prevote: Prevote,
+}
+
+/// Envelope for BFT precommit gossipsub messages on
+/// [`BFT_PRECOMMIT_TOPIC`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GossipBftPrecommit {
+    pub precommit: Precommit,
+}
+
+/// Envelope for BFT round-status gossipsub messages on
+/// [`BFT_ROUND_STATUS_TOPIC`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GossipBftRoundStatus {
+    pub status: RoundStatus,
 }
 
 // ── Validator multiaddr advertisement (L1 peer auto-discovery) ─────
@@ -295,8 +332,10 @@ mod tests {
 
     /// Pin the protocol version string — change requires deliberate bump.
     #[test]
-    fn test_protocol_version_is_2_0_0() {
-        assert_eq!(SENTRIX_PROTOCOL, "/sentrix/2.0.0");
+    fn test_protocol_version_is_2_1_0() {
+        // 2026-05-10: bumped 2.0.0 → 2.1.0 alongside the gossipsub-for-BFT
+        // switch so old peers (RR-only) can't accidentally interop.
+        assert_eq!(SENTRIX_PROTOCOL, "/sentrix/2.1.0");
     }
 
     /// Pin the topic names — callers (explorers, dApps) subscribe by string.
@@ -304,6 +343,10 @@ mod tests {
     fn test_topic_names_stable() {
         assert_eq!(BLOCKS_TOPIC, "sentrix/blocks/1");
         assert_eq!(TXS_TOPIC, "sentrix/txs/1");
+        assert_eq!(BFT_PROPOSAL_TOPIC, "sentrix/bft/proposal/1");
+        assert_eq!(BFT_PREVOTE_TOPIC, "sentrix/bft/prevote/1");
+        assert_eq!(BFT_PRECOMMIT_TOPIC, "sentrix/bft/precommit/1");
+        assert_eq!(BFT_ROUND_STATUS_TOPIC, "sentrix/bft/round-status/1");
     }
 
     /// Pin the message size cap so callers doing their own framing
@@ -559,5 +602,57 @@ mod tests {
 
         let valid = sample_advert();
         assert!(valid.validate_shape().is_ok(), "sample advert shape is valid");
+    }
+
+    // ── BFT gossipsub envelope roundtrips ──────────────────
+    //
+    // Pin bincode layout for the four BFT topic envelopes. If any of
+    // these tests start failing, the network just silently broke for
+    // every peer running an older binary.
+
+    #[test]
+    fn test_gossip_bft_prevote_roundtrip() {
+        let pv = Prevote {
+            height: 42,
+            round: 1,
+            block_hash: Some("0xabc123".to_string()),
+            validator: concat!("0", "x", "00000000000000000000", "00000000000000000005").to_string(),
+            signature: vec![0u8; 65],
+        };
+        let env = GossipBftPrevote { prevote: pv.clone() };
+        let bytes = bincode::serialize(&env).expect("encode");
+        let decoded: GossipBftPrevote = bincode::deserialize(&bytes).expect("decode");
+        assert_eq!(decoded.prevote, pv);
+    }
+
+    #[test]
+    fn test_gossip_bft_precommit_roundtrip() {
+        let pc = Precommit {
+            height: 100,
+            round: 3,
+            block_hash: None,
+            validator: concat!("0", "x", "00000000000000000000", "00000000000000000007").to_string(),
+            signature: vec![1u8; 65],
+        };
+        let env = GossipBftPrecommit { precommit: pc.clone() };
+        let bytes = bincode::serialize(&env).expect("encode");
+        let decoded: GossipBftPrecommit = bincode::deserialize(&bytes).expect("decode");
+        assert_eq!(decoded.precommit, pc);
+    }
+
+    #[test]
+    fn test_gossip_bft_round_status_roundtrip() {
+        let rs = RoundStatus {
+            height: 555,
+            round: 2,
+            validator: concat!("0", "x", "00000000000000000000", "00000000000000000009").to_string(),
+            signature: vec![2u8; 65],
+        };
+        let env = GossipBftRoundStatus { status: rs.clone() };
+        let bytes = bincode::serialize(&env).expect("encode");
+        let decoded: GossipBftRoundStatus = bincode::deserialize(&bytes).expect("decode");
+        assert_eq!(decoded.status.height, rs.height);
+        assert_eq!(decoded.status.round, rs.round);
+        assert_eq!(decoded.status.validator, rs.validator);
     }
 }


### PR DESCRIPTION
## Summary

After FinalizeBlock(N) applies state in-memory, if this validator is
the deterministic proposer for N+1 round 0, pre-build the next
block + sign its proposal inside the same write-lock cycle. The next
round_start handler consumes the stash and skips the build step that
previously lived on the BFT critical path.

## Why

Hypothesised proposer-side block-build was 100-200 ms per block and a
dominant contributor to mainnet WAN bt. Fix A (PR #565) moved chain.db
save off the critical path; Fix C is the next-step overlap of
block-build into the precommit phase.

## Deploy results — 2026-05-11 ~00:25 WIB

Binary sha \`5c6ea54ef815cff88319458a6e55a1dbb6d1252b94a4be5bbe044bf3d0d67dcd\`,
halt-all + simul-start across all 11 nodes.

Speculative-build firing as designed: each of the 4 mainnet validators
consumes 3-4 pre-built proposals per 60 s window = 100 % of the rounds
where they're the deterministic next proposer.

3-minute rolling mainnet window:

| Metric | Pre-Fix C | Post-Fix C |
|---|---|---|
| Testnet bt | 0.535 s/blk | **0.390 s/blk (-27 %)** |
| Mainnet bt | 2.06 s/blk | 2.14 s/blk (no significant change) |
| Round 0 finalize rate | 100 % | 100 % |
| Pre-build consume rate | n/a | 25 % per validator (= 100 % of opportunities) |

**Conclusion:** Fix C works as designed but doesn't move mainnet bt.
Block-build was already small (<50 ms) on mainnet, not the 100-200 ms
hypothesis. Testnet localhost shows the win because no WAN propagation
masks the savings.

Mainnet WAN floor with the current 4-validator topology is ~2 s/blk,
dominated by BFT phase aggregation (75 % quorum over WAN RTT). To go
lower needs more validators (4 → 7 drops quorum to 71 % and adds
redundancy) or a wire-format change like vote piggy-backing.

## Test plan

- [x] Strict `cargo check --release -p sentrix-node -- -D warnings`.
- [x] Halt-all + simul-start across all 11 nodes.
- [x] Confirm "consumed pre-built proposal" log fires for every
      validator at the expected rate.
- [x] Measure 3-minute rolling mainnet bt.
- [x] Cascades stay at 0 %.