### PR TITLE
fix(bft): embed proposer's prevote UNSIGNED in Proposal (Variant A v3) — wire-incompat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,33 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.2.0] — 2026-05-11 — proposer-prevote piggy-back, redesigned (wire-incompatible)
+
+**Wire-incompatible**: `SENTRIX_PROTOCOL` bumped `/sentrix/2.1.0` → `/sentrix/2.2.0`. Halt-all + simul-start required. Mixed 2.1.x / 2.2.0 cluster will halt because a 2.1.x decoder rejects the extra trailing bytes on the new `Proposal` struct.
+
+**The change**: the proposer's own prevote for the block it just proposed rides inside the `Proposal` envelope as a struct field, **unsigned**. Receivers extract it after the outer proposal signature verifies, run a structural check (`proposer_prevote.validator == proposal.proposer`, `(h, r, block_hash)` match), and dispatch it as a regular `BftPrevote` event. The engine credits the proposer's vote at proposal-arrival time without waiting for the standalone gossipsub prevote hop.
+
+**Why unsigned**: the earlier PR #572 attempt signed the embedded prevote and broke the proposer's own proposal signature. Calling `prevote.sign(sk)` writes `(h, r, step=Prevote=1)` to `last-sign.json`. The subsequent `prop.sign(sk)` at `step=Proposal=0` then trips the LastSignBytes guard's `attempted <= last_signed` check and leaves the proposal signature empty. Testnet halted at h=3,196,667; reverted via PR #573.
+
+The redesign keeps the embedded prevote unsigned. Authenticity flows entirely from the proposal's outer signature: once `proposal.verify_sig()` passes, the signer's identity is established, and the structural `validator == proposer` check binds the embedded prevote to that identity. The engine boundary does not call `verify_sig` on the synthesised prevote.
+
+**Saving**: in a 4-validator quorum at WAN, the proposer's prevote needed one full gossipsub mesh hop to reach the other 3 validators. Variant A removes that hop for the proposer's vote (~50-200 ms per round under typical load; more under congestion).
+
+**Backward compatibility**: receivers running 2.1.x cannot decode the new Proposal struct (bincode trailing bytes). Hence the protocol bump and halt-all simul-start.
+
+**Files**:
+- `crates/sentrix-bft/src/messages.rs` — `Proposal.proposer_prevote` field + 3 unit tests including a regression test for the PR #572 sign-order trap.
+- `crates/sentrix-network/src/libp2p_node.rs` — receiver-side extract + structural-check + dispatch on both gossipsub and request-response paths.
+- `bin/sentrix/src/main.rs` — proposer-side embed (4 call sites: locked-proposal reuse, fresh-proposal build, speculative pre-build on FinalizeBlock-self arm, speculative pre-build on FinalizeBlock-peer arm).
+- `crates/sentrix-wire/src/lib.rs` — protocol bump + the version-pin test.
+- 17 × `Cargo.toml` — workspace 2.1.94 → 2.2.0; `sentrix-faucet` stays on 2.1.91.
+
+**Tests**: 119 sentrix-bft passing (+`test_proposal_sign_with_embedded_unsigned_prevote_succeeds`, +`test_proposal_unsigned_embedded_prevote_roundtrip`, +`test_proposal_without_embedded_prevote_decodes`); 18 sentrix-wire passing. `RUSTFLAGS="-D warnings" cargo check --workspace --release` clean.
+
+**Ops plan**:
+1. Testnet bake via `fast-deploy.sh testnet`; verify `finalize_trace` shows zero `precommit_count<3` rounds, no `bad signature` warnings, no `DoubleSignAttempt` errors, and that the bt distribution shifts left vs the v2.1.92 baseline. **A few hours minimum** per consensus-discipline rule.
+2. Mainnet halt-all + simul-start via `fast-deploy.sh mainnet`. State-root alignment pre-flight required. Canonical chain.db rsync ready as recovery path.
+
 ## [2.1.86] — 2026-05-08 — LastSignBytes guard same-bytes-replay exemption
 
 Closes the rebroadcast bug class that kept `LAST_SIGN_GUARD_PATH` env-disabled cluster-wide since v2.1.84/v2.1.85.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "hex",
  "proptest",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.1.94"
