### PR TITLE
block_executor: per-block apply-phase profile (env-gated)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -622,6 +622,27 @@ impl Blockchain {
     /// from `add_block` after Pass 1 has validated the block and the
     /// caller has taken a `BlockchainSnapshot` for rollback.
     fn apply_block_pass2(&mut self, block: Block) -> SentrixResult<()> {
+        // Per-block apply profile. Env-gated zero-cost when off
+        // (var_os check + Instant::now allocations skipped). When
+        // SENTRIX_APPLY_PROFILE=1, emits one tracing::info line per
+        // block at function exit with phase breakdowns:
+        //   apply-profile h=<height> txs=<n> tx_apply=<ms> trie=<ms> post=<ms> total=<ms>
+        // tx_apply = coinbase + tx loop + state mutations (everything
+        // before update_trie_for_block). trie = update_trie_for_block
+        // duration. post = state_root stamp + state_root check + prune
+        // dispatch. The prune itself runs on a background thread (v2.2.4)
+        // so its walk time is NOT included here.
+        let apply_profile = std::env::var_os("SENTRIX_APPLY_PROFILE")
+            .is_some_and(|v| v == "1");
+        let profile_t0 = if apply_profile {
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+        // Capture before `block` gets moved into self.chain mid-fn.
+        let profile_height = block.index;
+        let profile_txs = block.transactions.len();
+
         // EXTENDED_TOUCH_LIST fork (2026-05-07): clear the per-block
         // accumulator at start so each block sees a fresh set. Mutators
         // populate `accounts.touched_in_block` during apply;
@@ -1509,6 +1530,7 @@ impl Blockchain {
 
         // Update state trie after block commit, stamp state_root on the block header,
         // and verify the sender's committed root when receiving from peers.
+        let profile_t1 = profile_t0.map(|_| std::time::Instant::now());
         let trie_root = self.update_trie_for_block().map_err(|e| {
             SentrixError::Internal(format!(
                 "trie update failed at block {}: {}",
@@ -1516,6 +1538,7 @@ impl Blockchain {
                 e
             ))
         })?;
+        let profile_t2 = profile_t0.map(|_| std::time::Instant::now());
 
         if let Some(computed_root) = trie_root
             && let Some(last) = self.chain.last_mut()
@@ -1646,6 +1669,21 @@ impl Blockchain {
         // without a localised cause — this gives us the first per-block
         // fingerprint to compare across the fleet at next halt.
         emit_state_fingerprint(self, self.height());
+
+        // Per-block apply-phase profile (see top of fn for rationale).
+        if let (Some(t0), Some(t1), Some(t2)) = (profile_t0, profile_t1, profile_t2) {
+            let t3 = std::time::Instant::now();
+            tracing::info!(
+                target: "apply_profile",
+                "apply-profile h={} txs={} tx_apply={}ms trie={}ms post={}ms total={}ms",
+                profile_height,
+                profile_txs,
+                t1.duration_since(t0).as_millis(),
+                t2.duration_since(t1).as_millis(),
+                t3.duration_since(t2).as_millis(),
+                t3.duration_since(t0).as_millis(),
+            );
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Three-phase apply timing trace inside `apply_block_pass2`, env-gated by `SENTRIX_APPLY_PROFILE=1`. Emits one line per block:

\`\`\`
apply-profile h=N txs=K tx_apply=Xms trie=Yms post=Zms total=Tms
\`\`\`

- **tx_apply** = coinbase credit + tx loop + state mutations (everything before `update_trie_for_block`)
- **trie** = `update_trie_for_block` duration (trie-merkle update + state_root recompute)
- **post** = state_root stamp + state_root check + prune dispatch (NOT the prune itself — that runs on its own thread since 2.2.4)
- **total** = full `apply_block_pass2` wall clock

## Why

Mainnet bt sits at 2.0-2.5 s/blk steady, but BFT 3-phase at avg 65ms validator-to-validator RTT should floor at ~200ms. The other ~1.8s is hidden inside the apply path; we don't currently know whether revm, trie, or MDBX dominates. This trace lets us pick the next optimisation target (Frontier F-3 parallel apply, trie-write batching, MDBX tuning) based on real numbers from production.

Zero-cost when off: `var_os` check + no `Instant::now()` allocations when the env var is unset.

## Test plan

- [x] `cargo check --workspace --release` with `-D warnings` clean
- [ ] Deploy to one testnet validator with `SENTRIX_APPLY_PROFILE=1` for ~5 min, collect breakdown numbers
- [ ] Report findings in a follow-up to inform F-3 work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-block execution profiling that logs detailed phase timing information (transaction application, trie computation, and post-processing) when enabled via environment variable, enabling performance analysis and optimization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/594)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->