### PR TITLE
refactor(core): extract chain_params (block time, chain id, hash, window)

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -27,10 +27,14 @@ pub use crate::tokenomics::{
     max_supply_srx,
 };
 
-// ── Other chain constants ────────────────────────────────
-pub const BLOCK_TIME_SECS: u64 = 1;
-pub const MAX_TX_PER_BLOCK: usize = 5000;
-pub const CHAIN_ID: u64 = 7119; // default; overridable via SENTRIX_CHAIN_ID env
+// Chain parameter consts + chain-id accessor live in `crate::chain_params`
+// now — re-export so existing `crate::blockchain::{BLOCK_TIME_SECS,
+// MAX_TX_PER_BLOCK, CHAIN_ID, HASH_VERSION, CHAIN_WINDOW_SIZE, get_chain_id}`
+// import paths still resolve unchanged.
+pub use crate::chain_params::{
+    BLOCK_TIME_SECS, CHAIN_ID, CHAIN_WINDOW_SIZE, HASH_VERSION, MAX_TX_PER_BLOCK,
+    get_chain_id,
+};
 
 // Fork-height accessors live in `crate::fork_heights` now — re-export so
 // every existing caller path (`crate::blockchain::get_*_height(...)`) keeps
@@ -43,22 +47,11 @@ pub use crate::fork_heights::{
     warn_if_jail_consensus_armed,
 };
 
-/// Read chain_id from SENTRIX_CHAIN_ID env var, fallback to 7119.
-pub fn get_chain_id() -> u64 {
-    std::env::var("SENTRIX_CHAIN_ID")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(CHAIN_ID)
-}
-// Hash algorithm version — reserved for future hash algorithm migration
-pub const HASH_VERSION: u8 = 1; // 1 = SHA-256 (current)
 
 // Mempool consts live in `crate::mempool` now (next to the only code
 // that uses them) — re-export so `crate::blockchain::MAX_MEMPOOL_SIZE`
 // etc. still resolve for any path that was relying on it.
 pub use crate::mempool::{MAX_MEMPOOL_PER_SENDER, MAX_MEMPOOL_SIZE, MEMPOOL_MAX_AGE_SECS};
-// Sliding window size — only last N blocks kept in RAM; older blocks stay in MDBX storage
-pub const CHAIN_WINDOW_SIZE: usize = 1_000;
 
 // Address validation + protocol-reserved address constants live in
 // `crate::address` now — re-export so the existing import paths

--- a/crates/sentrix-core/src/chain_params.rs
+++ b/crates/sentrix-core/src/chain_params.rs
@@ -42,7 +42,9 @@ pub const HASH_VERSION: u8 = 1; // 1 = SHA-256 (current)
 /// Sliding-window size for the in-memory block cache. Only the last
 /// `CHAIN_WINDOW_SIZE` blocks live in RAM; older blocks remain on
 /// disk in MDBX and are read on demand through
-/// [`crate::blockchain::Blockchain::get_block`].
+/// [`crate::blockchain::Blockchain::get_block_any`] — the variant
+/// that falls back to MDBX storage when the in-memory window misses.
+/// Plain `get_block` returns `None` for out-of-window heights.
 pub const CHAIN_WINDOW_SIZE: usize = 1_000;
 
 #[cfg(test)]

