### PR TITLE
perf(trie): bump TRIE_PRUNE_EVERY 1000 → 5000

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -1889,7 +1889,16 @@ impl Blockchain {
     /// block applies. PRUNE_RUNNING gates overlap so a slow prune doesn't
     /// queue behind itself when the next boundary fires.
     pub fn maybe_prune_trie(&self) {
-        const TRIE_PRUNE_EVERY: u64 = 1000;
+        // 2026-05-12: bumped 1000 → 5000 because the per-1000-block
+        // prune walk takes 10–20 min on mainnet's 4.8 GB chain.db, and
+        // during the delete-batch phase MDBX write contention pushes
+        // bt from 2 s/blk to 5–10 s/blk. Stretching the interval 5×
+        // means fewer-but-longer contention windows (per hour) and
+        // more uninterrupted steady-state. TRIE_KEEP_VERSIONS unchanged
+        // — we still retain the last 1000 historical roots for any
+        // archive-node use; the deletion batch each prune just covers
+        // a larger range of older versions (~4000 instead of ~0–1000).
+        const TRIE_PRUNE_EVERY: u64 = 5000;
         const TRIE_KEEP_VERSIONS: u64 = 1000;
 
         let height = self.height();


### PR DESCRIPTION
## Summary

Bumps `TRIE_PRUNE_EVERY` from 1000 → 5000 in `blockchain.rs::maybe_prune_trie`. `TRIE_KEEP_VERSIONS` stays at 1000.

(Re-open of #609 — closed because the original commit didn't use a conventional-commit type and commitlint blocked merge.)

## Why

The 1000-block prune cycle on mainnet is producing 5-10 s/blk bt windows for 3-20 min at every multiple of 1000 because the prune delete batch contends with the apply path's trie writes on the MDBX write txn. The walk itself runs on its own thread (since 2.2.4), but each individual delete is a small write txn that interleaves with apply's commits.

Bumping to 5000 trades:

- **Before:** every ~25 min, 3-10 min degraded
- **After:** every ~2 hours, 15-25 min degraded

Same total prune work over 24 h, just concentrated in 5× fewer windows. Each window's contention is longer but the steady-state stretches between are much longer too. Net: better predictability + more time at the 1.7-2.5 s/blk floor.

## Trade-offs

- chain.db grows ~5× more between cycles (~25 MB extra vs ~5 MB at current 5 MB/1000-block growth rate — negligible on a 4.8 GB chain.db)
- `TRIE_KEEP_VERSIONS` unchanged: archive nodes still retain the last 1000 historical roots; the delete batch each prune just covers a larger range of older versions (~4000 instead of ~0-1000)

## Test plan

- [x] `cargo check -p sentrix-core --release` with `-D warnings` clean
- [x] 212 sentrix-core tests pass locally
- [ ] Testnet bake: confirm clean h=N×5000 boundary apply
- [ ] Mainnet bake: observe cadence + per-cycle duration vs current

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized blockchain maintenance operations to reduce processing overhead and improve overall system performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/610)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->