### PR TITLE
perf(storage): cursor-based log table scans (audit D-G3) — v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,30 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.2.1] — 2026-05-11 — perf: cursor-based log table scans (audit D-G3)
+
+**No wire change. No consensus change. Rolling deploy safe.**
+
+Replaces three `storage.iter(TABLE_LOGS)` full-table materialisations with cursor-range walks:
+
+1. **`crates/sentrix-core/src/block_executor.rs` per-block bloom build.** Was: every block apply pulled the entire `TABLE_LOGS` contents into a `Vec<(Vec<u8>, Vec<u8>)>`, then filtered by 8-byte height prefix. At 1M logs total that's ~200 MB allocated per block (~200-byte values × 1M entries) just to keep the few hundred that match. Now: `storage.iter_range(TABLE_LOGS, &height.to_be_bytes(), |..|..)` seeks via MDBX `set_range` to the first key >= the height prefix and walks only the contiguous run of matching keys.
+2. **`crates/sentrix-rpc/src/jsonrpc/helpers.rs::collect_logs`.** Was: every `eth_getLogs` call materialised the entire log table. Now: `iter_from(TABLE_LOGS, &from.to_be_bytes(), ..)` cursor-walks from the requested start height, stops the first time the decoded height exceeds `to`.
+3. **`crates/sentrix-rpc/src/jsonrpc/helpers.rs::load_logs_for_tx`.** Was: every `eth_getTransactionReceipt` call materialised the entire log table to filter for one tx's logs. Now: same `iter_range` prefix walk.
+
+Per-call cost drops from `O(total_logs_in_chain)` to `O(logs_in_requested_range)`.
+
+**Why it matters:** invisible while mainnet had ~100 EVM logs total. Would have quadratic-collapsed the validator the moment CoinBlast / DEX activity drove TABLE_LOGS into the millions. Audit at `audits/2026-05-11-postdeploy-audit.md` (operator-private) finding D-G3 documents the failure mode in detail.
+
+**Storage API additions** (both in `MdbxStorage`):
+- `iter_range(table, prefix, |k, v| -> bool)` — walks contiguous run of keys starting with `prefix`. Callback returns `false` to break early.
+- `iter_from(table, start_key, |k, v| -> bool)` — walks from `start_key` (or first key >= it) until callback returns `false`. Range upper bound is caller-decoded.
+
+Both add no Vec allocation. `MdbxStorage::iter` (the legacy whole-table materialiser) keeps a docstring warning steering future callers to the cursor variants.
+
+**Tests:** 4 new regression tests in `crates/sentrix-storage/src/mdbx.rs::tests` pin the cursor semantics (prefix scoping, no-match no-op, early-break, iter_from upward walk with stop condition). 23 storage tests pass; workspace `cargo check --workspace --release` clean with `-D warnings`.
+
+**Workspace 2.2.0 → 2.2.1.** Patch bump; no wire-format change.
+
 ## [2.2.0] — 2026-05-11 — proposer-prevote piggy-back, redesigned (wire-incompatible)
 
 **Wire-incompatible**: `SENTRIX_PROTOCOL` bumped `/sentrix/2.1.0` → `/sentrix/2.2.0`. Halt-all + simul-start required. Mixed 2.1.x / 2.2.0 cluster will halt because a 2.1.x decoder rejects the extra trailing bytes on the new `Proposal` struct.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "hex",
  "proptest",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -1398,24 +1398,21 @@ impl Blockchain {
                 self.execute_evm_tx_in_block(tx, block.index, &block.hash, tx_index)?;
             }
         }
