### PR TITLE
refactor(core): move tokenomics emission math to tokenomics.rs

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -736,44 +736,21 @@ impl Blockchain {
         }
     }
 
-    /// Tokenomics v2: max supply for a given height (fork-aware).
-    /// Pre-fork: 210M (`MAX_SUPPLY`). Post-fork: 315M (`MAX_SUPPLY_V2`).
+    // Tokenomics emission math — substance lives in `crate::tokenomics`.
+    // These delegators keep the existing `bc.max_supply_for(h)` /
+    // `bc.halving_interval_for(h)` / `Blockchain::halvings_at(h)` call
+    // sites working (sentrix-rpc, internal get_block_reward, tests).
+
     pub fn max_supply_for(&self, height: u64) -> u64 {
-        if Self::is_tokenomics_v2_height(height) {
-            MAX_SUPPLY_V2
-        } else {
-            MAX_SUPPLY
-        }
+        crate::tokenomics::max_supply_for(height)
     }
 
-    /// Tokenomics v2: halving interval for a given height (fork-aware).
-    /// Pre-fork: 42M blocks (1.33y). Post-fork: 126M blocks (4y BTC-parity).
     pub fn halving_interval_for(&self, height: u64) -> u64 {
-        if Self::is_tokenomics_v2_height(height) {
-            HALVING_INTERVAL_V2
-        } else {
-            HALVING_INTERVAL
-        }
+        crate::tokenomics::halving_interval_for(height)
     }
 
-    /// Halving count at a given height, fork-aware. Pre-fork blocks count
-    /// halvings against 42M intervals; post-fork blocks count against 126M
-    /// intervals **starting from the fork height** (so cumulative halvings
-    /// don't reset at fork moment, and no jump-up in reward).
-    ///
-    /// Assumes fork is activated while still within v1 era 0
-    /// (`fork_height < HALVING_INTERVAL` = 42M). At current mainnet height
-    /// ~600K, this is satisfied for any plausible fork target.
     fn halvings_at(height: u64) -> u32 {
-        let fork = get_tokenomics_v2_height();
-        if fork == u64::MAX || height < fork {
-            (height / HALVING_INTERVAL).try_into().unwrap_or(u32::MAX)
-        } else {
-            // Post-fork: count halvings from fork height using v2 interval.
-            // Pre-fork halvings = 0 by activation invariant (fork while in era 0).
-            let post = height.saturating_sub(fork);
-            (post / HALVING_INTERVAL_V2).try_into().unwrap_or(u32::MAX)
-        }
+        crate::tokenomics::halvings_at(height)
     }
 
     /// Is the given height at or after the EVM fork?

--- a/crates/sentrix-core/src/tokenomics.rs
+++ b/crates/sentrix-core/src/tokenomics.rs
@@ -55,6 +55,54 @@ pub fn max_supply_srx() -> f64 {
     (MAX_SUPPLY / 100_000_000) as f64
 }
 
+// ── Fork-aware emission math ─────────────────────────────
+//
+// These three functions used to live on `impl Blockchain` (max_supply_for,
+// halving_interval_for, halvings_at). Moved here so the tokenomics layer
+// owns its math; `Blockchain` keeps thin delegators for API compat with
+// existing instance-method callers.
+
+/// Max supply in sentri at the given height (fork-aware). Pre-fork:
+/// [`MAX_SUPPLY`] (210M). Post-fork: [`MAX_SUPPLY_V2`] (315M).
+pub fn max_supply_for(height: u64) -> u64 {
+    if crate::blockchain::Blockchain::is_tokenomics_v2_height(height) {
+        MAX_SUPPLY_V2
+    } else {
+        MAX_SUPPLY
+    }
+}
+
+/// Halving interval in blocks at the given height (fork-aware).
+/// Pre-fork: [`HALVING_INTERVAL`] (42M blocks ≈ 1.33y). Post-fork:
+/// [`HALVING_INTERVAL_V2`] (126M blocks ≈ 4y BTC-parity).
+pub fn halving_interval_for(height: u64) -> u64 {
+    if crate::blockchain::Blockchain::is_tokenomics_v2_height(height) {
+        HALVING_INTERVAL_V2
+    } else {
+        HALVING_INTERVAL
+    }
+}
+
+/// Halving count at a given height, fork-aware. Pre-fork blocks count
+/// halvings against 42M intervals; post-fork blocks count against 126M
+/// intervals **starting from the fork height** (so cumulative halvings
+/// don't reset at fork moment, and no jump-up in reward).
+///
+/// Assumes fork is activated while still within v1 era 0
+/// (`fork_height < HALVING_INTERVAL` = 42M). At current mainnet height
+/// ~600K, this is satisfied for any plausible fork target.
+pub fn halvings_at(height: u64) -> u32 {
+    let fork = crate::fork_heights::get_tokenomics_v2_height();
+    if fork == u64::MAX || height < fork {
+        (height / HALVING_INTERVAL).try_into().unwrap_or(u32::MAX)
+    } else {
+        // Post-fork: count halvings from fork height using v2 interval.
+        // Pre-fork halvings = 0 by activation invariant (fork while in era 0).
+        let post = height.saturating_sub(fork);
+        (post / HALVING_INTERVAL_V2).try_into().unwrap_or(u32::MAX)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Three fork-aware emission functions move out of `impl Blockchain` into `tokenomics.rs`:
- `max_supply_for(h)` — 210M / 315M cap (v1 / v2)
- `halving_interval_for(h)` — 42M / 126M blocks
- `halvings_at(h)` — fork-aware halving count

Used by `get_block_reward` + sentrix-rpc `explorer_api` / `accounts` routes + five internal tests. Logic + docs live in `tokenomics.rs` as free functions; `Blockchain` keeps thin delegator methods so `bc.max_supply_for(h)` and `Blockchain::halvings_at(h)` call sites keep working unchanged.

## Test plan

- [x] `cargo check -p sentrix-core -D warnings` clean
- [x] `cargo clippy -p sentrix-core --all-targets -D warnings` clean
- [x] `cargo test -p sentrix-core --release --lib` — **231 / 231 green** (including the 5 tokenomics math tests in blockchain.rs)
- [x] Pre-push leak grep clean
- [ ] CI green

blockchain.rs drops by ~26 LOC; tokenomics.rs grows by the moved methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized tokenomics emission calculation logic for improved code organization and maintainability.

* **New Features**
  * Added public functions to compute fork-aware tokenomics metrics across network upgrades.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/658)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->