### PR TITLE
chore: add PR + issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,29 @@
+name: Bug report
+description: Something isn't working as expected
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What's broken?
+      description: Describe what's not working.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list, ideally with commit hash + chain ID + URL.
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      placeholder: v2.1.85 / abc1234

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Report a bug in a canonical contract or deploy script
+title: "[bug] "
+labels: bug
+---
+
+**Component**
+
+- [ ] WSRX
+- [ ] Multicall3
+- [ ] SentrixSafe
+- [ ] TokenFactory
+- [ ] Deploy script (specify which)
+- [ ] CI / repo tooling
+
+**Network** (if on-chain)
+
+- [ ] Mainnet (7119)
+- [ ] Testnet (7120)
+- [ ] Local fork
+
+**Reproducer**
+
+Step-by-step (or paste a `forge test` command + output):
+
+```
+```
+
+**Expected vs actual**
+
+- Expected:
+- Actual:
+
+**Environment**
+
+- forge version: `forge --version`
+- solc version (from `foundry.toml`): 0.8.24
+- OS:
+
+**Severity**
+
+- [ ] Low (cosmetic / docs)
+- [ ] Medium (logic correctness, no fund loss)
+- [ ] High (fund loss possible, denial-of-service)
+- [ ] Critical (immediate exploit) → DO NOT FILE PUBLICLY. Email `security@sentrixchain.com`.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: mailto:security@sentriscloud.com
+    about: Report a security issue privately. Do NOT open a public issue.
+  - name: Sentrix Discord
+    url: https://discord.gg/sentrixchain
+    about: General questions and support

--- a/.github/ISSUE_TEMPLATE/deployment_request.md
+++ b/.github/ISSUE_TEMPLATE/deployment_request.md
@@ -1,0 +1,55 @@
+---
+name: Deployment request
+about: Request a coordinated deploy (testnet + mainnet) of a canonical contract
+title: "[deploy] vX.Y.Z — "
+labels: deployment
+---
+
+**Target version**
+
+`vX.Y.Z` (matches `VERSION` file at deploy time)
+
+**Contracts in this deploy**
+
+- [ ] WSRX
+- [ ] Multicall3
+- [ ] SentrixSafe
+- [ ] TokenFactory
+- [ ] (new contract — link to feature-request issue)
+
+**Pre-deploy checklist**
+
+- [ ] All contracts in scope have green CI on `main`
+- [ ] Slither passes (`make lint`)
+- [ ] Tests pass (`forge test`)
+- [ ] `docs/AUDIT.md` reviewed; if PENDING, founder sign-off captured below
+- [ ] Deployer wallet funded:
+  - Testnet (chain 7120): ≥ 0.5 SRX
+  - Mainnet (chain 7119): ≥ 0.5 SRX
+- [ ] Deployer keystore password rotated from placeholder
+- [ ] Foundry installed on the build host
+
+**Deploy plan**
+
+1. Testnet first (chain 7120) — record addresses
+2. Smoke test via `forge script script/CheckDeployment.s.sol`
+3. Mainnet (chain 7119) — same order
+4. Update `deployments/{7119,7120}.json` + run `./script/copy-abi.sh` + `./script/GenerateAddressDocs.sh`
+5. Update `CHANGELOG.md` `[vX.Y.Z]` section
+6. Append to `RELEASES.md` table
+7. `git tag vX.Y.Z && git push --tags` → `release.yml` auto-creates GH Release
+
+**Rollback plan if mainnet deploy goes wrong**
+
+- Halt all 4 mainnet validators per operator chain-halt runbook
+- Investigate root cause
+- Patch + redeploy as `vX.Y.Z+1`
+- Migration advisory in `RELEASES.md`
+
+**Founder sign-off**
+
+- [ ] Reviewed contract diffs since last release
+- [ ] Audit status acceptable for this risk profile
+- [ ] Approve deploy
+
+Signed-off by: @satyakwok on YYYY-MM-DD

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,18 @@
+name: Feature request
+description: Suggest something new
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,43 @@
+---
+name: Feature request
+about: Propose a new contract or extension to existing canonical set
+title: "[feat] "
+labels: enhancement
+---
+
+**Proposal**
+
+What new contract or feature should be added to the canonical set? One-line summary.
+
+**Use case**
+
+What dApps / integrations would consume this? Concrete example helps.
+
+**Why canonical** (vs ad-hoc deploy)
+
+Canonical contracts are immutable, audited, and Sourcify-verified across the chain. They earn that status because:
+- Many independent dApps need the same logic, OR
+- The contract sets a standard (e.g., WSRX as canonical wrapped token), OR
+- Operator wants treasury / governance to live behind a known address
+
+Pick which applies + explain.
+
+**Spec sketch**
+
+Solidity-style sketch of the public interface:
+
+```solidity
+function exampleFunction(...) external returns (...);
+```
+
+**Alternatives considered**
+
+- Existing canonical contract that could be extended:
+- Off-the-shelf (OZ / Solady) reference:
+- Reasons those don't fit:
+
+**Risk**
+
+- Pausable? Upgradeable? Owner-controlled?
+- Audit complexity (lines of code, novelty):
+- Migration path if v2 ever needed:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!-- Brief one-line title above. -->
+
+## Summary
+
+What changed and why. 1-3 sentences.
+
+## Scope
+
+- [ ] Contract change (new file or logic edit) — needs slither pass + audit consideration
+- [ ] Test-only change
+- [ ] Deploy script / CI / docs only
+- [ ] Repo tooling (Makefile, lefthook, etc.)
+
+## Checks
+
+- [ ] `forge build` clean
+- [ ] `forge test` green (including fuzz + invariant)
+- [ ] `forge fmt --check` clean
+- [ ] `slither --no-fail-pedantic` reviewed (no new high-severity findings)
+- [ ] Storage layout diff reviewed if any contract field added/removed (run `make storage` and inspect `docs/storage/*.json`)
+
+## Linked issue
+
+Closes #
+
+## Deploy impact
+
+- [ ] No on-chain change (test/CI/docs only)
+- [ ] Requires v-bump + redeploy when shipped
+- [ ] Backwards-compatible (extends, doesn't reorder storage)
+- [ ] Breaking — needs migration plan in `RELEASES.md`


### PR DESCRIPTION
Round-2 audit gap. Templates pulled from `sentrix-labs/canonical-contracts` (already has them) — bug report, feature request, security contact-link, PR checklist matching the rest of the org.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized GitHub issue templates for bug reports, feature requests, and deployment requests to streamline contributor workflows.
  * Added pull request template with guidelines for testing, validation, and release considerations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/581)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->