### PR TITLE
trie prune: dispatch to background thread (v2.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.2.4] — 2026-05-12 — fix: dispatch trie prune to background thread
+
+**No wire change. No consensus change. Halt-all + simul-start deploy (same lane as 2.2.3).**
+
+`Blockchain::maybe_prune_trie` (called every 1000 blocks from `apply_block_pass2`) now spawns the prune on its own OS thread instead of running inline. Apply path releases the `chain.write()` lock immediately; the cursor walk in `gc_orphaned_nodes` proceeds against MDBX in parallel with the next block applies. A `PRUNE_RUNNING` `AtomicBool` gates overlap — if a second 1000-block boundary fires while a prior prune is still walking, the second cycle is skipped (same semantics as the existing "failed prune" path: storage grows until the next successful prune).
+
+**Why the 2.2.3 fix wasn't enough:** the cursor walk in `gc_table` is O(N) over the trie node table (millions of entries on a fullnode that's been replaying from snapshot). Switching `iter()` → `iter_from()` removed the memory spike but the walk duration was unchanged. Holding `chain.write()` for that whole walk still froze the apply loop at every 1000-block prune boundary — which is why mainnet fullnodes kept wedging post-2.2.3 even though their RSS stayed low.
+
+Found 2026-05-12 immediately after the 2.2.3 deploy when fullnodes wedged again at the next 1000-block boundary (last `STATE-FP` h=1,701,999, then silent for 20+ min until force-recreate). 2.2.4 moves the lock-holding work off the apply path.
+
 ## [2.2.3] — 2026-05-12 — perf: stream trie GC via cursor walks
 
 **No wire change. No consensus change. Halt-all + simul-start deploy (storage path, same as 2.2.1).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "hex",
  "proptest",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -15,6 +15,7 @@ use sentrix_trie::tree::SentrixTrie;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 // ── Chain constants ──────────────────────────────────────
 //
