### PR TITLE
refactor(core): move fork-predicate substance to fork_heights.rs

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -495,148 +495,73 @@ impl Blockchain {
         self.chain.first().map(|b| b.index).unwrap_or(0)
     }
 
-    /// Is the given height at or after the Voyager DPoS fork?
-    ///
-    /// **Static / env-var only.** Returns true iff the operator set
-    /// `VOYAGER_FORK_HEIGHT` to a real value AND the height is past it.
-    /// Default `u64::MAX` makes this return false for all heights —
-    /// the mainnet-safe-default-pre-activation pattern.
-    ///
-    /// **Use [`voyager_mode_for`] in consensus paths** — it ORs this
-    /// check with the runtime persisted `voyager_activated` flag, so
-    /// post-activation chains don't depend on the env var being set
-    /// correctly. The 2026-04-26 mainnet stall (covered by operator
-    /// incident runbooks) happened because `validate_block` called this
-    /// static function:
-    /// env var was at default `u64::MAX`, function returned false,
-    /// validate_block fell through to Pioneer auth check, which
-    /// rejected legitimate Voyager skip-round blocks.
+    // ── Fork-height predicates ──────────────────────────────
+    //
+    // The substance + docs for each predicate live in
+    // `crate::fork_heights`. These `impl Blockchain` methods stay as
+    // thin delegators so all the external callers that already write
+    // `Blockchain::is_X_height(h)` keep working — and so the instance
+    // variants (`is_X_active(&self)`) have one obvious home.
+
     pub fn is_voyager_height(height: u64) -> bool {
-        let fork = get_voyager_fork_height();
-        fork != u64::MAX && height >= fork
+        crate::fork_heights::is_voyager_height(height)
     }
 
-    /// Is the current chain past the Voyager fork?
-    /// Static-only env-var check; see [`is_voyager_height`] caveats.
     pub fn is_voyager_active(&self) -> bool {
-        Self::is_voyager_height(self.height())
+        crate::fork_heights::is_voyager_height(self.height())
     }
 
-    /// Voyager-mode check for a specific block height that respects
-    /// BOTH the env-var fork height AND the runtime persisted
-    /// `voyager_activated` flag from chain.db.
-    ///
-    /// Returns true if EITHER:
-    /// - `voyager_activated == true` (chain has actually activated
-    ///   Voyager via `Blockchain::activate_voyager()`), OR
-    /// - `is_voyager_height(height) == true` (env var pinned a fork
-    ///   height + we're past it)
-    ///
-    /// This is the consensus-safe check — call this in `validate_block`
-    /// and any other path where rejecting valid Voyager blocks would
-    /// fork the chain. The OR semantics mean a chain that activated
-    /// Voyager via the runtime path (with env var unset / wrong)
-    /// continues to apply blocks correctly.
+    /// Voyager-mode check that respects BOTH the env-var fork height
+    /// AND the runtime persisted `voyager_activated` flag. Consensus-
+    /// safe — use this in `validate_block`. The OR semantics mean a
+    /// chain that activated Voyager via the runtime path (with env var
+    /// unset / wrong) continues to apply blocks correctly.
     pub fn voyager_mode_for(&self, height: u64) -> bool {
-        self.voyager_activated || Self::is_voyager_height(height)
+        self.voyager_activated || crate::fork_heights::is_voyager_height(height)
     }
 
-    /// V4 Step 3: is the given height at or after the reward-v2 fork?
-    /// Post-fork: coinbase routes to PROTOCOL_TREASURY, ClaimRewards
-    /// dispatch is consensus-valid.
     pub fn is_reward_v2_height(height: u64) -> bool {
-        let fork = get_reward_v2_fork_height();
-        fork != u64::MAX && height >= fork
+        crate::fork_heights::is_reward_v2_height(height)
     }
 
     pub fn is_reward_v2_active(&self) -> bool {
-        Self::is_reward_v2_height(self.height())
+        crate::fork_heights::is_reward_v2_height(self.height())
     }
 
-    /// Tokenomics v2: is the given height at or after the fork?
-    /// Post-fork: 126M halving + 315M cap (BTC-parity 4-year emission).
     pub fn is_tokenomics_v2_height(height: u64) -> bool {
-        let fork = get_tokenomics_v2_height();
-        fork != u64::MAX && height >= fork
+        crate::fork_heights::is_tokenomics_v2_height(height)
     }
 
