### PR TITLE
perf(trie): batch node + value + root in a single MDBX transaction

### DIFF
--- a/crates/sentrix-trie/src/cache.rs
+++ b/crates/sentrix-trie/src/cache.rs
@@ -3,7 +3,8 @@
 use crate::node::{NodeHash, TrieNode};
 use crate::storage::TrieStorage;
 use lru::LruCache;
-use sentrix_primitives::SentrixResult;
+use sentrix_primitives::{SentrixError, SentrixResult};
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Mutex;
 
@@ -11,8 +12,22 @@ use std::sync::Mutex;
 /// The LRU is wrapped in a Mutex to allow shared-reference access (V7-M-03).
 /// This enables `prove()` on SentrixTrie to take `&self` (read lock on blockchain
 /// is sufficient for proof generation — no write lock needed).
+///
+/// `pending_nodes` / `pending_values` buffer the trie writes for the
+/// current uncommitted version. `put_node` / `store_value` write here +
+/// to the LRU, never to MDBX directly. `flush_pending(version, root)`
+/// drains both buffers in a single MDBX transaction (batched write),
+/// avoiding the per-op transaction overhead that dominated the trie
+/// phase of block apply (~340 ms → ~15 ms expected on mainnet).
+///
+/// Reads hit LRU → pending → MDBX in order. A buffered write is always
+/// also in the LRU, so the pending lookup only matters if LRU evicted
+/// the entry before flush — at the 10 k default capacity this is
+/// extremely rare, but the path covers it for correctness.
 pub struct TrieCache {
     lru: Mutex<LruCache<NodeHash, TrieNode>>,
+    pending_nodes: Mutex<HashMap<NodeHash, TrieNode>>,
+    pending_values: Mutex<HashMap<NodeHash, Vec<u8>>>,
     pub(crate) storage: TrieStorage,
     /// Stored for use by Clone (V7-I-03).
     pub(crate) capacity: usize,
@@ -26,6 +41,8 @@ impl TrieCache {
         let cap = NonZeroUsize::new(capacity).unwrap_or(NonZeroUsize::MIN);
         Self {
             lru: Mutex::new(LruCache::new(cap)),
+            pending_nodes: Mutex::new(HashMap::new()),
+            pending_values: Mutex::new(HashMap::new()),
             storage,
             capacity,
         }
@@ -33,9 +50,25 @@ impl TrieCache {
 
     /// Acquire the LRU lock, mapping a poison error to SentrixError::Internal.
     fn lock_lru(&self) -> SentrixResult<std::sync::MutexGuard<'_, LruCache<NodeHash, TrieNode>>> {
-        self.lru.lock().map_err(|e| {
-            sentrix_primitives::SentrixError::Internal(format!("trie LRU lock poisoned: {e}"))
-        })
+        self.lru
+            .lock()
+            .map_err(|e| SentrixError::Internal(format!("trie LRU lock poisoned: {e}")))
+    }
+
+    fn lock_pending_nodes(
+        &self,
+    ) -> SentrixResult<std::sync::MutexGuard<'_, HashMap<NodeHash, TrieNode>>> {
+        self.pending_nodes
+            .lock()
+            .map_err(|e| SentrixError::Internal(format!("trie pending_nodes lock poisoned: {e}")))
+    }
+
+    fn lock_pending_values(
+        &self,
+    ) -> SentrixResult<std::sync::MutexGuard<'_, HashMap<NodeHash, Vec<u8>>>> {
+        self.pending_values
+            .lock()
+            .map_err(|e| SentrixError::Internal(format!("trie pending_values lock poisoned: {e}")))
     }
 
     /// Fetch a node by hash — LRU first, then persistent storage.
