### PR TITLE
trie storage: stream gc_table + prune_old_roots via iter_from (v2.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.2.3] — 2026-05-12 — perf: stream trie GC via cursor walks
+
+**No wire change. No consensus change. Halt-all + simul-start deploy (storage path, same as 2.2.1).**
+
+`crates/sentrix-trie/src/storage.rs::gc_table` (called from `gc_orphaned_nodes` during `maybe_prune_trie`) used to call `self.mdbx.iter(table)`, which builds a `Vec<(Vec<u8>, Vec<u8>)>` of the entire `TABLE_TRIE_NODES` and `TABLE_TRIE_VALUES` before the GC loop starts. Same materialisation problem fixed in 2.2.1 for the logs path.
+
+`prune_old_roots` gets the same treatment on `TABLE_TRIE_ROOTS` for consistency (smaller table, not the OOM driver, but same class of fix).
+
+**Why it matters:** at every 1000-block prune boundary on a fullnode container (4.8 GB chain.db inside a 4 GiB memory limit), the alloc froze the block-apply loop for 16+ min — `chain.write()` was held the whole time so `STATE-FP` for the boundary block never emitted. Looked like silent thread death but it was just a stuck alloc. Validators have 8 GiB headroom and didn't hit it. Found 2026-05-12 while diagnosing two recurring fullnode RPC wedges.
+
+## [2.2.2] — 2026-05-11 — perf: tighten BFT proposal rebroadcast 2s → 500ms
+
+**No wire change. No consensus change. Timer-constant only.**
+
+`bin/sentrix/src/main.rs:3473`: `REBROADCAST_INTERVAL` 2s → 500ms, `MAX_REBROADCASTS` 7 → 28. Recovers dropped proposals inside one round window instead of waiting 2s. Mainnet bt 2.5 → 2.05 s/blk steady (-18%).
+
 ## [2.2.1] — 2026-05-11 — perf: cursor-based log table scans (audit D-G3)
 
 **No wire change. No consensus change. Rolling deploy safe.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "hex",
  "proptest",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-trie/src/storage.rs
+++ b/crates/sentrix-trie/src/storage.rs
@@ -180,30 +180,33 @@ impl TrieStorage {
     }
 
     /// Prune old trie roots, keeping only the last `keep` versions.
