### PR TITLE
refactor(node): extract balance / history / genesis-wallets to commands/misc.rs

### DIFF
--- a/bin/sentrix/src/commands/misc.rs
+++ b/bin/sentrix/src/commands/misc.rs
@@ -1,0 +1,109 @@
+//! `sentrix` miscellaneous subcommands — small standalone CLI handlers
+//! that don't share a domain with the other `commands/` modules:
+//! `balance`, `history`, `genesis-wallets`.
+//!
+//! - `balance` / `history` are read-only account queries against the
+//!   chain DB.
+//! - `genesis-wallets` is a one-shot setup helper: generates seven
+//!   labelled keypairs (founder / ecosystem_fund / early_validator /
+//!   reserve / genesis_node_1..3) and writes them to
+//!   `<wallets_dir>/genesis_wallets.json` for bootstrap-time use.
+//!   The file contains private keys in plaintext — the command
+//!   prints a CRITICAL reminder to back it up offline and delete
+//!   from disk immediately after.
+
+use sentrix::storage::db::Storage;
+use sentrix::wallet::wallet::Wallet;
+
+use crate::{get_db_path, get_wallets_dir};
+
+pub fn cmd_balance(address: &str) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+    let balance = bc.accounts.get_balance(address);
+    println!("Address: {}", address);
+    println!(
+        "Balance: {} sentri ({} SRX)",
+        balance,
+        balance as f64 / 100_000_000.0
+    );
+    Ok(())
+}
+
+pub fn cmd_genesis_wallets() -> anyhow::Result<()> {
+    println!("Generating 7 genesis wallets for Sentrix...\n");
+
+    let roles = [
+        "founder",
+        "ecosystem_fund",
+        "early_validator",
+        "reserve",
+        "genesis_node_1",
+        "genesis_node_2",
+        "genesis_node_3",
+    ];
+
+    let mut wallets_json = serde_json::json!({});
+
+    for role in &roles {
+        let wallet = Wallet::generate();
+        println!("[{}]", role.to_uppercase());
+        println!("  Address:     {}", wallet.address);
+        println!("  Public key:  {}", wallet.public_key);
+        println!("  Private key: {}", wallet.secret_key_hex());
+        println!();
+
+        wallets_json[*role] = serde_json::json!({
+            "address": wallet.address,
+            "public_key": wallet.public_key,
+            "private_key": wallet.secret_key_hex(),
+        });
+    }
+
+    // Save to file
+    let output_path = format!("{}/genesis_wallets.json", get_wallets_dir());
+    std::fs::write(&output_path, serde_json::to_string_pretty(&wallets_json)?)?;
+    println!("Saved to: {}", output_path);
+    println!("\nCRITICAL: Back up genesis_wallets.json offline immediately.");
+    println!("          Delete from this machine after backup.");
+    Ok(())
+}
+
+pub fn cmd_history(address: &str) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+    let balance = bc.accounts.get_balance(address);
+    let nonce = bc.accounts.get_nonce(address);
+    let history = bc.get_address_history(address, 20, 0);
+
+    println!("Address: {}", address);
+    println!(
+        "Balance: {} sentri ({} SRX)",
+        balance,
+        balance as f64 / 100_000_000.0
+    );
+    println!("Nonce:   {}", nonce);
+    println!("Transactions: {}\n", history.len());
+
+    for tx in history.iter().rev().take(20) {
+        let dir = tx["direction"].as_str().unwrap_or("?");
+        let label = match dir {
+            "reward" => "REWARD",
+            "in" => "IN    ",
+            "out" => "OUT   ",
+            _ => "?     ",
+        };
+        println!(
+            "  [{}] {} | {} sentri | Block #{}",
+            label,
+            &tx["txid"].as_str().unwrap_or("?")[..24],
+            tx["amount"],
+            tx["block_index"],
+        );
+    }
+    Ok(())
+}

--- a/bin/sentrix/src/commands/mod.rs
+++ b/bin/sentrix/src/commands/mod.rs
@@ -8,6 +8,7 @@
 //! directly. Everything else moves here, one logical group per file.
 
 pub mod chain;
+pub mod misc;
 pub mod state;
 pub mod validator;
 pub mod wallet;

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -774,11 +774,11 @@ async fn main() -> anyhow::Result<()> {
             MempoolCommands::Stats => cmd_mempool_stats()?,
         },
 
-        Commands::Balance { address } => cmd_balance(&address)?,
+        Commands::Balance { address } => commands::misc::cmd_balance(&address)?,
 
