### PR TITLE
Revert F-D Variant A — sign-order bug poisons proposal signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,24 +14,6 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [2.2.0] — 2026-05-11 — proposer-prevote piggy-back (wire-incompatible)
-
-**Wire-incompatible**: `SENTRIX_PROTOCOL` bumped `/sentrix/2.1.0` → `/sentrix/2.2.0`. Halt-all + simul-start required. Mixed 2.1.x / 2.2.0 cluster will halt: the new `Proposal` struct carries an extra `proposer_prevote: Option<Prevote>` field, which a 2.1.x decoder reads as trailing bytes and rejects via bincode.
-
-**The change**: the proposer's own prevote for the block it just proposed is now bundled inside the `Proposal` envelope. Receivers extract it on arrival, verify the signature matches the proposer, and feed it into the BFT engine's prevote tally as a regular `BftPrevote` event — same dedupe path as a standalone prevote. The proposer's standalone gossipsub prevote still fires (via `on_own_proposal`), but the standalone arrival is now a dedupe no-op rather than the critical-path message.
-
-**Why**: in a 4-validator quorum at 1 s block target, the proposer's prevote was the most-delayed vote at every round — the proposer needed one full gossipsub mesh hop to deliver its own vote to itself's BFT engine. Variant A removes that hop. Expected wall-clock saving per round: 1 RTT of gossipsub propagation (~50-200 ms at WAN, more under load).
-
-**Backwards compat**: `Option<Prevote>` defaults to `None` via `#[serde(default)]` for any future change, but bincode itself isn't tolerant of trailing-byte additions on existing wires — hence the protocol bump rather than a silent rollout. The proposer-side change is gated on the type field existing, which means stage-by-stage upgrades won't fan out malformed bytes during the simul-start window.
-
-**Includes pending v2.1.92 / v2.1.93 changes** (CHANGELOG entries below already cover them): inbound-silence watchdog removed (PR #568), V2-DBG `eprintln` cleanup (PR #570), public-repo internal-ref scrub (PR #571). Cluster is currently on v2.1.92; v2.1.93 was never deployed, so the next halt-all carries v2.1.92 → v2.2.0 in one step.
-
-**Files**: `crates/sentrix-bft/src/messages.rs` (Proposal struct + 2 tests), `crates/sentrix-network/src/libp2p_node.rs` (receiver-side extract + dispatch), `bin/sentrix/src/main.rs` (proposer-side build + embed at 4 call sites), `crates/sentrix-wire/src/lib.rs` (protocol bump). Workspace version 2.1.93 → 2.2.0 across 17 Cargo.toml files; `sentrix-faucet` stays on 2.1.91 (independent lifecycle).
-
-**Tests**: 118 sentrix-bft passing (+`test_proposal_with_embedded_prevote_roundtrip`, +`test_legacy_proposal_without_prevote_decodes`); 18 sentrix-wire passing.
-
-**Ops**: testnet bake mandatory per consensus-discipline rule before mainnet halt-all. Run testnet a few hours minimum; verify finalize_trace shows zero `precommit_count<3` rounds and bt distribution shifts left.
-
 ## [2.1.86] — 2026-05-08 — LastSignBytes guard same-bytes-replay exemption
 
 Closes the rebroadcast bug class that kept `LAST_SIGN_GUARD_PATH` env-disabled cluster-wide since v2.1.84/v2.1.85.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "hex",
  "proptest",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.0"
+version = "2.1.93"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "hex",
  "proptest",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.93"
+version = "2.1.94"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1558,7 +1558,7 @@ async fn cmd_start(
         }
         Some(tokio::spawn(async move {
             use sentrix::core::bft::{BftAction, BftEngine, BftPhase};
-            use sentrix::core::bft_messages::{BftMessage, Prevote, Proposal};
+            use sentrix::core::bft_messages::{BftMessage, Proposal};
             use sentrix::core::block::Block;
 
             // V2 M-15 Step 4+5 helper: produce a signed Proposal for the
@@ -1570,31 +1570,6 @@ async fn cmd_start(
             // existing `create_block_voyager` path.
             //
             // Design: audits/v2-locked-block-repropose-implementation-plan.md
-            // Build + sign the proposer's own prevote for `block_hash` so it
-            // can travel inside the proposal envelope (Variant A piggy-back).
-            // Receivers count proposer's vote immediately from the proposal
-            // message and skip waiting for a separate BftPrevote gossipsub
-            // hop. Standalone broadcast still fires via on_own_proposal so
-            // peers on older binaries continue to count the vote (engine
-            // dedups by signer+height+round).
-            fn build_proposer_prevote(
-                height: u64,
-                round: u32,
-                block_hash: &str,
-                wallet_address: &str,
-                validator_sk: &secp256k1::SecretKey,
-            ) -> Prevote {
-                let mut prevote = Prevote {
-                    height,
-                    round,
-                    block_hash: Some(block_hash.to_string()),
-                    validator: wallet_address.to_string(),
-                    signature: vec![],
-                };
-                prevote.sign(validator_sk);
-                prevote
-            }
-
             fn build_or_reuse_proposal(
                 bft: &BftEngine,
                 bc: &mut Blockchain,
@@ -1602,7 +1577,6 @@ async fn cmd_start(
                 validator_sk: &secp256k1::SecretKey,
                 height: u64,
             ) -> Option<(Block, Proposal)> {
-                let round = bft.round();
                 if let Some((cached_hash, cached_bytes)) = bft.locked_proposal_bytes() {
                     match bincode::deserialize::<Block>(&cached_bytes) {
                         Ok(block) => {
@@ -1610,23 +1584,15 @@ async fn cmd_start(
                                 "V2 M-15: re-proposing locked block {:.16}... at height {} round {}",
                                 cached_hash,
                                 height,
-                                round
-                            );
-                            let proposer_prevote = build_proposer_prevote(
-                                height,
-                                round,
-                                &cached_hash,
-                                wallet_address,
-                                validator_sk,
+                                bft.round()
                             );
                             let mut proposal = Proposal {
                                 height,
-                                round,
+                                round: bft.round(),
                                 block_hash: cached_hash,
                                 block_data: cached_bytes,
                                 proposer: wallet_address.to_string(),
                                 signature: vec![],
-                                proposer_prevote: Some(proposer_prevote),
                             };
                             proposal.sign(validator_sk);
                             return Some((block, proposal));
@@ -1643,21 +1609,13 @@ async fn cmd_start(
                     Ok(block) => {
                         let block_hash = block.hash.clone();
                         let block_data = bincode::serialize(&block).unwrap_or_default();
-                        let proposer_prevote = build_proposer_prevote(
-                            height,
-                            round,
-                            &block_hash,
-                            wallet_address,
-                            validator_sk,
-                        );
                         let mut proposal = Proposal {
                             height,
-                            round,
+                            round: bft.round(),
                             block_hash,
                             block_data,
                             proposer: wallet_address.to_string(),
                             signature: vec![],
-                            proposer_prevote: Some(proposer_prevote),
                         };
                         proposal.sign(validator_sk);
                         Some((block, proposal))
@@ -2734,13 +2692,6 @@ async fn cmd_start(
                                                                 Ok(block) => {
                                                                     let block_hash = block.hash.clone();
                                                                     let block_data = bincode::serialize(&block).unwrap_or_default();
-                                                                    let proposer_prevote = build_proposer_prevote(
-                                                                        next_h,
-                                                                        0,
-                                                                        &block_hash,
-                                                                        &wallet.address,
-                                                                        &validator_secret_key,
-                                                                    );
                                                                     let mut prop = Proposal {
                                                                         height: next_h,
                                                                         round: 0,
@@ -2748,7 +2699,6 @@ async fn cmd_start(
                                                                         block_data,
                                                                         proposer: wallet.address.clone(),
                                                                         signature: vec![],
-                                                                        proposer_prevote: Some(proposer_prevote),
                                                                     };
                                                                     prop.sign(&validator_secret_key);
                                                                     tracing::debug!(
@@ -3302,13 +3252,6 @@ async fn cmd_start(
                                                         Ok(block) => {
                                                             let block_hash = block.hash.clone();
                                                             let block_data = bincode::serialize(&block).unwrap_or_default();
-                                                            let proposer_prevote = build_proposer_prevote(
-                                                                next_h_pf,
-                                                                0,
-                                                                &block_hash,
-                                                                &wallet.address,
-                                                                &validator_secret_key,
-                                                            );
                                                             let mut prop = Proposal {
                                                                 height: next_h_pf,
                                                                 round: 0,
@@ -3316,7 +3259,6 @@ async fn cmd_start(
                                                                 block_data,
                                                                 proposer: wallet.address.clone(),
                                                                 signature: vec![],
-                                                                proposer_prevote: Some(proposer_prevote),
                                                             };
                                                             prop.sign(&validator_secret_key);
                                                             tracing::debug!(

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/src/messages.rs
+++ b/crates/sentrix-bft/src/messages.rs
@@ -104,12 +104,6 @@ pub struct Proposal {
     pub block_data: Vec<u8>, // bincode-encoded Block
     pub proposer: String,    // validator address
     pub signature: Vec<u8>,  // ed25519 signature over (height, round, block_hash)
-    /// Proposer's own prevote for this block, bundled so receivers can count
-    /// the proposer's vote immediately from the proposal message and skip
-    /// waiting for a separate BftPrevote gossipsub broadcast. `None` for
-    /// legacy encodings (serde default); new proposers always set it.
-    #[serde(default)]
-    pub proposer_prevote: Option<Prevote>,
 }
 
 impl Proposal {
@@ -733,66 +727,10 @@ mod tests {
             block_data: vec![1, 2, 3],
             proposer: wallet.address.clone(),
             signature: vec![],
-            proposer_prevote: None,
         };
         prop.sign(&sk);
         assert_eq!(prop.signature.len(), 65);
         assert!(prop.verify_sig());
-    }
-
-    #[test]
-    fn test_proposal_with_embedded_prevote_roundtrip() {
-        let wallet = make_wallet();
-        let sk = wallet.get_secret_key().unwrap();
-        let mut prevote = Prevote {
-            height: 300,
-            round: 0,
-            block_hash: Some("hash_ghi".into()),
-            validator: wallet.address.clone(),
-            signature: vec![],
-        };
-        prevote.sign(&sk);
-        let mut prop = Proposal {
-            height: 300,
-            round: 0,
-            block_hash: "hash_ghi".into(),
-            block_data: vec![1, 2, 3],
-            proposer: wallet.address.clone(),
-            signature: vec![],
-            proposer_prevote: Some(prevote.clone()),
-        };
-        prop.sign(&sk);
-        let bytes = bincode::serialize(&prop).expect("encode");
-        let decoded: Proposal = bincode::deserialize(&bytes).expect("decode");
-        assert!(decoded.verify_sig());
-        assert_eq!(decoded.proposer_prevote.as_ref().unwrap(), &prevote);
-        assert!(decoded.proposer_prevote.unwrap().verify_sig());
-    }
-
-    #[test]
-    fn test_legacy_proposal_without_prevote_decodes() {
-        // Forward-compat: encoder writes the new struct with None and
-        // a decoder built against the same code reads None back. Older
-        // encoders that wrote the pre-field layout deserialise via
-        // serde-default; this test pins the None case round-trips
-        // cleanly so a regression in the field's serde attributes is
-        // caught without a wire-format harness.
-        let wallet = make_wallet();
-        let sk = wallet.get_secret_key().unwrap();
-        let mut prop = Proposal {
-            height: 1,
-            round: 0,
-            block_hash: "h".into(),
-            block_data: vec![],
-            proposer: wallet.address.clone(),
-            signature: vec![],
-            proposer_prevote: None,
-        };
-        prop.sign(&sk);
-        let bytes = bincode::serialize(&prop).expect("encode");
-        let decoded: Proposal = bincode::deserialize(&bytes).expect("decode");
-        assert!(decoded.verify_sig());
-        assert!(decoded.proposer_prevote.is_none());
     }
 
     #[test]

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -1037,32 +1037,6 @@ async fn on_swarm_event(
                             );
                             return;
                         }
-                        // Variant A piggy-back: if the proposal carries the
-                        // proposer's own prevote, dispatch it as a regular
-                        // prevote event so the engine counts the proposer's
-                        // vote without waiting for a separate gossipsub hop.
-                        // Engine dedups by signer+height+round so the
-                        // proposer's standalone prevote arriving later is a
-                        // no-op.
-                        if let Some(pv) = proposal.proposer_prevote.clone() {
-                            if pv.validator != proposal.proposer {
-                                tracing::warn!(
-                                    "gossip bft proposal: embedded prevote signer {} != proposer {}",
-                                    &pv.validator, &proposal.proposer
-                                );
-                            } else if !pv.verify_sig() {
-                                tracing::warn!(
-                                    "gossip bft proposal: embedded prevote bad signature from {}",
-                                    &pv.validator
-                                );
-                            } else {
-                                try_send_event(
-                                    event_tx,
-                                    NodeEvent::BftPrevote(pv),
-                                    "BftPrevote(embedded)",
-                                );
-                            }
-                        }
                         try_send_event(event_tx, NodeEvent::BftProposal(proposal), "BftProposal");
                     }
                     Err(e) => tracing::debug!("gossip bft proposal: bad bincode: {}", e),

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.2.0"
+version = "2.1.93"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.93"
+version = "2.1.94"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."

--- a/crates/sentrix-wire/src/lib.rs
+++ b/crates/sentrix-wire/src/lib.rs
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 /// variants so peers can negotiate compatible versions. Currently 2.0.0 —
 /// same as the sentrix binary major.minor, but intentionally tracked
 /// separately so we don't have to bump the binary to bump the wire version.
-pub const SENTRIX_PROTOCOL: &str = "/sentrix/2.2.0";
+pub const SENTRIX_PROTOCOL: &str = "/sentrix/2.1.0";
 
 // ── Gossipsub topic names ────────────────────────────────
 
@@ -332,12 +332,10 @@ mod tests {
 
     /// Pin the protocol version string — change requires deliberate bump.
     #[test]
-    fn test_protocol_version_is_2_2_0() {
-        // 2026-05-11: bumped 2.1.0 → 2.2.0 alongside the proposer-prevote
-        // piggy-back so old peers (which decode the Proposal struct
-        // without the new `proposer_prevote` field) can't accidentally
-        // interop and bincode-fail on trailing bytes.
-        assert_eq!(SENTRIX_PROTOCOL, "/sentrix/2.2.0");
+    fn test_protocol_version_is_2_1_0() {
+        // 2026-05-10: bumped 2.0.0 → 2.1.0 alongside the gossipsub-for-BFT
+        // switch so old peers (RR-only) can't accidentally interop.
+        assert_eq!(SENTRIX_PROTOCOL, "/sentrix/2.1.0");
     }
 
     /// Pin the topic names — callers (explorers, dApps) subscribe by string.


### PR DESCRIPTION
**Reverts #572.** Testnet deploy 2026-05-11 surfaced a structural bug in the merged Variant A path that bricks the proposer's own proposal signature. See the diagnosis comment on #572 for the full trace; summary below.

## Bug

\`build_proposer_prevote()\` in \`bin/sentrix/src/main.rs\` calls \`prevote.sign(sk)\` to fill the prevote signature before embedding it in the Proposal. \`prevote.sign()\` invokes the LastSignBytes guard, which records \`(h, r, step=Prevote=1)\` in \`last-sign.json\`. The subsequent \`prop.sign(sk)\` then attempts to record \`(h, r, step=Proposal=0)\`; the guard sees \`attempted (h, r, 0) <= last_signed (h, r, 1)\` and refuses. Proposal signature stays \`vec![]\`. Peers reject.

Sign-order swap (proposal first, then prevote) breaks deterministic bincode because the proposal signature would need to be computed over an envelope that already contains the embedded prevote — and the prevote hasn't been built yet.

## Evidence

Testnet h=3,196,667 logs:
\`\`\`
REFUSING TO SIGN PROPOSAL — equivocation attempt:
  DoubleSignAttempt: attempted (h=3196667, r=0, s=0) <= last_signed (h=3196667, r=0, s=1)
gossip bft proposal: bad signature from 0x245785f409d853bb04d6910a3a0f78df7cbd184c
BFT: UNSIGNED vote from 0x4f9988506a (empty signature)
\`\`\`

Same root cause for both the \"double-sign\" and \"bad signature\" symptoms.

## Recovery

- Testnet rolled back to v2.1.92 + \`last-sign.json\` removed across val1-4 + simul-restart. Chain advancing at h≈3,196,800+.
- Mainnet was NOT touched — v2.1.92 cluster-wide, halt-all never executed.

## What this PR does

- Reverts the entire #572 diff (Proposal struct field, sign helper, receiver-side dispatch, version bumps, CHANGELOG entry).
- Bumps workspace 2.1.93 → 2.1.94 per the every-fix-bumps rule.
- \`SENTRIX_PROTOCOL\` returns to \`/sentrix/2.1.0\`. Cluster compat unchanged.

## Next steps (separate PR, NOT this one)

The right F-D Variant A design embeds an UNSIGNED prevote and lets receivers derive authenticity from the proposal's outer signature (proposer == embedded signer enforced structurally). Receiver-side dispatch synthesises a proxy-signed \`NodeEvent::BftPrevote\` for the BFT engine. Regression test must pin sign-order: a Proposal signed at \`step=0\` cannot follow a prevote signed at \`step=1\` for the same \`(h, r)\` under the LastSignBytes guard's current contract.

## Tests

\`cargo check --workspace --release\` clean with \`-D warnings\`.