### PR TITLE
feat(core): SENTRIX_DISABLE_TRIE_PRUNE for archive-mode opt-in

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -1901,6 +1901,18 @@ impl Blockchain {
         const TRIE_PRUNE_EVERY: u64 = 5000;
         const TRIE_KEEP_VERSIONS: u64 = 1000;
 
+        // Archive-mode opt-in: when SENTRIX_DISABLE_TRIE_PRUNE=1 is set
+        // in the environment, the periodic prune skips entirely. The
+        // node accumulates every historical trie version, enabling
+        // state-at-past-block queries (eth_call at historic h, bridge
+        // proofs, explorer historical analytics). Off by default — only
+        // the dedicated archive fullnode sets this; validators stay
+        // lean. Predicate matches SENTRIX_APPLY_PROFILE's "1"-only
+        // semantics (block_executor.rs:635) for consistency.
+        if trie_prune_disabled() {
+            return;
+        }
+
         let height = self.height();
         if height == 0 || !height.is_multiple_of(TRIE_PRUNE_EVERY) {
             return;
@@ -1967,6 +1979,24 @@ impl Blockchain {
 /// — storage will continue to grow until the next successful prune, same
 /// as the existing "failed prune" semantics documented above.
 static PRUNE_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Archive-mode opt-in. When `SENTRIX_DISABLE_TRIE_PRUNE=1` is set in
+/// the environment, [`Blockchain::maybe_prune_trie`] returns immediately
+/// without scheduling a prune. The node accumulates every historical
+/// trie version forever — enabling state-at-past-block queries
+/// (`eth_call` at historic h, bridge proofs, explorer historical
+/// analytics) at the cost of unbounded disk growth.
+///
+/// Default off. Production validators leave this unset and keep the
+/// rolling `TRIE_KEEP_VERSIONS = 1000` window. Dedicated archive
+/// fullnodes set this flag.
+///
+/// Match SENTRIX_APPLY_PROFILE's strict "1" semantics (any other value
+/// is treated as off) so accidental `=true` / `=yes` / empty-value
+/// settings don't silently activate the archive path.
+fn trie_prune_disabled() -> bool {
+    std::env::var_os("SENTRIX_DISABLE_TRIE_PRUNE").is_some_and(|v| v == "1")
+}
 
 #[cfg(test)]
 mod tests {
@@ -2923,6 +2953,39 @@ mod tests {
 
         assert!(bc.add_to_mempool(tx).is_ok());
         assert_eq!(bc.mempool_size(), 1);
+    }
+
+    // ── Archive-mode opt-in: SENTRIX_DISABLE_TRIE_PRUNE ─────────
+
+    /// `trie_prune_disabled()` reflects exactly the env var state.
+    /// Default off; set "1" to enable; other values (empty, "true",
+    /// "yes", "0") all map to disabled-flag-off-prune-still-runs.
+    #[test]
+    fn test_trie_prune_disabled_env_var() {
+        let _guard = crate::test_util::env_test_lock();
+        unsafe {
+            // Baseline: unset → prune runs (predicate false).
+            std::env::remove_var("SENTRIX_DISABLE_TRIE_PRUNE");
+            assert!(!trie_prune_disabled());
+
+            // Strict "1" → archive mode on.
+            std::env::set_var("SENTRIX_DISABLE_TRIE_PRUNE", "1");
+            assert!(trie_prune_disabled());
+
+            // Anything else → treated as off (no silent activation).
+            std::env::set_var("SENTRIX_DISABLE_TRIE_PRUNE", "");
+            assert!(!trie_prune_disabled());
+            std::env::set_var("SENTRIX_DISABLE_TRIE_PRUNE", "true");
+            assert!(!trie_prune_disabled());
+            std::env::set_var("SENTRIX_DISABLE_TRIE_PRUNE", "yes");
+            assert!(!trie_prune_disabled());
+            std::env::set_var("SENTRIX_DISABLE_TRIE_PRUNE", "0");
+            assert!(!trie_prune_disabled());
+
+            // Cleanup so other tests see a clean env.
+            std::env::remove_var("SENTRIX_DISABLE_TRIE_PRUNE");
+            assert!(!trie_prune_disabled());
+        }
     }
 
     // ── M-04: Mempool TTL + prune_mempool() ─────────────


### PR DESCRIPTION
## Summary

Adds an env-var toggle on \`Blockchain::maybe_prune_trie\`. When \`SENTRIX_DISABLE_TRIE_PRUNE=1\` is set, the periodic prune skips entirely. The node accumulates every historical trie version, enabling state-at-past-block queries (historic \`eth_call\`, bridge proofs, explorer historical analytics) at the cost of unbounded disk growth.

**Default off.** Validators leave this unset and keep the existing rolling \`TRIE_KEEP_VERSIONS = 1000\` window. Only the dedicated archive fullnode (planned vps6 deployment, separate PR for the runbook) sets the flag.

## Why this shape

Sentrix already runs Cosmos-style sentry separation — validators sign, fullnodes serve RPC. The trie prune is hardcoded on every node today; we have no way to ask one fullnode to retain full history without forking the binary. This toggle is the smallest change that unblocks an archive fullnode without affecting any other node.

Three consumers we know want this:
- **Indexer** (\`Sentriscloud/indexer-rs\`) — currently walks block bodies (chain already retains those); fine without state archive today, but historic-tx-search wants \`eth_call\` at past h
- **Bridge production proofs** (LayerZero / Hyperlane mainnet, future workstream)
- **Public dApp historic analytics** — speculative

## Strict semantics

Matches \`SENTRIX_APPLY_PROFILE\`'s existing \`"1"\`-only convention (see \`block_executor.rs:635\`). Accidental \`=true\` / \`=yes\` / empty-value settings do NOT activate the archive path — explicit \`"1"\` only. Test covers every case.

## Code surface

- \`crates/sentrix-core/src/blockchain.rs\`: +1 early-return + \`trie_prune_disabled()\` helper + regression test
- No other file touched

## Consensus-touching gates

This sits on the trie-prune hot path. Per project rules:

- [x] One conceptual change — no surrounding cleanup
- [x] Regression test that fails on \`main\` (no helper exists) and passes here
- [x] **Fresh-brain review required** — please review in a different session before merging
- [x] Testnet bake before mainnet enables the flag on any node — though setting the flag on a *new* archive fullnode (genesis sync) is lower-risk than flipping it on an existing validator, since the production validators continue to behave identically

## Test

\`\`\`
cargo test -p sentrix-core --release   # 213 passed
cargo test -p sentrix-core --release test_trie_prune_disabled_env_var   # 1 passed
RUSTFLAGS="-D warnings" cargo check -p sentrix-core   # clean
RUSTFLAGS="-D warnings" cargo clippy -p sentrix-core --tests   # clean
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Archive mode: the environment variable SENTRIX_DISABLE_TRIE_PRUNE now requires the exact value "1" to disable automatic trie pruning. Other values (including empty or boolean-like strings) keep pruning enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/633)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->