### PR TITLE
chain: tighten BFT proposal rebroadcast 2s → 500ms (v2.2.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "hex",
  "proptest",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -3470,9 +3470,17 @@ async fn cmd_start(
                     // need the proposal even after we've moved to prevote
                     // collection so they can validate the prevotes they're
                     // receiving from us.
+                    // v2.2.2: tightened 2s → 500ms after mainnet bt RCA 2026-05-11.
+                    // Round trace at h=1,690,662 (mainnet WAN vps3↔vps6) showed
+                    // a dropped proposal costing ~1.5s before the 2s retry
+                    // fired; with ~30% of rounds hitting at least one drop on
+                    // the public-IPv4 path, mean bt sat at 2.5 s/blk vs the
+                    // sub-1s target. Tighter retry brings recovery inside one
+                    // round window. Total budget stays 14 s for cold-start
+                    // peers — MAX_REBROADCASTS rises in lockstep.
                     const REBROADCAST_INTERVAL: std::time::Duration =
-                        std::time::Duration::from_secs(2);
-                    const MAX_REBROADCASTS: u32 = 7;
+                        std::time::Duration::from_millis(500);
+                    const MAX_REBROADCASTS: u32 = 28;
                     // v2.1.89 fix: replay the originally-signed proposal verbatim
                     // instead of rebuilding + re-signing. The pre-fix path called
                     // `bincode::serialize(block)` and `proposal.sign()` afresh on

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

- `bin/sentrix/src/main.rs:3473` — `REBROADCAST_INTERVAL` 2s → 500ms, `MAX_REBROADCASTS` 7 → 28
- Workspace bumped 2.2.1 → 2.2.2 across 17 Cargo.toml

## Why

After foundation rejoin earlier today, mainnet settled at ~2.5 s/blk vs the sub-1s target. Round trace at h=1,690,662 showed a dropped proposal on vps3↔vps6 public-IPv4 paying ~1.5s for the 2s retry timer. Testnet (single-host docker) hits 0.3-0.4 s/blk on the same v2.2.1 binary — gap is WAN-driven, not consensus-logic.

## Risk

- **Happy-path rounds never trigger this code.** The condition requires `phase ∈ {Propose, Prevote}` AND no advance past either — under prevote quorum the phase moves on and the timer never elapses. So no bandwidth change at steady state.
- **Same-bytes replay is byte-identical** (v2.1.89). LastSignBytes guard has the same-bytes-replay exemption (v2.1.86). No slashing-risk delta from more retries.
- **Cold-start total budget unchanged** at 14s (28 × 500ms = 14s, same as 7 × 2s).

## Expected impact

Rounds with one peer's proposal dropped recover in ~500ms instead of 2s → ~1.5s shaved per affected round. With ~30% of rounds hitting at least one drop on the WAN, mean bt should drop from 2.5 s/blk → ~1.5-1.8 s/blk.

## Test plan

- [ ] Testnet deploy + ~5 min bake (single-host, drop-free → no rebroadcast firing → bt should remain 0.3-0.4 s/blk, verifying no regression in happy path)
- [ ] Mainnet deploy + measure 3-min bt window
- [ ] Smoke-chain.sh 28-check pass