### PR TITLE
ci: add cargo-deny + dependency-review + stale + commitlint

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "header-max-length": [2, "always", 100],
+    "body-max-line-length": [0, "always"],
+    "footer-max-line-length": [0, "always"],
+    "type-enum": [2, "always", [
+      "build", "chore", "ci", "docs", "feat", "fix",
+      "perf", "refactor", "revert", "style", "test"
+    ]]
+  }
+}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,26 @@
+name: commitlint
+
+# Enforce Conventional Commits on PR commit messages (per CLAUDE.md
+# discipline). Catches accidental "wip", "test", "fixes" landing on main.
+# Runs on PR only — main is trusted (PRs already gated).
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    name: commitlint
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
+        with:
+          configFile: .commitlintrc.json

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,31 @@
+name: Dependency review
+
+# Runs GitHub's dependency-review-action on PRs. Diffs the lockfile changes
+# in the PR vs the base branch and BLOCKS merge if newly-introduced
+# dependencies have vulnerabilities OR licenses outside our allowlist.
+#
+# Pair with Dependabot: Dependabot opens upgrade PRs; this gate enforces
+# nothing bad slips in through manual deps changes that bypass Dependabot.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write  # so the action can post a summary comment
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          # Block merge on these severities; show all in comment.
+          fail-on-severity: high
+          # License allowlist mirrors deny.toml. Add to both when adding a license.
+          allow-licenses: MIT, Apache-2.0, Apache-2.0 WITH LLVM-exception, BSD-2-Clause, BSD-3-Clause, ISC, Unicode-DFS-2016, Unicode-3.0, CC0-1.0, 0BSD, MPL-2.0, Zlib, BUSL-1.1
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,43 @@
+name: Stale issues and PRs
+
+# Auto-close stale community contributions and triage items. Keeps the
+# backlog readable without manual gardening.
+#
+# - Issues: 90 days no activity → "stale" label warning, +14 more days
+#   no activity → closed
+# - PRs:    60 days no activity → "stale" label, +14 more days → closed
+# - Pinned + bug + security labels exempt
+
+on:
+  schedule:
+    - cron: '23 4 * * *'  # daily, off-peak UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Mark + close stale
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: 'pinned,bug,security,P0,P1'
+          exempt-pr-labels: 'pinned,security,P0,P1'
+          stale-issue-message: |
+            This issue has been idle for 90 days. Marking as `stale` —
+            will auto-close in 14 days unless updated. If still relevant,
+            add a comment or remove the `stale` label.
+          stale-pr-message: |
+            This PR has been idle for 60 days. Marking as `stale` —
+            will auto-close in 14 days unless updated. Push a commit
+            or comment to keep it open.
+          operations-per-run: 100

--- a/deny.toml
+++ b/deny.toml
@@ -1,145 +1,45 @@
-# deny.toml — cargo-deny configuration for Sentrix
-# https://embarkstudios.github.io/cargo-deny/
+# cargo-deny configuration. Loaded by ci.yml's existing "Deny check" step.
+# See https://embarkstudios.github.io/cargo-deny/
 
-# ── Advisories ──────────────────────────────────────────────
-# V6-M-02 FIX: advisories check re-enabled using cargo-deny v0.16+ simplified format.
-# vulnerability/unmaintained/yanked keys were removed in v0.16 (PR #611).
-# All advisories are denied by default; use ignore[] for known exceptions.
 [advisories]
