### PR TITLE
refactor(node): extract cmd_init to commands/init.rs

### DIFF
--- a/bin/sentrix/src/commands/init.rs
+++ b/bin/sentrix/src/commands/init.rs
@@ -1,0 +1,52 @@
+//! `sentrix init` — one-shot chain bootstrap. Creates the genesis block
+//! from either an embedded mainnet template or a custom TOML at
+//! `--genesis <path>` (for testnet / devnet / one-off chains), persists
+//! it as height 0, and prints the post-init state for the operator.
+//!
+//! Extracted from `main.rs`. Same pattern as the other `commands/`
+//! modules — pure CLI handler, no consensus path touched. The actual
+//! genesis assembly lives in `sentrix-core::Genesis` /
+//! `Blockchain::new_with_genesis`.
+
+use sentrix::core::blockchain::Blockchain;
+use sentrix::storage::db::Storage;
+
+use crate::get_db_path;
+
+pub fn cmd_init(admin: &str, genesis_path: Option<&str>) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    if storage.has_blockchain() {
+        println!("Chain already initialized.");
+        return Ok(());
+    }
+    // Load + validate genesis config up front so a malformed config aborts
+    // init before we touch storage. A custom --genesis path lets operators
+    // bootstrap non-mainnet chains (testnet, devnet) from TOML without
+    // rebuilding the binary.
+    let genesis = match genesis_path {
+        Some(path) => {
+            let g = sentrix::core::Genesis::from_path(path)?;
+            println!(
+                "Loaded genesis from {}: chain_id={} ({})",
+                path, g.chain.chain_id, g.chain.name
+            );
+            g
+        }
+        None => {
+            let g = sentrix::core::Genesis::mainnet()?;
+            println!(
+                "Using embedded mainnet genesis: chain_id={} ({})",
+                g.chain.chain_id, g.chain.name
+            );
+            g
+        }
+    };
+    let bc = Blockchain::new_with_genesis(admin.to_string(), &genesis);
+    storage.save_blockchain(&bc)?;
+    let premine_srx = genesis.total_premine() / 100_000_000;
+    println!("Chain initialized.");
+    println!("Admin address: {}", admin);
+    println!("Genesis block created. Height: 0");
+    println!("Total premine: {} SRX", premine_srx);
+    Ok(())
+}

--- a/bin/sentrix/src/commands/mod.rs
+++ b/bin/sentrix/src/commands/mod.rs
@@ -8,6 +8,7 @@
 //! directly. Everything else moves here, one logical group per file.
 
 pub mod chain;
+pub mod init;
 pub mod mempool;
 pub mod misc;
 pub mod state;

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -586,7 +586,9 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Init { admin, genesis } => cmd_init(&admin, genesis.as_deref())?,
+        Commands::Init { admin, genesis } => {
+            commands::init::cmd_init(&admin, genesis.as_deref())?
+        }
 
         Commands::Wallet { action } => match action {
             WalletCommands::Generate { password } => commands::wallet::cmd_wallet_generate(password)?,
@@ -802,48 +804,6 @@ fn resolve_key(cli_arg: Option<String>, env_var: &str, label: &str) -> anyhow::R
         )
     })
 }
-
-// ── Command implementations ──────────────────────────────
-
-fn cmd_init(admin: &str, genesis_path: Option<&str>) -> anyhow::Result<()> {
-    let storage = Storage::open(&get_db_path())?;
-    if storage.has_blockchain() {
-        println!("Chain already initialized.");
-        return Ok(());
-    }
-    // Load + validate genesis config up front so a malformed config aborts
-    // init before we touch storage. A custom --genesis path lets operators
-    // bootstrap non-mainnet chains (testnet, devnet) from TOML without
-    // rebuilding the binary.
-    let genesis = match genesis_path {
-        Some(path) => {
-            let g = sentrix::core::Genesis::from_path(path)?;
-            println!(
-                "Loaded genesis from {}: chain_id={} ({})",
-                path, g.chain.chain_id, g.chain.name
-            );
-            g
-        }
-        None => {
-            let g = sentrix::core::Genesis::mainnet()?;
-            println!(
-                "Using embedded mainnet genesis: chain_id={} ({})",
-                g.chain.chain_id, g.chain.name
-            );
-            g
-        }
-    };
-    let bc = Blockchain::new_with_genesis(admin.to_string(), &genesis);
-    storage.save_blockchain(&bc)?;
-    let premine_srx = genesis.total_premine() / 100_000_000;
-    println!("Chain initialized.");
-    println!("Admin address: {}", admin);
-    println!("Genesis block created. Height: 0");
-    println!("Total premine: {} SRX", premine_srx);
-    Ok(())
-}
-
-
 
 async fn cmd_start(
     // Take the validator wallet by value so the caller's `Zeroizing` envelope


### PR DESCRIPTION
## Summary

`cmd_init` (one-shot chain bootstrap) moves to `commands/init.rs`. Wraps `Genesis::from_path` / `Genesis::mainnet` + `Blockchain::new_with_genesis` + a first save. Pure CLI handler, no consensus path.

`main.rs` drops to **3675 lines** (peak was 4780 pre-decomposition, −23%). `cmd_start` (~2700 LOC, BFT engine + libp2p swarm + validator key load) is the only handler left inline — orchestration layer needs to drive it directly.

## Test plan

- [x] `cargo check -p sentrix-node -D warnings` clean
- [x] `cargo clippy -p sentrix-node --all-targets -D warnings` clean
- [x] `cargo test -p sentrix-node --release` — 25 / 25 green
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized initialization command implementation structure for improved code maintainability and modularity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/656)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->