### PR TITLE
refactor(core): extract Blockchain fork-activation mutations to own module

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -4,7 +4,6 @@ use crate::authority::AuthorityManager;
 use crate::vm::ContractRegistry;
 use sentrix_primitives::account::AccountDB;
 use sentrix_primitives::block::Block;
-use sentrix_primitives::error::SentrixResult;
 use sentrix_primitives::merkle::merkle_root;
 use sentrix_primitives::transaction::Transaction;
 use sentrix_storage::MdbxStorage;
@@ -485,72 +484,6 @@ impl Blockchain {
     /// Is the current chain past the EVM fork?
     pub fn is_evm_active(&self) -> bool {
         Self::is_evm_height(self.height())
-    }
-
-    /// Initialize EVM state at fork activation.
-    /// Called once when chain reaches VOYAGER_EVM_HEIGHT.
-    /// Migrates all account code_hash fields and initializes gas tracking.
-    /// Idempotent — guarded by the persistent `evm_activated` flag.
-    pub fn activate_evm(&mut self) {
-        if self.evm_activated {
-            tracing::debug!("activate_evm: already activated, skipping");
-            return;
-        }
-        tracing::info!("Activating EVM at height {}", self.height());
-        let migrated = self.accounts.migrate_to_evm();
-        self.evm_activated = true;
-        tracing::info!(
-            "EVM activated: {} accounts migrated, gas metering enabled",
-            migrated
-        );
-    }
-
-    /// Initialize Voyager state at fork activation.
-    /// Called once when chain reaches VOYAGER_DPOS_HEIGHT.
-    /// Migrates existing Pioneer validators to DPoS with equal stake.
-    /// Idempotent — guarded by the persistent `voyager_activated` flag so
-    /// validator restarts post-fork don't re-register validators or
-    /// re-snapshot the epoch.
-    pub fn activate_voyager(&mut self) -> SentrixResult<()> {
-        use sentrix_staking::MIN_SELF_STAKE;
-
-        if self.voyager_activated {
-            tracing::debug!("activate_voyager: already activated, skipping");
-            return Ok(());
-        }
-
-        // Migrate Pioneer validators → DPoS validators
-        let validators: Vec<String> = self
-            .authority
-            .active_validators()
-            .iter()
-            .map(|v| v.address.clone())
-            .collect();
-        for address in &validators {
-            if let Err(e) = self.stake_registry.register_validator(
-                address,
-                MIN_SELF_STAKE,
-                1000, // 10% default commission
-                self.height(),
-            ) {
-                tracing::warn!("Failed to migrate validator {}: {}", address, e);
-            }
-        }
-
-        // Initialize epoch manager with the new stake registry
-        self.stake_registry.update_active_set();
-        self.epoch_manager
-            .initialize(&self.stake_registry, self.height());
-
-        self.voyager_activated = true;
-
-        tracing::info!(
-            "Voyager DPoS activated at height {}. {} validators migrated.",
-            self.height(),
-            self.stake_registry.active_count()
-        );
-
-        Ok(())
     }
 
     // ── Chain validation ─────────────────────────────────

--- a/crates/sentrix-core/src/blockchain_activations.rs
+++ b/crates/sentrix-core/src/blockchain_activations.rs
@@ -1,0 +1,81 @@
+//! `Blockchain` fork-activation mutations — `activate_evm` and
+//! `activate_voyager`. One-shot migrations called from the validator
+//! loop at the corresponding fork height; idempotent via persistent
+//! `evm_activated` / `voyager_activated` flags on the `Blockchain`
+//! struct so post-fork restarts don't re-run the migration.
+//!
+//! Rust permits splitting `impl T { … }` across modules within the
+//! same crate; the call sites in the validator loop (sentrix bin)
+//! keep `bc.activate_evm()` / `bc.activate_voyager()` unchanged.
+
+use sentrix_primitives::error::SentrixResult;
+
+use crate::blockchain::Blockchain;
+
+impl Blockchain {
+    /// Initialize EVM state at fork activation.
+    /// Called once when chain reaches VOYAGER_EVM_HEIGHT.
+    /// Migrates all account code_hash fields and initializes gas tracking.
+    /// Idempotent — guarded by the persistent `evm_activated` flag.
+    pub fn activate_evm(&mut self) {
+        if self.evm_activated {
+            tracing::debug!("activate_evm: already activated, skipping");
+            return;
+        }
+        tracing::info!("Activating EVM at height {}", self.height());
+        let migrated = self.accounts.migrate_to_evm();
+        self.evm_activated = true;
+        tracing::info!(
+            "EVM activated: {} accounts migrated, gas metering enabled",
+            migrated
+        );
+    }
+
+    /// Initialize Voyager state at fork activation.
+    /// Called once when chain reaches VOYAGER_DPOS_HEIGHT.
+    /// Migrates existing Pioneer validators to DPoS with equal stake.
+    /// Idempotent — guarded by the persistent `voyager_activated` flag so
+    /// validator restarts post-fork don't re-register validators or
+    /// re-snapshot the epoch.
+    pub fn activate_voyager(&mut self) -> SentrixResult<()> {
+        use sentrix_staking::MIN_SELF_STAKE;
+
+        if self.voyager_activated {
+            tracing::debug!("activate_voyager: already activated, skipping");
+            return Ok(());
+        }
+
+        // Migrate Pioneer validators → DPoS validators
+        let validators: Vec<String> = self
+            .authority
+            .active_validators()
+            .iter()
+            .map(|v| v.address.clone())
+            .collect();
+        for address in &validators {
+            if let Err(e) = self.stake_registry.register_validator(
+                address,
+                MIN_SELF_STAKE,
+                1000, // 10% default commission
+                self.height(),
+            ) {
+                tracing::warn!("Failed to migrate validator {}: {}", address, e);
+            }
+        }
+
+        // Initialize epoch manager with the new stake registry
+        self.stake_registry.update_active_set();
+        self.epoch_manager
+            .initialize(&self.stake_registry, self.height());
+
+        self.voyager_activated = true;
+
+        tracing::info!(
+            "Voyager DPoS activated at height {}. {} validators migrated.",
+            self.height(),
+            self.stake_registry.active_count()
+        );
+
+        Ok(())
+    }
+}

--- a/crates/sentrix-core/src/lib.rs
+++ b/crates/sentrix-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod authority;
 pub mod block_executor;
 pub mod block_producer;
 pub mod blockchain;
+pub mod blockchain_activations;
 pub mod blockchain_block_accessors;
 pub mod blockchain_storage_io;
 pub mod blockchain_trie_ops;


### PR DESCRIPTION
## Summary

Two `impl Blockchain` methods move out of `blockchain.rs` into a new sibling module `crates/sentrix-core/src/blockchain_activations.rs`:

| Method | Purpose |
|---|---|
| `activate_evm` | one-shot AccountDB EVM migration at `VOYAGER_EVM_HEIGHT` |
| `activate_voyager` | Pioneer → DPoS validator migration + epoch init at `VOYAGER_DPOS_HEIGHT` |

Both are guarded by persistent flags on the `Blockchain` struct (`evm_activated` / `voyager_activated`) so post-fork restarts are no-ops.

Same multi-file `impl Blockchain` pattern as #659 / #660 / #661. Call sites in the sentrix bin's validator loop keep `bc.activate_evm()` / `bc.activate_voyager()?` unchanged.

`blockchain.rs`: **2619 → 2553 LOC** (−66).

## Test plan

- [x] `cargo check -p sentrix-core -D warnings` clean
- [x] `cargo clippy -p sentrix-core --all-targets -D warnings` clean
- [x] `cargo test -p sentrix-core --release --lib` — **231 / 231 green**
- [x] Pre-push leak grep clean
- [x] CI green

(Branched off main pre-#660 merge; trivial lib.rs rebase if #660 lands first.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved fork-activation logic into a dedicated module to improve organization and maintainability.
  * Preserved public activation APIs for EVM and Voyager; activations are implemented as idempotent, one-shot operations and retain their previous behavior.
  * Exposed the new module at the crate root.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/663)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->