### PR TITLE
chore: workspace package inheritance + sigs upload fix (2.2.9)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,11 +148,17 @@ jobs:
           gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 || \
             gh release create "${GITHUB_REF_NAME}" --generate-notes --notes "Binary sha256: \`${BIN_SHA}\`"
 
-          # Upload artifacts (--clobber overwrites if release was created earlier)
+          # Upload artifacts. The sign job uploads signatures preserving the
+          # original `./bin/` and `./sbom/` directory layout, so after download
+          # the actual files live under _artifacts/sigs/bin/ and
+          # _artifacts/sigs/sbom/. Glob each leaf explicitly instead of using
+          # `_artifacts/sigs/*` which would expand to the two subdirectories
+          # and trip gh upload with "is a directory".
           gh release upload "${GITHUB_REF_NAME}" \
             ./_artifacts/bin/sentrix \
             ./_artifacts/sbom/sentrix-sbom.cdx.json \
-            ./_artifacts/sigs/* \
+            ./_artifacts/sigs/bin/* \
+            ./_artifacts/sigs/sbom/* \
             --clobber
 
       - name: Verify reproducibility line in release notes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "bincode",
  "hex",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "bincode",
  "hex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5111,7 +5111,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.1.91"
+version = "2.2.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -5196,14 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "hex",
  "proptest",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "0.1.0"
+version = "2.2.9"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "bincode",
  "blake3",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.6"
+version = "2.2.9"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,24 @@
 resolver = "2"
 members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "crates/sentrix-wire", "crates/sentrix-grpc", "crates/sentrix-prom-exporter", "bin/sentrix", "bin/sentrix-faucet"]
 
-[package]
-name = "sentrix"
-version = "2.2.8"
+# Single source of truth for fields every workspace member shares.
+# Future version bumps = edit `version` here only; each member inherits via
+# `version.workspace = true`. Same goes for edition/license/repository so
+# they can't drift across crates.
+[workspace.package]
+version = "2.2.9"
 edition = "2024"
 license = "BUSL-1.1"
+repository = "https://github.com/sentrix-labs/sentrix"
+
+[package]
+name = "sentrix"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "Fast, secure Layer-1 blockchain built in Rust"
 homepage = "https://sentrix.sentriscloud.com"
-repository = "https://github.com/sentrix-labs/sentrix"
 keywords = ["blockchain", "layer1", "poa", "dpos", "bft"]
 categories = ["cryptography::cryptocurrencies"]
 

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sentrix-faucet"
-version = "2.1.91"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Sentrix testnet faucet HTTP service — signs and submits drip transactions"
 
 [[bin]]

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sentrix-node"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Sentrix blockchain node CLI"
 publish = false
 

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sentrix-bft"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "BFT consensus engine (Tendermint-style) for Sentrix blockchain"
-repository = "https://github.com/sentrix-labs/sentrix"
+repository.workspace = true
 
 [dependencies]
 sentrix-primitives = { path = "../sentrix-primitives" }

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sentrix-codec"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Centralised encoding: bincode + hex wrappers for Sentrix"
-repository = "https://github.com/sentrix-labs/sentrix"
+repository.workspace = true
 
 [dependencies]
 bincode = "1.3"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sentrix-core"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Sentrix blockchain core — Blockchain state, block execution, authority, mempool"
 publish = false
 

--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sentrix-evm"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "EVM execution layer (revm 37) for Sentrix blockchain"
-repository = "https://github.com/sentrix-labs/sentrix"
+repository.workspace = true
 
 [dependencies]
 sentrix-primitives = { path = "../sentrix-primitives" }

--- a/crates/sentrix-grpc/Cargo.toml
+++ b/crates/sentrix-grpc/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sentrix-grpc"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Tonic gRPC supplement transport for Sentrix Chain (parallel to JSON-RPC eth_*)"
 
 # 2026-05-05 v0.1 skeleton — handlers in src/lib.rs return tonic::Status::unimplemented

--- a/crates/sentrix-network/Cargo.toml
+++ b/crates/sentrix-network/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sentrix-network"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Sentrix P2P networking — libp2p gossipsub, kademlia, request-response"
 publish = false
 

--- a/crates/sentrix-precompiles/Cargo.toml
+++ b/crates/sentrix-precompiles/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sentrix-precompiles"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Sentrix-specific EVM precompile addresses (staking, slashing, ...)"
-repository = "https://github.com/sentrix-labs/sentrix"
+repository.workspace = true
 
 [dependencies]
 alloy-primitives = "1.5"

--- a/crates/sentrix-primitives/Cargo.toml
+++ b/crates/sentrix-primitives/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sentrix-primitives"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Core types and error handling for Sentrix blockchain"
-repository = "https://github.com/sentrix-labs/sentrix"
+repository.workspace = true
 keywords = ["blockchain", "sentrix", "types"]
 
 [dependencies]

--- a/crates/sentrix-prom-exporter/Cargo.toml
+++ b/crates/sentrix-prom-exporter/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sentrix-prom-exporter"
-version = "0.1.0"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "sentrix-prom-exporter"

--- a/crates/sentrix-rpc-types/Cargo.toml
+++ b/crates/sentrix-rpc-types/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sentrix-rpc-types"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "ETH ↔ Sentrix JSON-RPC type conversions + hex/address validation helpers"
-repository = "https://github.com/sentrix-labs/sentrix"
+repository.workspace = true
 
 [dependencies]
 serde_json = "1.0"

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sentrix-rpc"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Sentrix REST API, JSON-RPC, and block explorer"
 publish = false
 

--- a/crates/sentrix-staking/Cargo.toml
+++ b/crates/sentrix-staking/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sentrix-staking"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "DPoS staking, epoch management, and slashing for Sentrix blockchain"
-repository = "https://github.com/sentrix-labs/sentrix"
+repository.workspace = true
 
 [dependencies]
 sentrix-primitives = { path = "../sentrix-primitives" }

--- a/crates/sentrix-storage/Cargo.toml
+++ b/crates/sentrix-storage/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sentrix-storage"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Sentrix storage layer — libmdbx wrapper for blockchain persistence"
 publish = false
 

--- a/crates/sentrix-trie/Cargo.toml
+++ b/crates/sentrix-trie/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sentrix-trie"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Binary Sparse Merkle Tree (256-level) with MDBX persistence for Sentrix blockchain state"
-repository = "https://github.com/sentrix-labs/sentrix"
+repository.workspace = true
 
 [dependencies]
 sentrix-primitives = { path = "../sentrix-primitives" }

--- a/crates/sentrix-wallet/Cargo.toml
+++ b/crates/sentrix-wallet/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sentrix-wallet"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Wallet, keystore encryption, and signing for Sentrix blockchain"
-repository = "https://github.com/sentrix-labs/sentrix"
+repository.workspace = true
 
 [dependencies]
 sentrix-primitives = { path = "../sentrix-primitives" }

--- a/crates/sentrix-wire/Cargo.toml
+++ b/crates/sentrix-wire/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "sentrix-wire"
-version = "2.2.8"
-edition = "2024"
-license = "BUSL-1.1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dep."
-repository = "https://github.com/sentrix-labs/sentrix"
+repository.workspace = true
 
 # Why this crate exists
 # -------------------------


### PR DESCRIPTION
Two changes bundled in v2.2.9:

## 1. [workspace.package] inheritance

Single source of truth for version/edition/license/repository. Future bumps = 1 line edit.

Brings into sync (previously drifted):
- `bin/sentrix-faucet`: 2.1.91 → 2.2.9 (was 6 patches behind, flagged by CodeRabbit on #592)
- `crates/sentrix-prom-exporter`: 0.1.0 → 2.2.9

Other 17 crates: 2.2.8 → 2.2.9 (same uniform bump).

`cargo metadata --no-deps` confirms all 19 workspace members at 2.2.9.

## 2. release.yml sigs glob fix

v2.2.8 release published but signature files missing — `_artifacts/sigs/*` expanded to subdirectories `bin/` + `sbom/` (sign job uploaded preserving layout), and `gh release upload` failed with 'is a directory'.

Now: glob each leaf — `_artifacts/sigs/bin/*` + `_artifacts/sigs/sbom/*`.

## Verification

`cargo check --workspace` clean. All members compile at 2.2.9. CI will revalidate.

Once merged: push v2.2.9 tag → release.yml should produce a fully-signed release with binary + SBOM + 4 signature files (binary.sig/.crt + sbom.sig/.crt).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.2.9
  * Build configuration standardized across packages to use workspace-level package metadata
  * Release artifact upload process updated to preserve directory structure for signature files

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/593)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->