+version = "2.2.0"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1558,7 +1558,7 @@ async fn cmd_start(
         }
         Some(tokio::spawn(async move {
             use sentrix::core::bft::{BftAction, BftEngine, BftPhase};
-            use sentrix::core::bft_messages::{BftMessage, Proposal};
+            use sentrix::core::bft_messages::{BftMessage, Prevote, Proposal};
             use sentrix::core::block::Block;
 
             // V2 M-15 Step 4+5 helper: produce a signed Proposal for the
@@ -1586,13 +1586,32 @@ async fn cmd_start(
                                 height,
                                 bft.round()
                             );
+                            // F-D Variant A v3: embed proposer's own
+                            // UNSIGNED prevote so receivers credit the
+                            // proposer's vote at proposal-arrival time
+                            // instead of waiting for the standalone
+                            // gossipsub prevote hop. Authenticity flows
+                            // from the proposal's outer signature; the
+                            // prevote stays unsigned to avoid poisoning
+                            // the LastSignBytes guard at step=1 before
+                            // proposal.sign() records step=0 (the bug
+                            // that broke reverted PR #572).
+                            let cur_round = bft.round();
+                            let proposer_prevote = Some(Prevote {
+                                height,
+                                round: cur_round,
+                                block_hash: Some(cached_hash.clone()),
+                                validator: wallet_address.to_string(),
+                                signature: vec![],
+                            });
                             let mut proposal = Proposal {
                                 height,
-                                round: bft.round(),
+                                round: cur_round,
                                 block_hash: cached_hash,
                                 block_data: cached_bytes,
                                 proposer: wallet_address.to_string(),
                                 signature: vec![],
+                                proposer_prevote,
                             };
                             proposal.sign(validator_sk);
                             return Some((block, proposal));
@@ -1609,13 +1628,25 @@ async fn cmd_start(
                     Ok(block) => {
                         let block_hash = block.hash.clone();
                         let block_data = bincode::serialize(&block).unwrap_or_default();
+                        let cur_round = bft.round();
+                        // F-D Variant A v3: embed proposer's own UNSIGNED
+                        // prevote. See cached-hash branch above for the
+                        // signing-order rationale.
+                        let proposer_prevote = Some(Prevote {
+                            height,
+                            round: cur_round,
+                            block_hash: Some(block_hash.clone()),
+                            validator: wallet_address.to_string(),
+                            signature: vec![],
+                        });
                         let mut proposal = Proposal {
                             height,
-                            round: bft.round(),
+                            round: cur_round,
                             block_hash,
                             block_data,
                             proposer: wallet_address.to_string(),
                             signature: vec![],
+                            proposer_prevote,
                         };
                         proposal.sign(validator_sk);
                         Some((block, proposal))
@@ -2692,6 +2723,15 @@ async fn cmd_start(
                                                                 Ok(block) => {
                                                                     let block_hash = block.hash.clone();
                                                                     let block_data = bincode::serialize(&block).unwrap_or_default();
+                                                                    // F-D Variant A v3 embedded
+                                                                    // unsigned proposer prevote.
+                                                                    let proposer_prevote = Some(Prevote {
+                                                                        height: next_h,
+                                                                        round: 0,
+                                                                        block_hash: Some(block_hash.clone()),
+                                                                        validator: wallet.address.clone(),
+                                                                        signature: vec![],
+                                                                    });
                                                                     let mut prop = Proposal {
                                                                         height: next_h,
                                                                         round: 0,
@@ -2699,6 +2739,7 @@ async fn cmd_start(
                                                                         block_data,
                                                                         proposer: wallet.address.clone(),
                                                                         signature: vec![],
+                                                                        proposer_prevote,
                                                                     };
                                                                     prop.sign(&validator_secret_key);
                                                                     tracing::debug!(
@@ -3252,6 +3293,15 @@ async fn cmd_start(
                                                         Ok(block) => {
                                                             let block_hash = block.hash.clone();
                                                             let block_data = bincode::serialize(&block).unwrap_or_default();
+                                                            // F-D Variant A v3 embedded
+                                                            // unsigned proposer prevote.
+                                                            let proposer_prevote = Some(Prevote {
+                                                                height: next_h_pf,
+                                                                round: 0,
+                                                                block_hash: Some(block_hash.clone()),
+                                                                validator: wallet.address.clone(),
+                                                                signature: vec![],
+                                                            });
                                                             let mut prop = Proposal {
                                                                 height: next_h_pf,
                                                                 round: 0,
@@ -3259,6 +3309,7 @@ async fn cmd_start(
                                                                 block_data,
                                                                 proposer: wallet.address.clone(),
                                                                 signature: vec![],
+                                                                proposer_prevote,
                                                             };
                                                             prop.sign(&validator_secret_key);
                                                             tracing::debug!(

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-bft/src/messages.rs
+++ b/crates/sentrix-bft/src/messages.rs
@@ -104,6 +104,31 @@ pub struct Proposal {
     pub block_data: Vec<u8>, // bincode-encoded Block
     pub proposer: String,    // validator address
     pub signature: Vec<u8>,  // ed25519 signature over (height, round, block_hash)
+    /// Proposer's own prevote for this block, bundled UNSIGNED so receivers
+    /// can credit the proposer's vote at proposal-arrival time instead of
+    /// waiting for the standalone gossipsub prevote hop.
+    ///
+    /// Trust chain: the outer proposal `signature` covers `(height, round,
+    /// block_hash)` — once that verifies, the receiver knows the signer is
+    /// the proposer. The embedded prevote is then trusted via the
+    /// structural check `proposer_prevote.validator == self.proposer`. The
+    /// embedded prevote itself carries an empty `signature` field on the
+    /// wire — receivers MUST NOT call `verify_sig` on it; the proposal's
+    /// outer signature is the only authenticity anchor.
+    ///
+    /// Why unsigned: signing the embedded prevote before `Proposal::sign`
+    /// would poison the LastSignBytes guard's step ordering (prevote=1
+    /// recorded before proposal=0) and refuse the proposal sign as a
+    /// "double-vote attempt". See `project_proposer_prevote_signorder_trap`
+    /// memory + reverted PR #572 for the original failure mode.
+    ///
+    /// `#[serde(default)]` lets legacy decoders that haven't been rebuilt
+    /// after the v2.2.0 schema bump pretend the field was absent. The
+    /// SENTRIX_PROTOCOL bump means peers actually negotiate at the wire
+    /// level — this is belt-and-suspenders for in-process decoding paths
+    /// (snapshots, replay tooling) that may lag the wire bump.
+    #[serde(default)]
+    pub proposer_prevote: Option<Prevote>,
 }
 
 impl Proposal {
@@ -727,10 +752,110 @@ mod tests {
             block_data: vec![1, 2, 3],
             proposer: wallet.address.clone(),
             signature: vec![],
+            proposer_prevote: None,
         };
         prop.sign(&sk);
         assert_eq!(prop.signature.len(), 65);
         assert!(prop.verify_sig());
+    }
+
+    // Regression test for the v2.2.0-design pitfall (reverted PR #572).
+    // The proposer must be able to embed an UNSIGNED prevote and still
+    // sign the proposal successfully. The earlier design signed the
+    // embedded prevote first which poisoned the LastSignBytes guard at
+    // step=Prevote=1, so the subsequent proposal.sign() at step=Proposal=0
+    // failed with DoubleSignAttempt and left the proposal signature empty.
+    //
+    // This test pins the invariant: prop.sign() AFTER embedding an
+    // unsigned prevote must produce a non-empty signature and verify.
+    // If a future change reintroduces inner-prevote signing, this test
+    // fails immediately rather than waiting for a testnet halt to
+    // surface it.
+    #[test]
+    fn test_proposal_sign_with_embedded_unsigned_prevote_succeeds() {
+        let wallet = make_wallet();
+        let sk = wallet.get_secret_key().unwrap();
+        let unsigned_prevote = Prevote {
+            height: 300,
+            round: 0,
+            block_hash: Some("hash_ghi".into()),
+            validator: wallet.address.clone(),
+            signature: vec![], // unsigned by design — DO NOT call .sign() here
+        };
+        let mut prop = Proposal {
+            height: 300,
+            round: 0,
+            block_hash: "hash_ghi".into(),
+            block_data: vec![1, 2, 3],
+            proposer: wallet.address.clone(),
+            signature: vec![],
+            proposer_prevote: Some(unsigned_prevote),
+        };
+        prop.sign(&sk);
+        assert!(
+            !prop.signature.is_empty(),
+            "proposal signature must not be empty after sign() — peers would reject"
+        );
+        assert!(
+            prop.verify_sig(),
+            "proposal signature must verify — outer trust anchor for embedded prevote"
+        );
+        // The embedded prevote stays unsigned on the wire — receivers
+        // derive its authenticity from the proposal's outer signature,
+        // NOT from a prevote.verify_sig() call.
+        assert!(prop.proposer_prevote.as_ref().unwrap().signature.is_empty());
+    }
+
+    #[test]
+    fn test_proposal_unsigned_embedded_prevote_roundtrip() {
+        let wallet = make_wallet();
+        let sk = wallet.get_secret_key().unwrap();
+        let unsigned_prevote = Prevote {
+            height: 300,
+            round: 0,
+            block_hash: Some("hash_ghi".into()),
+            validator: wallet.address.clone(),
+            signature: vec![],
+        };
+        let mut prop = Proposal {
+            height: 300,
+            round: 0,
+            block_hash: "hash_ghi".into(),
+            block_data: vec![1, 2, 3],
+            proposer: wallet.address.clone(),
+            signature: vec![],
+            proposer_prevote: Some(unsigned_prevote.clone()),
+        };
+        prop.sign(&sk);
+        let bytes = bincode::serialize(&prop).expect("encode");
+        let decoded: Proposal = bincode::deserialize(&bytes).expect("decode");
+        assert!(decoded.verify_sig());
+        let decoded_pv = decoded.proposer_prevote.expect("prevote present");
+        assert_eq!(decoded_pv, unsigned_prevote);
+        assert!(decoded_pv.signature.is_empty()); // stayed unsigned across the wire
+    }
+
+    #[test]
+    fn test_proposal_without_embedded_prevote_decodes() {
+        // Forward-compat shape: None case round-trips so a regression in
+        // the field's serde(default) attribute is caught locally without
+        // needing a wire-format harness.
+        let wallet = make_wallet();
+        let sk = wallet.get_secret_key().unwrap();
+        let mut prop = Proposal {
+            height: 1,
+            round: 0,
+            block_hash: "h".into(),
+            block_data: vec![],
+            proposer: wallet.address.clone(),
+            signature: vec![],
+            proposer_prevote: None,
+        };
+        prop.sign(&sk);
+        let bytes = bincode::serialize(&prop).expect("encode");
+        let decoded: Proposal = bincode::deserialize(&bytes).expect("decode");
+        assert!(decoded.verify_sig());
+        assert!(decoded.proposer_prevote.is_none());
     }
 
     #[test]

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -1037,6 +1037,40 @@ async fn on_swarm_event(
                             );
                             return;
                         }
+                        // F-D Variant A v3: if the proposal carries the
+                        // proposer's UNSIGNED self-prevote, dispatch it as
+                        // a regular BftPrevote so the engine counts the
+                        // proposer's vote at proposal-arrival time without
+                        // waiting for the standalone gossipsub prevote.
+                        // Authenticity flows from the outer proposal
+                        // signature already verified above; the embedded
+                        // prevote stays unsigned by design (signing it
+                        // before proposal.sign() would poison the
+                        // LastSignBytes guard at step=1 and reject the
+                        // proposal sign at step=0 — see reverted PR #572).
+                        // Structural checks: signer == proposer, and the
+                        // (h, r, block_hash) triple matches the proposal.
+                        if let Some(pv) = proposal.proposer_prevote.clone() {
+                            let triple_matches = pv.height == proposal.height
+                                && pv.round == proposal.round
+                                && pv.block_hash.as_deref() == Some(proposal.block_hash.as_str());
+                            if pv.validator != proposal.proposer {
+                                tracing::warn!(
+                                    "gossip bft proposal: embedded prevote signer {} != proposer {} — dropping",
+                                    &pv.validator, &proposal.proposer,
+                                );
+                            } else if !triple_matches {
+                                tracing::warn!(
+                                    "gossip bft proposal: embedded prevote (h,r,hash) mismatch — dropping",
+                                );
+                            } else {
+                                try_send_event(
+                                    event_tx,
+                                    NodeEvent::BftPrevote(pv),
+                                    "BftPrevote(embedded)",
+                                );
+                            }
+                        }
                         try_send_event(event_tx, NodeEvent::BftProposal(proposal), "BftProposal");
                     }
                     Err(e) => tracing::debug!("gossip bft proposal: bad bincode: {}", e),
@@ -1619,6 +1653,28 @@ async fn on_inbound_request(
                     &proposal.proposer
                 );
                 return;
+            }
+            // F-D Variant A v3 piggy-back path — same logic as the
+            // gossipsub BftProposal branch above. Kept in sync explicitly
+            // because the request-response path is the legacy fallback
+            // when a peer is on a binary that hasn't subscribed to the
+            // BFT gossipsub mesh yet.
+            if let Some(pv) = proposal.proposer_prevote.clone() {
+                let triple_matches = pv.height == proposal.height
+                    && pv.round == proposal.round
+                    && pv.block_hash.as_deref() == Some(proposal.block_hash.as_str());
+                if pv.validator != proposal.proposer {
+                    tracing::warn!(
+                        "libp2p rr bft proposal: embedded prevote signer {} != proposer {} — dropping",
+                        &pv.validator, &proposal.proposer,
+                    );
+                } else if !triple_matches {
+                    tracing::warn!(
+                        "libp2p rr bft proposal: embedded prevote (h,r,hash) mismatch — dropping",
+                    );
+                } else {
+                    try_send_event(event_tx, NodeEvent::BftPrevote(pv), "BftPrevote(embedded)");
+                }
             }
             try_send_event(event_tx, NodeEvent::BftProposal(*proposal), "BftProposal");
         }

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.1.94"
+version = "2.2.0"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."

--- a/crates/sentrix-wire/src/lib.rs
+++ b/crates/sentrix-wire/src/lib.rs
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 /// variants so peers can negotiate compatible versions. Currently 2.0.0 —
 /// same as the sentrix binary major.minor, but intentionally tracked
 /// separately so we don't have to bump the binary to bump the wire version.
-pub const SENTRIX_PROTOCOL: &str = "/sentrix/2.1.0";
+pub const SENTRIX_PROTOCOL: &str = "/sentrix/2.2.0";
 
 // ── Gossipsub topic names ────────────────────────────────
 
@@ -335,7 +335,7 @@ mod tests {
     fn test_protocol_version_is_2_1_0() {
         // 2026-05-10: bumped 2.0.0 → 2.1.0 alongside the gossipsub-for-BFT
         // switch so old peers (RR-only) can't accidentally interop.
-        assert_eq!(SENTRIX_PROTOCOL, "/sentrix/2.1.0");
+        assert_eq!(SENTRIX_PROTOCOL, "/sentrix/2.2.0");
     }
 
     /// Pin the topic names — callers (explorers, dApps) subscribe by string.


### PR DESCRIPTION
**⚠️ WIRE-INCOMPATIBLE** — halt-all + simul-start required. \`SENTRIX_PROTOCOL\` bumped \`/sentrix/2.1.0\` → \`/sentrix/2.2.0\`. Mixed 2.1.x / 2.2.0 cluster will halt; bincode rejects the new trailing field in the \`Proposal\` struct.

**Draft** until testnet bake completes successfully.

## What changed vs the reverted #572

#572 signed the embedded prevote at proposer-build time. That call recorded \`(h, r, step=Prevote=1)\` in \`last-sign.json\` and made the subsequent \`prop.sign()\` at \`step=Proposal=0\` trip the LastSignBytes guard's \`attempted <= last_signed\` check. Proposal signature stayed empty, peers rejected, chain halted (testnet h=3,196,667 today).

This version keeps the embedded prevote **unsigned**. Authenticity flows from the proposal's outer signature only — once \`proposal.verify_sig()\` passes the signer's identity is established, and the structural \`prevote.validator == proposal.proposer\` check + \`(h, r, block_hash)\` match binds the embedded prevote to that identity. No \`verify_sig\` is called on the embedded prevote.

The regression test \`test_proposal_sign_with_embedded_unsigned_prevote_succeeds\` pins this — any future change that signs the embedded prevote before \`prop.sign()\` fails this test rather than surfacing as a testnet halt.

## Files

| File | Change |
|---|---|
| \`crates/sentrix-bft/src/messages.rs\` | \`Proposal.proposer_prevote: Option<Prevote>\` field with \`#[serde(default)]\`; 3 new unit tests |
| \`crates/sentrix-network/src/libp2p_node.rs\` | After \`proposal.verify_sig()\` passes on both gossipsub and request-response paths: structural check, then dispatch \`NodeEvent::BftPrevote(embedded)\` |
| \`bin/sentrix/src/main.rs\` | 4 proposer-side call sites embed the unsigned prevote (locked reuse, fresh build, speculative pre-build × 2 arms) |
| \`crates/sentrix-wire/src/lib.rs\` | Protocol bump + version-pin test |
| 17 × \`Cargo.toml\` | Workspace 2.1.94 → 2.2.0 |
| \`CHANGELOG.md\` | \`[2.2.0]\` entry with the wire-incompat banner |

## Saving

In a 4-validator quorum at WAN, the proposer's prevote needed one full gossipsub mesh hop to reach the other 3 validators. Variant A removes that hop for the proposer's vote (~50-200 ms per round under typical load; more under congestion). Engine dedupes a later standalone prevote from the same proposer at the same (h, r, validator).

## Trust chain

1. Receiver decodes \`GossipBftProposal\`.
2. \`proposal.verify_sig()\` over \`(height, round, block_hash)\` → identifies the proposer.
3. \`is_active_bft_signer(proposer)\` → rejects non-validators.
4. Embedded prevote structural check: \`pv.validator == proposal.proposer\` AND \`pv.height/round/block_hash\` match.
5. Dispatch as \`NodeEvent::BftPrevote(pv)\` → engine processes via standard \`on_prevote_weighted\` (no \`verify_sig\` call inside engine).

A peer cannot tamper with the embedded prevote without invalidating the outer proposal signature; a peer cannot forge the embedded prevote for a different validator because the structural check fails.

## Tests

\`\`\`
cargo check --workspace --release  # clean with -D warnings
cargo test -p sentrix-bft --lib    # 119 passed
cargo test -p sentrix-wire          # 18 passed
\`\`\`

New tests:
- \`test_proposal_sign_with_embedded_unsigned_prevote_succeeds\` — pins the sign-order invariant (this would have caught #572).
- \`test_proposal_unsigned_embedded_prevote_roundtrip\` — bincode encode/decode preserves the unsigned shape.
- \`test_proposal_without_embedded_prevote_decodes\` — \`None\` case round-trips, pins \`#[serde(default)]\`.

## Ops plan

1. **Testnet bake** via \`fast-deploy.sh testnet\`. A few hours minimum per consensus-discipline. Verify:
   - \`finalize_trace\` shows zero \`precommit_count<3\` rounds.
   - No \`gossip bft proposal: bad signature\` warnings.
   - No \`DoubleSignAttempt\` errors.
   - No \`BftPrevote(embedded)\` dispatches with structural-check warnings.
   - bt distribution shifts left vs the v2.1.92 baseline.
2. **Mainnet** halt-all + simul-start via \`fast-deploy.sh mainnet\` with state-root alignment pre-flight. Canonical chain.db rsync ready as recovery path.