### PR TITLE
refactor(core): move mempool size/age consts to mempool.rs

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -68,11 +68,10 @@ pub fn get_chain_id() -> u64 {
 // Hash algorithm version — reserved for future hash algorithm migration
 pub const HASH_VERSION: u8 = 1; // 1 = SHA-256 (current)
 
-// Mempool size limits to prevent RAM exhaustion under high load
-pub const MAX_MEMPOOL_SIZE: usize = 10_000;
-pub const MAX_MEMPOOL_PER_SENDER: usize = 100;
-// Mempool TTL — transactions older than this are automatically pruned
-pub const MEMPOOL_MAX_AGE_SECS: u64 = 3_600; // 1 hour
+// Mempool consts live in `crate::mempool` now (next to the only code
+// that uses them) — re-export so `crate::blockchain::MAX_MEMPOOL_SIZE`
+// etc. still resolve for any path that was relying on it.
+pub use crate::mempool::{MAX_MEMPOOL_PER_SENDER, MAX_MEMPOOL_SIZE, MEMPOOL_MAX_AGE_SECS};
 // Sliding window size — only last N blocks kept in RAM; older blocks stay in MDBX storage
 pub const CHAIN_WINDOW_SIZE: usize = 1_000;
 

--- a/crates/sentrix-core/src/mempool.rs
+++ b/crates/sentrix-core/src/mempool.rs
@@ -1,11 +1,24 @@
 // mempool.rs - Sentrix — Mempool management
 
-use crate::blockchain::{
-    Blockchain, MAX_MEMPOOL_PER_SENDER, MAX_MEMPOOL_SIZE, MEMPOOL_MAX_AGE_SECS,
-    is_valid_sentrix_address,
-};
+use crate::blockchain::{Blockchain, is_valid_sentrix_address};
 use sentrix_primitives::error::{SentrixError, SentrixResult};
 use sentrix_primitives::transaction::{TOKEN_OP_ADDRESS, TokenOp, Transaction};
+
+// ── Mempool capacity + lifetime limits ───────────────────────────────
+// These declarations used to live in `blockchain.rs`; they belong here
+// next to the code that enforces them (`add_to_mempool`, `prune_mempool`).
+// `blockchain.rs` re-exports the names so any caller path that read
+// `crate::blockchain::MAX_MEMPOOL_SIZE` still resolves.
+
+/// Total mempool size cap to prevent RAM exhaustion under high load.
+pub const MAX_MEMPOOL_SIZE: usize = 10_000;
+
+/// Per-sender cap. Protects against one sender flooding the mempool.
+pub const MAX_MEMPOOL_PER_SENDER: usize = 100;
+
+/// Mempool TTL — transactions older than this get pruned by the
+/// periodic `prune_mempool()` sweep.
+pub const MEMPOOL_MAX_AGE_SECS: u64 = 3_600; // 1 hour
 
 /// M-10: per-transaction size ceiling. Bounds worst-case memory impact
 /// of a single accepted mempool entry and caps block bloat from any


### PR DESCRIPTION
## Why

\`MAX_MEMPOOL_SIZE\`, \`MAX_MEMPOOL_PER_SENDER\`, and \`MEMPOOL_MAX_AGE_SECS\` were declared in \`blockchain.rs\` but only ever used by \`mempool.rs\` (which imported them back through the crate boundary). Moving them puts the constants next to the code that enforces them.

## Behaviour: bit-identical

\`blockchain.rs\` re-exports the three names via \`pub use crate::mempool::{...}\` so the existing \`crate::blockchain::MAX_MEMPOOL_SIZE\` import path keeps resolving for any external caller (none today, but defensive). \`mempool.rs\` drops the now-tautological \`use crate::blockchain::{MAX_MEMPOOL_* ...}\` line — was only there to read back what it had declared next-door.

## Tests

No test changes — the consts are already exercised through the existing mempool path tests (\`test_m04_prune_removes_expired_txs\`, etc.).

\`cargo test -p sentrix-core --release\`: **222 passed** (unchanged).

## Roadmap

Fifth refactor PR in the \`blockchain.rs\` decomposition series. Each PR is independently small + reviewable.

| PR | Status | Module |
|---|---|---|
| #634 | merged | fork_heights |
| #635 | open | divergence |
| #636 | open | address |
| #638 | open | tokenomics |
| **this PR** | open | mempool consts (moved into existing mempool.rs) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized mempool configuration constants to their logical home module while maintaining backward-compatible API paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/639)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->