@@ -1875,6 +1876,18 @@ impl Blockchain {
     ///
     /// Pruning failure is logged but never propagated — a failed prune leaves
     /// extra storage on disk but does not break consensus.
+    ///
+    /// 2026-05-12 (v2.2.4): prune now runs on its own OS thread instead of
+    /// inline. apply_block_pass2 calls this while holding the Blockchain
+    /// write lock from the gossip-block apply task in libp2p_node; the
+    /// cursor walk in gc_orphaned_nodes is O(N) over the trie node table
+    /// (millions of entries on mainnet) and was holding chain.write() for
+    /// tens of seconds at every 1000-block boundary, freezing the apply
+    /// loop and producing the recurring "silent fullnode wedge". By
+    /// dispatching to std::thread we release the write lock immediately;
+    /// the prune work proceeds against MDBX in parallel with the next
+    /// block applies. PRUNE_RUNNING gates overlap so a slow prune doesn't
+    /// queue behind itself when the next boundary fires.
     pub fn maybe_prune_trie(&self) {
         const TRIE_PRUNE_EVERY: u64 = 1000;
         const TRIE_KEEP_VERSIONS: u64 = 1000;
@@ -1884,30 +1897,67 @@ impl Blockchain {
             return;
         }
 
-        let Some(trie) = self.state_trie.as_ref() else {
+        if PRUNE_RUNNING
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+            .is_err()
+        {
+            tracing::info!(
+                "trie prune at height {} skipped: previous prune still running",
+                height
+            );
+            return;
+        }
+
+        let Some(trie) = self.state_trie.as_ref().cloned() else {
+            PRUNE_RUNNING.store(false, Ordering::Release);
             return;
         };
 
-        match trie.prune(TRIE_KEEP_VERSIONS) {
-            Ok((roots, nodes)) if roots > 0 || nodes > 0 => {
-                tracing::info!(
-                    "trie maintenance at height {}: retired {} old roots, GC'd {} nodes/values",
-                    height,
-                    roots,
-                    nodes
-                );
-            }
-            Ok(_) => {} // nothing to do
-            Err(e) => {
-                tracing::warn!(
-                    "trie prune at height {} failed: {} (storage will continue to grow until next successful prune)",
-                    height,
-                    e
-                );
-            }
-        }
+        std::thread::Builder::new()
+            .name(format!("trie-prune-h{}", height))
+            .spawn(move || {
+                let outcome = trie.prune(TRIE_KEEP_VERSIONS);
+                PRUNE_RUNNING.store(false, Ordering::Release);
+                match outcome {
+                    Ok((roots, nodes)) if roots > 0 || nodes > 0 => {
+                        tracing::info!(
+                            "trie maintenance at height {}: retired {} old roots, GC'd {} nodes/values",
+                            height,
+                            roots,
+                            nodes
+                        );
+                    }
+                    Ok(_) => {} // nothing to do
+                    Err(e) => {
+                        tracing::warn!(
+                            "trie prune at height {} failed: {} (storage will continue to grow until next successful prune)",
+                            height,
+                            e
+                        );
+                    }
+                }
+            })
+            .map_or_else(
+                |e| {
+                    PRUNE_RUNNING.store(false, Ordering::Release);
+                    tracing::warn!(
+                        "trie prune at height {} could not spawn background thread: {}",
+                        height,
+                        e
+                    );
+                },
+                |_handle| {},
+            );
     }
 }
+
+/// Guard: only one trie prune in flight at a time. Set true at the start
+/// of `maybe_prune_trie` via compare_exchange; the spawned thread clears
+/// it on completion (success or error). If a second 1000-block boundary
+/// fires while a prior prune is still walking, we skip the second cycle
+/// — storage will continue to grow until the next successful prune, same
+/// as the existing "failed prune" semantics documented above.
+static PRUNE_RUNNING: AtomicBool = AtomicBool::new(false);
 
 #[cfg(test)]
 mod tests {

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
## Summary

- `Blockchain::maybe_prune_trie` now spawns the prune on a named `std::thread` and returns immediately.
- A `PRUNE_RUNNING` `AtomicBool` gates overlap — a second 1000-block boundary while a prior prune is still walking is a no-op.
- Workspace 2.2.3 → 2.2.4 in lockstep across 17 Cargo.toml.

## Why

The 2.2.3 streaming-iter fix took the OOM-class memory spike out of `gc_orphaned_nodes` but didn't move the lock-holding work — `gc_table` still walks the entire `TABLE_TRIE_NODES` via cursor, which on mainnet with millions of entries takes tens of seconds. `apply_block_pass2` holds `Blockchain.write()` for that whole duration, so the gossip-block apply loop freezes at every 1000-block prune boundary.

Mainnet fullnodes visibly wedged a few minutes after the 2.2.3 deploy went out:

- last `STATE-FP` h=1,701,999 (one block before the h=1,702,000 prune boundary)
- silent for 20+ min until manual `docker compose force-recreate`
- container alive, `/health` returning 200, but `add_block_from_peer` blocked on `Blockchain.write()`

This patch decouples the prune duration from the apply path.

## Approach

`prune()` is `&self` in `sentrix-trie/tree.rs` and the MDBX layer serialises writes internally, so concurrent block-apply + prune share the database safely. `SentrixTrie` has an `Arc`-based `Clone` (per the existing `impl Clone`), so handoff to the worker thread is cheap.

```rust
static PRUNE_RUNNING: AtomicBool = AtomicBool::new(false);

pub fn maybe_prune_trie(&self) {
    // ... boundary check ...
    if PRUNE_RUNNING.compare_exchange(false, true, AcqRel, Relaxed).is_err() {
        return; // prior prune still walking
    }
    let trie = self.state_trie.as_ref().cloned()?;
    std::thread::Builder::new()
        .name(format!("trie-prune-h{}", height))
        .spawn(move || {
            let outcome = trie.prune(TRIE_KEEP_VERSIONS);
            PRUNE_RUNNING.store(false, Release);
            // ... log outcome ...
        });
}
```

## Test plan

- [x] 212 `sentrix-core` tests pass (one consensus-class test — `test_two_chains_same_blocks_reach_same_state_root` — included)
- [x] `cargo check --workspace --release` with `-D warnings` clean
- [ ] Testnet bake: confirm h=N×1000 boundary blocks emit `STATE-FP` immediately after the previous block (no >5s gap)
- [ ] Mainnet bake after testnet clean: same observation, plus public RPC stays responsive at boundaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.2.4 with comprehensive updates across all system packages and components.
  * Improved system responsiveness and efficiency of blockchain state management operations.
  * Optimized background data processing to reduce operational latency and improve overall platform performance during periods of peak activity.
  * Enhanced stability and reliability of node operations under demanding network conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/584)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->