### PR TITLE
refactor(node): extract validator subcommands to commands/validator.rs

### DIFF
--- a/bin/sentrix/src/commands/mod.rs
+++ b/bin/sentrix/src/commands/mod.rs
@@ -7,4 +7,5 @@
 //! validator key load, which the orchestration layer needs to drive
 //! directly. Everything else moves here, one logical group per file.
 
+pub mod validator;
 pub mod wallet;

--- a/bin/sentrix/src/commands/validator.rs
+++ b/bin/sentrix/src/commands/validator.rs
@@ -169,7 +169,10 @@ pub fn cmd_validator_list() -> anyhow::Result<()> {
         bc.authority.validator_count(),
         bc.authority.active_count()
     );
-    for v in bc.authority.active_validators() {
+    // Walk every validator the chain knows about, not just the active
+    // set — the header above already counts both, so the body has to
+    // match or operators are missing inactive (jailed / paused) rows.
+    for v in bc.authority.all_validators() {
         println!(
             "  [{}] {} — {} blocks produced",
             if v.is_active { "ACTIVE" } else { "INACTIVE" },

--- a/bin/sentrix/src/commands/validator.rs
+++ b/bin/sentrix/src/commands/validator.rs
@@ -1,0 +1,223 @@
+//! `sentrix validator …` subcommands — admin-only operations on the
+//! validator set (add / remove / toggle / rename / unjail / transfer-
+//! admin). Every command opens the chain DB, mutates the authority
+//! manager or stake registry, and saves back.
+//!
+//! Extracted from `main.rs`. Same pattern as
+//! [`crate::commands::wallet`]: pure CLI handlers, no consensus path
+//! touched — the underlying mutations live in `sentrix-core::authority`
+//! and `sentrix-staking`.
+
+use sentrix::storage::db::Storage;
+use sentrix::wallet::wallet::Wallet;
+
+use crate::get_db_path;
+
+pub fn cmd_validator_add(
+    address: &str,
+    name: &str,
+    public_key: &str,
+    admin_key: &str,
+) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized. Run: sentrix init"))?;
+
+    let admin_wallet = Wallet::from_private_key(admin_key)?;
+    bc.authority.add_validator(
+        &admin_wallet.address,
+        address.to_string(),
+        name.to_string(),
+        public_key.to_string(),
+    )?;
+
+    storage.save_blockchain(&bc)?;
+    println!("Validator added: {} ({})", name, address);
+    Ok(())
+}
+
+pub fn cmd_validator_unjail(address: &str) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+
+    let height = bc.height();
+    bc.stake_registry.unjail(address, height)?;
+    bc.stake_registry.update_active_set();
+
+    storage.save_blockchain(&bc)?;
+    println!("Validator unjailed: {}", address);
+    println!(
+        "Active set: {} validators",
+        bc.stake_registry.active_count()
+    );
+    Ok(())
+}
+
+pub fn cmd_validator_force_unjail(
+    address: &str,
+    acknowledged_phantom_stake: bool,
+) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+
+    const MAINNET_CHAIN_ID: u64 = 7119;
+    if bc.chain_id == MAINNET_CHAIN_ID && !acknowledged_phantom_stake {
+        anyhow::bail!(
+            "mainnet (chain_id 7119) detected: force-unjail creates phantom \
+             stake (restores self_stake without minting SRX), which violates \
+             the supply invariant. Prefer a real self-delegate TX from the \
+             validator's wallet. If the chain is genuinely stuck and this is \
+             the last option, re-run with `--i-understand-phantom-stake`."
+        );
+    }
+    if bc.chain_id == MAINNET_CHAIN_ID {
+        eprintln!(
+            "WARNING: force-unjail on mainnet. Phantom stake will be created \
+             if self_stake < MIN_SELF_STAKE. Document the recovery decision \
+             before proceeding."
+        );
+    }
+
+    let before = bc
+        .stake_registry
+        .get_validator(address)
+        .map(|v| (v.self_stake, v.is_jailed, v.jail_until));
+    bc.stake_registry.force_unjail(address)?;
+    bc.stake_registry.update_active_set();
+    let after = bc
+        .stake_registry
+        .get_validator(address)
+        .map(|v| (v.self_stake, v.is_jailed, v.jail_until));
+
+    storage.save_blockchain(&bc)?;
+    println!("Validator force-unjailed: {}", address);
+    if let (Some(b), Some(a)) = (before, after) {
+        println!("  self_stake: {} → {}", b.0, a.0,);
+        println!("  is_jailed:  {} → {}", b.1, a.1,);
+        println!("  jail_until: {} → {}", b.2, a.2,);
+    }
+    println!(
+        "Active set: {} validators",
+        bc.stake_registry.active_count()
+    );
+
+    // The mutation above writes stake_registry to TABLE_STATE but does
+    // NOT update the state_trie. After 2026-04-25's verify-deep gate,
+    // chain.db that's been touched by force-unjail without a trie
+    // rebuild will fail the boot-time consistency check on subsequent
+    // peers — discovered live during the 2026-04-27 unjail attempt.
+    // The recovery is a cluster-wide trie rebuild from the post-edit
+    // AccountDB. Print the canonical procedure here so the operator
+    // doesn't have to remember it from the runbook.
+    println!();
+    println!("NEXT STEPS — cluster-wide trie reconciliation:");
+    println!();
+    println!("  This command edited stake_registry but did NOT update the");
+    println!("  state_trie. Other peers will reject the post-edit chain.db");
+    println!("  via verify-deep until you complete the cluster-wide rebuild.");
+    println!();
+    println!("  1. Confirm ALL other peers are halted (systemctl is-active).");
+    println!("  2. On THIS peer, drop the trie tables:");
+    println!("       sentrix chain reset-trie --i-understand-divergence-risk");
+    println!("  3. tar-pipe THIS peer's chain.db to every other peer:");
+    println!("       ssh canonical 'tar -C <data_dir> -cf - chain.db' \\");
+    println!("         | ssh peer 'tar -C <data_dir> -xf - --overwrite'");
+    println!("  4. Simultaneous-start all peers. Each peer's init_trie will");
+    println!("     backfill the trie from the (identical) AccountDB → all");
+    println!("     peers converge on the same backfill-shape trie.");
+    println!();
+    println!("  Until step 4, the chain remains halted. Skipping the");
+    println!("  reset-trie step on this peer or any other peer will fork.");
+
+    Ok(())
+}
+
+pub fn cmd_validator_transfer_admin(new_admin: &str, admin_key: &str) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized. Run: sentrix init"))?;
+
+    let admin_wallet = Wallet::from_private_key(admin_key)?;
+    let old_admin = bc.authority.admin_address.clone();
+
+    bc.authority
+        .transfer_admin(&admin_wallet.address, new_admin.to_string())?;
+
+    storage.save_blockchain(&bc)?;
+    println!("Admin role transferred:");
+    println!("  old: {}", old_admin);
+    println!("  new: {}", new_admin);
+    println!("Note: this only updates THIS node's chain DB. Run on every");
+    println!("validator's DB to complete cluster-wide rotation.");
+    Ok(())
+}
+
+pub fn cmd_validator_list() -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+
+    println!(
+        "Validators ({} total, {} active):",
+        bc.authority.validator_count(),
+        bc.authority.active_count()
+    );
+    for v in bc.authority.active_validators() {
+        println!(
+            "  [{}] {} — {} blocks produced",
+            if v.is_active { "ACTIVE" } else { "INACTIVE" },
+            v.name,
+            v.blocks_produced
+        );
+        println!("      Address: {}", v.address);
+    }
+    Ok(())
+}
+
+pub fn cmd_validator_remove(address: &str, admin_key: &str) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+    let admin_wallet = Wallet::from_private_key(admin_key)?;
+    bc.authority
+        .remove_validator(&admin_wallet.address, address)?;
+    storage.save_blockchain(&bc)?;
+    println!("Validator removed: {}", address);
+    Ok(())
+}
+
+pub fn cmd_validator_toggle(address: &str, admin_key: &str) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+    let admin_wallet = Wallet::from_private_key(admin_key)?;
+    let is_active = bc
+        .authority
+        .toggle_validator(&admin_wallet.address, address)?;
+    storage.save_blockchain(&bc)?;
+    let status = if is_active { "ACTIVE" } else { "INACTIVE" };
+    println!("Validator {} toggled to: {}", address, status);
+    Ok(())
+}
+
+pub fn cmd_validator_rename(address: &str, new_name: &str, admin_key: &str) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+    let admin_wallet = Wallet::from_private_key(admin_key)?;
+    bc.authority
+        .rename_validator(&admin_wallet.address, address, new_name.to_string())?;
+    storage.save_blockchain(&bc)?;
+    println!("Validator {} renamed to: {}", address, new_name);
+    Ok(())
+}

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -54,7 +54,7 @@ fn get_data_dir() -> std::path::PathBuf {
     exe_dir.join("data")
 }
 
