### PR TITLE
fix(node): address CR follow-ups on #646 / #648 / #652

### DIFF
--- a/bin/sentrix/src/commands/misc.rs
+++ b/bin/sentrix/src/commands/misc.rs
@@ -65,19 +65,23 @@ pub fn cmd_genesis_wallets() -> anyhow::Result<()> {
     // Save to file. On Unix, force mode 0600 (owner read+write only) so
     // a permissive umask can't leak the file to other local users —
     // genesis_wallets.json holds plaintext private keys. CR #652
-    // flagged the default-umask path as an information-disclosure risk.
+    // flagged the default-umask path as an information-disclosure risk;
+    // CR #654 added: `OpenOptionsExt::mode` only applies to NEW files,
+    // so an existing file with broader perms keeps them when truncated.
+    // Call `set_permissions` explicitly after open to tighten both paths.
     let output_path = format!("{}/genesis_wallets.json", get_wallets_dir());
     let body = serde_json::to_string_pretty(&wallets_json)?;
     #[cfg(unix)]
     {
         use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
         let mut f = std::fs::OpenOptions::new()
             .create(true)
             .truncate(true)
             .write(true)
             .mode(0o600)
             .open(&output_path)?;
+        f.set_permissions(std::fs::Permissions::from_mode(0o600))?;
         f.write_all(body.as_bytes())?;
     }
     #[cfg(not(unix))]

--- a/bin/sentrix/src/commands/misc.rs
+++ b/bin/sentrix/src/commands/misc.rs
@@ -62,9 +62,28 @@ pub fn cmd_genesis_wallets() -> anyhow::Result<()> {
         });
     }
 
-    // Save to file
+    // Save to file. On Unix, force mode 0600 (owner read+write only) so
+    // a permissive umask can't leak the file to other local users —
+    // genesis_wallets.json holds plaintext private keys. CR #652
+    // flagged the default-umask path as an information-disclosure risk.
     let output_path = format!("{}/genesis_wallets.json", get_wallets_dir());
-    std::fs::write(&output_path, serde_json::to_string_pretty(&wallets_json)?)?;
+    let body = serde_json::to_string_pretty(&wallets_json)?;
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .mode(0o600)
+            .open(&output_path)?;
+        f.write_all(body.as_bytes())?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&output_path, body)?;
+    }
     println!("Saved to: {}", output_path);
     println!("\nCRITICAL: Back up genesis_wallets.json offline immediately.");
     println!("          Delete from this machine after backup.");
@@ -97,12 +116,20 @@ pub fn cmd_history(address: &str) -> anyhow::Result<()> {
             "out" => "OUT   ",
             _ => "?     ",
         };
+        // Slice by chars, not bytes, to avoid panicking when the fallback
+        // "?" (or any short / non-ascii string) doesn't have 24 bytes —
+        // CR #652 flagged this as a 🔴 Critical panic risk. Truncating by
+        // char count is the right level of granularity: txids are hex
+        // (ASCII), so chars == bytes for the normal path.
+        let txid_short: String = tx["txid"]
+            .as_str()
+            .unwrap_or("?")
+            .chars()
+            .take(24)
+            .collect();
         println!(
             "  [{}] {} | {} sentri | Block #{}",
-            label,
-            &tx["txid"].as_str().unwrap_or("?")[..24],
-            tx["amount"],
-            tx["block_index"],
+            label, txid_short, tx["amount"], tx["block_index"],
         );
     }
     Ok(())

--- a/bin/sentrix/src/commands/state.rs
+++ b/bin/sentrix/src/commands/state.rs
@@ -105,7 +105,6 @@ pub fn cmd_state_import(input: &str, force: bool) -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
 
     let count = bc.import_state(&snapshot)?;
-    storage.save_blockchain(&bc)?;
 
     // ROOT CAUSE fix (2026-04-21 deploy rollback post-mortem): import only
     // rewrites `accounts` and counters. The trie storage (trie_nodes +
