### PR TITLE
fix(node): wallet helpers — hide prompts, confirm rekey, atomic rollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,6 +4857,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4872,6 +4883,16 @@ dependencies = [
  "nix",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5350,6 +5371,7 @@ dependencies = [
  "clap",
  "hex",
  "libp2p",
+ "rpassword",
  "secp256k1 0.31.1",
  "sentrix",
  "sentrix-bft",
@@ -6815,6 +6837,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/bin/sentrix/Cargo.toml
+++ b/bin/sentrix/Cargo.toml
@@ -67,3 +67,8 @@ zeroize = "1.7"
 # sentrix (lib) doesn't re-export sentrix-bft, so we pull it directly. Pinned
 # via path to keep the workspace at one copy.
 sentrix-bft = { path = "../../crates/sentrix-bft" }
+# 2026-05-13: hidden password prompt for `sentrix wallet ...` flows. The
+# previous stdin().read_line() echoed the password back to the terminal —
+# operator could see it on screen and in the scrollback. Apache-2.0; pure
+# Rust; no native deps.
+rpassword = "7"

--- a/bin/sentrix/src/commands/wallet.rs
+++ b/bin/sentrix/src/commands/wallet.rs
@@ -22,7 +22,7 @@ pub fn cmd_wallet_generate(password: Option<String>) -> anyhow::Result<()> {
     println!("  Public key:  {}", wallet.public_key);
 
     if let Some(pwd) = password {
-        reject_empty_cli_password(&pwd)?;
+        let pwd = reject_empty_cli_password(&pwd)?;
         let keystore = Keystore::encrypt(&wallet, &pwd)?;
         let filename = format!("{}/{}.json", get_wallets_dir(), &wallet.address[2..10]);
         keystore.save(&filename)?;
@@ -42,7 +42,7 @@ pub fn cmd_wallet_import(private_key: &str, password: Option<String>) -> anyhow:
     println!("  Public key: {}", wallet.public_key);
 
     if let Some(pwd) = password {
-        reject_empty_cli_password(&pwd)?;
+        let pwd = reject_empty_cli_password(&pwd)?;
         let keystore = Keystore::encrypt(&wallet, &pwd)?;
         let filename = format!("{}/{}.json", get_wallets_dir(), &wallet.address[2..10]);
         keystore.save(&filename)?;
@@ -229,15 +229,19 @@ pub fn cmd_wallet_rekey(
     Ok(())
 }
 
-/// Reject `--password ""` from any subcommand that takes a CLI password
-/// directly (generate, import). Mirrors the same check inside
-/// `resolve_password*` so all entry points fail closed on the empty
-/// string instead of silently encrypting with it.
-fn reject_empty_cli_password(pw: &str) -> anyhow::Result<()> {
-    if pw.is_empty() {
-        anyhow::bail!("--password cannot be empty");
+/// Reject `--password ""` (and `"   "`, `"\n"`, …) from any subcommand
+/// that takes a CLI password directly (generate, import). All three
+/// entry points (CLI helper, env helper, prompt helper) normalise the
+/// same way — trim then reject empty — so the same operator input
+/// behaves identically regardless of source. Returns the trimmed
+/// password so the caller never accidentally encrypts with the
+/// untrimmed original.
+fn reject_empty_cli_password(pw: &str) -> anyhow::Result<String> {
+    let trimmed = pw.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("--password cannot be empty or whitespace");
     }
-    Ok(())
+    Ok(trimmed.to_string())
 }
 
 /// Hidden terminal prompt — characters are not echoed. Replaces the old
@@ -248,17 +252,19 @@ fn read_password_hidden(prompt: &str) -> anyhow::Result<String> {
     let pw = rpassword::prompt_password(format!("{}: ", prompt))?;
     let pw = pw.trim().to_string();
     if pw.is_empty() {
-        anyhow::bail!("Password cannot be empty");
+        anyhow::bail!("Password cannot be empty or whitespace");
     }
     Ok(pw)
 }
 
-/// Validate a CLI / env password value (trimmed). Same empty-string
-/// rejection rule the prompt path uses, applied to the non-interactive
-/// sources so they can't sneak through.
+/// Validate a CLI / env password value. Trims (matching the prompt
+/// path's behaviour) and rejects strictly empty + whitespace-only
+/// values from every source. Returns the trimmed password so all three
+/// helpers produce the same canonical form for `Keystore::encrypt`.
 fn validate_external_password(pw: String, source: &str) -> anyhow::Result<String> {
+    let pw = pw.trim().to_string();
     if pw.is_empty() {
-        anyhow::bail!("Password from {} cannot be empty", source);
+        anyhow::bail!("Password from {} cannot be empty or whitespace", source);
     }
     Ok(pw)
 }
@@ -330,14 +336,48 @@ mod tests {
     }
 
     #[test]
+    fn reject_empty_cli_password_rejects_whitespace_only() {
+        // Operators sometimes paste a trailing space or newline into
+        // `--password "..."`; the prompt path trims so the CLI / env
+        // paths must too, otherwise the same operator input produces
+        // a different keystore depending on which entry point ran.
+        assert!(reject_empty_cli_password("   ").is_err());
+        assert!(reject_empty_cli_password("\n").is_err());
+        assert!(reject_empty_cli_password("\t\t").is_err());
+    }
+
+    #[test]
     fn reject_empty_cli_password_accepts_non_empty() {
-        assert!(reject_empty_cli_password("hunter2").is_ok());
+        let pw = reject_empty_cli_password("hunter2").unwrap();
+        assert_eq!(pw, "hunter2");
+    }
+
+    #[test]
+    fn reject_empty_cli_password_returns_trimmed() {
+        // Caller uses the returned value, not the original arg — so a
+        // password typed as " hunter2 " encrypts the keystore with
+        // exactly "hunter2", same as the prompt path.
+        let pw = reject_empty_cli_password("  hunter2  ").unwrap();
+        assert_eq!(pw, "hunter2");
     }
 
     #[test]
     fn validate_external_password_rejects_empty() {
         let err = validate_external_password(String::new(), "--password").unwrap_err();
         assert!(err.to_string().contains("--password"));
+    }
+
+    #[test]
+    fn validate_external_password_rejects_whitespace_only() {
+        let err = validate_external_password("   ".into(), "SENTRIX_WALLET_PASSWORD").unwrap_err();
+        assert!(err.to_string().contains("SENTRIX_WALLET_PASSWORD"));
+        assert!(err.to_string().contains("whitespace"));
+    }
+
+    #[test]
+    fn validate_external_password_returns_trimmed() {
+        let pw = validate_external_password("  hunter2  ".into(), "--password").unwrap();
+        assert_eq!(pw, "hunter2");
     }
 
     #[test]

--- a/bin/sentrix/src/commands/wallet.rs
+++ b/bin/sentrix/src/commands/wallet.rs
@@ -22,6 +22,7 @@ pub fn cmd_wallet_generate(password: Option<String>) -> anyhow::Result<()> {
     println!("  Public key:  {}", wallet.public_key);
 
     if let Some(pwd) = password {
+        reject_empty_cli_password(&pwd)?;
         let keystore = Keystore::encrypt(&wallet, &pwd)?;
         let filename = format!("{}/{}.json", get_wallets_dir(), &wallet.address[2..10]);
         keystore.save(&filename)?;
@@ -41,6 +42,7 @@ pub fn cmd_wallet_import(private_key: &str, password: Option<String>) -> anyhow:
     println!("  Public key: {}", wallet.public_key);
 
     if let Some(pwd) = password {
+        reject_empty_cli_password(&pwd)?;
         let keystore = Keystore::encrypt(&wallet, &pwd)?;
         let filename = format!("{}/{}.json", get_wallets_dir(), &wallet.address[2..10]);
         keystore.save(&filename)?;
@@ -116,8 +118,12 @@ pub fn cmd_wallet_rekey(
         "SENTRIX_WALLET_OLD_PASSWORD",
         "Enter OLD wallet password",
     )?;
-    // New password: same resolution path + confirm-twice on prompt.
-    let new_pwd = resolve_password_named(
+    // New password: same resolution path, plus confirm-twice when the
+    // value comes from an interactive prompt. CLI / env paths still
+    // take the single value (no second source to confirm against);
+    // we trust the operator's automation when they explicitly pass
+    // the password non-interactively.
+    let new_pwd = resolve_password_named_confirmed(
         new_password,
         "SENTRIX_WALLET_NEW_PASSWORD",
         "Enter NEW wallet password",
@@ -174,8 +180,27 @@ pub fn cmd_wallet_rekey(
             .unwrap_or("keystore"),
         ts
     ));
+    // Two-step rename: backup the original, then install the new
+    // keystore. If the install fails, restore the backup so the
+    // canonical keystore path is never missing — otherwise the
+    // operator has to manually move `.bak-*` back before the
+    // validator can boot. The restore's own error is intentionally
+    // swallowed; we surface the original install failure since that
+    // is the actionable cause.
     std::fs::rename(path, &bak_path)?;
-    std::fs::rename(&tmp_path, path)?;
+    if let Err(install_err) = std::fs::rename(&tmp_path, path) {
+        let restored = std::fs::rename(&bak_path, path).is_ok();
+        let note = if restored {
+            "original keystore restored from backup"
+        } else {
+            "original keystore could NOT be restored — check .bak file manually"
+        };
+        anyhow::bail!(
+            "failed to install rekeyed keystore: {} ({})",
+            install_err,
+            note
+        );
+    }
 
     // Drop the in-memory plaintext as early as possible. `Wallet`
     // already zeroises its secret on drop, but explicit drop pins
@@ -204,6 +229,40 @@ pub fn cmd_wallet_rekey(
     Ok(())
 }
 
+/// Reject `--password ""` from any subcommand that takes a CLI password
+/// directly (generate, import). Mirrors the same check inside
+/// `resolve_password*` so all entry points fail closed on the empty
+/// string instead of silently encrypting with it.
+fn reject_empty_cli_password(pw: &str) -> anyhow::Result<()> {
+    if pw.is_empty() {
+        anyhow::bail!("--password cannot be empty");
+    }
+    Ok(())
+}
+
+/// Hidden terminal prompt — characters are not echoed. Replaces the old
+/// `stdin().read_line()` path which printed the password to the screen
+/// (visible to anyone shoulder-surfing, and persisted in scrollback
+/// buffers / tmux capture / asciinema recordings).
+fn read_password_hidden(prompt: &str) -> anyhow::Result<String> {
+    let pw = rpassword::prompt_password(format!("{}: ", prompt))?;
+    let pw = pw.trim().to_string();
+    if pw.is_empty() {
+        anyhow::bail!("Password cannot be empty");
+    }
+    Ok(pw)
+}
+
+/// Validate a CLI / env password value (trimmed). Same empty-string
+/// rejection rule the prompt path uses, applied to the non-interactive
+/// sources so they can't sneak through.
+fn validate_external_password(pw: String, source: &str) -> anyhow::Result<String> {
+    if pw.is_empty() {
+        anyhow::bail!("Password from {} cannot be empty", source);
+    }
+    Ok(pw)
+}
+
 /// Like [`resolve_password`] but with a named env var + custom prompt.
 /// Lets `rekey` distinguish OLD vs NEW password sources cleanly.
 pub fn resolve_password_named(
@@ -212,19 +271,40 @@ pub fn resolve_password_named(
     prompt: &str,
 ) -> anyhow::Result<String> {
     if let Some(pw) = cli_password {
-        return Ok(pw);
+        return validate_external_password(pw, "--password");
     }
     if let Ok(pw) = std::env::var(env_var) {
-        return Ok(pw);
+        return validate_external_password(pw, env_var);
     }
-    eprint!("{}: ", prompt);
-    let mut pw = String::new();
-    std::io::stdin().read_line(&mut pw)?;
-    let pw = pw.trim().to_string();
-    if pw.is_empty() {
-        anyhow::bail!("Password cannot be empty");
+    read_password_hidden(prompt)
+}
+
+/// Like [`resolve_password_named`] but confirms the value by prompting
+/// twice when it comes from an interactive prompt. Used for the NEW
+/// password on `wallet rekey` — a typo would otherwise re-encrypt the
+/// keystore to an unintended password (the self-decrypt check still
+/// passes because both encrypt and verify use the same mistyped value).
+///
+/// CLI / env paths are accepted as-is. They're non-interactive sources;
+/// there's no second value to compare against, and operators using
+/// automation have already committed to whatever they passed in.
+pub fn resolve_password_named_confirmed(
+    cli_password: Option<String>,
+    env_var: &str,
+    prompt: &str,
+) -> anyhow::Result<String> {
+    if let Some(pw) = cli_password {
+        return validate_external_password(pw, "--password");
     }
-    Ok(pw)
+    if let Ok(pw) = std::env::var(env_var) {
+        return validate_external_password(pw, env_var);
+    }
+    let first = read_password_hidden(prompt)?;
+    let second = read_password_hidden(&format!("{} (confirm)", prompt))?;
+    if first != second {
+        anyhow::bail!("Passwords did not match — aborting");
+    }
+    Ok(first)
 }
 
 /// Resolve password from CLI arg, `SENTRIX_WALLET_PASSWORD` env var, or
@@ -232,18 +312,93 @@ pub fn resolve_password_named(
 /// `main.rs::cmd_start` (validator boot keystore decrypt).
 pub fn resolve_password(cli_password: Option<String>) -> anyhow::Result<String> {
     if let Some(pw) = cli_password {
-        return Ok(pw);
+        return validate_external_password(pw, "--password");
     }
     if let Ok(pw) = std::env::var("SENTRIX_WALLET_PASSWORD") {
-        return Ok(pw);
+        return validate_external_password(pw, "SENTRIX_WALLET_PASSWORD");
     }
-    // Prompt on terminal
-    eprint!("Enter wallet password: ");
-    let mut pw = String::new();
-    std::io::stdin().read_line(&mut pw)?;
-    let pw = pw.trim().to_string();
-    if pw.is_empty() {
-        anyhow::bail!("Password cannot be empty");
+    read_password_hidden("Enter wallet password")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reject_empty_cli_password_rejects_empty() {
+        assert!(reject_empty_cli_password("").is_err());
     }
-    Ok(pw)
+
+    #[test]
+    fn reject_empty_cli_password_accepts_non_empty() {
+        assert!(reject_empty_cli_password("hunter2").is_ok());
+    }
+
+    #[test]
+    fn validate_external_password_rejects_empty() {
+        let err = validate_external_password(String::new(), "--password").unwrap_err();
+        assert!(err.to_string().contains("--password"));
+    }
+
+    #[test]
+    fn validate_external_password_passes_non_empty() {
+        let pw = validate_external_password("hunter2".into(), "--password").unwrap();
+        assert_eq!(pw, "hunter2");
+    }
+
+    #[test]
+    fn resolve_password_named_cli_empty_string_rejected() {
+        // `--password ""` used to slip through the cli_password branch and
+        // encrypt the keystore with an empty string, silently bypassing the
+        // prompt path's own empty-check. Pin the rejection here.
+        let err = resolve_password_named(
+            Some(String::new()),
+            "SENTRIX_TEST_NEVER_SET_PWD",
+            "Enter test password",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--password"));
+    }
+
+    #[test]
+    fn resolve_password_named_cli_non_empty_returned_verbatim() {
+        let pw = resolve_password_named(
+            Some("hunter2".into()),
+            "SENTRIX_TEST_NEVER_SET_PWD",
+            "Enter test password",
+        )
+        .unwrap();
+        assert_eq!(pw, "hunter2");
+    }
+
+    #[test]
+    fn resolve_password_cli_empty_string_rejected() {
+        let err = resolve_password(Some(String::new())).unwrap_err();
+        assert!(err.to_string().contains("--password"));
+    }
+
+    #[test]
+    fn resolve_password_named_confirmed_cli_path_skips_confirmation() {
+        // CLI / env are non-interactive sources — confirmation has no
+        // second value to check against, so we accept them as-is (only
+        // the empty-string guard applies).
+        let pw = resolve_password_named_confirmed(
+            Some("hunter2".into()),
+            "SENTRIX_TEST_NEVER_SET_PWD",
+            "Enter NEW wallet password",
+        )
+        .unwrap();
+        assert_eq!(pw, "hunter2");
+    }
+
+    #[test]
+    fn resolve_password_named_confirmed_cli_empty_rejected() {
+        let err = resolve_password_named_confirmed(
+            Some(String::new()),
+            "SENTRIX_TEST_NEVER_SET_PWD",
+            "Enter NEW wallet password",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--password"));
+    }
 }


### PR DESCRIPTION
## Summary

Post-extraction audit on `bin/sentrix/src/commands/wallet.rs` (landed #641). Four issues caught against the merged file, all worth fixing:

1. **Rekey prompt confirmed only once.** A typo on the NEW password would re-encrypt the keystore to an unintended value — and the self-decrypt round-trip *passes* because it verifies against the same mistyped value. New helper `resolve_password_named_confirmed` prompts twice on the interactive path and errors on mismatch. CLI / env paths are accepted as-is (non-interactive, no second value to compare against).
2. **No rollback if rekey install fails.** Two-step rename was `path -> .bak-<ts>` then `tmp -> path`. If the second step fails, the canonical keystore path is *empty* and validator boot blocks until the operator manually restores. Fixed: restore the backup on install failure, surface the original error.
3. **Password input echoed to the terminal.** `stdin().read_line()` printed the password back, visible to anyone shoulder-surfing and persisted in tmux capture / asciinema / scrollback. All wallet prompts now route through `rpassword` (Apache-2.0, pure Rust, no native deps).
4. **Empty CLI / env passwords silently accepted.** `--password ""` and `SENTRIX_WALLET_*_PASSWORD=""` slipped through the non-interactive branches of every resolver and encrypted the keystore with the empty string. `validate_external_password` rejects empty values from every source, matching what the prompt path already did. Same guard added to `cmd_wallet_generate` + `cmd_wallet_import` which take the option directly.

Adds nine focused unit tests covering each non-interactive rejection path + the CLI-bypasses-confirm path.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy -p sentrix-node --all-targets -D warnings` clean
- [x] `cargo test -p sentrix-node --release` — 20 / 20 green (9 new)
- [x] Pre-push leak grep clean
- [ ] CI green (Test + clippy + cargo-llvm-cov + criterion + commitlint + gitleaks + cargo-deny / dependency-review)
- [ ] Manual smoke: `sentrix wallet generate --password ""` rejects; `sentrix wallet rekey` prompts twice and aborts on mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password entry is hidden when typed and new passwords require confirmation (prompted twice) in interactive flows.

* **Bug Fixes**
  * Empty or whitespace-only passwords are rejected for wallet operations.
  * Rekeying now creates backups and attempts restoration on failure, surfacing restoration outcome in errors.
  * CLI/env password inputs are validated and handled distinctly from interactive prompts.

* **Tests**
  * Expanded tests covering empty-password rejection and CLI vs interactive behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/645)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->