### PR TITLE
chore(ci): pin remaining unpinned actions in commitlint + fuzz

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -17,7 +17,7 @@ jobs:
     name: commitlint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload crash artifacts on failure
         if: failure() && steps.run.conclusion == 'failure'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: fuzz-crash-${{ matrix.target }}
           path: |


### PR DESCRIPTION
Self-audit pass caught 2 unpinned action references in workflows added today:

- `commitlint.yml` — `actions/checkout@v5`
- `fuzz.yml` — `actions/upload-artifact@v5`

Pinned both per existing repo policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to use pinned versions, improving build consistency and reproducibility across runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/608)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->