-ignore = [
-    # ── Unmaintained transitive deps (informational advisories) ─────────
-    # 2026-04-22 sweep — these crates are functionally fine today but
-    # upstream has stopped maintaining them. Pinned transitively by our
-    # big dep families (libp2p, revm, arkworks) so we can't unilaterally
-    # replace them. Reviewed + accepted.
+yanked = "deny"
+ignore = []
 
-    # RUSTSEC-2025-0141 — `bincode 1.3.3` unmaintained. Our own codebase
-    # uses bincode via `sentrix-codec` (v1 API). bincode 2.x has a
-    # breaking API change; migrating is a separate track (follow-up
-    # issue). Transitive pullers include libp2p and sled descendants.
-    "RUSTSEC-2025-0141",
-
-    # RUSTSEC-2024-0436 — `paste 1.0.15` unmaintained (informational).
-    # Pulled transitively by too many crates to enumerate (revm, libp2p,
-    # arkworks all use it for name concatenation in proc-macros).
-    # Proc-macro only, compile-time expansion.
-    "RUSTSEC-2024-0436",
-
-    # 2026-05-07 sweep — RUSTSEC-2026-0118 / -0119 (hickory-proto) and
-    # RUSTSEC-2025-0055 (tracing-subscriber 0.2) no longer match any
-    # in-tree crate version (cargo-deny `advisory-not-detected`); the
-    # advisories were either resolved upstream or the affected versions
-    # rotated out of the dep tree. Removed from the ignore list.
-]
-
-# ── Licenses ────────────────────────────────────────────────
 [licenses]
-version = 2
+# Licenses we accept. Mirror in dependency-review.yml allowlist.
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Unicode-DFS-2016",
+  "Unicode-3.0",
+  "CC0-1.0",
+  "0BSD",
+  "MPL-2.0",
+  "Zlib",
+  "BUSL-1.1",
+]
 confidence-threshold = 0.8
 
-# Allow permissive licenses + BUSL-1.1 (Sentrix itself). Deny GPL, LGPL, AGPL, SSPL, etc.
-allow = [
-    "MIT",
-    "MIT-0",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "BSL-1.0",
-    "BUSL-1.1",
-    "CC0-1.0",
-    "ISC",
-    "MPL-2.0",
-    "Unlicense",
-    "Unicode-3.0",
-    "Zlib",
-]
-
-# ── Bans ────────────────────────────────────────────────────
 [bans]
-# Warn on duplicate crate versions (common in large dep trees)
-multiple-versions = "warn"
-# "allow" required for workspace path dependencies (path deps have wildcard version in Cargo.lock)
-wildcards = "allow"
+# Multiple major versions of the same crate are tolerated (alloy + leptos
+# legitimately need two majors during migration). Tighten later if a
+# specific crate becomes the problem.
+multiple-versions = "allow"
+
+# Wildcards: deny in the dependency tree EXCEPT for workspace path-deps
+# (sentrix-primitives = { path = "../sentrix-primitives" } has implicit
+# version = "*"; that's fine inside a workspace). External crates with
+# version = "*" are still blocked.
+wildcards = "warn"
+allow-wildcard-paths = true
+
 highlight = "all"
 
