### PR TITLE
refactor(core): extract address validation + protocol constants

### DIFF
--- a/crates/sentrix-core/src/address.rs
+++ b/crates/sentrix-core/src/address.rs
@@ -1,0 +1,102 @@
+//! Sentrix address format validation + protocol-reserved constants.
+//!
+//! Extracted from `crate::blockchain` so the validation helpers and the
+//! handful of compiled-in protocol addresses live in one focused module.
+//! All symbols are re-exported from `crate::blockchain::*` so existing
+//! caller paths continue to resolve unchanged.
+
+/// Sentrix addresses are 42-char hex strings (0x + 40 hex digits).
+///
+/// This is the only structural check — case is not normalised here
+/// (callers that need a canonical form lowercase the string before
+/// indexing). Use [`is_spendable_sentrix_address`] when the address
+/// is the target of a value transfer to reject the burn sentinel
+/// silently.
+pub fn is_valid_sentrix_address(addr: &str) -> bool {
+    addr.len() == 42 && addr.starts_with("0x") && addr[2..].chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Canonical zero address. Used as a burn sink by `AuthorityManager`
+/// and as an invalid target for value-bearing token operations (M-02).
+pub const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+
+/// Sentrix address that is valid-format AND not the burn sentinel. Use
+/// this for value-bearing targets (token transfers, mints, SRX sends)
+/// where the zero address would silently burn tokens without setting
+/// the protocol's `total_burned` counter. [`is_valid_sentrix_address`]
+/// alone remains the right guard for addresses that legitimately
+/// include the zero sentinel (e.g. internal tracking fields).
+pub fn is_spendable_sentrix_address(addr: &str) -> bool {
+    is_valid_sentrix_address(addr) && addr != ZERO_ADDRESS
+}
+
+// ── Protocol-reserved addresses ──────────────────────────────────────
+// The canonical premine allocations live in `genesis/mainnet.toml` and
+// load via [`crate::Genesis`]. Only constants still referenced at
+// runtime (outside of initialisation) live here.
+
+/// Ecosystem Fund receives the ecosystem share of token-operation fees
+/// (see `token_ops.rs`). Kept as a const because it is a compiled-in
+/// protocol parameter, not just a premine recipient.
+pub const ECOSYSTEM_FUND_ADDRESS: &str = "0xeb70fdefd00fdb768dec06c478f450c351499f14";
+
+/// Total premine across all genesis allocations, in sentri units. An
+/// economic invariant of the mainnet spec; surfaced for tests / tooling.
+/// Drift against `genesis/mainnet.toml` is caught by
+/// `test_total_premine_matches_hardcoded` in `genesis.rs`.
+pub const TOTAL_PREMINE: u64 = 63_000_000 * 100_000_000;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_address_accepts_42_char_hex() {
+        assert!(is_valid_sentrix_address(
+            "0x0123456789abcdef0123456789ABCDEF01234567"
+        ));
+    }
+
+    #[test]
+    fn valid_address_rejects_wrong_length() {
+        assert!(!is_valid_sentrix_address("0xabcd"));
+        assert!(!is_valid_sentrix_address(
+            "0x0123456789abcdef0123456789abcdef0123456789"
+        ));
+    }
+
+    #[test]
+    fn valid_address_rejects_missing_prefix() {
+        assert!(!is_valid_sentrix_address(
+            "0123456789abcdef0123456789abcdef01234567"
+        ));
+    }
+
+    #[test]
+    fn valid_address_rejects_non_hex() {
+        assert!(!is_valid_sentrix_address(
+            "0x0123456789ABCDEFGHIJ0123456789abcdef0123"
+        ));
+    }
+
+    #[test]
+    fn spendable_address_rejects_zero() {
+        assert!(is_valid_sentrix_address(ZERO_ADDRESS));
+        assert!(!is_spendable_sentrix_address(ZERO_ADDRESS));
+    }
+
+    #[test]
+    fn spendable_accepts_real_address() {
+        let real = "0x753f2f68829fbe76a0132295624f48b27ce2e2d9";
+        assert!(is_valid_sentrix_address(real));
+        assert!(is_spendable_sentrix_address(real));
+    }
+
+    #[test]
+    fn protocol_constants_self_consistent() {
+        assert_eq!(ZERO_ADDRESS.len(), 42);
+        assert!(is_valid_sentrix_address(ECOSYSTEM_FUND_ADDRESS));
+        assert!(is_spendable_sentrix_address(ECOSYSTEM_FUND_ADDRESS));
+        assert_eq!(TOTAL_PREMINE, 63_000_000_u64 * 100_000_000);
+    }
+}

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -76,40 +76,13 @@ pub const MEMPOOL_MAX_AGE_SECS: u64 = 3_600; // 1 hour
 // Sliding window size — only last N blocks kept in RAM; older blocks stay in MDBX storage
 pub const CHAIN_WINDOW_SIZE: usize = 1_000;
 