@@ -121,7 +120,17 @@ pub fn cmd_state_import(input: &str, force: bool) -> anyhow::Result<()> {
     // freshly imported accounts on next startup. The backfill produces
     // the SAME root any validator would compute from the same account
     // set, restoring cross-validator determinism.
+    //
+    // RESET BEFORE SAVE (CR #648): the previous order was
+    // save_blockchain → reset_trie. If reset_trie failed mid-flight,
+    // the imported accounts were already persisted while the stale
+    // trie tables remained — exactly the unsafe mixed state this
+    // command exists to prevent. The non-zero-height guard above then
+    // blocks retry. Wiping the trie tables first means a failure here
+    // leaves a torn-but-detectable state (reset succeeded, no save)
+    // and the operator's retry path is clean.
     storage.reset_trie()?;
+    storage.save_blockchain(&bc)?;
 
     println!(
         "State imported: {} accounts from snapshot at height {}",

--- a/bin/sentrix/src/commands/wallet.rs
+++ b/bin/sentrix/src/commands/wallet.rs
@@ -23,7 +23,7 @@ pub fn cmd_wallet_generate(password: Option<String>) -> anyhow::Result<()> {
     println!("  Public key:  {}", wallet.public_key);
 
     if let Some(pwd) = password {
-        let pwd = reject_empty_cli_password(&pwd)?;
+        let pwd = reject_empty_cli_password(pwd)?;
         let keystore = Keystore::encrypt(&wallet, &pwd)?;
         let filename = format!("{}/{}.json", get_wallets_dir(), &wallet.address[2..10]);
         keystore.save(&filename)?;
@@ -43,7 +43,7 @@ pub fn cmd_wallet_import(private_key: &str, password: Option<String>) -> anyhow:
     println!("  Public key: {}", wallet.public_key);
 
     if let Some(pwd) = password {
-        let pwd = reject_empty_cli_password(&pwd)?;
+        let pwd = reject_empty_cli_password(pwd)?;
         let keystore = Keystore::encrypt(&wallet, &pwd)?;
         let filename = format!("{}/{}.json", get_wallets_dir(), &wallet.address[2..10]);
         keystore.save(&filename)?;
@@ -238,7 +238,16 @@ pub fn cmd_wallet_rekey(
 /// password wrapped in `Zeroizing` so the heap allocation is wiped on
 /// drop (matching how the rest of the binary handles secret material —
 /// `Wallet::secret_key_bytes`, the `SENTRIX_VALIDATOR_KEY` env var).
-fn reject_empty_cli_password(pw: &str) -> anyhow::Result<Zeroizing<String>> {
+///
+/// Takes the password by value (not `&str`) so the caller's untrimmed
+/// `String` allocation is moved into a `Zeroizing` envelope and wiped
+/// on drop too. A previous version took `&str` and the caller's heap
+/// buffer (from clap / env) survived unzeroed; CodeRabbit caught it on
+/// PR #646.
+fn reject_empty_cli_password(pw: String) -> anyhow::Result<Zeroizing<String>> {
+    // Wrap the caller's allocation first so it can't leak if the
+    // trim-clone below panics or bails early.
+    let pw = Zeroizing::new(pw);
     let trimmed = pw.trim();
     if trimmed.is_empty() {
         anyhow::bail!("--password cannot be empty or whitespace");
@@ -344,7 +353,7 @@ mod tests {
 
     #[test]
     fn reject_empty_cli_password_rejects_empty() {
-        assert!(reject_empty_cli_password("").is_err());
+        assert!(reject_empty_cli_password(String::new()).is_err());
     }
 
     #[test]
@@ -353,14 +362,14 @@ mod tests {
         // `--password "..."`; the prompt path trims so the CLI / env
         // paths must too, otherwise the same operator input produces
         // a different keystore depending on which entry point ran.
-        assert!(reject_empty_cli_password("   ").is_err());
-        assert!(reject_empty_cli_password("\n").is_err());
-        assert!(reject_empty_cli_password("\t\t").is_err());
+        assert!(reject_empty_cli_password("   ".into()).is_err());
+        assert!(reject_empty_cli_password("\n".into()).is_err());
+        assert!(reject_empty_cli_password("\t\t".into()).is_err());
     }
 
     #[test]
     fn reject_empty_cli_password_accepts_non_empty() {
-        let pw = reject_empty_cli_password("hunter2").unwrap();
+        let pw = reject_empty_cli_password("hunter2".into()).unwrap();
         assert_eq!(pw.as_str(), "hunter2");
     }
 
@@ -369,7 +378,7 @@ mod tests {
         // Caller uses the returned value, not the original arg — so a
         // password typed as " hunter2 " encrypts the keystore with
         // exactly "hunter2", same as the prompt path.
-        let pw = reject_empty_cli_password("  hunter2  ").unwrap();
+        let pw = reject_empty_cli_password("  hunter2  ".into()).unwrap();
         assert_eq!(pw.as_str(), "hunter2");
     }
 
@@ -466,7 +475,7 @@ mod tests {
         let _proof: Zeroizing<String> =
             resolve_password_named_confirmed(Some("x".into()), "_", "_").unwrap();
         let _proof: Zeroizing<String> = resolve_password(Some("x".into())).unwrap();
-        let _proof: Zeroizing<String> = reject_empty_cli_password("x").unwrap();
+        let _proof: Zeroizing<String> = reject_empty_cli_password("x".into()).unwrap();
         let _proof: Zeroizing<String> =
             validate_external_password("x".into(), "--password").unwrap();
     }


### PR DESCRIPTION
## Summary

Four CodeRabbit findings on the three most recent merges. All validated against current code, all real.

### wallet.rs (PR #646)

`reject_empty_cli_password` took `&str`; the caller's `String` allocation (from clap / env) was never zeroized. The function returns a trimmed `Zeroizing<String>`, but the ORIGINAL heap buffer outlived the call unprotected.

Take the password by value, wrap in `Zeroizing` immediately, then trim. Tests updated to pass owned `String`s via `.into()`.

### state.rs (PR #648)

Sequence was `save_blockchain` → `reset_trie`. If `reset_trie` failed, imported accounts were already persisted while the stale trie tables remained — exactly the unsafe mixed state the command exists to prevent. The non-zero-height guard above then blocks retry.

Reordered to `reset_trie` → `save_blockchain`; a failure now leaves the trie tables wiped and the operator retries cleanly.

### misc.rs (PR #652) — two findings

1. **`genesis_wallets.json` permissions.** File was written with default umask. Plaintext private keys readable by other local users on permissive-umask hosts. On Unix the file now opens with mode `0o600` (owner read/write only). Non-unix targets keep the default since they don't share the umask risk model.

2. **`cmd_history` slice panic.** `&tx["txid"].as_str().unwrap_or("?")[..24]` panicked when the fallback `"?"` (1 byte) or any short value reached that line. Switched to `.chars().take(24).collect()` — panic-safe regardless of input length. Txids are hex so chars == bytes on the normal path; no display drift.

## Test plan

- [x] `cargo check -p sentrix-node -D warnings` clean
- [x] `cargo clippy -p sentrix-node --all-targets -D warnings` clean
- [x] `cargo test -p sentrix-node --release` — 25 / 25 green
- [x] Pre-push leak grep clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction ID display reliability to prevent errors
  * Enhanced state import safety by reordering steps to avoid inconsistent saves

* **Security**
  * Strengthened wallet password in-memory handling for better protection
  * Write-generated wallet data now uses restricted file permissions to protect sensitive files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/654)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->