### PR TITLE
fix(ci): reset Cargo.lock before bench-results checkout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,6 +55,15 @@ jobs:
           cargo bench --bench trie_insert -p sentrix-trie -- --output-format bencher \
             | tee bench-output.txt
 
+      - name: Reset cargo-modified files before bench-results checkout
+        # github-action-benchmark's first step is `git switch bench-results`,
+        # which aborts if Cargo.lock (or anything else) is dirty from the
+        # bench run. Reset working tree but keep bench-output.txt for the
+        # next step.
+        run: |
+          git checkout -- Cargo.lock || true
+          git stash --include-untracked -- '*.rs' '*.toml' || true
+
       - name: Store + compare against baseline
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1
         with:


### PR DESCRIPTION
github-action-benchmark's internal `git switch bench-results` aborts when `cargo bench` leaves Cargo.lock dirty (every PR currently fails this step). Adds an explicit `git checkout -- Cargo.lock` between the bench run and the benchmark-action step.

Blocks every PR that touches code (every `cargo bench` leaves Cargo.lock dirty). #610 just merged because benchmark check was non-required — but the workflow is wasting CI minutes on every PR until this fix lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved benchmark workflow stability by adding cleanup steps to ensure a clean workspace state during CI operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/611)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->