### PR TITLE
fix(ci): exempt Swatinem/rust-cache LGPL-3.0 from dependency-review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,4 +28,10 @@ jobs:
           fail-on-severity: high
           # License allowlist mirrors deny.toml. Add to both when adding a license.
           allow-licenses: MIT, Apache-2.0, Apache-2.0 WITH LLVM-exception, BSD-2-Clause, BSD-3-Clause, ISC, Unicode-DFS-2016, Unicode-3.0, CC0-1.0, 0BSD, MPL-2.0, Zlib, NCSA, BUSL-1.1
+          # Surgical exemptions — these dependencies are build-time only
+          # (GitHub Actions, never linked into the binary) so their
+          # copyleft licenses don't propagate to our redistributed
+          # artifact. Adding them to allow-licenses would be wrong because
+          # it would also accept LGPL Rust crates as runtime deps.
+          allow-dependencies-licenses: pkg:githubactions/Swatinem/rust-cache
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
Stops the Dependency Review X on every PR that uses the benchmark or fuzz workflow.

`Swatinem/rust-cache` is LGPL-3.0 — fine for a GitHub Action (build-time, not in our binary) but currently flagged because it's not on `allow-licenses`. **NOT adding LGPL-3.0 globally** because that would accept LGPL Rust crates as runtime deps (which would actually contaminate BUSL-1.1 redistribution).

Surgical fix: `allow-dependencies-licenses: pkg:githubactions/Swatinem/rust-cache`. Specific action exempted, broad LGPL still denied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to include license exemptions for build-time dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/606)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->