@@ -54,7 +87,20 @@ impl TrieCache {
         if let Some(node) = lru.get(hash) {
             return Ok(Some(node.clone()));
         }
-        // Miss — load from MDBX while still holding the lock. This
+        // LRU miss — try the pending-write buffer (the entry might be a
+        // node we just put_node()'d this block, not yet flushed to MDBX).
+        // We check pending BEFORE MDBX because the LRU is the primary
+        // hot-path; pending is a small fallback when LRU evicted under
+        // pressure within the same uncommitted block.
+        {
+            let pending = self.lock_pending_nodes()?;
+            if let Some(node) = pending.get(hash) {
+                let cloned = node.clone();
+                lru.put(*hash, cloned.clone());
+                return Ok(Some(cloned));
+            }
+        }
+        // Miss — load from MDBX while still holding the LRU lock. This
         // serialises miss fills against concurrent deletes, preventing
         // the stale-resurrection race documented above.
         let opt = self.storage.load_node(hash)?;
@@ -64,22 +110,58 @@ impl TrieCache {
         Ok(opt)
     }
 
-    /// Write a node to both cache and persistent storage.
+    /// Buffer a node write to be flushed in the next commit. Also puts
+    /// into the LRU so reads in the current block see it without a
+    /// pending-buffer lookup.
     pub fn put_node(&self, hash: NodeHash, node: TrieNode) -> SentrixResult<()> {
-        self.storage.store_node(&hash, &node)?;
+        {
+            let mut pending = self.lock_pending_nodes()?;
+            pending.insert(hash, node.clone());
+        }
         let mut lru = self.lock_lru()?;
         lru.put(hash, node);
         Ok(())
     }
 
-    /// Persist a raw value blob keyed by its value_hash.
+    /// Buffer a value-blob write to be flushed in the next commit.
     pub fn store_value(&self, hash: &NodeHash, value: &[u8]) -> SentrixResult<()> {
-        self.storage.store_value(hash, value)
+        let mut pending = self.lock_pending_values()?;
+        pending.insert(*hash, value.to_vec());
+        Ok(())
     }
 
-    /// Load a raw value blob by value_hash.
+    /// Load a raw value blob by value_hash. Check pending buffer first
+    /// (current uncommitted block's writes), fall back to MDBX.
     pub fn load_value(&self, hash: &NodeHash) -> SentrixResult<Option<Vec<u8>>> {
+        {
+            let pending = self.lock_pending_values()?;
+            if let Some(v) = pending.get(hash) {
+                return Ok(Some(v.clone()));
+            }
+        }
         self.storage.load_value(hash)
+    }
+
+    /// Drain both pending buffers + write the root + reverse-index entry
+    /// in a single MDBX transaction. Called by `Trie::commit(version)`.
+    /// Atomic by construction — either every buffered write lands together
+    /// with the root advance, or nothing changes (MDBX rollback on error).
+    pub fn flush_pending(&self, version: u64, root: &NodeHash) -> SentrixResult<()> {
+        let nodes: Vec<(NodeHash, TrieNode)> = {
+            let pending = self.lock_pending_nodes()?;
+            pending.iter().map(|(k, v)| (*k, v.clone())).collect()
+        };
+        let values: Vec<(NodeHash, Vec<u8>)> = {
+            let pending = self.lock_pending_values()?;
+            pending.iter().map(|(k, v)| (*k, v.clone())).collect()
+        };
+        self.storage
+            .flush_trie_batch(&nodes, &values, version, root)?;
+        // Only clear after a successful MDBX commit so a failure leaves
+        // the buffers intact for the next retry.
+        self.lock_pending_nodes()?.clear();
+        self.lock_pending_values()?.clear();
+        Ok(())
     }
 
     /// T-B: Evict a node from the LRU cache and remove it from persistent storage.
@@ -98,12 +180,19 @@ impl TrieCache {
         let mut lru = self.lock_lru()?;
         self.storage.delete_node(hash)?;
         lru.pop(hash);
+        // Also drop from the pending buffer, otherwise a node that was
+        // put_node'd this block and then delete_node'd would survive in
+        // pending and re-land in MDBX at the next flush — defeating the
+        // delete.
+        self.lock_pending_nodes()?.remove(hash);
         Ok(())
     }
 
-    /// T-B: Remove a value blob from persistent storage.
+    /// T-B: Remove a value blob from persistent storage + pending buffer.
     pub fn delete_value(&self, hash: &NodeHash) -> SentrixResult<()> {
-        self.storage.delete_value(hash)
+        self.storage.delete_value(hash)?;
+        self.lock_pending_values()?.remove(hash);
+        Ok(())
     }
 }
 