-    /// Phase B (consensus-jail): is the given height at or after the fork?
-    /// Post-fork: `StakingOp::JailEvidenceBundle` dispatch is consensus-valid;
-    /// epoch-boundary proposer includes evidence; peers verify and apply
-    /// jail as on-chain state mutation. Pre-fork: legacy local check_liveness.
     pub fn is_jail_consensus_height(height: u64) -> bool {
-        let fork = get_jail_consensus_height();
-        fork != u64::MAX && height >= fork
+        crate::fork_heights::is_jail_consensus_height(height)
     }
 
-    /// Is the given height at or after the NFT TokenOp fork?
-    /// Post-fork: SRC-721 + SRC-1155 TokenOp variants dispatch.
-    /// Pre-fork: dispatch rejects (wire format stable, storage layer
-    /// + REST handlers gated until activation).
     pub fn is_nft_tokenop_height(height: u64) -> bool {
-        let fork = get_nft_tokenop_height();
-        fork != u64::MAX && height >= fork
+        crate::fork_heights::is_nft_tokenop_height(height)
     }
 
-    /// Is the given height at or after the AddSelfStake fork?
-    /// Post-fork: `StakingOp::AddSelfStake` dispatch is consensus-valid —
-    /// validators can bond real SRX into their own self_stake without
-    /// phantom-mint. Pre-fork: dispatch rejects (wire format stable from
-    /// the activation PR; gate keeps it dormant until operator rollout).
     pub fn is_add_self_stake_height(height: u64) -> bool {
-        let fork = get_add_self_stake_height();
-        fork != u64::MAX && height >= fork
+        crate::fork_heights::is_add_self_stake_height(height)
     }
 
-    /// EVM value-transfer fork-gate. Pre-fork: Pass-2 EVM apply runs every
-    /// tx with `TxEnv.value = U256::ZERO` (v2.1.48 behaviour, divergence-free).
-    /// Post-fork: envelope value flows into revm — value-bearing EVM txs
-    /// move SRX between accounts. See `EVM_VALUE_TRANSFER_HEIGHT_DEFAULT`
-    /// for the regression context this gate manages.
     pub fn is_evm_value_transfer_height(height: u64) -> bool {
-        let fork = get_evm_value_transfer_height();
-        fork != u64::MAX && height >= fork
+        crate::fork_heights::is_evm_value_transfer_height(height)
     }
 
-    /// Audit H3 — true once `EVM_GAS_FIX_HEIGHT` activates. Post-fork
-    /// the write-path EVM tx skips revm's internal gas accounting
-    /// (`cfg.disable_base_fee = true`); Pass-1 flat `tx.fee` is the
-    /// entire fee, supply invariant restored.
     pub fn is_evm_gas_fix_height(height: u64) -> bool {
-        let fork = get_evm_gas_fix_height();
-        fork != u64::MAX && height >= fork
+        crate::fork_heights::is_evm_gas_fix_height(height)
     }
 
-    /// state_root v2 drift fix — true once `EXTENDED_TOUCH_LIST_HEIGHT`
-    /// activates. Post-fork `update_trie_for_block` augments the
-    /// `tx.from`/`tx.to`/validator/+TREASURY touch list with every
-    /// address in `accounts.touched_in_block` (every AccountDB mutator
-    /// records there). Closes the EVM-CREATE'd contract + internal
-    /// CALL trie-vs-AccountDB divergence class.
     pub fn is_extended_touch_list_height(height: u64) -> bool {
-        let fork = get_extended_touch_list_height();
-        fork != u64::MAX && height >= fork
+        crate::fork_heights::is_extended_touch_list_height(height)
     }
 
-    /// Strict justification verification — true once
-    /// `STRICT_JUSTIFICATION_HEIGHT` activates. Post-fork every
-    /// peer-supplied block runs full crypto verification on its
-    /// justification precommits (recover signer, match against
-    /// claimed validator, sum verified stake from receiver's own
-    /// registry). Closes the chain-fork class identified by halt #9.
     pub fn is_strict_justification_height(height: u64) -> bool {
-        let fork = get_strict_justification_height();
-        fork != u64::MAX && height >= fork
+        crate::fork_heights::is_strict_justification_height(height)
     }
 
-    /// BFT-gate-relax: is the given height at or after the fork?
-    /// Post-fork: validator-loop's P1 BFT safety gate uses
-    /// `active >= ⌈2/3 × total⌉` instead of `active >= MIN_BFT_VALIDATORS (=4)`.
-    /// For 4-validator network: gate becomes 3 instead of 4 (= 1-jail tolerance).
-    /// See `audits/jail-cascade-root-cause-analysis.md`.
     pub fn is_bft_gate_relax_height(height: u64) -> bool {
-        let fork = get_bft_gate_relax_height();
-        fork != u64::MAX && height >= fork
+        crate::fork_heights::is_bft_gate_relax_height(height)
     }
 
     /// BFT-gate-relax: minimum active validator count for BFT participation.

