### PR TITLE
chore: align sentrix-evm description with actual revm version

### DIFF
--- a/crates/sentrix-evm/Cargo.toml
+++ b/crates/sentrix-evm/Cargo.toml
@@ -3,7 +3,7 @@ name = "sentrix-evm"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "EVM execution layer (revm 37) for Sentrix blockchain"
+description = "EVM execution layer (revm 38) for Sentrix blockchain"
 repository.workspace = true
 
 [dependencies]


### PR DESCRIPTION
One-line fix. `crates/sentrix-evm/Cargo.toml` line 6 said `revm 37` but line 12 already bumped to `revm = "38"`. Lost during the parallel bump-PR cascade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying EVM execution layer to a newer version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/595)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->