### PR TITLE
fix(ci): add actions/checkout to release job (final publish step needs git)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,10 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [build, sbom, sign]
     steps:
+      # gh release uses local git to figure out which repo to target;
+      # without a checkout the call errors with "not a git repository".
+      - uses: actions/checkout@v5
+
       - uses: actions/download-artifact@v5
         with:
           name: sentrix-binary


### PR DESCRIPTION
v2.2.6 release.yml run reached the final publish step with 3/4 jobs green (build + sbom + sign), then failed on `gh release create` with `fatal: not a git repository`.

`gh release` reads the upstream slug from the local git config. The release job had no checkout, just download-artifact + run steps, so cwd had no .git directory.

Adding `actions/checkout@v5` as the first step. Once this lands, push v2.2.7 to retry — all four jobs should pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow stability by ensuring proper repository context during artifact operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/589)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->