--- a/crates/sentrix-core/src/chain_params.rs
+++ b/crates/sentrix-core/src/chain_params.rs
@@ -1,0 +1,99 @@
+//! Chain parameters that aren't tokenomics or address validation —
+//! per-block timing + transaction-count limits, the chain identifier,
+//! the hash-algorithm version marker, and the in-memory window size.
+//!
+//! Each is a compile-time default; the chain ID also accepts a runtime
+//! override via `SENTRIX_CHAIN_ID` so testnet (7120) shares one binary
+//! with mainnet (7119). Extracted from `crate::blockchain` so the
+//! protocol-parameter layer lives in one focused module.
+
+/// Target block time in seconds. The block producer doesn't shorten
+/// below this; networks under high load fall toward this floor.
+pub const BLOCK_TIME_SECS: u64 = 1;
+
+/// Maximum transactions per block. Bounds worst-case apply duration
+/// and serialization size. The mempool can hold more
+/// ([`crate::blockchain::MAX_MEMPOOL_SIZE`]); excess waits for the next
+/// block.
+pub const MAX_TX_PER_BLOCK: usize = 5000;
+
+/// Default chain ID. Mainnet — overridable per-process via the
+/// `SENTRIX_CHAIN_ID` env var for testnet (7120), devnet, or local
+/// integration runs. Use [`get_chain_id`] to read the effective value
+/// at runtime, never refer to this constant directly outside
+/// genesis / boot paths.
+pub const CHAIN_ID: u64 = 7119;
+
+/// Read the chain ID for this process — `SENTRIX_CHAIN_ID` env var
+/// when present and parseable, otherwise [`CHAIN_ID`] (7119 / mainnet).
+pub fn get_chain_id() -> u64 {
+    std::env::var("SENTRIX_CHAIN_ID")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(CHAIN_ID)
+}
+
+/// Hash-algorithm version. Reserved for a future migration from
+/// SHA-256 (the only allocated value today) to a different family.
+/// The chain stamps this into block headers so a future fork can
+/// recognise pre-migration vs post-migration blocks.
+pub const HASH_VERSION: u8 = 1; // 1 = SHA-256 (current)
+
+/// Sliding-window size for the in-memory block cache. Only the last
+/// `CHAIN_WINDOW_SIZE` blocks live in RAM; older blocks remain on
+/// disk in MDBX and are read on demand through
+/// [`crate::blockchain::Blockchain::get_block`].
+pub const CHAIN_WINDOW_SIZE: usize = 1_000;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::env_test_lock;
+
+    /// Block time floor is exactly 1 second — pinning the literal so a
+    /// stray edit is loud at build time. const-assert (not a runtime
+    /// test) because the value is compile-time.
+    const _: () = assert!(BLOCK_TIME_SECS == 1);
+
+    /// Per-block tx cap must be > 0 and ≤ mempool size cap, otherwise
+    /// users can't ever queue ahead. Const-assert so a drift in either
+    /// constant fails the build, not just `cargo test`.
+    const _: () = assert!(MAX_TX_PER_BLOCK > 0);
+    const _: () = assert!(MAX_TX_PER_BLOCK <= crate::blockchain::MAX_MEMPOOL_SIZE);
+
+    #[test]
+    fn chain_id_default_is_mainnet() {
+        let _guard = env_test_lock();
+        unsafe {
+            std::env::remove_var("SENTRIX_CHAIN_ID");
+            assert_eq!(get_chain_id(), 7119);
+            assert_eq!(get_chain_id(), CHAIN_ID);
+        }
+    }
+
+    #[test]
+    fn chain_id_env_override_round_trip() {
+        let _guard = env_test_lock();
+        unsafe {
+            std::env::set_var("SENTRIX_CHAIN_ID", "7120");
+            assert_eq!(get_chain_id(), 7120);
+
+            std::env::set_var("SENTRIX_CHAIN_ID", "not_a_number");
+            assert_eq!(get_chain_id(), CHAIN_ID);
+
+            std::env::remove_var("SENTRIX_CHAIN_ID");
+            assert_eq!(get_chain_id(), CHAIN_ID);
+        }
+    }
+
+    /// If someone bumps to 2+ they're claiming a hash-algorithm
+    /// migration. The chain header decoder enforces this; the const-
+    /// assert pins the literal so a stray edit fails the build.
+    const _: () = assert!(HASH_VERSION == 1);
+
+    /// Sliding window must be > 0 (used as a slice index) and smaller
+    /// than mempool size cap (no point keeping more blocks in RAM than
+    /// the mempool can hold pending txs).
+    const _: () = assert!(CHAIN_WINDOW_SIZE > 0);
+    const _: () = assert!(CHAIN_WINDOW_SIZE <= crate::blockchain::MAX_MEMPOOL_SIZE);
+}

--- a/crates/sentrix-core/src/lib.rs
+++ b/crates/sentrix-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod authority;
 pub mod block_executor;
 pub mod block_producer;
 pub mod blockchain;
+pub mod chain_params;
 pub mod chain_queries;
 pub(crate) mod divergence;
 pub mod fork_heights;


### PR DESCRIPTION
## Why

Pulled the small remaining \"chain parameter\" constants out of \`blockchain.rs\` into \`crate::chain_params\`:

| Symbol | What it sets |
|---|---|
| \`BLOCK_TIME_SECS\` | per-block timing floor (1s) |
| \`MAX_TX_PER_BLOCK\` | per-block tx cap (5000) |
| \`CHAIN_ID\` + \`get_chain_id()\` | chain id + env override |
| \`HASH_VERSION\` | hash-algorithm version marker |
| \`CHAIN_WINDOW_SIZE\` | in-memory sliding-window cache size (1000) |

## Behaviour: bit-identical

\`blockchain.rs\` re-exports via \`pub use crate::chain_params::{...}\`. Existing import paths resolve unchanged. Only one cross-crate caller — \`bin/sentrix/main.rs\` imports \`BLOCK_TIME_SECS\` via \`sentrix::core::blockchain::BLOCK_TIME_SECS\` — keeps working through the re-export.

## Tests

Compile-time \`const _: () = assert!(...)\` for invariants that are pure constant arithmetic (catch silent drift between paired constants at build time, not just \`cargo test\`). Plus two runtime tests for \`get_chain_id\` covering default + env-override + invalid-input fallback.

\`cargo test -p sentrix-core --release\`: **230 passed** (was 222 on main).

## Roadmap

Sixth refactor PR in the \`blockchain.rs\` decomposition series.

| PR | Status | Module |
|---|---|---|
| #634 | merged | fork_heights |
| #635 | open | divergence |
| #636 | open | address |
| #638 | open | tokenomics |
| #639 | open | mempool consts |
| **this PR** | open | chain_params |

After all in-flight PRs land: \`blockchain.rs\` LOC 3,967 → ~3,470 (-12.5%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chain ID can be configured at runtime via SENTRIX_CHAIN_ID, with automatic fallback to defaults.
  * Default block timing and per-block transaction limits are now provided for consistent behavior.

* **Refactor**
  * Chain and protocol parameters consolidated and re-exported for clearer, stable public access.

* **Tests**
  * Added unit tests validating defaults and runtime chain ID override behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/640)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->