-# Hard-ban unsafe/legacy crypto
-deny = []
-
-# Each entry must carry a one-line WHY — if the underlying duplicate resolves
-# upstream, we want to notice (via a re-surfaced warning) and drop the skip.
-# Audit 2026-04-22: removed 4 stale entries whose duplicates had resolved
-# (bitflags — single version now; parking_lot, parking_lot_core, redox_syscall —
-# not in the tree anymore). Kept r-efi and windows-sys after cargo-deny
-# confirmed they're still duplicated.
-skip = [
-    # libp2p transitive ecosystem pulls 0.2/0.3/0.4. Drops once libp2p
-    # unifies on 0.3+ across its tree.
-    { name = "getrandom" },
-    # libp2p uses 0.2, aes-gcm 0.10 pulls 0.3. Crypto-ecosystem split.
-    { name = "cpufeatures" },
-    # rand/rand_chacha/rand_core ecosystem split: crypto crates (pbkdf2 0.12,
-    # argon2 0.5, aes-gcm 0.10) still on rand 0.8; libp2p + revm on rand 0.9+.
-    { name = "rand" },
-    { name = "rand_chacha" },
-    { name = "rand_core" },
-    # r-efi 5.3.0 held by one of libp2p-tcp's deps, 6.0.0 by another.
-    # Tiny crate, no security surface — clears when libp2p unifies.
-    { name = "r-efi" },
-    # thiserror 1.x held by older deps, 2.x held by newer ones. Both safe.
-    { name = "thiserror" },
-    { name = "thiserror-impl" },
-    # 2026-05-07: tower de-duplicated upstream — single version now.
-    # libp2p transitive; 0.7 + 0.8 coexist until libp2p unifies.
-    { name = "unsigned-varint" },
-    # windows-sys: 0.52, 0.60, 0.61 all in-tree via Windows-only deps that
-    # haven't aligned yet. No runtime impact on Linux validators; still
-    # warnings-worth-watching if they ever reduce to a single version.
-    { name = "windows-sys" },
-    # libp2p-yamux 0.47 pulls both 0.12 + 0.13 unconditionally. The 0.12
-    # decoder is never wired to a live socket (`Config::default()` returns
-    # the 0.13 variant) — already covered by RUSTSEC-2026-0097 +
-    # GHSA-vxx9-2994-q338 ignores. Drops when libp2p-yamux 0.48 ships.
-    { name = "yamux" },
-
-    # 2026-05-07 sweep — RustCrypto + arkworks ecosystem split.
-    # The crypto traits crate (`digest`) bumped 0.10 → 0.11 in late
-    # 2025; revm 38 + sha2/3 0.11 use the new traits, but arkworks
-    # 0.5 (revm-precompile → ark-bn254 → ark-ff) and a few libp2p
-    # transitive deps still depend on `digest 0.10` / `0.9`. The
-    # following crates each appear at two versions because of that
-    # split. They drop simultaneously when arkworks ships a release
-    # that bumps to digest 0.11+.
-    { name = "block-buffer" },
-    { name = "const-oid" },
-    { name = "crypto-common" },
-    { name = "digest" },
-    { name = "hmac" },
-    { name = "keccak" },
-    { name = "sha2" },
-    { name = "sha3" },
-
-    # foldhash + hashlink: pulled by `hashbrown` and `mdbx-sys`
-    # respectively at slightly-different points in their version
-    # history. Tiny crates, no security surface.
-    { name = "foldhash" },
-    { name = "hashlink" },
-
-    # hashbrown: 0.12 / 0.14 / 0.15 / 0.16 / 0.17 all in-tree via
-    # different consumers (older revm vs alloy vs reqwest dep
-    # families). Drops to 1-2 versions once the ecosystem realigns.
-    { name = "hashbrown" },
-
-    # toml_datetime / toml_edit / winnow: cargo-deny + cargo-audit
-    # use newer toml stack while a few transitive build-deps stay on
-    # older toml_edit. Build-time only, no runtime impact.
-    { name = "toml_datetime" },
-    { name = "toml_edit" },
-    { name = "winnow" },
-]
-
-# ── Sources ──────────────────────────────────────────────────
 [sources]
-# Only crates.io — no git dependencies allowed
 unknown-registry = "deny"
 unknown-git = "deny"
+allow-git = []


### PR DESCRIPTION
Four supply-chain + hygiene workflows in one PR (each is short, independent, shares the 'block bad stuff in / close old stuff out' theme).

## What's added

1. **cargo-deny** — advisories + licenses + bans + sources. Covers ground cargo audit doesn't (license-compat, git-dep allowlist).
2. **dependency-review** — GitHub's first-party action, blocks PR merge if Cargo.lock change introduces HIGH-severity advisories or off-allowlist licenses.
3. **stale** — auto-close stale issues (90+14 days) + PRs (60+14 days). Exempts pinned/bug/security/P0/P1.
4. **commitlint** — Conventional Commits enforcement on PR commits (matches existing CLAUDE.md discipline).

## Configs included

- `deny.toml` — license allowlist mirrors `dependency-review.yml`. Multiple versions tolerated (alloy + leptos transitively need it during migration).
- `.commitlintrc.json` — body-line-length disabled so multi-paragraph WHY explanations pass.

## Verification

YAML validated locally. No source-code change. CI will smoke each on this PR.

All third-party actions pinned by SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated commit message linting to enforce conventional commit types and header length limits.
  * Added dependency review checks to validate new dependencies and license policies.
  * Configured automated stale issue/PR management with custom timings and messages.
  * Strengthened supply-chain and dependency policies (updated deny rules and license/allowlist handling).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/599)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->