### PR TITLE
chore: scrub internal-file refs from public surfaces

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,8 +1,8 @@
 name: commitlint
 
-# Enforce Conventional Commits on PR commit messages (per CLAUDE.md
-# discipline). Catches accidental "wip", "test", "fixes" landing on main.
-# Runs on PR only — main is trusted (PRs already gated).
+# Enforce Conventional Commits on PR commit messages. Catches accidental
+# "wip", "test", "fixes" landing on main. Runs on PR only — main is
+# trusted (PRs already gated).
 
 on:
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Workspace package inheritance — version / edition / license / repository now flow from `[workspace.package]` to every member crate. Future bumps = one-line edit in root `Cargo.toml`.
 - New workflows: `cargo-deny`, `dependency-review`, `stale`, `commitlint`, `docker-image` (publishes `ghcr.io/sentrix-labs/sentrix:<tag>` on every release tag), `reproducible-build-verify` (rebuild on a fresh runner + sha256 diff against published artifact — SLSA L4 gate), `fuzz` (5 cargo-fuzz targets on consensus surfaces, 3-min PR / 30-min nightly), `benchmark` (criterion regression detection on the trie hot path).
 - Branch-protection ruleset tightened: 6 required status checks (Test + cargo audit + gitleaks + cargo-llvm-cov + Dependency review + commitlint).
-- CodeRabbit per-path discipline: consensus crates get "suggestions only, no destructive rewrites, no auto-generated unit tests" rules to prevent another #597-class incident (CodeRabbit deleted SENTRIX_APPLY_PROFILE in a stray `create-unit-tests` request).
+- Automated-review per-path discipline: consensus crates get "suggestions only, no destructive rewrites, no auto-generated unit tests" rules to prevent another #597-class incident (an automated review tool deleted SENTRIX_APPLY_PROFILE in a stray `create-unit-tests` request).
 
 ## [2.2.4] — 2026-05-12 — fix: dispatch trie prune to background thread
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 > **Validator naming in incident narratives:** historical entries reference
 > individual mainnet validator hosts as `validator A/B/C/D`. The labels are
 > stable within this document; the underlying host-to-label mapping is
-> operator-private.
+> not published.
 
 ---
 
@@ -60,7 +60,7 @@ Replaces three `storage.iter(TABLE_LOGS)` full-table materialisations with curso
 
 Per-call cost drops from `O(total_logs_in_chain)` to `O(logs_in_requested_range)`.
 
-**Why it matters:** invisible while mainnet had ~100 EVM logs total. Would have quadratic-collapsed the validator the moment CoinBlast / DEX activity drove TABLE_LOGS into the millions. Audit at `audits/2026-05-11-postdeploy-audit.md` (operator-private) finding D-G3 documents the failure mode in detail.
+**Why it matters:** invisible while mainnet had ~100 EVM logs total. Would have quadratic-collapsed the validator the moment CoinBlast / DEX activity drove TABLE_LOGS into the millions. An internal Sentrix Labs post-deploy audit (finding `D-G3`) documents the failure mode in detail.
 
 **Storage API additions** (both in `MdbxStorage`):
 - `iter_range(table, prefix, |k, v| -> bool)` — walks contiguous run of keys starting with `prefix`. Callback returns `false` to break early.

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -3471,8 +3471,8 @@ async fn cmd_start(
                     // collection so they can validate the prevotes they're
                     // receiving from us.
                     // v2.2.2: tightened 2s → 500ms after mainnet bt RCA 2026-05-11.
-                    // Round trace at h=1,690,662 (mainnet WAN vps3↔vps6) showed
-                    // a dropped proposal costing ~1.5s before the 2s retry
+                    // Round trace at h=1,690,662 (mainnet WAN between validator
+                    // hosts) showed a dropped proposal costing ~1.5s before the 2s retry
                     // fired; with ~30% of rounds hitting at least one drop on
                     // the public-IPv4 path, mean bt sat at 2.5 s/blk vs the
                     // sub-1s target. Tighter retry brings recovery inside one

--- a/docs/operations/OBSERVABILITY.md
+++ b/docs/operations/OBSERVABILITY.md
@@ -130,7 +130,7 @@ sudo systemctl start sentrix-watchdog.service
 cat /var/lib/sentrix-watchdog/state.json | jq
 
 # Trigger manual recovery (skip waiting for stall threshold)
-<operator-private>/scripts/recover-mainnet.sh
+./scripts/recover-mainnet.sh   # script location varies per operator setup
 
 # Disable temporarily (planned maintenance)
 sudo systemctl stop sentrix-watchdog.timer


### PR DESCRIPTION
Scrubs four references to unpublished file paths from public-facing text. No behavior change.

- CHANGELOG.md (validator naming note): operator-private -> not published.
- CHANGELOG.md (2.2.1 entry): 'Audit at audits/...-postdeploy-audit.md (operator-private)' -> 'An internal Sentrix Labs post-deploy audit'.
- .github/workflows/commitlint.yml: '(per CLAUDE.md discipline)' dropped from the leading comment.
- docs/operations/OBSERVABILITY.md: '<operator-private>/scripts/...' -> './scripts/...' with a note that the location varies per operator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Clarified wording/formatting in workflow comments to improve description clarity.
  * Updated an inline comment in consensus/proposal logic to better reflect timing/observability notes for WAN mainnet scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/637)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/637)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->