### PR TITLE
refactor(node): extract state subcommands to commands/state.rs

### DIFF
--- a/bin/sentrix/src/commands/mod.rs
+++ b/bin/sentrix/src/commands/mod.rs
@@ -8,5 +8,6 @@
 //! directly. Everything else moves here, one logical group per file.
 
 pub mod chain;
+pub mod state;
 pub mod validator;
 pub mod wallet;

--- a/bin/sentrix/src/commands/state.rs
+++ b/bin/sentrix/src/commands/state.rs
@@ -1,0 +1,141 @@
+//! `sentrix state …` subcommands — export / import / verify the full
+//! account + validator + contract snapshot.
+//!
+//! Extracted from `main.rs`. Same pattern as the other `commands/`
+//! modules: pure CLI handlers, the real work lives in
+//! `sentrix-core::blockchain` (export_state / import_state /
+//! verify_snapshot).
+//!
+//! `state import` carries one of the heaviest comment blocks in the
+//! binary because the v2.1.5 / 2026-04-21 mainnet 3-way fork was
+//! caused by this exact path. The bail-on-non-zero-height guard +
+//! env-override + trie-reset-on-import are intentional safety rails;
+//! the comments stay with the code so any future edit sees why the
+//! shape is the way it is.
+
+use sentrix::core::blockchain::Blockchain;
+use sentrix::storage::db::Storage;
+
+use crate::get_db_path;
+
+pub fn cmd_state_export(output: Option<String>) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+
+    let snapshot = bc.export_state()?;
+    let out_path = output.unwrap_or_else(|| format!("state_{}.json", snapshot.metadata.height));
+    let json = serde_json::to_string_pretty(&snapshot)?;
+    std::fs::write(&out_path, &json)?;
+    println!(
+        "State exported: {} ({} accounts, {} validators, {:.4} SRX total)",
+        out_path,
+        snapshot.accounts.len(),
+        snapshot.validators.len(),
+        snapshot.accounts.iter().map(|a| a.balance).sum::<u64>() as f64 / 100_000_000.0
+    );
+    println!("Height: {}", snapshot.metadata.height);
+    println!("Chain ID: {}", snapshot.metadata.chain_id);
+    Ok(())
+}
+
+pub fn cmd_state_import(input: &str, force: bool) -> anyhow::Result<()> {
+    if !force {
+        anyhow::bail!(
+            "State import replaces ALL current accounts, validators, and contracts.\n\
+             This is destructive. Pass --force to confirm."
+        );
+    }
+
+    let json = std::fs::read_to_string(input)?;
+    let snapshot: sentrix::core::state_export::StateSnapshot = serde_json::from_str(&json)?;
+
+    // Verify first
+    Blockchain::verify_snapshot(&snapshot)?;
+
+    let storage = Storage::open(&get_db_path())?;
+
+    // 2026-04-21 mainnet 3-way fork root cause: pre-v2.1.5 `state_import` on
+    // production validators re-populated the account set without rebuilding
+    // the trie identically to peers'. The v2.1.5 trie-reset-on-import fix
+    // + v2.1.6 strict state_root enforcement + PR #206 boot-time integrity
+    // check now catch the damage, but the safest contract is: never allow
+    // state_import on a non-genesis chain at all. On mainnet / an existing
+    // network, the right recovery is rsync-from-peer (preserves incremental
+    // trie shape, matches peers bit-for-bit). state_import is only correct
+    // for fresh genesis bootstrapping or isolated devnet testing.
+    let current_height = storage
+        .load_height()
+        .map_err(|e| anyhow::anyhow!("reading chain height: {e}"))?;
+    if current_height > 0 {
+        // Env override check lives INSIDE this branch. A prior draft ordered
+        // `bail!` first and the override after, making the override dead code.
+        let override_set = std::env::var("SENTRIX_ALLOW_STATE_IMPORT_ON_NONZERO_HEIGHT")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        if !override_set {
+            anyhow::bail!(
+                "Refusing state import on a chain at height {current_height} > 0.\n\
+                 This command wipes and rebuilds AccountDB from the snapshot, \
+                 then resets the trie so init_trie rebuilds it on next boot. On \
+                 a chain past genesis that rebuild CAN produce a state_root that \
+                 disagrees with peers who built their trie incrementally block by \
+                 block (see the 2026-04-21 3-way fork incident for what that \
+                 looks like — took ~30h to recover).\n\
+                 \n\
+                 Correct recoveries on a non-genesis chain:\n\
+                 1. Stop this node.\n\
+                 2. rsync /opt/sentrix/data/chain.db from a healthy peer (all validators stopped).\n\
+                 3. Restart. Boot-time integrity check confirms the copy is intact.\n\
+                 \n\
+                 If you really need state_import on a non-genesis chain (isolated \
+                 devnet / one-off testing only), set `SENTRIX_ALLOW_STATE_IMPORT_ON_NONZERO_HEIGHT=1` \
+                 in your environment. There is no supported use of this flag on a shared chain."
+            );
+        }
+        tracing::warn!(
+            "state import proceeding on non-zero height (h={current_height}) via env override — \
+             fork is very likely on a shared chain"
+        );
+    }
+
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+
+    let count = bc.import_state(&snapshot)?;
+    storage.save_blockchain(&bc)?;
+
+    // ROOT CAUSE fix (2026-04-21 deploy rollback post-mortem): import only
+    // rewrites `accounts` and counters. The trie storage (trie_nodes +
+    // trie_values + trie_roots MDBX tables) is untouched. On the next
+    // `sentrix start`, `init_trie` finds the existing committed root for
+    // the current height + its nodes still present → uses the stale trie
+    // that reflects the PRE-import accounts. Every block applied after
+    // restart then computes a state_root from the stale trie, diverging
+    // from peers whose trie matches their (non-imported) accounts. The
+    // `#1e strict reject` guard fires and the chain halts.
+    //
+    // Resetting the trie here forces `init_trie` to backfill from the
+    // freshly imported accounts on next startup. The backfill produces
+    // the SAME root any validator would compute from the same account
+    // set, restoring cross-validator determinism.
+    storage.reset_trie()?;
+
+    println!(
+        "State imported: {} accounts from snapshot at height {}",
+        count, snapshot.metadata.height
+    );
+    println!("Trie storage reset — next startup will rebuild it from the imported accounts.");
+    println!("Restart the node to rebuild the state trie.");
+    Ok(())
+}
+
+pub fn cmd_state_verify(input: &str) -> anyhow::Result<()> {
+    let json = std::fs::read_to_string(input)?;
+    let snapshot: sentrix::core::state_export::StateSnapshot = serde_json::from_str(&json)?;
+    let summary = Blockchain::verify_snapshot(&snapshot)?;
+    println!("{}", summary);
+    Ok(())
+}

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -762,9 +762,11 @@ async fn main() -> anyhow::Result<()> {
         },
 
         Commands::State { action } => match action {
-            StateCommands::Export { output } => cmd_state_export(output)?,
-            StateCommands::Import { input, force } => cmd_state_import(&input, force)?,
-            StateCommands::Verify { input } => cmd_state_verify(&input)?,
+            StateCommands::Export { output } => commands::state::cmd_state_export(output)?,
+            StateCommands::Import { input, force } => {
+                commands::state::cmd_state_import(&input, force)?
+            }
+            StateCommands::Verify { input } => commands::state::cmd_state_verify(&input)?,
         },
 
         Commands::Mempool { action } => match action {
@@ -3562,129 +3564,6 @@ async fn cmd_start(
     )
     .with_graceful_shutdown(shutdown_signal)
     .await?;
-    Ok(())
-}
-
-
-fn cmd_state_export(output: Option<String>) -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-
-    let snapshot = bc.export_state()?;
-    let out_path = output.unwrap_or_else(|| format!("state_{}.json", snapshot.metadata.height));
-    let json = serde_json::to_string_pretty(&snapshot)?;
-    std::fs::write(&out_path, &json)?;
-    println!(
-        "State exported: {} ({} accounts, {} validators, {:.4} SRX total)",
-        out_path,
-        snapshot.accounts.len(),
-        snapshot.validators.len(),
-        snapshot.accounts.iter().map(|a| a.balance).sum::<u64>() as f64 / 100_000_000.0
-    );
-    println!("Height: {}", snapshot.metadata.height);
-    println!("Chain ID: {}", snapshot.metadata.chain_id);
-    Ok(())
-}
-
-fn cmd_state_import(input: &str, force: bool) -> anyhow::Result<()> {
-    if !force {
-        anyhow::bail!(
-            "State import replaces ALL current accounts, validators, and contracts.\n\
-             This is destructive. Pass --force to confirm."
-        );
-    }
-
-    let json = std::fs::read_to_string(input)?;
-    let snapshot: sentrix::core::state_export::StateSnapshot = serde_json::from_str(&json)?;
-
-    // Verify first
-    Blockchain::verify_snapshot(&snapshot)?;
-
-    let storage = Storage::open(&get_db_path())?;
-
-    // 2026-04-21 mainnet 3-way fork root cause: pre-v2.1.5 `state_import` on
-    // production validators re-populated the account set without rebuilding
-    // the trie identically to peers'. The v2.1.5 trie-reset-on-import fix
-    // + v2.1.6 strict state_root enforcement + PR #206 boot-time integrity
-    // check now catch the damage, but the safest contract is: never allow
-    // state_import on a non-genesis chain at all. On mainnet / an existing
-    // network, the right recovery is rsync-from-peer (preserves incremental
-    // trie shape, matches peers bit-for-bit). state_import is only correct
-    // for fresh genesis bootstrapping or isolated devnet testing.
-    let current_height = storage
-        .load_height()
-        .map_err(|e| anyhow::anyhow!("reading chain height: {e}"))?;
-    if current_height > 0 {
-        // Env override check lives INSIDE this branch. A prior draft ordered
-        // `bail!` first and the override after, making the override dead code.
-        let override_set = std::env::var("SENTRIX_ALLOW_STATE_IMPORT_ON_NONZERO_HEIGHT")
-            .map(|v| v == "1")
-            .unwrap_or(false);
-        if !override_set {
-            anyhow::bail!(
-                "Refusing state import on a chain at height {current_height} > 0.\n\
-                 This command wipes and rebuilds AccountDB from the snapshot, \
-                 then resets the trie so init_trie rebuilds it on next boot. On \
-                 a chain past genesis that rebuild CAN produce a state_root that \
-                 disagrees with peers who built their trie incrementally block by \
-                 block (see the 2026-04-21 3-way fork incident for what that \
-                 looks like — took ~30h to recover).\n\
-                 \n\
-                 Correct recoveries on a non-genesis chain:\n\
-                 1. Stop this node.\n\
-                 2. rsync /opt/sentrix/data/chain.db from a healthy peer (all validators stopped).\n\
-                 3. Restart. Boot-time integrity check confirms the copy is intact.\n\
-                 \n\
-                 If you really need state_import on a non-genesis chain (isolated \
-                 devnet / one-off testing only), set `SENTRIX_ALLOW_STATE_IMPORT_ON_NONZERO_HEIGHT=1` \
-                 in your environment. There is no supported use of this flag on a shared chain."
-            );
-        }
-        tracing::warn!(
-            "state import proceeding on non-zero height (h={current_height}) via env override — \
-             fork is very likely on a shared chain"
-        );
-    }
-
-    let mut bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-
-    let count = bc.import_state(&snapshot)?;
-    storage.save_blockchain(&bc)?;
-
-    // ROOT CAUSE fix (2026-04-21 deploy rollback post-mortem): import only
-    // rewrites `accounts` and counters. The trie storage (trie_nodes +
-    // trie_values + trie_roots MDBX tables) is untouched. On the next
-    // `sentrix start`, `init_trie` finds the existing committed root for
-    // the current height + its nodes still present → uses the stale trie
-    // that reflects the PRE-import accounts. Every block applied after
-    // restart then computes a state_root from the stale trie, diverging
-    // from peers whose trie matches their (non-imported) accounts. The
-    // `#1e strict reject` guard fires and the chain halts.
-    //
-    // Resetting the trie here forces `init_trie` to backfill from the
-    // freshly imported accounts on next startup. The backfill produces
-    // the SAME root any validator would compute from the same account
-    // set, restoring cross-validator determinism.
-    storage.reset_trie()?;
-
-    println!(
-        "State imported: {} accounts from snapshot at height {}",
-        count, snapshot.metadata.height
-    );
-    println!("Trie storage reset — next startup will rebuild it from the imported accounts.");
-    println!("Restart the node to rebuild the state trie.");
-    Ok(())
-}
-
-fn cmd_state_verify(input: &str) -> anyhow::Result<()> {
-    let json = std::fs::read_to_string(input)?;
-    let snapshot: sentrix::core::state_export::StateSnapshot = serde_json::from_str(&json)?;
-    let summary = Blockchain::verify_snapshot(&snapshot)?;
-    println!("{}", summary);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Three `cmd_state_*` functions move out of `main.rs` into `commands/state.rs`:
- `cmd_state_export`
- `cmd_state_import`
- `cmd_state_verify`

Same pattern as #641 (wallet) / #643 (validator) / #644 (chain): pure CLI handlers, no consensus path touched. The heavy comment block on `state_import` — documenting why the bail-on-non-zero-height + env override + trie-reset shape exists (2026-04-21 3-way fork incident, v2.1.5 fix, PR #206 boot integrity check) — stays with the code; future edits need to see the *why*.

`main.rs` drops from **4102 → 3981 lines** (−121). `cmd_start` (BFT engine + libp2p swarm + validator key load) stays inline since the orchestration layer needs to drive it directly.

## Test plan

- [x] `cargo check -p sentrix-node -D warnings` clean
- [x] `cargo clippy -p sentrix-node --all-targets -D warnings` clean
- [x] `cargo test -p sentrix-node --release` — 25 / 25 green (no behavior change)
- [x] Pre-push leak grep clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal reorganization of state command handlers into a dedicated module for improved code structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/648)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->