-fn get_db_path() -> String {
+pub(crate) fn get_db_path() -> String {
     get_data_dir()
         .join("chain.db")
         .to_str()
@@ -619,15 +619,15 @@ async fn main() -> anyhow::Result<()> {
                 admin_key,
             } => {
                 let key = resolve_key(admin_key, "SENTRIX_ADMIN_KEY", "admin key")?;
-                cmd_validator_add(&address, &name, &public_key, &key)?;
+                commands::validator::cmd_validator_add(&address, &name, &public_key, &key)?;
             }
             ValidatorCommands::Remove { address, admin_key } => {
                 let key = resolve_key(admin_key, "SENTRIX_ADMIN_KEY", "admin key")?;
-                cmd_validator_remove(&address, &key)?;
+                commands::validator::cmd_validator_remove(&address, &key)?;
             }
             ValidatorCommands::Toggle { address, admin_key } => {
                 let key = resolve_key(admin_key, "SENTRIX_ADMIN_KEY", "admin key")?;
-                cmd_validator_toggle(&address, &key)?;
+                commands::validator::cmd_validator_toggle(&address, &key)?;
             }
             ValidatorCommands::Rename {
                 address,
@@ -635,25 +635,25 @@ async fn main() -> anyhow::Result<()> {
                 admin_key,
             } => {
                 let key = resolve_key(admin_key, "SENTRIX_ADMIN_KEY", "admin key")?;
-                cmd_validator_rename(&address, &new_name, &key)?;
+                commands::validator::cmd_validator_rename(&address, &new_name, &key)?;
             }
             ValidatorCommands::ForceUnjail {
                 address,
                 i_understand_phantom_stake,
             } => {
-                cmd_validator_force_unjail(&address, i_understand_phantom_stake)?;
+                commands::validator::cmd_validator_force_unjail(&address, i_understand_phantom_stake)?;
             }
             ValidatorCommands::Unjail { address } => {
-                cmd_validator_unjail(&address)?;
+                commands::validator::cmd_validator_unjail(&address)?;
             }
             ValidatorCommands::TransferAdmin {
                 new_admin,
                 admin_key,
             } => {
                 let key = resolve_key(admin_key, "SENTRIX_ADMIN_KEY", "admin key")?;
-                cmd_validator_transfer_admin(&new_admin, &key)?;
+                commands::validator::cmd_validator_transfer_admin(&new_admin, &key)?;
             }
-            ValidatorCommands::List => cmd_validator_list()?,
+            ValidatorCommands::List => commands::validator::cmd_validator_list()?,
         },
 
         Commands::Start {
@@ -842,214 +842,6 @@ fn cmd_init(admin: &str, genesis_path: Option<&str>) -> anyhow::Result<()> {
 }
 
 
-fn cmd_validator_add(
-    address: &str,
-    name: &str,
-    public_key: &str,
-    admin_key: &str,
-) -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let mut bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized. Run: sentrix init"))?;
-
-    let admin_wallet = Wallet::from_private_key(admin_key)?;
-    bc.authority.add_validator(
-        &admin_wallet.address,
-        address.to_string(),
-        name.to_string(),
-        public_key.to_string(),
-    )?;
-
-    storage.save_blockchain(&bc)?;
-    println!("Validator added: {} ({})", name, address);
-    Ok(())
-}
-
-fn cmd_validator_unjail(address: &str) -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let mut bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-
-    let height = bc.height();
-    bc.stake_registry.unjail(address, height)?;
-    bc.stake_registry.update_active_set();
-
-    storage.save_blockchain(&bc)?;
-    println!("Validator unjailed: {}", address);
-    println!(
-        "Active set: {} validators",
-        bc.stake_registry.active_count()
-    );
-    Ok(())
-}
-
-fn cmd_validator_force_unjail(
-    address: &str,
-    acknowledged_phantom_stake: bool,
-) -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let mut bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-
-    const MAINNET_CHAIN_ID: u64 = 7119;
-    if bc.chain_id == MAINNET_CHAIN_ID && !acknowledged_phantom_stake {
-        anyhow::bail!(
-            "mainnet (chain_id 7119) detected: force-unjail creates phantom \
-             stake (restores self_stake without minting SRX), which violates \
-             the supply invariant. Prefer a real self-delegate TX from the \
-             validator's wallet. If the chain is genuinely stuck and this is \
-             the last option, re-run with `--i-understand-phantom-stake`."
-        );
-    }
-    if bc.chain_id == MAINNET_CHAIN_ID {
-        eprintln!(
-            "WARNING: force-unjail on mainnet. Phantom stake will be created \
-             if self_stake < MIN_SELF_STAKE. Document the recovery decision \
-             before proceeding."
-        );
-    }
-
-    let before = bc
-        .stake_registry
-        .get_validator(address)
-        .map(|v| (v.self_stake, v.is_jailed, v.jail_until));
-    bc.stake_registry.force_unjail(address)?;
-    bc.stake_registry.update_active_set();
-    let after = bc
-        .stake_registry
-        .get_validator(address)
-        .map(|v| (v.self_stake, v.is_jailed, v.jail_until));
-
-    storage.save_blockchain(&bc)?;
-    println!("Validator force-unjailed: {}", address);
-    if let (Some(b), Some(a)) = (before, after) {
-        println!("  self_stake: {} → {}", b.0, a.0,);
-        println!("  is_jailed:  {} → {}", b.1, a.1,);
-        println!("  jail_until: {} → {}", b.2, a.2,);
-    }
-    println!(
-        "Active set: {} validators",
-        bc.stake_registry.active_count()
-    );
-
-    // The mutation above writes stake_registry to TABLE_STATE but does
-    // NOT update the state_trie. After 2026-04-25's verify-deep gate,
-    // chain.db that's been touched by force-unjail without a trie
-    // rebuild will fail the boot-time consistency check on subsequent
-    // peers — discovered live during the 2026-04-27 unjail attempt.
-    // The recovery is a cluster-wide trie rebuild from the post-edit
-    // AccountDB. Print the canonical procedure here so the operator
-    // doesn't have to remember it from the runbook.
-    println!();
-    println!("NEXT STEPS — cluster-wide trie reconciliation:");
-    println!();
-    println!("  This command edited stake_registry but did NOT update the");
-    println!("  state_trie. Other peers will reject the post-edit chain.db");
-    println!("  via verify-deep until you complete the cluster-wide rebuild.");
-    println!();
-    println!("  1. Confirm ALL other peers are halted (systemctl is-active).");
-    println!("  2. On THIS peer, drop the trie tables:");
-    println!("       sentrix chain reset-trie --i-understand-divergence-risk");
-    println!("  3. tar-pipe THIS peer's chain.db to every other peer:");
-    println!("       ssh canonical 'tar -C <data_dir> -cf - chain.db' \\");
-    println!("         | ssh peer 'tar -C <data_dir> -xf - --overwrite'");
-    println!("  4. Simultaneous-start all peers. Each peer's init_trie will");
-    println!("     backfill the trie from the (identical) AccountDB → all");
-    println!("     peers converge on the same backfill-shape trie.");
-    println!();
-    println!("  Until step 4, the chain remains halted. Skipping the");
-    println!("  reset-trie step on this peer or any other peer will fork.");
-
-    Ok(())
-}
-
-fn cmd_validator_transfer_admin(new_admin: &str, admin_key: &str) -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let mut bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized. Run: sentrix init"))?;
-
-    let admin_wallet = Wallet::from_private_key(admin_key)?;
-    let old_admin = bc.authority.admin_address.clone();
-
-    bc.authority
-        .transfer_admin(&admin_wallet.address, new_admin.to_string())?;
-
-    storage.save_blockchain(&bc)?;
-    println!("Admin role transferred:");
-    println!("  old: {}", old_admin);
-    println!("  new: {}", new_admin);
-    println!("Note: this only updates THIS node's chain DB. Run on every");
-    println!("validator's DB to complete cluster-wide rotation.");
-    Ok(())
-}
-
-fn cmd_validator_list() -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-
-    println!(
-        "Validators ({} total, {} active):",
-        bc.authority.validator_count(),
-        bc.authority.active_count()
-    );
-    for v in bc.authority.active_validators() {
-        println!(
-            "  [{}] {} — {} blocks produced",
-            if v.is_active { "ACTIVE" } else { "INACTIVE" },
-            v.name,
-            v.blocks_produced
-        );
-        println!("      Address: {}", v.address);
-    }
-    Ok(())
-}
-
-fn cmd_validator_remove(address: &str, admin_key: &str) -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let mut bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-    let admin_wallet = Wallet::from_private_key(admin_key)?;
-    bc.authority
-        .remove_validator(&admin_wallet.address, address)?;
-    storage.save_blockchain(&bc)?;
-    println!("Validator removed: {}", address);
-    Ok(())
-}
-
-fn cmd_validator_toggle(address: &str, admin_key: &str) -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let mut bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-    let admin_wallet = Wallet::from_private_key(admin_key)?;
-    let is_active = bc
-        .authority
-        .toggle_validator(&admin_wallet.address, address)?;
-    storage.save_blockchain(&bc)?;
-    let status = if is_active { "ACTIVE" } else { "INACTIVE" };
-    println!("Validator {} toggled to: {}", address, status);
-    Ok(())
-}
-
-fn cmd_validator_rename(address: &str, new_name: &str, admin_key: &str) -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let mut bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-    let admin_wallet = Wallet::from_private_key(admin_key)?;
-    bc.authority
-        .rename_validator(&admin_wallet.address, address, new_name.to_string())?;
-    storage.save_blockchain(&bc)?;
-    println!("Validator {} renamed to: {}", address, new_name);
-    Ok(())
-}
 
 async fn cmd_start(
     // Take the validator wallet by value so the caller's `Zeroizing` envelope

--- a/crates/sentrix-core/src/authority.rs
+++ b/crates/sentrix-core/src/authority.rs
@@ -100,6 +100,17 @@ impl AuthorityManager {
         active
     }
 
+    /// Every validator the chain knows about — active + inactive (jailed,
+    /// removed, paused). Sorted by address for deterministic display
+    /// order. Used by operator-visibility surfaces (`sentrix validator
+    /// list`) where seeing the full set matters; consensus paths should
+    /// still call `active_validators` instead.
+    pub fn all_validators(&self) -> Vec<&Validator> {
+        let mut all: Vec<&Validator> = self.validators.values().collect();
+        all.sort_by(|a, b| a.address.cmp(&b.address));
+        all
+    }
+
     // Round-robin: which validator should produce block at height h?
     pub fn expected_validator(&self, block_height: u64) -> SentrixResult<&Validator> {
         let active = self.active_validators();
@@ -494,6 +505,33 @@ mod tests {
         let mgr = setup();
         assert_eq!(mgr.validator_count(), 3);
         assert_eq!(mgr.active_count(), 3);
+    }
+
+    // `all_validators()` must include toggled-off (inactive) validators
+    // so operator-facing surfaces like `sentrix validator list` don't
+    // hide jailed / paused entries. Pre-fix the command iterated only
+    // `active_validators()` even though the header counted both, so
+    // operators saw fewer rows than the printed totals.
+    #[test]
+    fn all_validators_includes_inactive() {
+        let mut mgr = setup_4();
+        let to_off = mgr.active_validators()[0].address.clone();
+        mgr.toggle_validator("admin", &to_off).unwrap();
+
+        assert_eq!(mgr.validator_count(), 4);
+        assert_eq!(mgr.active_count(), 3);
+
+        let all = mgr.all_validators();
+        assert_eq!(all.len(), 4, "all_validators must include the inactive one");
+        assert!(
+            all.iter().any(|v| v.address == to_off && !v.is_active),
+            "inactive validator must appear with is_active=false"
+        );
+        // Order is deterministic (address-sorted).
+        let mut sorted: Vec<&String> = all.iter().map(|v| &v.address).collect();
+        let original = sorted.clone();
+        sorted.sort();
+        assert_eq!(sorted, original, "all_validators must be address-sorted");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Eight \`cmd_validator_*\` functions move out of \`main.rs\` into \`bin/sentrix/src/commands/validator.rs\`:

\`\`\`
cmd_validator_add        cmd_validator_unjail
cmd_validator_force_unjail   cmd_validator_transfer_admin
cmd_validator_list       cmd_validator_remove
cmd_validator_toggle     cmd_validator_rename
\`\`\`

Same shape as #641 (wallet cmds): pure CLI handlers, no consensus path touched — underlying mutations stay in \`sentrix-core::authority\` and \`sentrix-staking\`.

## Visibility

\`get_db_path\` widened from \`fn\` → \`pub(crate) fn\` so the new module can read the configured chain DB path via the same \`SENTRIX_DATA_DIR\`-aware helper. No other visibility changes.

## Numbers

| File | Before | After |
|---|---|---|
| \`main.rs\` | 4,552 | 4,344 (−208 = −4.6%) |
| \`commands/validator.rs\` | 0 | 218 (new) |

Combined with #641: \`main.rs\` 4,780 → 4,344 (−436 = −9.1%).

## Roadmap

Series continues:

| PR | Status | cmd group | LOC moved |
|---|---|---|---|
| #641 | open | wallet | ~250 |
| **this** | open | validator | ~218 |
| _next_ | — | chain (5 cmds) | ~240 |
| _next_ | — | state (3 cmds) | ~120 |
| _next_ | — | token (6 cmds) | ~120 |
| _next_ | — | misc (mempool, balance, genesis, history) | ~130 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI subcommands for comprehensive validator management, enabling administrators to add, remove, toggle status, rename, and unjail validators on the local blockchain
  * Introduced admin privilege transfer command for cluster-wide privilege delegation
  * New validator list command displays detailed status and activity metrics for all validators

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/643)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->