@@ -170,5 +259,77 @@ mod tests {
     fn test_cache_capacity_stored() {
         let (_dir, cache) = temp_cache(42);
         assert_eq!(cache.capacity, 42);
+    }
+
+    /// Regression test for the batched-commit path.
+    ///
+    /// Invariant: between `put_node` and `flush_pending`, the buffered
+    /// nodes are visible via `get_node` (LRU + pending fallback) but NOT
+    /// yet present in persistent MDBX. After `flush_pending`, MDBX
+    /// contains them and the buffer is empty.
+    ///
+    /// Locks in the new contract — fails on `main` before this change
+    /// (where `put_node` was synchronous-write).
+    #[test]
+    fn test_pending_buffer_visible_before_flush_persistent_after() {
+        let (_dir, cache) = temp_cache(10_000);
+        let h1 = {
+            let mut h = [0u8; 32];
+            h[0] = 0x01;
+            h
+        };
+        let node1 = TrieNode::Leaf {
+            key: [0u8; 32],
+            value_hash: [0u8; 32],
+        };
+
+        cache.put_node(h1, node1.clone()).unwrap();
+        cache.store_value(&h1, b"hello").unwrap();
+
+        // Visible via cache (LRU hit).
+        assert!(cache.get_node(&h1).unwrap().is_some());
+        // Visible via cache (load_value checks pending first).
+        assert_eq!(cache.load_value(&h1).unwrap(), Some(b"hello".to_vec()));
+        // NOT yet in persistent storage.
+        assert!(cache.storage.load_node(&h1).unwrap().is_none());
+        assert!(cache.storage.load_value(&h1).unwrap().is_none());
+
+        // Flush — single MDBX transaction lands nodes + values + root.
+        let root_hash = [0xAB; 32];
+        cache.flush_pending(0, &root_hash).unwrap();
+
+        // Now in persistent storage.
+        assert!(cache.storage.load_node(&h1).unwrap().is_some());
+        assert_eq!(cache.storage.load_value(&h1).unwrap(), Some(b"hello".to_vec()));
+        // Root stored too.
+        assert_eq!(cache.storage.load_root(0).unwrap(), Some(root_hash));
+        // Pending buffers drained.
+        assert!(cache.lock_pending_nodes().unwrap().is_empty());
+        assert!(cache.lock_pending_values().unwrap().is_empty());
+    }
+
+    /// `get_node` falls through LRU → pending → MDBX. If a node is in
+    /// pending but LRU has been evicted under capacity pressure, the
+    /// pending fallback must still serve the read.
+    #[test]
+    fn test_get_node_falls_back_to_pending_after_lru_eviction() {
+        let (_dir, cache) = temp_cache(2); // tiny LRU
+        let mk_hash = |b: u8| {
+            let mut h = [0u8; 32];
+            h[0] = b;
+            h
+        };
+        let node = TrieNode::Leaf {
+            key: [0u8; 32],
+            value_hash: [0u8; 32],
+        };
+
+        cache.put_node(mk_hash(1), node.clone()).unwrap();
+        cache.put_node(mk_hash(2), node.clone()).unwrap();
+        cache.put_node(mk_hash(3), node.clone()).unwrap(); // evicts h(1) from LRU
+        // h(1) was just evicted from LRU but it's still in pending —
+        // pre-flush, MDBX doesn't have it yet. get_node must find it
+        // via the pending fallback or the test catches the regression.
+        assert!(cache.get_node(&mk_hash(1)).unwrap().is_some());
     }
 }

--- a/crates/sentrix-trie/src/storage.rs
+++ b/crates/sentrix-trie/src/storage.rs
@@ -75,6 +75,63 @@ impl TrieStorage {
         Ok(())
     }
 