-// Sentrix addresses are 42-char hex strings (0x + 40 hex digits)
-pub fn is_valid_sentrix_address(addr: &str) -> bool {
-    addr.len() == 42 && addr.starts_with("0x") && addr[2..].chars().all(|c| c.is_ascii_hexdigit())
-}
-
-/// Canonical zero address. Used as a burn sink by AuthorityManager and
-/// as an invalid target for value-bearing token operations (M-02).
-pub const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
-
-/// Sentrix address that is valid-format AND not the burn sentinel. Use
-/// this for value-bearing targets (token transfers, mints, SRX sends)
-/// where the zero address would silently burn tokens without setting
-/// the protocol's `total_burned` counter. `is_valid_sentrix_address`
-/// alone remains the right guard for addresses that legitimately
-/// include the zero sentinel (e.g. internal tracking fields).
-pub fn is_spendable_sentrix_address(addr: &str) -> bool {
-    is_valid_sentrix_address(addr) && addr != ZERO_ADDRESS
-}
-
-// ── Genesis addresses ────────────────────────────────────
-// The canonical premine allocations now live in `genesis/mainnet.toml` and
-// are loaded via [`crate::Genesis`]. Only constants still referenced at
-// runtime (outside of initialisation) remain here.
-
-/// Ecosystem Fund receives the ecosystem share of token-operation fees
-/// (see `token_ops.rs`). Kept as a const because it is a compiled-in
-/// protocol parameter, not just a premine recipient.
-pub const ECOSYSTEM_FUND_ADDRESS: &str = "0xeb70fdefd00fdb768dec06c478f450c351499f14";
-
-/// Total premine across all genesis allocations, in sentri units. This is
-/// an economic invariant of the mainnet spec and is still exposed for
-/// tests / tooling. Drift against `genesis/mainnet.toml` is caught by
-/// `test_total_premine_matches_hardcoded` in `genesis.rs`.
-pub const TOTAL_PREMINE: u64 = 63_000_000 * 100_000_000;
+// Address validation + protocol-reserved address constants live in
+// `crate::address` now — re-export so the existing import paths
+// (`crate::blockchain::is_valid_sentrix_address` etc.) still resolve.
+pub use crate::address::{
+    ECOSYSTEM_FUND_ADDRESS, TOTAL_PREMINE, ZERO_ADDRESS,
+    is_spendable_sentrix_address, is_valid_sentrix_address,
+};
 
 // ── Blockchain struct ────────────────────────────────────
 // Chain field excluded from serde — blocks are saved individually in MDBX storage

--- a/crates/sentrix-core/src/lib.rs
+++ b/crates/sentrix-core/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![allow(missing_docs)]
 
+pub mod address;
 pub mod authority;
 pub mod block_executor;
 pub mod block_producer;


### PR DESCRIPTION
## Why

\`is_valid_sentrix_address\` / \`is_spendable_sentrix_address\` + the protocol-reserved address constants (\`ZERO_ADDRESS\`, \`ECOSYSTEM_FUND_ADDRESS\`, \`TOTAL_PREMINE\`) live at the top of \`blockchain.rs\` for historical reasons. They're pure validation helpers with zero dependency on the \`Blockchain\` struct — natural module of their own.

## Behaviour: bit-identical

\`crate::address\` houses everything; \`blockchain.rs\` re-exports via \`pub use crate::address::*\`. Every existing import path continues to resolve:
- \`crate::blockchain::is_valid_sentrix_address\` ✓
- \`crate::blockchain::is_spendable_sentrix_address\` ✓
- \`crate::blockchain::{ZERO_ADDRESS, ECOSYSTEM_FUND_ADDRESS, TOTAL_PREMINE}\` ✓
- \`sentrix_core::blockchain::is_valid_sentrix_address\` (external from sentrix-rpc) ✓

Callers verified — many internal in sentrix-core (mempool, block_executor, authority, state_export, token_ops, genesis) plus one external in \`sentrix-rpc/routes/accounts.rs\`. All continue via the re-export.

## Tests

7 focused new tests in \`address::tests\` (format accept/reject, missing prefix, non-hex, spendable rejects \`ZERO_ADDRESS\`, accepts real validator address, protocol-constant self-consistency).

\`cargo test -p sentrix-core --release\`: **222 passed** (was 215 on main).

## Roadmap

Third refactor PR in the \`blockchain.rs\` decomposition series after #634 (fork_heights) and #635 (divergence — currently in flight). \`blockchain.rs\` LOC trajectory: 3,967 → 3,653 → 3,626. Pace is intentional (one concept per PR, fresh-brain reviewable, no consensus path touched).

Next candidates (still non-consensus): supply/halving constants extract, chain_window helpers extract, ZERO_ADDRESS-callers cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Reorganized address validation and protocol parameters into a dedicated module while maintaining backward compatibility with existing API paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/636)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->