### PR TITLE
fix(ci): add NCSA to license allowlist (libfuzzer-sys)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,5 +27,5 @@ jobs:
           # Block merge on these severities; show all in comment.
           fail-on-severity: high
           # License allowlist mirrors deny.toml. Add to both when adding a license.
-          allow-licenses: MIT, Apache-2.0, Apache-2.0 WITH LLVM-exception, BSD-2-Clause, BSD-3-Clause, ISC, Unicode-DFS-2016, Unicode-3.0, CC0-1.0, 0BSD, MPL-2.0, Zlib, BUSL-1.1
+          allow-licenses: MIT, Apache-2.0, Apache-2.0 WITH LLVM-exception, BSD-2-Clause, BSD-3-Clause, ISC, Unicode-DFS-2016, Unicode-3.0, CC0-1.0, 0BSD, MPL-2.0, Zlib, NCSA, BUSL-1.1
           comment-summary-in-pr: on-failure

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@ allow = [
   "0BSD",
   "MPL-2.0",
   "Zlib",
+  "NCSA",
   "BUSL-1.1",
 ]
 confidence-threshold = 0.8


### PR DESCRIPTION
Dependency-review flagged `libfuzzer-sys@0.4.12` because its compound license `(MIT OR Apache-2.0) AND NCSA` includes NCSA which wasn't on our allowlist.

NCSA = University of Illinois Open Source License. OSI-approved, permissive (modified BSD), fully compatible with BUSL-1.1.

Added to both `dependency-review.yml` + `deny.toml` allowlists for sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency license allowlist to include NCSA-licensed packages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/604)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->