-        Commands::History { address } => cmd_history(&address)?,
+        Commands::History { address } => commands::misc::cmd_history(&address)?,
 
-        Commands::GenesisWallets => cmd_genesis_wallets()?,
+        Commands::GenesisWallets => commands::misc::cmd_genesis_wallets()?,
     }
 
     Ok(())
@@ -3585,97 +3585,6 @@ fn cmd_mempool_stats() -> anyhow::Result<()> {
         .load_blockchain()?
         .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
     println!("Mempool size: {} transactions", bc.mempool_size());
-    Ok(())
-}
-
-fn cmd_balance(address: &str) -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-    let balance = bc.accounts.get_balance(address);
-    println!("Address: {}", address);
-    println!(
-        "Balance: {} sentri ({} SRX)",
-        balance,
-        balance as f64 / 100_000_000.0
-    );
-    Ok(())
-}
-
-fn cmd_genesis_wallets() -> anyhow::Result<()> {
-    println!("Generating 7 genesis wallets for Sentrix...\n");
-
-    let roles = [
-        "founder",
-        "ecosystem_fund",
-        "early_validator",
-        "reserve",
-        "genesis_node_1",
-        "genesis_node_2",
-        "genesis_node_3",
-    ];
-
-    let mut wallets_json = serde_json::json!({});
-
-    for role in &roles {
-        let wallet = Wallet::generate();
-        println!("[{}]", role.to_uppercase());
-        println!("  Address:     {}", wallet.address);
-        println!("  Public key:  {}", wallet.public_key);
-        println!("  Private key: {}", wallet.secret_key_hex());
-        println!();
-
-        wallets_json[*role] = serde_json::json!({
-            "address": wallet.address,
-            "public_key": wallet.public_key,
-            "private_key": wallet.secret_key_hex(),
-        });
-    }
-
-    // Save to file
-    let output_path = format!("{}/genesis_wallets.json", get_wallets_dir());
-    std::fs::write(&output_path, serde_json::to_string_pretty(&wallets_json)?)?;
-    println!("Saved to: {}", output_path);
-    println!("\nCRITICAL: Back up genesis_wallets.json offline immediately.");
-    println!("          Delete from this machine after backup.");
-    Ok(())
-}
-
-fn cmd_history(address: &str) -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    let bc = storage
-        .load_blockchain()?
-        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
-    let balance = bc.accounts.get_balance(address);
-    let nonce = bc.accounts.get_nonce(address);
-    let history = bc.get_address_history(address, 20, 0);
-
-    println!("Address: {}", address);
-    println!(
-        "Balance: {} sentri ({} SRX)",
-        balance,
-        balance as f64 / 100_000_000.0
-    );
-    println!("Nonce:   {}", nonce);
-    println!("Transactions: {}\n", history.len());
-
-    for tx in history.iter().rev().take(20) {
-        let dir = tx["direction"].as_str().unwrap_or("?");
-        let label = match dir {
-            "reward" => "REWARD",
-            "in" => "IN    ",
-            "out" => "OUT   ",
-            _ => "?     ",
-        };
-        println!(
-            "  [{}] {} | {} sentri | Block #{}",
-            label,
-            &tx["txid"].as_str().unwrap_or("?")[..24],
-            tx["amount"],
-            tx["block_index"],
-        );
-    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Three small top-level helpers move out of `main.rs` into `commands/misc.rs`:
- `cmd_balance` — print SRX balance for an address
- `cmd_history` — print recent transactions for an address (paginated)
- `cmd_genesis_wallets` — one-shot bootstrap helper that generates the seven labelled keypairs (founder / ecosystem_fund / early_validator / reserve / genesis_node_1..3) and writes them to `<wallets_dir>/genesis_wallets.json` with the CRITICAL "back up offline + delete from disk" reminder

Different domains but small enough that one `misc` module is cleaner than splintering into three single-fn files. `balance` / `history` hit `Blockchain` accessors; `genesis_wallets` generates wallets + writes a plaintext file.

`main.rs` drops to **3890 lines** (peak was 4780 pre-decomposition).

## Test plan

- [x] `cargo check -p sentrix-node -D warnings` clean
- [x] `cargo clippy -p sentrix-node --all-targets -D warnings` clean
- [x] `cargo test -p sentrix-node --release` — 25 / 25 green
- [x] Pre-push leak grep clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for CLI command handlers.

---

**Note:** This release contains no user-facing changes. Updates are internal to code structure and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/652)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->