### PR TITLE
refactor(core): extract tokenomics constants into own module

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -17,32 +17,17 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-// ── Chain constants ──────────────────────────────────────
-//
-// Tokenomics v1 (genesis-active): 210M cap, 42M-block halving, 1 SRX initial.
-// Geometric series math: 1 × 42M × 2 = 84M from mining + 63M premine = 147M
-// asymptotic — caps unreachable, validator runway era 5 = year 6.66 (cliff).
-//
-// Tokenomics v2 (`TOKENOMICS_V2_HEIGHT` fork-gated): 315M cap, 126M-block
-// halving (BTC-parity 4-year), 1 SRX initial unchanged. Geometric: 1 × 126M
-// × 2 = 252M mining + 63M premine = 315M (cap reachable). Premine ratio
-// drops from 30% (intended) → 20% (mining-share dilution from 70% → 80%).
-// Validator runway era 5 = year ~20. See `feat: tokenomics v2 fork` PR.
-pub const MAX_SUPPLY: u64 = 210_000_000 * 100_000_000; // in sentri (v1)
-pub const MAX_SUPPLY_V2: u64 = 315_000_000 * 100_000_000; // in sentri (post-fork)
-pub const BLOCK_REWARD: u64 = 100_000_000; // 1 SRX in sentri (unchanged across forks)
+// ── Tokenomics constants ─────────────────────────────────
+// MAX_SUPPLY, MAX_SUPPLY_V2, BLOCK_REWARD, HALVING_INTERVAL,
+// HALVING_INTERVAL_V2, and the `max_supply_srx()` display helper
+// live in `crate::tokenomics` now — re-export so existing import
+// paths (`crate::blockchain::MAX_SUPPLY` etc.) still resolve.
+pub use crate::tokenomics::{
+    BLOCK_REWARD, HALVING_INTERVAL, HALVING_INTERVAL_V2, MAX_SUPPLY, MAX_SUPPLY_V2,
+    max_supply_srx,
+};
 
-/// MAX_SUPPLY expressed in whole SRX as f64 — used by RPC/explorer display paths.
-/// Single source of truth; do NOT redefine as a local constant.
-///
-/// **Pre-tokenomics-v2 callers:** prefer `Blockchain::max_supply_for(height)`
-/// at runtime to get the fork-aware value. This helper returns the v1 number
-/// for backward compatibility with non-`&self` paths only.
-pub fn max_supply_srx() -> f64 {
-    (MAX_SUPPLY / 100_000_000) as f64
-}
-pub const HALVING_INTERVAL: u64 = 42_000_000; // blocks (v1)
-pub const HALVING_INTERVAL_V2: u64 = 126_000_000; // blocks (post-fork, BTC-parity 4y at 1s blocks)
+// ── Other chain constants ────────────────────────────────
 pub const BLOCK_TIME_SECS: u64 = 1;
 pub const MAX_TX_PER_BLOCK: usize = 5000;
 pub const CHAIN_ID: u64 = 7119; // default; overridable via SENTRIX_CHAIN_ID env

--- a/crates/sentrix-core/src/lib.rs
+++ b/crates/sentrix-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod parallel;
 pub mod state_export;
 pub mod storage;
 pub mod token_ops;
+pub mod tokenomics;
 pub mod vm;
 
 // Re-export key types at crate root for convenience

