### PR TITLE
fix(bench): port trie_insert to criterion 0.8 black_box

### DIFF
--- a/crates/sentrix-trie/benches/trie_insert.rs
+++ b/crates/sentrix-trie/benches/trie_insert.rs
@@ -6,18 +6,17 @@
 //! than catching it post-deploy when fullnode lag starts compounding.
 //!
 //! Bench groups:
-//!  - `insert_single`:  one insert into an empty trie. Measures the
-//!                      cold-cache path (every node traversal is a
-//!                      fresh MDBX read).
-//!  - `insert_batch_100`: 100 sequential inserts into a fresh trie.
-//!                      Measures the warm-cache path with the
-//!                      TrieCache populated mid-flight — the more
-//!                      realistic block-apply shape.
-//!  - `commit_100`:     same 100 inserts, then commit() the result.
-//!                      Catches regressions in the WriteBatch flush
-//!                      + state_root recomputation.
+//! - `insert_single`: one insert into an empty trie. Measures the
+//!   cold-cache path (every node traversal is a fresh MDBX read).
+//! - `insert_batch_100`: 100 sequential inserts into a fresh trie.
+//!   Measures the warm-cache path with the TrieCache populated
+//!   mid-flight — the more realistic block-apply shape.
+//! - `commit_100`: same 100 inserts, then commit() the result.
+//!   Catches regressions in the WriteBatch flush + state_root
+//!   recomputation.
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use sentrix_trie::{address::account_value_bytes, tree::SentrixTrie};
 use sentrix_storage::MdbxStorage;
 use std::sync::Arc;


### PR DESCRIPTION
## Summary

#631 bumped criterion 0.5 → 0.8.2 which marks `criterion::black_box` as deprecated (upstream `std::hint::black_box` has been stable since Rust 1.66). The bench compiled but `cargo clippy --workspace --all-targets -D warnings` broke locally with:
- 6 deprecation errors on `criterion::black_box` calls
- 7 `doc_overindented_list_items` errors on the module-header bullet list

Pulled `black_box` from `std::hint` and tightened the doc list indentation (4-space gutter → 2-space, matching rustdoc list spec). No behaviour change; criterion 0.8's `black_box` re-exports the same `std::hint::black_box` internally.

CI on `main` (`CI/CD` workflow) didn't catch this because it doesn't run clippy on benches with `-D warnings`. Worth fixing anyway for clean local builds.

## Test plan

- [x] `cargo clippy -p sentrix-trie --benches -D warnings` clean
- [x] `cargo clippy --workspace --all-targets -D warnings` clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal benchmark infrastructure and documentation formatting for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/653)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->