### PR TITLE
refactor(node): extract mempool subcommands to commands/mempool.rs

### DIFF
--- a/bin/sentrix/src/commands/mempool.rs
+++ b/bin/sentrix/src/commands/mempool.rs
@@ -1,0 +1,38 @@
+//! `sentrix mempool …` subcommands — admin operations on the pending
+//! transaction pool (clear, stats).
+//!
+//! Extracted from `main.rs`. Same pattern as the other `commands/`
+//! modules: pure CLI handlers, the mempool itself lives in
+//! `sentrix-core::mempool` and is reached through `Blockchain::mempool_size`
+//! / `clear_mempool`.
+//!
+//! `mempool clear` is destructive (drops every pending tx). It's a
+//! local-only operation — peers still hold their own copies and will
+//! re-broadcast on the next tick — but the operator's own
+//! recently-submitted tx will need re-sending if it wasn't already
+//! gossiped out.
+
+use sentrix::storage::db::Storage;
+
+use crate::get_db_path;
+
+pub fn cmd_mempool_clear() -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+    let old_size = bc.mempool_size();
+    bc.clear_mempool();
+    storage.save_blockchain(&bc)?;
+    println!("Mempool cleared: {} transactions removed", old_size);
+    Ok(())
+}
+
+pub fn cmd_mempool_stats() -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+    println!("Mempool size: {} transactions", bc.mempool_size());
+    Ok(())
+}

--- a/bin/sentrix/src/commands/mod.rs
+++ b/bin/sentrix/src/commands/mod.rs
@@ -8,6 +8,7 @@
 //! directly. Everything else moves here, one logical group per file.
 
 pub mod chain;
+pub mod mempool;
 pub mod misc;
 pub mod state;
 pub mod validator;

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -770,8 +770,8 @@ async fn main() -> anyhow::Result<()> {
         },
 
         Commands::Mempool { action } => match action {
-            MempoolCommands::Clear => cmd_mempool_clear()?,
-            MempoolCommands::Stats => cmd_mempool_stats()?,
+            MempoolCommands::Clear => commands::mempool::cmd_mempool_clear()?,
+            MempoolCommands::Stats => commands::mempool::cmd_mempool_stats()?,
         },
 
         Commands::Balance { address } => commands::misc::cmd_balance(&address)?,
@@ -3567,26 +3567,6 @@ async fn cmd_start(
     Ok(())
 }
 
-fn cmd_mempool_clear() -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let mut bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-    let old_size = bc.mempool_size();
-    bc.clear_mempool();
-    storage.save_blockchain(&bc)?;
-    println!("Mempool cleared: {} transactions removed", old_size);
-    Ok(())
-}
-
-fn cmd_mempool_stats() -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-    println!("Mempool size: {} transactions", bc.mempool_size());
-    Ok(())
-}
 
 // ── Token commands ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two `cmd_mempool_*` functions move out of `main.rs` into `commands/mempool.rs`:
- `cmd_mempool_clear` — drops every pending tx (local only; peers re-broadcast on next tick)
- `cmd_mempool_stats` — print pending count

Same pattern as the prior extractions (#641 / #643 / #644 / #648 / #649). `main.rs` drops to 3961 lines.

## Test plan

- [x] `cargo check -p sentrix-node -D warnings` clean
- [x] `cargo clippy -p sentrix-node --all-targets -D warnings` clean
- [x] `cargo test -p sentrix-node --release` — 25 / 25 green
- [x] Pre-push leak grep clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sentrix mempool clear` command to remove pending transactions and report how many were removed.
  * Added `sentrix mempool stats` command to display the current mempool size.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/651)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->