### PR TITLE
chore: bump workspace 2.2.4 → 2.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "hex",
  "proptest",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 
 [package]
 name = "sentrix"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Fast, secure Layer-1 blockchain built in Rust"

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-node"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain node CLI"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-bft"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-codec"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-core"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-evm"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "EVM execution layer (revm 37) for Sentrix blockchain"

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-grpc"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-network"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-primitives"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Core types and error handling for Sentrix blockchain"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-rpc"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix REST API, JSON-RPC, and block explorer"

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-staking"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-storage"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-trie"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wallet"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentrix-wire"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 license = "BUSL-1.1"
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."


### PR DESCRIPTION
Prep for v2.2.5 tag — first release cut after #585 fixed the release.yml YAML bug.

No code changes vs v2.2.4. Once this merges I'll push the v2.2.5 tag to trigger the (now-working) release pipeline → publishes signed binary + SBOM + SLSA attestation to the Releases page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project version updated to 2.2.5 across all packages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/586)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->