+    ///
+    /// Walks `TABLE_TRIE_ROOTS` via a streaming cursor (`iter_from`) so the
+    /// full table never lands in a `Vec<(Vec<u8>, Vec<u8>)>` — see the
+    /// `iter_from` callsite rationale; same class of fix as PR #575 for
+    /// the logs/receipts paths.
     pub fn prune_old_roots(&self, latest_version: u64, keep: u64) -> SentrixResult<usize> {
         if latest_version <= keep {
             return Ok(0);
         }
         let cutoff = latest_version - keep;
-        let mut removed = 0usize;
-
-        let entries = self
-            .mdbx
-            .iter(tables::TABLE_TRIE_ROOTS)
-            .map_err(|e| SentrixError::StorageError(e.to_string()))?;
 
         let mut to_delete: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
-        for (k, v) in &entries {
-            if k.len() == 8 {
-                let mut buf = [0u8; 8];
-                buf.copy_from_slice(k);
-                let version = u64::from_be_bytes(buf);
-                if version <= cutoff {
-                    to_delete.push((k.clone(), v.clone()));
+        self.mdbx
+            .iter_from(tables::TABLE_TRIE_ROOTS, &[], |k, v| {
+                if k.len() == 8 {
+                    let mut buf = [0u8; 8];
+                    buf.copy_from_slice(k);
+                    let version = u64::from_be_bytes(buf);
+                    if version <= cutoff {
+                        to_delete.push((k.to_vec(), v.to_vec()));
+                    }
                 }
-            }
-        }
+                true
+            })
+            .map_err(|e| SentrixError::StorageError(e.to_string()))?;
 
+        let mut removed = 0usize;
         for (key, root_hash) in &to_delete {
             self.mdbx
                 .delete(tables::TABLE_TRIE_ROOTS, key.as_slice())
@@ -230,26 +233,35 @@ impl TrieStorage {
     }
 
     /// Shared helper: scan an MDBX table for hashes not in `live_hashes` and remove them.
+    ///
+    /// Streams the table via `iter_from` so only the orphan-hash subset
+    /// (32 bytes each) lands in memory, not every `(key, value)` pair.
+    /// Earned via the 2026-05-12 fullnode wedge: `iter()` materialised a
+    /// `Vec<(Vec<u8>, Vec<u8>)>` of the entire `TABLE_TRIE_NODES`, which
+    /// on a 4.8 GB chain.db inside a 4 GiB container froze the chain-apply
+    /// loop for ~16+ min at every 1000-block prune boundary. The cursor
+    /// walk keeps a single MDBX RO txn open for the same duration but
+    /// avoids the per-row Vec allocation amortisation that was the
+    /// actual stall cause.
     fn gc_table(
         &self,
         table: &str,
         live_hashes: &std::collections::HashSet<NodeHash>,
     ) -> SentrixResult<usize> {
-        let entries = self
-            .mdbx
-            .iter(table)
+        let mut to_delete: Vec<NodeHash> = Vec::new();
+        self.mdbx
+            .iter_from(table, &[], |k, _v| {
+                if k.len() == 32 {
+                    let mut arr = [0u8; 32];
+                    arr.copy_from_slice(k);
+                    if !live_hashes.contains(&arr) {
+                        to_delete.push(arr);
+                    }
+                }
+                true
+            })
             .map_err(|e| SentrixError::StorageError(e.to_string()))?;
 
-        let mut to_delete: Vec<NodeHash> = Vec::new();
-        for (k, _) in &entries {
-            if k.len() == 32 {
-                let mut arr = [0u8; 32];
-                arr.copy_from_slice(k);
-                if !live_hashes.contains(&arr) {
-                    to_delete.push(arr);
-                }
-            }
-        }
         let count = to_delete.len();
         for hash in &to_delete {
             self.mdbx

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

- \`gc_table\` streams via \`iter_from\` instead of materialising the entire \`TABLE_TRIE_NODES\` / \`TABLE_TRIE_VALUES\` into a \`Vec<(Vec<u8>, Vec<u8>)>\` before iterating.
- \`prune_old_roots\` same pattern on \`TABLE_TRIE_ROOTS\` for consistency.
- Workspace 2.2.2 → 2.2.3 in lockstep across 17 Cargo.toml.

## Why

2026-05-12 mainnet fullnodes wedged twice (once near h=1,700,000, once at h=1,700,999). STATE-FP loop went silent at every 1000-block prune boundary while the container stayed alive but did no chain I/O.

RCA: \`maybe_prune_trie\` inside \`apply_block_pass2\` fires every 1000 blocks (block_executor.rs:1639), then calls \`gc_orphaned_nodes\` → \`gc_table\`. Old \`gc_table\` did \`mdbx.iter(table)\` which materialises every \`(Vec<u8>, Vec<u8>)\` row into a single Vec before the gc loop even starts. On a 4.8 GB chain.db inside a 4 GiB container the alloc froze the block-apply path. \`chain.write()\` was held the whole time so STATE-FP for the boundary block never emitted — looked like silent thread death but it was just a stuck alloc.

Validators didn't hit it because their containers have 8 GiB headroom and BFT-driven apply interleaves more naturally, so they don't backlog gossip-block tasks the same way.

Same class as PR #575's logs/receipts cursor walk — the "never \`iter()\` on a big MDBX table" rule applies to the trie tables too. The mdbx.iter() docstring already says "see \`iter_range\` / \`iter_from\` for cursor-based scans that don't allocate the world".

## Test plan

- [x] All 57 \`sentrix-trie\` tests pass on the patched code
- [x] \`cargo check --workspace --release\` with \`-D warnings\` clean
- [ ] Testnet bake: verify a 1000-block boundary applies without STATE-FP gap > 5s
- [ ] Mainnet bake same after testnet clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 2.2.3 across all crates.
  * Adjusted proposal rebroadcast timing and retry behavior (operational change).

* **Refactor**
  * Improved trie garbage-collection and root pruning to reduce memory usage and improve performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/583)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->