### PR TITLE
fix(ci): rebuild release.yml verify-notes step (broken YAML scalar)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,25 +151,34 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BIN_SHA: ${{ needs.build.outputs.bin_sha }}
         run: |
-          # Append verification block to release notes
-          gh release edit "${GITHUB_REF_NAME}" --notes-file - <<NOTES
-$(gh release view "${GITHUB_REF_NAME}" --json body --jq '.body')
+          # Append verification block to release notes.
+          # - YAML scalar requires every here-doc line to stay indented (>=10
+          #   spaces) so the `|` block doesn't terminate
+          # - `sed` strips the 10-space prefix before piping to gh
+          # - Unquoted `<<NOTES` lets bash expand ${BIN_SHA} → real hash
+          # - Markdown triple-backticks + bash line-continuations are
+          #   backslash-escaped so they survive the heredoc parser and end
+          #   up rendered literally in the published release notes
+          {
+            gh release view "${GITHUB_REF_NAME}" --json body --jq '.body'
+            sed 's/^          //' <<NOTES
 
-## Verify
+          ## Verify
 
-\`\`\`bash
-# Binary checksum
-echo "${BIN_SHA}  sentrix" | sha256sum -c
+          \`\`\`bash
+          # Binary checksum
+          echo "${BIN_SHA}  sentrix" | sha256sum -c
 
-# Cosign keyless verify (binary)
-cosign verify-blob \\
-  --certificate-identity-regexp "https://github.com/sentrix-labs/sentrix" \\
-  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \\
-  --signature sentrix.sig \\
-  --certificate sentrix.crt \\
-  sentrix
+          # Cosign keyless verify (binary)
+          cosign verify-blob \\
+            --certificate-identity-regexp "https://github.com/sentrix-labs/sentrix" \\
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \\
+            --signature sentrix.sig \\
+            --certificate sentrix.crt \\
+            sentrix
 
-# SLSA build provenance
-gh attestation verify --owner sentrix-labs sentrix
-\`\`\`
-NOTES
+          # SLSA build provenance
+          gh attestation verify --owner sentrix-labs sentrix
+          \`\`\`
+          NOTES
+          } | gh release edit "${GITHUB_REF_NAME}" --notes-file -


### PR DESCRIPTION
**Root cause for the release.yml failures since v2.1.85.**

The 'Verify reproducibility line in release notes' step had a bash here-doc body where line 156 dropped the leading indent. YAML's literal-block (`|`) scalar ends when indent decreases, so line 156 onwards was re-parsed at top level where `$(...)` is invalid YAML. GitHub's response: 0 jobs ever ran on this workflow, marked as 'failure' with no logs.

Every tag from v2.1.86 → v2.2.4 hit this — explains why those versions exist as tags but **no GitHub Releases** were published.

## Fix
- Keep all here-doc lines indented to match the YAML scalar (10 spaces)
- Use `sed 's/^          //'` to strip the 10-space prefix before piping to `gh release edit --notes-file -`
- Wrap the entire output (existing body + verify block) in a single `{ ...; ...; }` group → single stream

## Verification
`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — clean.
Top-level keys + 4 jobs (build, sbom, sign, release) all parse.

End-to-end validation requires pushing a v* tag — defer that until merge so we can backfill v2.2.4 release artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the release workflow to automatically append a verification section to release notes. Releases now include checksum validation instructions, keyless digital-signature verification steps, and SLSA provenance attestation guidance to help independently validate binary integrity and provenance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/585)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->