--- a/crates/sentrix-core/src/tokenomics.rs
+++ b/crates/sentrix-core/src/tokenomics.rs
@@ -1,0 +1,101 @@
+//! Tokenomics constants — max supply, halving intervals, block reward.
+//!
+//! Tokenomics v1 (genesis-active): 210M cap, 42M-block halving, 1 SRX
+//! initial. Geometric series math: 1 × 42M × 2 = 84M from mining + 63M
+//! premine = 147M asymptotic — caps unreachable, validator runway era
+//! 5 = year 6.66 (cliff).
+//!
+//! Tokenomics v2 ([`crate::fork_heights::get_tokenomics_v2_height`]
+//! fork-gated): 315M cap, 126M-block halving (BTC-parity 4-year), 1 SRX
+//! initial unchanged. Geometric: 1 × 126M × 2 = 252M mining + 63M
+//! premine = 315M (cap reachable). Premine ratio drops from 30%
+//! (intended) → 20% (mining-share dilution from 70% → 80%). Validator
+//! runway era 5 = year ~20.
+//!
+//! Extracted from `crate::blockchain` so the tokenomics layer lives in
+//! one focused module. `blockchain.rs` re-exports the constants and the
+//! free helper so existing import paths continue to resolve.
+
+/// Maximum supply in sentri (v1 — pre-tokenomics-v2 fork). Equal to
+/// 210,000,000 SRX × 100,000,000 sentri/SRX.
+pub const MAX_SUPPLY: u64 = 210_000_000 * 100_000_000;
+
+/// Maximum supply in sentri after the tokenomics-v2 fork activates.
+/// Equal to 315,000,000 SRX × 100,000,000 sentri/SRX. The cap is reachable
+/// under v2 (vs. asymptotic-only under v1) because the longer halving
+/// interval lets the geometric series sum to the literal cap.
+pub const MAX_SUPPLY_V2: u64 = 315_000_000 * 100_000_000;
+
+/// Era-zero block reward in sentri. Equal to 1 SRX × 100,000,000
+/// sentri/SRX. Halving schedule applies per [`HALVING_INTERVAL`] (v1) or
+/// [`HALVING_INTERVAL_V2`] (post-fork) — the initial reward itself is
+/// unchanged across forks.
+pub const BLOCK_REWARD: u64 = 100_000_000;
+
+/// Blocks per halving era (v1). At 1-second block time this is ~1.33y
+/// per era. Combined with [`MAX_SUPPLY`] = 210M, era-5 supply asymptote
+/// would land at year ~6.66 (operator-flagged as a runway cliff).
+pub const HALVING_INTERVAL: u64 = 42_000_000;
+
+/// Blocks per halving era (post-tokenomics-v2 fork). At 1-second block
+/// time this is ~4 years per era — BTC-parity. Combined with
+/// [`MAX_SUPPLY_V2`] = 315M, the geometric series sums to the literal
+/// cap (no runway cliff).
+pub const HALVING_INTERVAL_V2: u64 = 126_000_000;
+
+/// [`MAX_SUPPLY`] expressed in whole SRX as f64 — used by RPC/explorer
+/// display paths. Single source of truth; do NOT redefine as a local
+/// constant elsewhere.
+///
+/// **Pre-tokenomics-v2 callers:** prefer
+/// [`crate::blockchain::Blockchain::max_supply_for`] at runtime to get
+/// the fork-aware value. This helper returns the v1 number for backward
+/// compatibility with non-`&self` paths only.
+pub fn max_supply_srx() -> f64 {
+    (MAX_SUPPLY / 100_000_000) as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn v1_cap_arithmetic() {
+        assert_eq!(MAX_SUPPLY, 21_000_000_000_000_000);
+        assert_eq!(max_supply_srx(), 210_000_000.0);
+    }
+
+    #[test]
+    fn v2_cap_arithmetic() {
+        assert_eq!(MAX_SUPPLY_V2, 31_500_000_000_000_000);
+    }
+
+    #[test]
+    fn v2_cap_is_v1_cap_one_and_half() {
+        // 315 / 210 = 1.5 exactly. Catches typo'd zeros in either constant.
+        assert_eq!(MAX_SUPPLY_V2 * 2, MAX_SUPPLY * 3);
+    }
+
+    #[test]
+    fn block_reward_is_one_srx() {
+        // 1 SRX = 10^8 sentri (8 decimals)
+        assert_eq!(BLOCK_REWARD, 100_000_000);
+    }
+
+    #[test]
+    fn halving_intervals_self_consistent() {
+        // v2 interval is exactly 3× v1, matching the cap ratio. If
+        // either constant drifts, the geometric supply curve breaks.
+        assert_eq!(HALVING_INTERVAL_V2, HALVING_INTERVAL * 3);
+    }
+
+    #[test]
+    fn halving_v2_is_btc_parity() {
+        // ~4 years at 1-second block time. 4 × 365.25 × 86400 = 126,230,400.
+        // The protocol rounds down to a clean 126M.
+        let four_years_secs: u64 = 4 * 365 * 24 * 3600;
+        let diff = HALVING_INTERVAL_V2.abs_diff(four_years_secs);
+        // Within ~0.2% of the literal 4-year second count.
+        assert!(diff < HALVING_INTERVAL_V2 / 500);
+    }
+}


### PR DESCRIPTION
## Why

Pulled \`MAX_SUPPLY\`, \`MAX_SUPPLY_V2\`, \`BLOCK_REWARD\`, \`HALVING_INTERVAL\`, \`HALVING_INTERVAL_V2\`, and \`max_supply_srx()\` into \`crate::tokenomics\`. The v1/v2 tokenomics doc paragraph that explained both fork eras moved with them — useful context lives next to the constants it describes.

## Behaviour: bit-identical

\`blockchain.rs\` re-exports via \`pub use crate::tokenomics::{...}\` — every existing import path resolves unchanged. Callers verified: only one cross-crate path (\`crate::blockchain::MAX_SUPPLY\` from \`genesis.rs\`) continues to work through the re-export.

State-dependent supply methods (\`Blockchain::max_supply_for(height)\`, \`Blockchain::halving_interval_for(height)\`, \`get_block_reward()\`) stay on the \`Blockchain\` struct — they read live chain state, so they don't belong in the pure-constants module.

## Tests

6 focused new tests in \`tokenomics::tests\`:
- v1 cap arithmetic
- v2 cap arithmetic
- v2/v1 cap ratio (3:2) — catches typo'd zeros
- block reward = exactly 1 SRX in sentri
- halving-interval ratio (v2 = 3× v1) — must drift together with the cap pair
- v2 halving ≈ 4-year BTC parity (within 0.2%)

These pin invariants that had no test coverage before — purely additive safety.

\`cargo test -p sentrix-core --release\`: **221 passed** (was 215 on main; +6 from new tokenomics::tests).

## Roadmap

Fourth refactor PR in the \`blockchain.rs\` decomposition series.

| PR | Module | blockchain.rs LOC |
|---|---|---|
| main (before #634) | — | 3,967 |
| #634 merged | fork_heights | 3,653 |
| #635 (in flight) | divergence | 3,512 |
| #636 (in flight) | address | 3,485 |
| **this PR** | tokenomics | **3,470** (effective once all merge) |

Cumulative reduction ~12.5%. Next non-consensus candidates: mempool consts → mempool.rs (already exists), chain_window helpers, ZERO_ADDRESS centralization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tokenomics module is now publicly accessible from the library, providing direct access to supply caps, block rewards, and halving intervals.

* **Refactor**
  * Reorganized tokenomics constants and helper functions into a dedicated module for improved code organization and better separation of concerns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/638)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->