--- a/crates/sentrix-core/src/fork_heights.rs
+++ b/crates/sentrix-core/src/fork_heights.rs
@@ -275,6 +275,135 @@ pub fn get_strict_justification_height() -> u64 {
         .unwrap_or(STRICT_JUSTIFICATION_HEIGHT_DEFAULT)
 }
 
+// ── Height predicates ────────────────────────────────────
+//
+// Every fork-height predicate has the same shape:
+//   `is_X_height(height) := fork != u64::MAX && height >= fork`
+// `u64::MAX` is the unset sentinel — the operator hasn't pinned an
+// activation height, so the gate stays closed (returns false) on
+// every block. Once the env var is set to a real height, the gate
+// flips open at that height.
+//
+// These used to live as `impl Blockchain { pub fn is_X_height(h) … }`
+// inside `blockchain.rs`. Moved here so the const + accessor + gate
+// for every fork sit in one module. `Blockchain` keeps thin
+// delegating methods for API compat.
+
+/// **Static / env-var only.** Returns true iff the operator set
+/// `VOYAGER_FORK_HEIGHT` to a real value AND the height is past it.
+/// Default `u64::MAX` makes this return false for all heights —
+/// the mainnet-safe-default-pre-activation pattern.
+///
+/// **Use [`crate::Blockchain::voyager_mode_for`] in consensus paths** —
+/// it ORs this check with the runtime persisted `voyager_activated`
+/// flag, so post-activation chains don't depend on the env var being
+/// set correctly. The 2026-04-26 mainnet stall happened because
+/// `validate_block` called this static function: env var was at
+/// default `u64::MAX`, function returned false, validate_block fell
+/// through to Pioneer auth check, which rejected legitimate Voyager
+/// skip-round blocks.
+pub fn is_voyager_height(height: u64) -> bool {
+    let fork = get_voyager_fork_height();
+    fork != u64::MAX && height >= fork
+}
+
+/// V4 Step 3: is the given height at or after the reward-v2 fork?
+/// Post-fork: coinbase routes to `PROTOCOL_TREASURY`, `ClaimRewards`
+/// dispatch is consensus-valid.
+pub fn is_reward_v2_height(height: u64) -> bool {
+    let fork = get_reward_v2_fork_height();
+    fork != u64::MAX && height >= fork
+}
+
+/// Tokenomics v2: is the given height at or after the fork?
+/// Post-fork: 126M halving + 315M cap (BTC-parity 4-year emission).
+pub fn is_tokenomics_v2_height(height: u64) -> bool {
+    let fork = get_tokenomics_v2_height();
+    fork != u64::MAX && height >= fork
+}
+
+/// Phase B (consensus-jail): is the given height at or after the fork?
+/// Post-fork: `StakingOp::JailEvidenceBundle` dispatch is consensus-
+/// valid; epoch-boundary proposer includes evidence; peers verify and
+/// apply jail as on-chain state mutation. Pre-fork: legacy local
+/// check_liveness.
+pub fn is_jail_consensus_height(height: u64) -> bool {
+    let fork = get_jail_consensus_height();
+    fork != u64::MAX && height >= fork
+}
+
+/// Is the given height at or after the NFT TokenOp fork?
+/// Post-fork: SRC-721 + SRC-1155 `TokenOp` variants dispatch.
+/// Pre-fork: dispatch rejects (wire format stable, storage layer +
+/// REST handlers gated until activation).
+pub fn is_nft_tokenop_height(height: u64) -> bool {
+    let fork = get_nft_tokenop_height();
+    fork != u64::MAX && height >= fork
+}
+
+/// Is the given height at or after the `AddSelfStake` fork?
+/// Post-fork: `StakingOp::AddSelfStake` dispatch is consensus-valid —
+/// validators can bond real SRX into their own self_stake without
+/// phantom-mint. Pre-fork: dispatch rejects (wire format stable from
+/// the activation PR; gate keeps it dormant until operator rollout).
+pub fn is_add_self_stake_height(height: u64) -> bool {
+    let fork = get_add_self_stake_height();
+    fork != u64::MAX && height >= fork
+}
+
+/// EVM value-transfer fork-gate. Pre-fork: Pass-2 EVM apply runs every
+/// tx with `TxEnv.value = U256::ZERO` (v2.1.48 behaviour, divergence-
+/// free). Post-fork: envelope value flows into revm — value-bearing
+/// EVM txs move SRX between accounts. See
+/// `EVM_VALUE_TRANSFER_HEIGHT_DEFAULT` for the regression context
+/// this gate manages.
+pub fn is_evm_value_transfer_height(height: u64) -> bool {
+    let fork = get_evm_value_transfer_height();
+    fork != u64::MAX && height >= fork
+}
+
+/// Audit H3 — true once `EVM_GAS_FIX_HEIGHT` activates. Post-fork the
+/// write-path EVM tx skips revm's internal gas accounting
+/// (`cfg.disable_base_fee = true`); Pass-1 flat `tx.fee` is the entire
+/// fee, supply invariant restored.
+pub fn is_evm_gas_fix_height(height: u64) -> bool {
+    let fork = get_evm_gas_fix_height();
+    fork != u64::MAX && height >= fork
+}
+
+/// state_root v2 drift fix — true once `EXTENDED_TOUCH_LIST_HEIGHT`
+/// activates. Post-fork `update_trie_for_block` augments the
+/// `tx.from`/`tx.to`/validator/+TREASURY touch list with every address
+/// in `accounts.touched_in_block` (every AccountDB mutator records
+/// there). Closes the EVM-CREATE'd contract + internal CALL trie-vs-
+/// AccountDB divergence class.
+pub fn is_extended_touch_list_height(height: u64) -> bool {
+    let fork = get_extended_touch_list_height();
+    fork != u64::MAX && height >= fork
+}
+
+/// Strict justification verification — true once
+/// `STRICT_JUSTIFICATION_HEIGHT` activates. Post-fork every peer-
+/// supplied block runs full crypto verification on its justification
+/// precommits (recover signer, match against claimed validator, sum
+/// verified stake from receiver's own registry). Closes the chain-
+/// fork class identified by halt #9.
+pub fn is_strict_justification_height(height: u64) -> bool {
+    let fork = get_strict_justification_height();
+    fork != u64::MAX && height >= fork
+}
+
+/// BFT-gate-relax: is the given height at or after the fork?
+/// Post-fork: validator-loop's P1 BFT safety gate uses
+/// `active >= ⌈2/3 × total⌉` instead of `active >= MIN_BFT_VALIDATORS
+/// (=4)`. For a 4-validator network: gate becomes 3 instead of 4
+/// (= 1-jail tolerance). See `audits/jail-cascade-root-cause-
+/// analysis.md`.
+pub fn is_bft_gate_relax_height(height: u64) -> bool {
+    let fork = get_bft_gate_relax_height();
+    fork != u64::MAX && height >= fork
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Eleven `is_X_height` static predicates lived as `impl Blockchain` methods with heavy doc comments documenting incident history + fork semantics. The actual logic was a 2-line `fork != u64::MAX && height >= fork` wrapper around the const accessor that already lives in `fork_heights`.

Moved logic + doc bulk to `fork_heights.rs` as free functions; the `Blockchain` impl methods stay as 1-line delegators so the ~17 external call sites (`Blockchain::is_X_height(h)`) keep working.

**Predicates moved:**
- `is_voyager_height`, `is_reward_v2_height`, `is_tokenomics_v2_height`
- `is_jail_consensus_height`, `is_nft_tokenop_height`, `is_add_self_stake_height`
- `is_evm_value_transfer_height`, `is_evm_gas_fix_height`
- `is_extended_touch_list_height`, `is_strict_justification_height`
- `is_bft_gate_relax_height`

`is_voyager_active` / `is_reward_v2_active` / `voyager_mode_for` stay on Blockchain since they need `self.height()` / `self.voyager_activated`. They now call `fork_heights::is_voyager_height` directly instead of `Self::is_voyager_height`.

`blockchain.rs` drops from 3481 → 3406 lines. `fork_heights.rs` grows 323 → 452 lines (absorbed the docs).

## Test plan

- [x] `cargo check -p sentrix-core -D warnings` clean
- [x] `cargo clippy -p sentrix-core --all-targets -D warnings` clean
- [x] `cargo test -p sentrix-core --release --lib` — 231 / 231 green
- [x] Pre-push leak grep clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized fork height activation logic by centralizing predicate functions, improving code maintainability and consistency across consensus mechanisms including Voyager, Reward v2, Tokenomics v2, and other protocol upgrades.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/657)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->