-        // Sprint 2: compute + persist per-block logs bloom. Cheap enough to
-        // re-scan the height-prefix range because EVM txs per block are
-        // bounded; keeps the bloom exactly aligned with TABLE_LOGS without a
-        // parallel in-memory accumulator.
+        // Sprint 2: compute + persist per-block logs bloom. Walks the
+        // 8-byte height prefix in TABLE_LOGS via a cursor (single
+        // sequential read, no Vec materialisation of the entire log
+        // table — see 2026-05-11 audit finding D-G3 for the prior
+        // O(total_logs) per-block scan that this replaces).
         if let Some(storage) = self.mdbx_storage.as_ref() {
             use sentrix_evm::{StoredLog, add_log_to_bloom, empty_bloom};
             let mut bloom = empty_bloom();
             let prefix = block.index.to_be_bytes();
-            if let Ok(entries) = storage.iter(sentrix_storage::tables::TABLE_LOGS) {
-                for (k, v) in entries {
-                    if k.len() >= 8
-                        && k[..8] == prefix
-                        && let Ok(log) = bincode::deserialize::<StoredLog>(&v)
-                    {
-                        add_log_to_bloom(&mut bloom, &log.address, &log.topics);
-                    }
+            let _ = storage.iter_range(sentrix_storage::tables::TABLE_LOGS, &prefix, |_k, v| {
+                if let Ok(log) = bincode::deserialize::<StoredLog>(v) {
+                    add_log_to_bloom(&mut bloom, &log.address, &log.topics);
                 }
-            }
+                true
+            });
             // TABLE_BLOOM is a query-side optimization (feeds
             // `eth_getLogs` fast-path); a put failure is non-consensus
             // (block still commits, logs still stored in TABLE_LOGS,

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-rpc/src/jsonrpc/helpers.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/helpers.rs
@@ -204,42 +204,42 @@ pub(super) fn collect_logs(
         Some(s) => s,
         None => return Vec::new(),
     };
-    let all = match storage.iter(sentrix_storage::tables::TABLE_LOGS) {
-        Ok(v) => v,
-        Err(_) => return Vec::new(),
-    };
+    // Cursor-based range walk: seek to first key >= from.to_be_bytes(),
+    // step forward until height > to. No allocation of the whole log
+    // table — see 2026-05-11 audit D-G3.
+    let start_key = from.to_be_bytes();
     let mut out = Vec::new();
-    for (k, v) in all {
+    let _ = storage.iter_from(sentrix_storage::tables::TABLE_LOGS, &start_key, |k, v| {
         if k.len() < 16 {
-            continue;
+            return true;
         }
         let mut h_bytes = [0u8; 8];
         h_bytes.copy_from_slice(&k[..8]);
         let height = u64::from_be_bytes(h_bytes);
-        if height < from || height > to {
-            continue;
+        if height > to {
+            return false; // walked past the requested range
         }
-        if let Some(bloom_bytes) = storage
-            .get(sentrix_storage::tables::TABLE_BLOOM, &h_bytes)
-            .ok()
-            .flatten()
+        if !addrs.is_empty()
+            && let Some(bloom_bytes) = storage
+                .get(sentrix_storage::tables::TABLE_BLOOM, &h_bytes)
+                .ok()
+                .flatten()
             && bloom_bytes.len() == 256
-            && !addrs.is_empty()
         {
             let mut bloom = [0u8; 256];
             bloom.copy_from_slice(&bloom_bytes);
             let any_hit = addrs.iter().any(|a| sentrix_evm::bloom_contains(&bloom, a));
             if !any_hit {
-                continue;
+                return true; // skip this entry, keep walking
             }
         }
-        let Ok(log) = sentrix_codec::decode::<sentrix_evm::StoredLog>(&v) else {
-            continue;
-        };
-        if log_matches(&log, addrs, topics) {
+        if let Ok(log) = sentrix_codec::decode::<sentrix_evm::StoredLog>(v)
+            && log_matches(&log, addrs, topics)
+        {
             out.push(log.to_rpc_json());
         }
-    }
+        true
+    });
     out
 }
 
@@ -258,24 +258,20 @@ pub(super) fn load_logs_for_tx(
         None => return (Vec::new(), "0x".to_string() + &"00".repeat(256)),
     };
     let prefix = block_height.to_be_bytes();
-    let entries = match storage.iter(sentrix_storage::tables::TABLE_LOGS) {
-        Ok(v) => v,
-        Err(_) => return (Vec::new(), "0x".to_string() + &"00".repeat(256)),
-    };
     let mut logs = Vec::new();
     let mut bloom = sentrix_evm::empty_bloom();
-    for (k, v) in entries {
-        if k.len() < 8 || k[..8] != prefix {
-            continue;
-        }
-        let Ok(log) = sentrix_codec::decode::<sentrix_evm::StoredLog>(&v) else {
-            continue;
-        };
-        if log.tx_hash == target_hash {
+    // Cursor walk over this block's height prefix — single sequential
+    // read of `block_height`'s log entries, no whole-table materialisation
+    // (audit D-G3, 2026-05-11).
+    let _ = storage.iter_range(sentrix_storage::tables::TABLE_LOGS, &prefix, |_k, v| {
+        if let Ok(log) = sentrix_codec::decode::<sentrix_evm::StoredLog>(v)
+            && log.tx_hash == target_hash
+        {
             sentrix_evm::add_log_to_bloom(&mut bloom, &log.address, &log.topics);
             logs.push(log.to_rpc_json());
         }
-    }
+        true
+    });
     (logs, format!("0x{}", hex::encode(bloom)))
 }
 

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-storage/src/mdbx.rs
+++ b/crates/sentrix-storage/src/mdbx.rs
@@ -197,8 +197,8 @@ impl MdbxStorage {
     ///
     /// Replaces the `iter(...).into_iter().filter(...)` pattern that
     /// materialised every entry in the table (and was the root of the
-    /// per-block O(total_logs) scan in the bloom builder + `eth_getLogs`
-    /// + `eth_getTransactionReceipt` paths). MDBX `set_range` seeks
+    /// per-block O(total_logs) scan in the bloom builder, `eth_getLogs`,
+    /// and `eth_getTransactionReceipt` paths). MDBX `set_range` seeks
     /// directly to the first key >= `prefix`; the walk stops the first
     /// time a key no longer starts with `prefix` (MDBX keys are
     /// lexicographically sorted, so all matches are contiguous).

--- a/crates/sentrix-storage/src/mdbx.rs
+++ b/crates/sentrix-storage/src/mdbx.rs
@@ -172,6 +172,12 @@ impl MdbxStorage {
     // ── Iteration ───────────────────────────────────────────
 
     /// Iterate all key-value pairs in a table (ordered by key).
+    ///
+    /// Materialises the entire table into a `Vec`. Fine for small admin
+    /// tables (table list, validator set, etc.). Do NOT use for
+    /// `TABLE_LOGS` / `TABLE_RECEIPTS` / any unbounded-growth table —
+    /// see `iter_range` / `iter_from` for cursor-based scans that don't
+    /// allocate the world.
     pub fn iter(&self, table: &str) -> StorageResult<Vec<(Vec<u8>, Vec<u8>)>> {
         let tx = self.db.begin_ro_txn()?;
         let tbl = tx.open_table(Some(table))?;
@@ -182,6 +188,75 @@ impl MdbxStorage {
             results.push((key.to_vec(), value.to_vec()));
         }
         Ok(results)
+    }
+
+    /// Cursor-based range scan with a single sequential walk and no
+    /// intermediate `Vec` allocation. Calls `f(key, value)` for every
+    /// entry whose key starts with `prefix`, in key-sorted order.
+    /// Callback returns `false` to break early.
+    ///
+    /// Replaces the `iter(...).into_iter().filter(...)` pattern that
+    /// materialised every entry in the table (and was the root of the
+    /// per-block O(total_logs) scan in the bloom builder + `eth_getLogs`
+    /// + `eth_getTransactionReceipt` paths). MDBX `set_range` seeks
+    /// directly to the first key >= `prefix`; the walk stops the first
+    /// time a key no longer starts with `prefix` (MDBX keys are
+    /// lexicographically sorted, so all matches are contiguous).
+    pub fn iter_range<F>(&self, table: &str, prefix: &[u8], mut f: F) -> StorageResult<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> bool,
+    {
+        let tx = self.db.begin_ro_txn()?;
+        let tbl = tx.open_table(Some(table))?;
+        let mut cursor = tx.cursor(&tbl)?;
+        let first: Option<(Vec<u8>, Vec<u8>)> = cursor.set_range(prefix)?;
+        let Some((k, v)) = first else {
+            return Ok(());
+        };
+        if !k.starts_with(prefix) {
+            return Ok(());
+        }
+        if !f(&k, &v) {
+            return Ok(());
+        }
+        while let Some((k, v)) = cursor.next::<Vec<u8>, Vec<u8>>()? {
+            if !k.starts_with(prefix) {
+                break;
+            }
+            if !f(&k, &v) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// Cursor walk starting at `start_key` (or first key >= `start_key`),
+    /// no prefix constraint. Callback returns `false` to break.
+    ///
+    /// Use this when the stop condition is value-derived rather than a
+    /// fixed key prefix — e.g. range-walking by block height where the
+    /// caller decodes the height out of the key and stops at an
+    /// upper bound.
+    pub fn iter_from<F>(&self, table: &str, start_key: &[u8], mut f: F) -> StorageResult<()>
+    where
+        F: FnMut(&[u8], &[u8]) -> bool,
+    {
+        let tx = self.db.begin_ro_txn()?;
+        let tbl = tx.open_table(Some(table))?;
+        let mut cursor = tx.cursor(&tbl)?;
+        let first: Option<(Vec<u8>, Vec<u8>)> = cursor.set_range(start_key)?;
+        let Some((k, v)) = first else {
+            return Ok(());
+        };
+        if !f(&k, &v) {
+            return Ok(());
+        }
+        while let Some((k, v)) = cursor.next::<Vec<u8>, Vec<u8>>()? {
+            if !f(&k, &v) {
+                break;
+            }
+        }
+        Ok(())
     }
 
     /// Count entries in a table.
@@ -409,5 +484,104 @@ mod tests {
         let loaded: Block = storage.get_bincode(TABLE_BLOCKS, &key).unwrap().unwrap();
         assert_eq!(loaded.index, 0);
         assert_eq!(loaded.hash, block.hash);
+    }
+
+    // Regression tests for the audit D-G3 fix (per-block bloom build +
+    // eth_getLogs + eth_getTransactionReceipt previously did
+    // `storage.iter(TABLE_LOGS)` and pulled every log in the chain into
+    // RAM; replaced by `iter_range` / `iter_from` cursor walks).
+
+    #[test]
+    fn test_iter_range_walks_prefix_only() {
+        let (_dir, storage) = temp_storage();
+        // Two heights × two logs each. Keys: 8-byte BE height || 8 bytes
+        // of per-tx noise so each entry is unique.
+        for height in [1u64, 2, 3] {
+            for idx in 0u8..3 {
+                let mut k = Vec::with_capacity(16);
+                k.extend_from_slice(&height.to_be_bytes());
+                k.extend_from_slice(&[idx; 8]);
+                storage
+                    .put(TABLE_META, &k, &[height as u8, idx])
+                    .unwrap();
+            }
+        }
+        let prefix = 2u64.to_be_bytes();
+        let mut seen = Vec::new();
+        storage
+            .iter_range(TABLE_META, &prefix, |k, v| {
+                seen.push((k.to_vec(), v.to_vec()));
+                true
+            })
+            .unwrap();
+        assert_eq!(seen.len(), 3, "should only see the 3 entries at height=2");
+        for (k, _) in &seen {
+            assert_eq!(&k[..8], &prefix, "every yielded key must start with prefix");
+        }
+    }
+
+    #[test]
+    fn test_iter_range_no_match_is_no_op() {
+        let (_dir, storage) = temp_storage();
+        // Insert a few keys at height=1; query height=9 → no walk.
+        for idx in 0u8..3 {
+            let mut k = Vec::with_capacity(16);
+            k.extend_from_slice(&1u64.to_be_bytes());
+            k.extend_from_slice(&[idx; 8]);
+            storage.put(TABLE_META, &k, &[idx]).unwrap();
+        }
+        let mut seen = 0;
+        storage
+            .iter_range(TABLE_META, &9u64.to_be_bytes(), |_k, _v| {
+                seen += 1;
+                true
+            })
+            .unwrap();
+        assert_eq!(seen, 0);
+    }
+
+    #[test]
+    fn test_iter_range_early_break() {
+        let (_dir, storage) = temp_storage();
+        for idx in 0u8..5 {
+            let mut k = Vec::with_capacity(16);
+            k.extend_from_slice(&5u64.to_be_bytes());
+            k.extend_from_slice(&[idx; 8]);
+            storage.put(TABLE_META, &k, &[idx]).unwrap();
+        }
+        let mut count = 0;
+        storage
+            .iter_range(TABLE_META, &5u64.to_be_bytes(), |_k, _v| {
+                count += 1;
+                count < 3 // stop after the 3rd entry
+            })
+            .unwrap();
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn test_iter_from_walks_upward_with_stop_condition() {
+        let (_dir, storage) = temp_storage();
+        // Heights 1..=10, one entry each. Walk from height=3,
+        // stop when height > 7. Expect 5 entries (3, 4, 5, 6, 7).
+        for height in 1u64..=10 {
+            storage
+                .put(TABLE_META, &height.to_be_bytes(), &[height as u8])
+                .unwrap();
+        }
+        let mut heights = Vec::new();
+        storage
+            .iter_from(TABLE_META, &3u64.to_be_bytes(), |k, _v| {
+                let mut h_bytes = [0u8; 8];
+                h_bytes.copy_from_slice(&k[..8]);
+                let h = u64::from_be_bytes(h_bytes);
+                if h > 7 {
+                    return false; // stop
+                }
+                heights.push(h);
+                true
+            })
+            .unwrap();
+        assert_eq!(heights, vec![3, 4, 5, 6, 7]);
     }
 }

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
**No wire change. No consensus change. Rolling deploy safe.** Patch bump 2.2.0 → 2.2.1.

## The bug

Three sites called `storage.iter(TABLE_LOGS)` — which loads the **entire** \`TABLE_LOGS\` into a \`Vec<(Vec<u8>, Vec<u8>)>\` and then filters in Rust. At 1M logs that's ~200 MB allocated **per call**:

| Site | When it fires | Impact at 1M logs |
|---|---|---|
| \`block_executor.rs\` per-block bloom build | every block apply | ~200 MB allocated per block → jemalloc page churn alone consumes a CPU |
| \`helpers.rs::collect_logs\` | every \`eth_getLogs\` call | ~200 MB per RPC call → trivial dApp eth_getLogs nukes the node |
| \`helpers.rs::load_logs_for_tx\` | every \`eth_getTransactionReceipt\` | same |

Invisible today because mainnet has ~100 EVM logs total. **Quadratic-collapses the validator the moment CoinBlast / DEX traffic ramps up.**

## The fix

Two new \`MdbxStorage\` methods that walk via MDBX cursor (\`set_range\` → \`next\`), no \`Vec\` preload:

\`\`\`rust
pub fn iter_range<F>(&self, table: &str, prefix: &[u8], mut f: F) -> StorageResult<()>
where F: FnMut(&[u8], &[u8]) -> bool;  // false to stop

pub fn iter_from<F>(&self, table: &str, start_key: &[u8], mut f: F) -> StorageResult<()>
where F: FnMut(&[u8], &[u8]) -> bool;
\`\`\`

\`iter_range\` walks the contiguous run of keys starting with \`prefix\`. \`iter_from\` walks from \`start_key\` upward until the callback says stop — useful when the upper bound is value-derived (e.g. \`eth_getLogs\` walks by decoded height, not by a fixed prefix).

All three call sites now use these. Per-call cost drops from \`O(total_logs_in_chain)\` to \`O(matching_range)\`.

\`MdbxStorage::iter\` (the legacy whole-table materialiser) keeps a docstring steering future callers to the cursor variants for unbounded-growth tables.

## Behavioural equivalence

| Path | Before | After |
|---|---|---|
| Bloom contents | byte-identical | byte-identical |
| \`eth_getLogs\` ordering | key-sorted (block then tx index) | key-sorted (block then tx index) |
| Receipts | logs for matching tx_hash | logs for matching tx_hash |
| Storage writes | unchanged | unchanged |

No consensus, no wire, no chain.db schema change.

## Tests

\`\`\`
cargo test -p sentrix-storage --lib    # 23 passed (4 new)
cargo check --workspace --release -- -D warnings   # clean
\`\`\`

New tests in \`crates/sentrix-storage/src/mdbx.rs\`:

- \`test_iter_range_walks_prefix_only\` — 3 heights × 3 entries; query height=2 yields exactly 3 entries, all start with the height-2 prefix.
- \`test_iter_range_no_match_is_no_op\` — query for a prefix with no entries doesn't call the callback at all.
- \`test_iter_range_early_break\` — callback returning \`false\` halts the walk; verifies bounded cost.
- \`test_iter_from_walks_upward_with_stop_condition\` — start mid-range, stop via callback when value-derived height exceeds upper bound.

## Ops plan

- Rolling deploy safe — no halt-all needed. Existing v2.2.0 cluster can take 2.2.1 one node at a time (verify each node's bloom output matches the previous one via the \`TABLE_BLOOM\` height-keyed entries after a few blocks).
- Promote to top of merge order per audit (\`founder-private/audits/2026-05-11-postdeploy-audit.md\` D-G3): "**upgrade-immediately territory** — a single sustained-EVM-traffic block can quadratic-collapse the validator".