### PR TITLE
fix(ci): download release artifacts to isolated _artifacts/ tree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,18 +120,23 @@ jobs:
       # without a checkout the call errors with "not a git repository".
       - uses: actions/checkout@v5
 
+      # Download artifacts into an isolated _artifacts/ tree to avoid
+      # colliding with the repo's `bin/sentrix/` workspace member directory
+      # — checkout puts the repo at the workspace root, and pointing
+      # download-artifact at ./bin tries to write sentrix as a file
+      # where bin/sentrix/ already exists as a directory.
       - uses: actions/download-artifact@v5
         with:
           name: sentrix-binary
-          path: ./bin
+          path: ./_artifacts/bin
       - uses: actions/download-artifact@v5
         with:
           name: sentrix-sbom
-          path: ./sbom
+          path: ./_artifacts/sbom
       - uses: actions/download-artifact@v5
         with:
           name: signatures
-          path: ./sigs
+          path: ./_artifacts/sigs
 
       - name: Create / update GitHub release
         env:
@@ -145,9 +150,9 @@ jobs:
 
           # Upload artifacts (--clobber overwrites if release was created earlier)
           gh release upload "${GITHUB_REF_NAME}" \
-            ./bin/sentrix \
-            ./sbom/sentrix-sbom.cdx.json \
-            ./sigs/* \
+            ./_artifacts/bin/sentrix \
+            ./_artifacts/sbom/sentrix-sbom.cdx.json \
+            ./_artifacts/sigs/* \
             --clobber
 
       - name: Verify reproducibility line in release notes


### PR DESCRIPTION
v2.2.7 release run kept failing on `actions/download-artifact` with `Artifact download failed after 5 retries`. Not a transient flake — reproduced across 2 reruns.

Root cause: `actions/checkout` (added in #589) puts the repo at workspace root → `bin/sentrix/` is a directory there (Cargo workspace member). `download-artifact` then can't write the `sentrix` binary as a file at `./bin/sentrix` because the directory already exists. v5 surfaces this as a generic 'download failed' instead of a clear collision error.

Moving downloads to `./_artifacts/{bin,sbom,sigs}/` — fully outside the repo tree. `gh release upload` paths updated to match.

Once this lands: push v2.2.8 (bump + tag) for the final retry. The build/sbom/sign jobs already pass cleanly — only the publish step has been blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to organize build artifacts in a dedicated directory during the release process, improving artifact management and preventing potential directory conflicts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/591)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->