### PR TITLE
fix(ci): drop --output-pattern from cargo cyclonedx (sbom step fails)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Generate SBOM (workspace)
         run: |
-          cargo cyclonedx --format json --output-pattern bom --override-filename sentrix-sbom.cdx
+          cargo cyclonedx --format json --override-filename sentrix-sbom.cdx
           ls -la sentrix-sbom*
 
       - uses: actions/upload-artifact@v5


### PR DESCRIPTION
v2.2.5 release.yml run: build job ✅, sbom job ❌ on `error: unexpected argument '--output-pattern' found`.

`cargo-cyclonedx 0.5.9` only has `--override-filename`; `--output-pattern` either never existed or got removed. Dropping the flag is sufficient — the output filename is fully controlled by `--override-filename sentrix-sbom.cdx`.

After this lands, re-run release.yml by force-pushing v2.2.5 tag (or push v2.2.6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build workflow configuration for Software Bill of Materials generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/587)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->