### PR TITLE
chore: add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+This project follows the **[Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)** as its code of conduct.
+
+## Scope
+
+Applies to all project spaces — GitHub repositories, issues, pull requests, discussions — and to anyone representing the project in public.
+
+## Reporting
+
+If you observe behavior that violates the linked code of conduct, report it privately via GitHub's security advisory form at:
+
+`https://github.com/sentrix-labs/sentrix/security/advisories/new`
+
+Reports are reviewed by the maintainers. Reporter identity is kept confidential.
+
+## Enforcement
+
+Maintainers may issue warnings, temporary bans, or permanent bans depending on severity and repetition, following the enforcement guidelines in the linked Contributor Covenant text.


### PR DESCRIPTION
## Summary

Adds a top-level `CODE_OF_CONDUCT.md` that adopts Contributor Covenant v2.1 by reference. Closes the GitHub Community Standards checklist gap.

## Why this shape

- **Link-out instead of inlined text** — single source of truth, no drift if the upstream covenant updates.
- **Reports route through GitHub security advisories** — keeps reporter identity confidential without exposing a personal email in the public repo.
- **Standard scope + enforcement language** in 10 lines, no boilerplate sprawl.

## Test plan

- [ ] PR merges, GitHub Community Standards shows Code of Conduct as ✓
- [ ] Security-advisory link resolves (it's auto-created by GitHub when private vulnerability reporting is enabled — verify enabled in Settings → Security)