### PR TITLE
fix(observability): emit apply-profile on legacy-tolerated path

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -1619,6 +1619,18 @@ impl Blockchain {
                                 // continuity is preserved.
                                 last.state_root = Some(received_root);
                                 self.maybe_prune_trie();
+                                // Mirror the end-of-function profile emit so
+                                // SENTRIX_APPLY_PROFILE=1 still records timing
+                                // on the legacy-tolerated path. Without this,
+                                // pre-cutoff replay leaves a gap in the
+                                // apply-profile log.
+                                emit_apply_profile(
+                                    profile_t0,
+                                    profile_t1,
+                                    profile_t2,
+                                    profile_height,
+                                    profile_txs,
+                                );
                                 return Ok(());
                             }
 
@@ -1671,19 +1683,7 @@ impl Blockchain {
         emit_state_fingerprint(self, self.height());
 
         // Per-block apply-phase profile (see top of fn for rationale).
-        if let (Some(t0), Some(t1), Some(t2)) = (profile_t0, profile_t1, profile_t2) {
-            let t3 = std::time::Instant::now();
-            tracing::info!(
-                target: "apply_profile",
-                "apply-profile h={} txs={} tx_apply={}ms trie={}ms post={}ms total={}ms",
-                profile_height,
-                profile_txs,
-                t1.duration_since(t0).as_millis(),
-                t2.duration_since(t1).as_millis(),
-                t3.duration_since(t2).as_millis(),
-                t3.duration_since(t0).as_millis(),
-            );
-        }
+        emit_apply_profile(profile_t0, profile_t1, profile_t2, profile_height, profile_txs);
 
         Ok(())
     }
@@ -1732,6 +1732,36 @@ impl Blockchain {
 ///   [STATE-FP] h=<height> acc=<8-byte-hex> fp=<8-byte-hex>
 ///
 /// Cost when enabled: ~O(N) sha256 over AccountDB content per block,
+/// Per-block apply-phase profile emitter. Single exit point for the
+/// `apply-profile h=... txs=... tx_apply=...ms trie=...ms post=...ms total=...ms`
+/// log line, so every return path through `apply_block_pass2` records
+/// timing when SENTRIX_APPLY_PROFILE=1. Pre-helper, the legacy-tolerated
+/// branch returned without emitting — replay of pre-cutoff blocks left a
+/// gap in the profile log.
+///
+/// No-op when any of the three timestamps is None (profiling disabled).
+fn emit_apply_profile(
+    t0: Option<std::time::Instant>,
+    t1: Option<std::time::Instant>,
+    t2: Option<std::time::Instant>,
+    height: u64,
+    txs: usize,
+) {
+    if let (Some(t0), Some(t1), Some(t2)) = (t0, t1, t2) {
+        let t3 = std::time::Instant::now();
+        tracing::info!(
+            target: "apply_profile",
+            "apply-profile h={} txs={} tx_apply={}ms trie={}ms post={}ms total={}ms",
+            height,
+            txs,
+            t1.duration_since(t0).as_millis(),
+            t2.duration_since(t1).as_millis(),
+            t3.duration_since(t2).as_millis(),
+            t3.duration_since(t0).as_millis(),
+        );
+    }
+}
+
 /// where N = total accounts + contract storage entries. At Sentrix
 /// mainnet scale (~tens of thousands of accounts, sparse contract
 /// storage) this adds ~1-2 ms per block. Acceptable for debug runs.


### PR DESCRIPTION
## Summary

`apply_block_pass2` has two `return Ok(())` exits. The end-of-function emit for the apply-phase profile log (`apply-profile h=... txs=... tx_apply=...ms trie=...ms post=...ms total=...ms`) only fires on the happy path. The legacy-tolerated-mismatch branch (`block_index < SENTRIX_LEGACY_VALIDATION_HEIGHT`) does an early `return Ok(())` and skips the emit, leaving a gap in the profile log during pre-cutoff replay.

Extracted the emit into a single-exit helper `emit_apply_profile()` and called it at both sites.

## Behaviour

- **Profiling off** (`SENTRIX_APPLY_PROFILE` unset): helper is a no-op (`Option<Instant>` triple is None). Zero overhead, zero log line. Identical to before.
- **Profiling on** (`SENTRIX_APPLY_PROFILE=1`): every block-apply emits the profile line, regardless of which return path fires. Closes the legacy-tolerated gap.

## Consensus surface

Pure observability fix — no behaviour change. The apply path's logic for accepting/rejecting blocks is untouched; the helper only prints. Mainnet is past the legacy cutoff (`SENTRIX_LEGACY_VALIDATION_HEIGHT=557144`, height ~1.7M+), so the early-return is unreachable on current mainnet anyway. Matters for chain replay + historical analysis.

## Verification

`cargo check --workspace` — clean.

Caught by CodeRabbit on an unrelated PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of profiling logs by ensuring apply-phase profiling is recorded across all execution paths, fixing previously missing logs in certain replay scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/596)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->