+    /// Flush a buffer of (node, value) writes plus the new root + reverse-index
+    /// entry in a single MDBX transaction. Replaces the per-node + per-value
+    /// individual `put()` calls that opened a fresh MDBX transaction each —
+    /// ~2560 writes per typical mainnet block × ~150 µs per transaction
+    /// = the bulk of the trie phase in `apply_profile`. Batched, the same
+    /// 2560 puts share one transaction and one fsync.
+    ///
+    /// Atomicity is critical: the root advance must land in the same MDBX
+    /// commit as the node/value writes it references, otherwise a crash
+    /// between flushing nodes and storing the root would leave us with a
+    /// fresh root pointing into the previous block's node set on next boot.
+    /// Single tx fixes this by construction.
+    pub fn flush_trie_batch(
+        &self,
+        pending_nodes: &[(NodeHash, TrieNode)],
+        pending_values: &[(NodeHash, Vec<u8>)],
+        version: u64,
+        root: &NodeHash,
+    ) -> SentrixResult<()> {
+        let batch = self
+            .mdbx
+            .begin_write()
+            .map_err(|e| SentrixError::StorageError(e.to_string()))?;
+
+        for (hash, node) in pending_nodes {
+            let bytes = bincode::serialize(node)
+                .map_err(|e| SentrixError::SerializationError(e.to_string()))?;
+            batch
+                .put(tables::TABLE_TRIE_NODES, hash, &bytes)
+                .map_err(|e| SentrixError::StorageError(e.to_string()))?;
+        }
+        for (hash, value) in pending_values {
+            batch
+                .put(tables::TABLE_TRIE_VALUES, hash, value)
+                .map_err(|e| SentrixError::StorageError(e.to_string()))?;
+        }
+        batch
+            .put(
+                tables::TABLE_TRIE_ROOTS,
+                &version.to_be_bytes(),
+                root.as_slice(),
+            )
+            .map_err(|e| SentrixError::StorageError(e.to_string()))?;
+        batch
+            .put(
+                tables::TABLE_TRIE_COMMITTED,
+                root.as_slice(),
+                &version.to_be_bytes(),
+            )
+            .map_err(|e| SentrixError::StorageError(e.to_string()))?;
+
+        batch
+            .commit()
+            .map_err(|e| SentrixError::StorageError(e.to_string()))?;
+        Ok(())
+    }
+
     pub fn load_node(&self, hash: &NodeHash) -> SentrixResult<Option<TrieNode>> {
         match self
             .mdbx

--- a/crates/sentrix-trie/src/tree.rs
+++ b/crates/sentrix-trie/src/tree.rs
@@ -421,7 +421,10 @@ impl SentrixTrie {
     /// Persist the current root under `version` (block height) and advance the trie version.
     /// Call once per block after all inserts for that block are done.
     pub fn commit(&mut self, version: u64) -> SentrixResult<NodeHash> {
-        self.cache.storage.store_root(version, &self.root)?;
+        // Drain the per-block write buffer + store the root in one MDBX
+        // transaction. Atomic — a crash mid-commit either lands the full
+        // (nodes, values, root, reverse-index) tuple or none of it.
+        self.cache.flush_pending(version, &self.root)?;
         self.version = version;
         Ok(self.root)
     }
@@ -1246,6 +1249,9 @@ mod tests {
             let val = account_value_bytes(1_000_000 * i as u64, i as u64);
             trie.insert(&key, &val).unwrap();
         }
+        // commit() flushes the pending node + value buffer to MDBX —
+        // verify_integrity walks MDBX directly so commit must precede it.
+        trie.commit(0).unwrap();
         trie.verify_integrity().unwrap();
     }
 
@@ -1261,6 +1267,8 @@ mod tests {
             let key = address_to_key(&addr);
             trie.insert(&key, &account_value_bytes(1_000 * i as u64, 0)).unwrap();
         }
+        // Flush pending writes to MDBX before we can damage them.
+        trie.commit(0).unwrap();
 
         // The root is an Internal node — delete it (or one of its children)
         // to simulate orphan reference.
@@ -1287,6 +1295,8 @@ mod tests {
         let key = address_to_key(addr);
         let val = account_value_bytes(777, 0);
         trie.insert(&key, &val).unwrap();
+        // Flush pending writes to MDBX so storage.load_node sees them.
+        trie.commit(0).unwrap();
 
         // Walk from root to find the single Leaf and delete its value.
         let mut node_hash = trie.root;


### PR DESCRIPTION
## Summary

Per-block trie commit dominates block apply on mainnet (\`SENTRIX_APPLY_PROFILE\` traces consistently show **trie ~340 ms** vs tx_apply ~50 ms vs post ~10 ms). Root cause: every \`cache.put_node\` / \`cache.store_value\` opens a fresh MDBX read-write transaction, writes one key, commits, fsyncs. A typical mainnet block does ~2,560 trie node writes + per-account value writes, so the trie phase paid **2,500+ transactions worth of fsync overhead** serially. The \`WriteBatch\` API in \`sentrix-storage\` already exists but the trie didn't use it.

This PR buffers the writes in a per-block pending buffer and drains them through one \`WriteBatch\` inside \`Trie::commit\`. The batch carries the buffered nodes, values, the \`trie_roots\` entry, and the \`trie_committed_roots\` reverse-index — all in one transaction.

## Expected impact

Back-of-envelope:
- Before: 2,560 transactions × ~150 µs/fsync = **~380 ms** (matches the observed trie phase)
- After: 1 transaction × 30 µs + 2,560 puts × ~5 µs = **~13 ms**
- Trie phase drops ~340 ms → ~15-50 ms.
- Mainnet steady-state bt floor potentially **~2.5 s → ~2.0 s**.

Will need an \`SENTRIX_APPLY_PROFILE=1\` run on testnet to confirm.

## Read-path semantics

\`get_node\` now checks LRU → pending → MDBX (was LRU → MDBX). The pending fallback only matters when LRU evicted a buffered node under capacity pressure inside the same uncommitted block — rare at the 10 k default, but covered by a regression test (\`test_get_node_falls_back_to_pending_after_lru_eviction\`).

\`load_value\` similarly checks pending → MDBX.

## Crash safety — strictly stronger than before

The buffer drains only inside \`commit\`, and \`commit\` flushes the nodes + the root in a single MDBX transaction. A crash mid-commit either lands the full \`(nodes, values, root, reverse-index)\` tuple or nothing.

Pre-change, a crash between writing all the nodes and writing the root could leave a fresh root pointing at the previous block's node set. This is now structurally impossible.

## Concurrency

\`prune\` runs in a background thread (v2.2.4) and only deletes nodes NOT referenced by any committed root. Buffered nodes aren't reachable from any committed root yet (the root advance lands together with them in the same commit), so prune never touches buffered nodes.

\`delete_node\` / \`delete_value\` now also drop from the pending buffer so a delete-after-put within the same block doesn't re-land at flush.

## Tests

- \`test_pending_buffer_visible_before_flush_persistent_after\` — pins the new invariant: between put and flush, nodes are visible via cache but not in MDBX; after flush, they're in MDBX and pending is drained.
- \`test_get_node_falls_back_to_pending_after_lru_eviction\` — pins the LRU → pending → MDBX read order under eviction pressure.
- Three pre-existing \`verify_integrity_*\` tests adjusted to call \`commit()\` before walking MDBX (was an undocumented coupling on synchronous-write semantics).
- All 59 sentrix-trie tests pass. sentrix-core 8 tests pass.

## Discipline gates

This is consensus-touching. Per the operating rules:
- One conceptual change ✓ (no surrounding cleanup bundled)
- Regression test that fails on \`main\` + passes here ✓
- Fresh-brain review required — please do not self-merge in the same session this was written
- Testnet bake before mainnet activation

## Build

\`\`\`
RUSTFLAGS="-D warnings" cargo check -p sentrix-trie -p sentrix-core   # clean
RUSTFLAGS="-D warnings" cargo clippy -p sentrix-trie -p sentrix-core --tests   # clean
cargo test -p sentrix-trie --release   # 59 passed
cargo test -p sentrix-core --release   # 8 passed
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cache now buffers write operations and persists them atomically in batches for improved performance.
  * Added explicit flush method to finalize pending cache operations.

* **Bug Fixes**
  * Deletion operations now correctly prevent deleted items from reappearing after flushes.

* **Tests**
  * Improved test coverage for batched persistence operations and cache lifecycle validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/627)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->