### PR TITLE
chore(deny): drop three unused license allowances

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,13 +14,10 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "ISC",
-  "Unicode-DFS-2016",
   "Unicode-3.0",
   "CC0-1.0",
-  "0BSD",
   "MPL-2.0",
   "Zlib",
-  "NCSA",
   "BUSL-1.1",
 ]
 confidence-threshold = 0.8


### PR DESCRIPTION
## Summary

`cargo deny check licenses bans sources` warned that three entries in `deny.toml`'s allow list were never matched by any encountered crate:

- `0BSD`
- `NCSA`
- `Unicode-DFS-2016`

Stale entries — probably added defensively when a transitive dep briefly carried one of these, then churned to something else. Dropping them; `cargo deny check licenses` still passes (`licenses ok`) on the current tree.

If a future dep brings one back, the failure will be loud + we can re-add with a one-line PR (same shape as the `NCSA` add for `libfuzzer-sys` in #604).

The other cargo-deny warnings (wildcard path deps on internal `sentrix-*` crates) are intrinsic to our workspace layout — every crate uses path deps for its in-workspace siblings, and `allow-wildcard-paths = true` is set so they're tolerated. Those would only matter if we published to crates.io.

## Test plan

- [x] `cargo deny check licenses` — `licenses ok`
- [x] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency license allowlist to align with current project requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/662)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->