### PR TITLE
docs(validator): rewrite onboarding for permissionless DPoS + cosmetics

### DIFF
--- a/docs/operations/VALIDATORS.md
+++ b/docs/operations/VALIDATORS.md
@@ -1,76 +1,148 @@
 # Validators
 
-4 active validators in DPoS+BFT consensus (Voyager, v2.1.30+).
+Sentrix runs **Voyager DPoS + BFT** with a permissionless, uncapped
+candidate set and a top-21 active set rotated by total stake. Block
+time targets ~2.5 s. Block producer at height `h` = `active_set[h %
+active_set.len()]`.
 
-## Current Set
+> [!NOTE]
+> **To run your own validator:** see **[VALIDATOR_ONBOARDING.md](./VALIDATOR_ONBOARDING.md)** —
+> permissionless since 2026-04-25 (Voyager activation), candidate cap
+> lifted in v2.2.11 (2026-05-13).
+
+## Current active set (reference fleet)
 
 | Slot | Name | Address prefix | Role |
 |------|------|---------------|------|
-| 0 | Sentrix Treasury   | `0x0804...` | Treasury validator |
-| 1 | Sentrix Foundation | `0x753f...` | Foundation validator |
-| 2 | Sentrix Core       | `0x87c9...` | Core validator |
-| 3 | Sentrix Beacon     | `0x4cad...` | Beacon validator |
+| 0 | Sentrix Treasury   | `0x0804…` | Treasury validator |
+| 1 | Sentrix Foundation | `0x753f…` | Foundation validator |
+| 2 | Sentrix Core       | `0x87c9…` | Core validator |
+| 3 | Sentrix Beacon     | `0x4cad…` | Beacon validator |
 
-Sorted by address. Block producer = `height % 4`.
+Sorted by address. The reference fleet is operator-run on hosts owned
+by Sentrix Labs; this is the seed set, not a permanent ceiling.
+**Anyone with ≥15,000 SRX bonded can register and join the active set
+once they rank top-21 by stake.**
 
-(Nusantara, BlockForge Asia, PacificStake, Archipelago — decommissioned during v2.0.0 reset; services stopped, NOT on chain.)
+(Nusantara / BlockForge Asia / PacificStake / Archipelago —
+decommissioned during the v2.0.0 reset; services stopped, never on
+mainnet's current registry.)
 
-## Adding a Validator
+## Active-set rules
 
-Needs admin auth + valid secp256k1 pubkey that derives to the address.
+| Parameter | Value | Source |
+|---|---|---|
+| `MIN_SELF_STAKE` | 15,000 SRX | `sentrix-staking/staking.rs` |
+| `MAX_ACTIVE_VALIDATORS` | 21 | `sentrix-staking/staking.rs` |
+| `MAX_CANDIDATES` | `usize::MAX` (was 100, lifted v2.2.11) | `sentrix-staking/staking.rs` |
+| `MIN_BFT_VALIDATORS` | 4 (Voyager activation floor) | `sentrix-staking/staking.rs` |
+| `MIN_ACTIVE_VALIDATORS` | 1 (chain can produce with 1 active) | `sentrix-core/authority.rs` |
+| Commission range | 0 – 10,000 bp (0 – 100%) | `sentrix-staking/staking.rs` |
+| Unbonding period | 201,600 blocks (~7 days at 3 s) | `sentrix-staking/staking.rs` |
+
+## Add a validator (permissionless path, current)
+
+Submit `StakingOp::RegisterValidator` from your wallet — the tx is its
+own admission proof. See **[VALIDATOR_ONBOARDING.md §8](./VALIDATOR_ONBOARDING.md#8-register-as-a-validator-permissionless)**
+for the full flow.
+
+```text
+tx.from_address  = your-wallet (becomes validator address)
+tx.to_address    = TOKEN_OP_ADDRESS
+tx.amount        = ≥ 15,000 SRX  (bond moved to protocol treasury)
+tx.data          = StakingOp::RegisterValidator {
+                       self_stake: u64,        // must equal tx.amount
+                       commission_rate: u16,   // 0..=10000 bp
+                       public_key: String,     // uncompressed secp256k1 hex
+                   }
+```
+
+No admin co-sign, no whitelist, no Foundation approval.
+
+## Admin path (legacy / emergency)
+
+> [!CAUTION]
+> The admin-curated `sentrix validator add` path is **not the normal
+> onboarding flow today**. It's retained for:
+>
+> - Emergency recovery (chain-halted, can't process registration tx)
+> - Pre-Voyager bootstrap (no DPoS yet, no stake to bond against)
+>
+> If you're running a validator under standard ops, use the
+> permissionless `StakingOp::RegisterValidator` path above.
 
 ```bash
-# CLI
-sentrix validator add --address 0x... --public-key 04... --name "Name"
+# Admin co-signs (requires the chain admin key)
+sentrix validator add --address 0x... --public-key 04... \
+  --name "Operator Name" --admin-key <hex>
 
-# API
-curl -X POST http://[NODE_IP]:8545/validators \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: <key>" \
-  -d '{"address":"0x...","public_key":"04...","name":"Name","caller":"<admin>"}'
+# Live-node guard (v2.2.11+): if the node is producing blocks during
+# the call, the command refuses to persist (avoids overwriting in-
+# flight state). Stop the validator first, or set
+# SENTRIX_ALLOW_ONLINE_VALIDATOR_MUTATION=1 in deliberate recovery.
 ```
 
-## Changing Validator Set (Read This)
+## Set-change procedure (multi-node coordination)
 
-This is the one procedure that can brick the chain. Round-robin depends on all nodes having the exact same validator set.
+> [!IMPORTANT]
+> Round-robin depends on every node having an identical active set.
+> Adding a validator to some nodes but not others = stalled chain.
 
 ```
-1. Stop ALL nodes on ALL machines
+1. Stop ALL validator nodes
 2. Run add/remove on EVERY data directory
-3. Start ALL nodes
+3. Start ALL nodes simultaneously
 ```
 
-If you add a validator to some nodes but not others, they'll disagree on whose turn it is → chain stalls permanently.
+This is operationally heavy and only relevant to the **admin path**.
+The permissionless path applies the change as a normal block tx —
+every node sees it via consensus, no coordination needed.
 
-## Other Commands
+## CLI commands
 
 ```bash
-sentrix validator list
-sentrix validator toggle --address 0x... --active false
-sentrix validator rename --address 0x... --name "New Name"
-sentrix validator remove --address 0x...
+sentrix validator list                                 # all candidates + status
+sentrix validator unjail --address 0x...               # re-enter after jail
+sentrix validator force-unjail --address 0x... \      # phantom-stake unjail (mainnet
+    --i-understand-phantom-stake                        # acknowledgement required)
+sentrix validator toggle --address 0x... --admin-key  # active <-> inactive (admin)
+sentrix validator rename --address 0x... --name "…"   # display name (admin)
+sentrix validator remove --address 0x... --admin-key  # full removal (admin)
+sentrix validator transfer-admin --new-admin 0x... \  # rotate admin key
+    --admin-key <hex>
 ```
 
-`MIN_ACTIVE_VALIDATORS = 1` (since PR #234, v2.1.11). The chain can
-proceed with a single active validator if the rest are jailed or
-inactive. `MIN_BFT_VALIDATORS = 4` is the BFT-quorum floor for
-Voyager activation.
+Status shown in `validator list` (v2.2.11+):
 
-## Audit Trail
+- `[JAILED]` — `stake_registry.is_jailed` (downtime / double-sign / unjail-pending)
+- `[INACTIVE]` — admin toggled the authority entry off
+- `[ACTIVE]` — neither jailed nor toggled
 
-Every operation logged. View with:
+## Block production economics
+
+At ~2.5 s block time and 21 active validators in round-robin, each
+active validator produces roughly:
+
+- **3,433 blocks/day** (24 × 3,600 / 2.5 / 21 ≈ 3,432.5)
+- **~3,433 SRX/day** in block reward (1 SRX per block, pre-halving)
+- Plus `commission_rate × validator_pool_share` of delegated rewards
+- Plus a share of tx fees in produced blocks
+
+Delegators get the rest of the validator's pool, distributed proportionally.
+
+## Audit trail
+
+Every admin op logs to the append-only `admin_log` on
+`AuthorityManager`:
 
 ```bash
-curl -H "X-API-Key: <key>" http://[NODE_IP]:8545/admin/log
+curl -H "X-API-Key: <key>" https://rpc.sentrixchain.com/admin/log
 ```
 
-## Economics
+## See also
 
-Each validator produces ~21,600 blocks/day (86,400 1-second slots ÷ 4
-validators). That's ~21,600 SRX/day per validator from rewards alone,
-plus `floor(fee/2)` from each included transaction. Total chain
-throughput stays at 86,400 blocks/day (1s block time).
-
-## Voyager
-
-DPoS: open registration with 15K SRX stake, top 100 by stake score, epoch-based rotation, slashing. See [Voyager](../roadmap/PHASE2.md).
+- **[VALIDATOR_ONBOARDING.md](./VALIDATOR_ONBOARDING.md)** — full validator setup walkthrough
+- **[VALIDATOR_GUIDE.md](./VALIDATOR_GUIDE.md)** — cheat-sheet quickstart
+- **[../tokenomics/STAKING.md](../tokenomics/STAKING.md)** — staking + delegation + reward mechanics
+- **[CLAIM_REWARDS.md](./CLAIM_REWARDS.md)** — claim accrued rewards (post-V4 fork)
+- **[MONITORING.md](./MONITORING.md)** — Prometheus + journald setup

--- a/docs/operations/VALIDATOR_GUIDE.md
+++ b/docs/operations/VALIDATOR_GUIDE.md
@@ -1,54 +1,55 @@
-# Validator Guide
+# Validator Guide — Cheat Sheet
 
-Run a Sentrix validator node and participate in block production.
+> [!NOTE]
+> Run a Sentrix validator in 5 minutes. The full onboarding doc with
+> hardware sizing, recovery procedures, FAQ, and chain comparison
+> lives at **[VALIDATOR_ONBOARDING.md](./VALIDATOR_ONBOARDING.md)**.
 
-## Requirements
+## Quickstart
 
-| | Minimum | Recommended |
+```bash
+# 1. Build
+git clone https://github.com/sentrix-labs/sentrix.git && cd sentrix
+cargo build --release -p sentrix-node
+
+# 2. Generate keystore
+./target/release/sentrix wallet generate --password "<strong-passphrase>"
+
+# 3. Fund ≥15,000 SRX to the new address
+#    Testnet: https://faucet.sentrixchain.com
+#    Mainnet: buy / OTC
+
+# 4. Install + run
+sudo cp target/release/sentrix /opt/sentrix/
+sudo systemctl enable --now sentrix-<your-name>
+
+# 5. Submit RegisterValidator tx → block production rotates you in
+```
+
+## Hardware
+
+| Resource | Minimum | Recommended |
 |---|---|---|
-| CPU | 2 cores | 4 cores |
-| RAM | 2 GB | 4 GB |
-| Disk | 20 GB SSD | 50 GB NVMe |
-| Network | 10 Mbps | 100 Mbps |
+| vCPU | 4 | 6 – 8 |
+| RAM | 8 GiB | 16 GiB |
+| Swap | 8 GiB persistent | 16 GiB |
+| Disk | 60 GiB SSD | 120 GiB NVMe |
+| Network | 100 Mbit | 1 Gbit |
 | OS | Ubuntu 22.04+ | Ubuntu 24.04 |
 
-## Quick Start
+> [!CAUTION]
+> 2 GiB RAM / no swap was the pre-Voyager minimum. **Do not use it
+> today** — chain.db is mmap'd and tight memory under load causes
+> silent stalls. Stick to the table above.
 
-### 1. Get the binary
+## systemd unit
 
-```bash
-# Option A: build from source
-git clone https://github.com/sentrix-labs/sentrix.git
-cd sentrix
-cargo build --release
-cp target/release/sentrix /opt/sentrix/sentrix
-
-# Option B: download from latest release
-curl -L https://github.com/sentrix-labs/sentrix/releases/latest/download/sentrix -o /opt/sentrix/sentrix
-chmod +x /opt/sentrix/sentrix
-```
-
-### 2. Generate a validator wallet
-
-```bash
-sentrix wallet generate
-# Save the address + private key securely.
-# Then encrypt:
-sentrix wallet encrypt <private_key_hex> --output /opt/sentrix/data/wallets/validator.keystore
-```
-
-### 3. Register as validator
-
-Contact the chain admin to register your address + public key. On Pioneer (PoA), validators are admin-added. On Voyager (DPoS), you self-register via staking.
-
-### 4. Configure systemd
-
-Create `/etc/systemd/system/sentrix-validator.service`:
+`/etc/systemd/system/sentrix-<your-name>.service`:
 
 ```ini
 [Unit]
-Description=Sentrix Validator
-After=network.target
+Description=Sentrix Validator (<your-name>)
+After=network-online.target
 
 [Service]
 Type=simple
@@ -57,115 +58,108 @@ WorkingDirectory=/opt/sentrix
 ExecStart=/opt/sentrix/sentrix start \
     --validator-keystore /opt/sentrix/data/wallets/validator.keystore \
     --port 30303 \
-    --peers <bootstrap_node>:30303
+    --peers <bootstrap-multiaddrs>
 Restart=on-failure
 RestartSec=5
 LimitNOFILE=65535
-
-# Required environment
+EnvironmentFile=/etc/sentrix/sentrix-<your-name>.env
 Environment=SENTRIX_DATA_DIR=/opt/sentrix/data
 Environment=SENTRIX_API_PORT=8545
 Environment=SENTRIX_ENCRYPTED_DISK=true
-Environment=SENTRIX_WALLET_PASSWORD=<your_keystore_password>
 Environment=RUST_LOG=info
 
 [Install]
 WantedBy=multi-user.target
 ```
 
-**Important:** `chmod 600` the service file to hide the wallet password from non-root users.
-
-### 5. Start
+> [!IMPORTANT]
+> Wallet password goes in `EnvironmentFile=/etc/sentrix/…env` (mode
+> `600`, owner = service user). Never inline in the unit file —
+> env files don't appear in `ps`; unit files do.
 
 ```bash
 sudo systemctl daemon-reload
-sudo systemctl enable sentrix-validator
-sudo systemctl start sentrix-validator
+sudo systemctl enable --now sentrix-<your-name>
+sudo journalctl -u sentrix-<your-name> -f
 ```
 
-### 6. Verify
+## Verify
 
 ```bash
 # Service running?
-sudo systemctl status sentrix-validator
+sudo systemctl status sentrix-<your-name>
 
-# Health OK?
+# Health endpoint
 curl http://localhost:8545/health
 
-# Chain syncing?
-curl http://localhost:8545/chain/info
+# Chain advancing?
+watch -n 3 'curl -s http://localhost:8545/chain/info | jq .height'
 
-# Block height increasing?
-watch -n 3 'curl -s http://localhost:8545/chain/info | python3 -m json.tool | grep height'
+# You appear in stake registry?
+curl -s https://rpc.sentrixchain.com/staking/validators \
+  | jq '.validators[] | select(.address=="0x<yours>")'
 ```
 
-## Monitoring
+## Register as validator (permissionless)
 
-### Health check
+> [!NOTE]
+> Pre-Voyager docs said "contact the admin to register". That's
+> obsolete since Voyager activated (h=579,047, 2026-04-25) and the
+> candidate cap was lifted in v2.2.11 (2026-05-13).
+>
+> Today: bond ≥15,000 SRX and submit `StakingOp::RegisterValidator`.
+> No email, no DM, no admin co-sign.
+
+See [§8 of the onboarding doc](./VALIDATOR_ONBOARDING.md#8-register-as-a-validator-permissionless)
+for the exact tx format.
+
+## Monitoring essentials
 
 ```bash
-curl http://localhost:8545/health
-# {"status":"ok","node":"sentrix-chain"}
-```
-
-### Prometheus metrics
-
-```bash
+# Prometheus metrics
 curl http://localhost:8545/metrics
-# Returns: sentrix_block_height, sentrix_active_validators, sentrix_tx_pool_size, etc.
+
+# Logs
+sudo journalctl -u sentrix-<your-name> -f --since '5 min ago'
+
+# Critical events only
+sudo journalctl -u sentrix-<your-name> --since '1 hour ago' | grep CRITICAL
 ```
 
-Add to your `prometheus.yml`:
-
-```yaml
-scrape_configs:
-  - job_name: sentrix
-    static_configs:
-      - targets: ['localhost:8545']
-    metrics_path: /metrics
-    scrape_interval: 15s
-```
-
-### Logs
-
-```bash
-sudo journalctl -u sentrix-validator -f
-```
+Alert on:
+- `systemctl is-failed sentrix-<your-name>`
+- `/chain/info .height` delta = 0 for >2 min
+- Disk free < 10 GiB
+- `CRITICAL` log lines
 
 ## Troubleshooting
 
 | Symptom | Fix |
 |---|---|
-| Node not producing blocks | Check `ps aux` — is the process running? Check logs for errors. |
-| `Error: Wrong password` | Password in systemd doesn't match keystore. Re-check. |
-| `Error: disk encryption not confirmed` | Set `SENTRIX_ENCRYPTED_DISK=true` in systemd. |
-| Height stuck | Check peers — `curl localhost:8545/chain/info` should show `active_validators > 0`. |
-| State root mismatch after upgrade | Run `sentrix chain reset-trie` (stops and rebuilds trie from AccountDB). |
-| High memory usage | Normal for ~200K+ blocks. Sled caches aggressively. Restart clears cache. |
+| Node not producing blocks | `systemctl status` + check logs. If running but no blocks, verify you're in active top-21 by stake. |
+| `Error: Wrong password` | Env file password ≠ keystore password. Re-check. |
+| `Error: disk encryption not confirmed` | Set `SENTRIX_ENCRYPTED_DISK=true` in env. |
+| Height stuck across restart | Peer mesh gap — confirm `--peers` list current. |
+| State root mismatch after upgrade | `sentrix chain reset-trie --i-understand-divergence-risk`, then sync. |
+| High RAM usage | Normal mmap behaviour at 1M+ blocks. Tight swap is the actual problem; see hardware table. |
+| Jailed (inactive in `validator list`) | Submit `StakingOp::Unjail` after cooldown. |
 
-## Staking (Voyager DPoS — Testnet)
+## Security checklist
 
-On the Voyager testnet, validators self-register via staking:
+- [ ] `chmod 600` on keystore + env file
+- [ ] Wallet password in `EnvironmentFile`, not unit
+- [ ] Disk encrypted (`SENTRIX_ENCRYPTED_DISK=true`)
+- [ ] `--validator-key <hex>` CLI flag **never** used (removed v2.0.1, audit C-06 — leaks via `ps aux`)
+- [ ] SSH: `PasswordAuthentication=no`, fail2ban, UFW restricting non-essential ports
+- [ ] RPC port (`8545`) bound to `127.0.0.1` unless front-proxied with rate limit
+- [ ] Keystore + password backed up offline (password manager + encrypted USB)
+- [ ] Operator vulnerability disclosure: <security@sentrixchain.com>
 
-```bash
-# Minimum self-stake: 15,000 SRX
-curl -X POST http://localhost:9545/staking/register \
-  -H "Content-Type: application/json" \
-  -d '{"address":"0x...", "stake": 1500000000000, "commission": 1000}'
-```
+## See also
 
-See [docs/tokenomics/STAKING.md](../tokenomics/STAKING.md) for full staking mechanics.
-
-## Security
-
-- **Never share your private key or keystore password.**
-- Always load the validator key via `--validator-keystore <path>` or the
-  `SENTRIX_VALIDATOR_KEY` env var. The legacy `--validator-key <hex>` CLI
-  flag was removed in v2.0.1 (audit C-06) — CLI args leak via `ps aux`,
-  shell history, and process snapshots.
-- Source `SENTRIX_WALLET_PASSWORD` from a systemd `EnvironmentFile=` (or
-  equivalent secret store) so it never appears in `systemctl show` output
-  or `journalctl` logs.
-- `chmod 600` all systemd unit files that contain passwords.
-- Enable disk encryption on the validator host (`SENTRIX_ENCRYPTED_DISK=true`).
-- See [SECURITY.md on GitHub](https://github.com/sentrix-labs/sentrix/blob/main/SECURITY.md) for the vulnerability disclosure policy, or email `security@sentrixchain.com`.
+- **[VALIDATOR_ONBOARDING.md](./VALIDATOR_ONBOARDING.md)** — full deep guide (hardware, recovery, FAQ, chain comparison)
+- **[VALIDATORS.md](./VALIDATORS.md)** — current active set
+- **[../tokenomics/STAKING.md](../tokenomics/STAKING.md)** — staking + delegation + reward mechanics
+- **[CLAIM_REWARDS.md](./CLAIM_REWARDS.md)** — post-V4-fork reward claim flow
+- **[MONITORING.md](./MONITORING.md)** — Prometheus + Grafana setup
+- **[`SECURITY.md`](https://github.com/sentrix-labs/sentrix/blob/main/SECURITY.md)** — vulnerability disclosure policy

--- a/docs/operations/VALIDATOR_ONBOARDING.md
+++ b/docs/operations/VALIDATOR_ONBOARDING.md
@@ -1,17 +1,40 @@
-# Running a Sentrix validator
+# Running a Sentrix Validator
 
-This is the end-to-end guide for an independent operator — **not the
-Sentrix founder, not an internal team member** — who wants to run a
-Sentrix validator node. You provide the hardware, the time, and the
-stake (where staking applies). The chain does not care who you are or
-where your host is; it only cares that your validator address is in
-the on-chain authority registry and that your node produces valid
+> [!NOTE]
+> Sentrix is **permissionless** under Voyager DPoS — anyone with the
+> required self-stake can register as a validator without contacting the
+> Foundation. The chain does not maintain a whitelist.
+
+This is the end-to-end guide for an **independent operator** — not the
+Sentrix team, not an internal contributor — who wants to run a Sentrix
+validator node. You provide the hardware, the time, and the stake. The
+chain does not care who you are or where your host is; it only cares
+that your validator address is in the on-chain stake registry, that you
+bonded `MIN_SELF_STAKE` (15,000 SRX), and that your node produces valid
 blocks when it's your turn.
 
-This doc assumes you can read a Linux manpage, can use systemd, and
+The doc assumes you can read a Linux manpage, can use `systemd`, and
 have shell access to a server under your control. No specific cloud
-provider is required, no specific OS version is required, no "join
-the operator's private fleet" is required.
+provider, no specific OS version, no "join the operator's private
+fleet" required.
+
+---
+
+## Table of contents
+
+1. [What you're signing up for](#1-what-youre-signing-up-for)
+2. [How Sentrix compares](#2-how-sentrix-compares)
+3. [5-minute quickstart](#3-5-minute-quickstart)
+4. [Hardware + network](#4-hardware--network)
+5. [Get the binary](#5-get-the-binary)
+6. [Keystore](#6-keystore)
+7. [systemd unit](#7-systemd-unit)
+8. [Register as a validator (permissionless)](#8-register-as-a-validator-permissionless)
+9. [Deploying updates](#9-deploying-updates)
+10. [Monitoring](#10-monitoring)
+11. [Recovery paths](#11-recovery-paths)
+12. [FAQ](#12-faq)
+13. [Where to ask](#13-where-to-ask)
 
 ---
 
@@ -19,77 +42,119 @@ the operator's private fleet" is required.
 
 ### Consensus responsibility
 
-Sentrix runs **Voyager DPoS + BFT** on mainnet, live since
-h=579,047 (2026-04-25). Stake-weighted, unbounded validator set;
-3-phase BFT round (propose / prevote / precommit) per block; 2/3+1
-of stake-weighted active set finalises. Active validators today
-(reference set): Foundation, Treasury, Core, Beacon — additional
-operators expand the set without protocol changes.
+Sentrix runs **Voyager DPoS + BFT** on mainnet, live since h=579,047
+(2026-04-25). Stake-weighted, **uncapped candidate set** (cap was
+lifted v2.2.11), 21 active validators rotate based on stake rank,
+3-phase BFT round (propose / prevote / precommit) per block, 2/3+1 of
+stake-weighted active set finalises. Block time targets ~2.5 s.
 
-- Your node is expected to be online **>99.5%**. The in-chain liveness
-  tracker jails validators that miss more than 70% of their slots in a
-  rolling 14,400-block window (~4 hours at 1 s block time).
-- You sign every block in your turn; double-signing is slashable
-  (stake cut 20%, plus auto-jail).
-- **Self-stake minimum: 15,000 SRX** (1,500,000,000,000 sentri) —
-  matches the reference active set. The protocol enforces no hard
-  floor; the threshold is a coordination expectation so a new validator
-  carries comparable weight in the BFT supermajority. See
-  `docs/operations/CLAIM_REWARDS.md` for the post-V4-fork reward
-  flow (coinbase routes to protocol treasury; validators + delegators
-  claim accrued rewards via `StakingOp::ClaimRewards`).
+> [!IMPORTANT]
+> - Node uptime expectation: **>99.5%**. The in-chain liveness tracker
+>   jails validators that miss more than 70% of slots in a rolling
+>   14,400-block window (~4 hours at 1 s block time).
+> - You sign every block in your turn. **Double-signing is slashable
+>   (20% stake cut + auto-jail).**
+> - Self-stake minimum: **15,000 SRX** (1,500,000,000,000 sentri),
+>   enforced by `register_validator` apply path.
+> - You may delegate additional stake to yourself to climb the active-
+>   set ranking (top-21 produce blocks).
 
 ### Operational responsibility
 
 - Running the `sentrix` binary under systemd.
-- Firewall + SSH hardening. We assume UFW + fail2ban + `PasswordAuthentication=no`.
+- Firewall + SSH hardening. Recommended: UFW + fail2ban + `PasswordAuthentication=no`.
 - Encrypted keystore (Argon2id v2). Never publish your private key,
-  never ship it in an environment variable that leaks into process
-  listings.
+  never ship it in an env variable that ends up in process listings.
 - Monitoring: read your own `journalctl -u sentrix-<your-name>` and
-  know what a `CRITICAL #1e: state_root mismatch` line means (it means
-  you're diverging from canonical — page us).
-- Upgrades: watch the chain's release channel, deploy the new binary
+  know what `CRITICAL #1e: state_root mismatch` means (= you're
+  diverging from canonical, recovery procedure in §11).
+- Upgrades: track the chain's release channel, deploy new binaries
   within the announced maintenance window.
 
 ---
 
-## 2. Hardware + network
+## 2. How Sentrix compares
 
-Minimum (reference mainnet at h≈1.6M, 2026-05):
+| Chain | Active | Candidate cap | Min self-stake | Permissionless |
+|---|---:|---:|---|:---:|
+| BNB Beacon | 21 | ~50 | 10,000 BNB | ❌ (whitelist) |
+| **Sentrix** | **21** | **unlimited** | **15,000 SRX** | ✅ |
+| Polkadot | ~300 | unlimited | 1,000 DOT (nomination) | ✅ |
+| Cosmos Hub | 180 | unlimited | 1 ATOM (effective) | ✅ |
+| Solana | ~1500 | unlimited | none | ✅ |
+| Avalanche | ~1000+ | unlimited | 2,000 AVAX | ✅ |
 
-| Resource | Minimum | Comfortable |
-|---|---|---|
-| vCPU  | 4       | 6 – 8 |
-| RAM   | **8 GiB** | 16 GiB |
-| Swap  | **8 GiB** persistent (`/etc/fstab`) | 16 GiB |
-| Disk  | 60 GiB SSD | 120 GiB NVMe |
-| Bandwidth | 100 Mbit sustained | 1 Gbit |
-
-The RAM/swap floor is non-negotiable: chain.db is mmap'd, and
-empirically tight memory + zero swap = page-cache thrash under
-sustained tx load = tokio worker stalls = silent halts. Any 64-bit
-Linux works; we have deployed on Ubuntu 22.04 + 24.04 in production.
-
-**The consensus binary is OS-deterministic across kernel, glibc, and
-CPU family** — verified across the Ubuntu 22.04 (glibc 2.35) and
-24.04 (glibc 2.39) hosts in the reference fleet.
-
-Open inbound ports:
-
-- `30303/tcp` (or whatever you configure via `--port`) — libp2p P2P.
-- `22/tcp` — SSH. Restrict to your own IP or a jumpbox if you can.
-
-Do **not** expose the RPC port (`8545` etc) publicly without a
-reverse proxy + rate limit. Bind RPC to `127.0.0.1` and front it with
-Cloudflare / Caddy / nginx if you want to offer public RPC; otherwise
-keep it local-only.
+Sentrix sits between BNB (tight active set, sub-second-ish BFT) and
+Cosmos (large flexible set, ~6 s blocks). The small active set is
+deliberate — BFT supermajority round-trips stay short, block time
+stays low.
 
 ---
 
-## 3. Get the binary
+## 3. 5-minute quickstart
 
-You have two paths:
+For operators who already run blockchain nodes and just want the
+"happy path" — fill in `<…>` placeholders:
+
+```bash
+# 1. Pull + build (Rust 1.95+)
+git clone https://github.com/sentrix-labs/sentrix.git && cd sentrix
+cargo build --release -p sentrix-node    # binary: target/release/sentrix
+
+# 2. Generate keystore (writes data/wallets/<addr>.json)
+./target/release/sentrix wallet generate --password "<strong-passphrase>"
+
+# 3. Fund the new address with ≥15,000 SRX (mainnet — buy / OTC / earn;
+#    testnet — faucet at https://faucet.sentrixchain.com)
+
+# 4. Install + run as systemd (see §7 for unit template)
+sudo cp target/release/sentrix /opt/sentrix/
+sudo systemctl enable --now sentrix-<your-name>
+
+# 5. Submit RegisterValidator tx (see §8 for the exact JSON-RPC payload)
+#    Or wait for the upcoming `sentrix validator register` CLI helper.
+```
+
+That's the whole permissionless flow. No email, no DM, no approval.
+
+---
+
+## 4. Hardware + network
+
+Mainnet reference at h ≈ 1.74M (2026-05):
+
+| Resource | Minimum | Comfortable |
+|---|---|---|
+| vCPU | 4 | 6 – 8 |
+| RAM | **8 GiB** | 16 GiB |
+| Swap | **8 GiB** persistent (`/etc/fstab`) | 16 GiB |
+| Disk | 60 GiB SSD | 120 GiB NVMe |
+| Bandwidth | 100 Mbit sustained | 1 Gbit |
+
+> [!CAUTION]
+> RAM + swap floor is **non-negotiable**. `chain.db` is mmap'd; tight
+> memory with zero swap → page-cache thrash under tx load → tokio
+> worker stalls → silent halts. Empirically observed across 2026-04
+> incidents. Any 64-bit Linux works (Ubuntu 22.04 + 24.04 verified).
+
+The consensus binary is **OS-deterministic** across kernel, glibc,
+and CPU family — verified across Ubuntu 22.04 (glibc 2.35) and 24.04
+(glibc 2.39) hosts.
+
+Open inbound ports:
+
+- `30303/tcp` (or your `--port`) — libp2p P2P
+- `22/tcp` — SSH (restrict to your IP / jumpbox if possible)
+
+> [!WARNING]
+> Do **not** expose the RPC port (`8545`) publicly without a reverse
+> proxy + rate limit. Bind RPC to `127.0.0.1` and front it via
+> Cloudflare / Caddy / nginx if you want public RPC. Otherwise keep
+> local-only.
+
+---
+
+## 5. Get the binary
 
 ### Build from source (recommended)
 
@@ -97,65 +162,72 @@ You have two paths:
 git clone https://github.com/sentrix-labs/sentrix.git
 cd sentrix
 cargo build --release -p sentrix-node
-# binary lands at target/release/sentrix
+# target/release/sentrix
 ```
 
-Rust 1.95+. The docker build (`docker run --rm -v $PWD:/w -w /w
-rust:1.95-bullseye cargo build --release -p sentrix-node`) is what the
-reference operator uses and produces a byte-reproducible binary —
-recommended if you want to compare MD5 against the published release
-hash.
+Toolchain: Rust 1.95+ (stable). The reference reproducible build:
+
+```bash
+docker run --rm -v "$PWD:/w" -w /w rust:1.95-bullseye \
+  cargo build --release -p sentrix-node
+```
+
+Compare `sha256sum target/release/sentrix` against the published
+release-notes hash to verify your build matches canonical.
 
 ### Download a release
 
-Signed tarballs are published at
-`https://github.com/sentrix-labs/sentrix/releases`. Verify the
-SHA256 against the release notes. Extract the `sentrix` binary and
+Signed tarballs at <https://github.com/sentrix-labs/sentrix/releases>.
+Verify SHA-256 against the release notes. Extract `sentrix` and
 `chmod +x`.
 
 ---
 
-## 4. Keystore
+## 6. Keystore
 
-Generate your validator keypair:
+Generate the validator keypair:
 
 ```bash
 ./sentrix wallet generate --password "<strong-passphrase>"
 # Address: 0x...
-# Keystore saved to data/wallets/<addr>.json
+# Keystore: data/wallets/<addr>.json
 ```
 
-Or, if you already have a private key (e.g. migrating from another
-setup):
+Or import an existing private key:
 
 ```bash
-./sentrix wallet encrypt "<hex-private-key>" --password "<pwd>" \
+./sentrix wallet encrypt "<hex-private-key>" \
+  --password "<pwd>" \
   --output /opt/sentrix/data/wallets/my-validator.keystore
 ```
 
-Set file permissions:
+Set permissions:
 
 ```bash
-sudo chmod 600 /opt/sentrix/data/wallets/*.keystore
-sudo chown <systemd-unit-user>:<group> /opt/sentrix/data/wallets/*.keystore
+sudo chmod 600 /opt/sentrix/data/wallets/*.json
+sudo chown <service-user>:<group> /opt/sentrix/data/wallets/*.json
 ```
+
+> [!TIP]
+> Wallet helpers (v2.2.10+) use a no-echo prompt (`rpassword`),
+> confirm-twice on `rekey`, atomic backup+rename with rollback on
+> failure, and zeroize passwords on drop. The `wallet rekey` command
+> verifies a decrypt round-trip before overwriting your only copy,
+> and leaves a `.bak-<ts>` you can `rm` after stable operation.
 
 ### Password hygiene
 
-- Password goes in the systemd env file at `mode 600`, never in the
-  unit file itself (env files are not in `ps`; unit files are).
-- Rotate with `sentrix wallet rekey <keystore> --old-password …
-  --new-password …`. The rekey is atomic: it verifies a decrypt
-  round-trip on the new keystore before renaming over the old copy,
-  and leaves a `.bak-<ts>` behind.
-- Lost password = lost validator. There is no recovery path. Store the
-  password offline (password manager + encrypted backup).
+- Password lives in the systemd `EnvironmentFile` at mode `600`. Never
+  in the unit file itself (env files don't show in `ps`; unit files do).
+- Rotate with `sentrix wallet rekey <keystore> --old-password … --new-password …`.
+- **Lost password = lost validator.** There is no recovery path. Use a
+  password manager + encrypted backup.
 
 ---
 
-## 5. systemd unit
+## 7. systemd unit
 
-Create `/etc/systemd/system/sentrix-<your-name>.service`:
+`/etc/systemd/system/sentrix-<your-name>.service`:
 
 ```ini
 [Unit]
@@ -169,8 +241,7 @@ User=<unprivileged-service-user>
 WorkingDirectory=/opt/sentrix
 ExecStart=/opt/sentrix/sentrix start \
   --validator-keystore /opt/sentrix/data/wallets/<my>.keystore \
-  --peers <comma-separated list of bootstrap peers — ask in the
-           operator channel for current bootstrap multiaddrs>
+  --peers <bootstrap-multiaddrs-from-channel>
 Restart=always
 RestartSec=5
 LimitNOFILE=65536
@@ -182,14 +253,14 @@ Environment=SENTRIX_ENCRYPTED_DISK=true
 WantedBy=multi-user.target
 ```
 
-Create the env file at `/etc/sentrix/sentrix-<your-name>.env`
-(mode 600, owner = service user):
+Env file `/etc/sentrix/sentrix-<your-name>.env` (mode `600`, owner =
+service user):
 
 ```
 SENTRIX_WALLET_PASSWORD=<your-keystore-password>
 ```
 
-Enable + start:
+Start + tail:
 
 ```bash
 sudo systemctl daemon-reload
@@ -205,42 +276,72 @@ P2P transport: libp2p (Noise encrypted)
 Peer connected: 12D3KooW…
 ```
 
----
-
-## 6. Get added to the authority registry
-
-Your node is now running, but it's not yet a VALIDATOR — it's just a
-peer. To become an authority:
-
-1. Email **`validators@sentrixchain.com`** with:
-   - Your validator address + uncompressed public key (both are
-     printed by `./sentrix wallet info <keystore>`).
-   - Your operator name as you want it displayed in the on-chain
-     registry + block explorer (e.g. `"Acme Validator Co"`).
-   - Self-stake amount you intend to bond (≥ 15,000 SRX) and the
-     funding source (we'll coordinate testnet first if you're
-     bootstrapping fresh).
-   - Optional: jurisdiction, host region, ops contact for incident
-     coordination.
-2. The chain admin co-signs `sentrix validator add` (mainnet) or
-   `RegisterValidator` (post-Voyager dispatch). Activation height
-   is shared back so you can verify your appearance in
-   `GET /chain/info → validators` and at `scan.sentrixchain.com/validators`.
-3. Self-bond via `StakingOp::Delegate` once activated — you can
-   delegate your own stake before external delegators do, raising
-   your active-set weight.
-
-Admin op is verified on-chain — your admission cannot be tampered with
-once in a block.
-
-**The `<your-name>` string lands in the on-chain validator registry and
-drives the block-explorer label. Choose it to represent your operation
-(e.g. `"Acme Validator Co"`, `"nodes.guru"`, `"Operator Alice"`). It's
-not a hostname — it's a public-facing identity.**
+> [!NOTE]
+> Bootstrap peer multiaddrs are published in the chain's release
+> notes and refreshed periodically. Ask in the operator channel
+> if you're unsure which set is current.
 
 ---
 
-## 7. Deploying updates
+## 8. Register as a validator (permissionless)
+
+Your node is running as a peer. To produce blocks you must register
+in the on-chain stake registry.
+
+### Requirements
+
+| Field | Value |
+|---|---|
+| Bond | **`tx.amount` must equal `self_stake` and be ≥ 15,000 SRX** |
+| Commission rate | 0 – 100% (basis points; `1000` = 10%) |
+| Validator address | Your wallet's address (= sender of the tx) |
+| Public key | Uncompressed secp256k1 hex (printed by `wallet info`) |
+
+The bond moves your SRX to the protocol treasury during apply; you
+can unbond later via `StakingOp::Undelegate` (subject to a 7-day
+unbonding period).
+
+### Build + submit the transaction
+
+The wire format is `StakingOp::RegisterValidator { self_stake, commission_rate, public_key }`
+sent as a regular signed transaction with `to_address = TOKEN_OP_ADDRESS`
+and `tx.amount == self_stake`.
+
+Until the dedicated CLI helper ships, use any of:
+
+- **`sentrix` REPL / scripted tx builder** — the chain ships
+  `cli_create_token_tx` (same shape as token ops); analogous
+  `cli_create_staking_tx` helper coming in a follow-up release.
+- **JSON-RPC eth_sendRawTransaction** — encode `StakingOp` as the tx
+  `data` field, sign with your wallet, broadcast.
+- **Web tooling** — a simple form will land at
+  `https://validators.sentrixchain.com` for non-CLI operators.
+
+### Verify registration
+
+```bash
+# Stake registry (your address should appear)
+curl -s https://rpc.sentrixchain.com/staking/validators | jq '.validators[] | select(.address=="0x<yours>")'
+
+# Authority (round-robin scheduler — RegisterValidator mirrors here)
+curl -s https://rpc.sentrixchain.com/chain/info | jq '.active_validators'
+```
+
+You'll appear immediately in stake_registry, and rotate into the
+active set at the next epoch boundary if you're in the top-21 by
+total stake (self + delegated).
+
+> [!IMPORTANT]
+> The protocol does **not** require operator approval, a moniker
+> whitelist, or off-chain registration. Pre-2026-05-13 docs that
+> described an email + admin-cosign flow are now obsolete — that was
+> the PoA Pioneer path before Voyager DPoS activated. Voyager has
+> been live since h=579,047 and the candidate cap (was 100) was
+> lifted in v2.2.11.
+
+---
+
+## 9. Deploying updates
 
 Use the generic `scripts/deploy-validator.sh` in the repo:
 
@@ -254,76 +355,169 @@ Use the generic `scripts/deploy-validator.sh` in the repo:
   --binary   ./target/release/sentrix
 ```
 
-This SCPs the binary, archives the previous copy, restarts the
-service, and health-checks it. It's the same primitive the reference
-operator uses in their multi-host fleet — there's no "special" tool
-for us vs you.
+SCPs the binary, archives the previous copy, restarts the service,
+health-checks it.
 
-For a rolling restart across many validators, loop over the above for
-each host. `MIN_ACTIVE_VALIDATORS = 1` since PR #234 (v2.1.11) — the
-chain technically tolerates a single active validator, but in practice
-keep 3+ up during a rolling deploy so block production never depends on
-one host.
+For a rolling restart across many validators, loop over the above.
+`MIN_ACTIVE_VALIDATORS = 1` since v2.1.11 — the chain technically
+tolerates a single active validator, but keep 3+ up during a rolling
+deploy so block production never depends on a single host.
 
 ---
 
-## 8. Monitoring
+## 10. Monitoring
 
 At minimum, alert on:
 
-- Systemd unit failed (`systemctl is-failed sentrix-<your-name>`).
-- `journalctl -u sentrix-<your-name> --since '5 min ago' | grep -c
-  CRITICAL` > threshold.
-- Height not advancing for 2 min (`/chain/info` `.height` delta).
-- Disk free < 10 GiB.
+- `systemctl is-failed sentrix-<your-name>`
+- `journalctl -u sentrix-<your-name> --since '5 min ago' | grep -c CRITICAL` > threshold
+- `/chain/info` `.height` delta = 0 for >2 min
+- Disk free < 10 GiB
 
-Sentrix emits a rolling-window state_root-mismatch alarm (PR #217,
-v2.1.9+) that fires one LOUD log line if you start rejecting >100
-peer blocks per 5 min — the message includes the rsync-recovery
-playbook inline.
+Sentrix emits a rolling-window state_root-mismatch alarm (v2.1.9+)
+that fires one LOUD log line if you start rejecting >100 peer blocks
+per 5 min — the message includes the rsync-recovery playbook inline.
+
+Grafana dashboard templates: see operator issue #625 (work-in-progress).
 
 ---
 
-## 9. Recovery paths
+## 11. Recovery paths
 
 ### You missed a lot of blocks (< 1 week)
 
-The node will sync from peers automatically on restart. The
-`GetBlocks` handler serves evicted history from MDBX (PR #225), so
-fresh nodes and long-stalled nodes both catch up without a state
-snapshot.
+The node syncs from peers automatically on restart. The `GetBlocks`
+handler serves evicted history from MDBX, so fresh nodes and long-
+stalled nodes both catch up without a state snapshot.
 
 ### Your state diverges
 
-Described in `docs/operations/DEPLOYMENT.md` and the incident archive
-at `internal operator runbook`. The short
-version: **frozen-rsync** your chain.db from a peer you trust, with
-ALL validators halted. Do not use `sentrix state export/import` on
-a post-genesis chain — v2.1.5 + later refuse to start on a keystore
-built from that path.
+> [!CAUTION]
+> **Do not run `sentrix state import` on a post-genesis chain.**
+> v2.1.5 and later refuse to start on a keystore built from that path.
+> The correct recovery is **frozen-rsync** of `chain.db` from a peer
+> you trust, with ALL validators halted.
+
+Short procedure:
+
+```bash
+# 1. Stop your node + the trusted peer
+systemctl stop sentrix-<your-name>            # local
+ssh trusted "systemctl stop sentrix-<theirs>"
+
+# 2. Rsync chain.db
+rsync -avz trusted:/opt/sentrix/data/chain.db /opt/sentrix/data/
+
+# 3. Start both
+systemctl start sentrix-<your-name>
+ssh trusted "systemctl start sentrix-<theirs>"
+```
+
+Full incident archive: internal operator runbooks.
 
 ### You lose your data directory
 
-Restore from backup, or sync from scratch. The node will re-fetch all
-blocks from peers. On Pioneer PoA you rejoin as soon as you're back;
-on Voyager you may be jailed and need an unjail op.
+Restore from backup, or sync from scratch. The node re-fetches all
+blocks from peers. On Voyager you may be jailed for downtime and
+need a `StakingOp::Unjail` tx.
 
 ---
 
-## 10. Where to ask
+## 12. FAQ
 
-- Validator onboarding + ops coordination: **`validators@sentrixchain.com`**
-- General docs: https://docs.sentrixchain.com/operations/
-- Block explorer: https://scan.sentrixchain.com (mainnet) · https://scan-testnet.sentrixchain.com (testnet)
-- Public RPC for sanity tests: `https://rpc.sentrixchain.com` (chain 7119) · `https://testnet-rpc.sentrixchain.com` (chain 7120)
-- Testnet faucet: https://faucet.sentrixchain.com
-- Sourcify verifier: https://verify.sentrixchain.com
-- gRPC + gRPC-Web (read-only state queries): https://grpc.sentrixchain.com · https://grpc-testnet.sentrixchain.com
-- GitHub issues: https://github.com/sentrix-labs/sentrix/issues
-- Security advisories: see `SECURITY.md` in the repo root.
+<details>
+<summary><strong>Do I need permission from the Sentrix team?</strong></summary>
 
-**This doc describes a chain that supports many independent operators
-on diverse hosts and OS versions. If any step above assumes the operator's
-infrastructure or invokes a Foundation node/Treasury node/Core node label in a way that isn't
-marked as a historical reference, that's a bug in the doc — please
-file a PR.**
+No. Since v2.2.11 (2026-05-13), registration is fully permissionless
+— any address with ≥15,000 SRX bonded can submit
+`StakingOp::RegisterValidator`. The candidate cap was lifted.
+
+</details>
+
+<details>
+<summary><strong>How do I get 15,000 SRX on mainnet?</strong></summary>
+
+Buy on a DEX once liquid, OTC from existing holders, or earn through
+ecosystem participation (faucet drops are too small for mainnet
+bonding — testnet faucet has enough for testing).
+
+</details>
+
+<details>
+<summary><strong>What's the difference between "candidate" and "active validator"?</strong></summary>
+
+- **Candidate** — anyone registered in the stake registry. No cap.
+- **Active** — top-21 by total stake (self + delegated), produces
+  blocks via round-robin. The 22nd-highest candidate sits on the
+  bench until an active spot frees up (jail, unbond, slash).
+
+</details>
+
+<details>
+<summary><strong>How are blocks scheduled?</strong></summary>
+
+Voyager uses round-robin over the active set: `proposer(h) =
+active_set[h % active_set.len()]`. Active set is sorted by stake
+(deterministic). Failed proposers timeout and the next-in-rotation
+takes over (BFT skip-round).
+
+</details>
+
+<details>
+<summary><strong>Can I run multiple validators from one host?</strong></summary>
+
+Technically yes (multiple systemd units + different keystores +
+different ports + different data dirs), but operationally fragile —
+one disk failure or noisy-neighbour CPU spike takes down both. The
+reference deployment co-tenants 3 validators per host only on hosts
+sized 8 vCPU / 24 GiB; sub-that you should run one validator per
+host.
+
+</details>
+
+<details>
+<summary><strong>What happens if I get jailed?</strong></summary>
+
+Your stake_registry entry flips `is_jailed = true`, you stop being
+in the active set, no blocks scheduled to you, no rewards accrue.
+Submit `StakingOp::Unjail` after the jail-cooldown to re-enter the
+candidate pool. Repeated jails = stake slash + tombstone (permanent
+removal) per the slashing parameters.
+
+</details>
+
+<details>
+<summary><strong>Is my private key recoverable?</strong></summary>
+
+**No.** Lost password = lost validator. Bonded SRX is unrecoverable
+without the signing key. Treat keystore + password like a hardware
+wallet seed.
+
+</details>
+
+---
+
+## 13. Where to ask
+
+| Channel | URL |
+|---|---|
+| Validator ops coordination | <validators@sentrixchain.com> |
+| Public docs | <https://docs.sentrixchain.com/operations/> |
+| Block explorer (mainnet) | <https://scan.sentrixchain.com> |
+| Block explorer (testnet) | <https://scan-testnet.sentrixchain.com> |
+| Public RPC mainnet (chain 7119) | <https://rpc.sentrixchain.com> |
+| Public RPC testnet (chain 7120) | <https://testnet-rpc.sentrixchain.com> |
+| Testnet faucet | <https://faucet.sentrixchain.com> |
+| Sourcify verifier | <https://verify.sentrixchain.com> |
+| gRPC + gRPC-Web | <https://grpc.sentrixchain.com> · <https://grpc-testnet.sentrixchain.com> |
+| GitHub issues | <https://github.com/sentrix-labs/sentrix/issues> |
+| Security advisories | `SECURITY.md` in repo root |
+
+---
+
+> [!NOTE]
+> This doc describes a chain that supports many independent operators
+> on diverse hosts and OS versions. If any step above assumes the
+> reference operator's infrastructure or invokes a Foundation /
+> Treasury / Core / Beacon label in a way that isn't marked as a
+> historical reference, file a PR or open an issue.


### PR DESCRIPTION
## Summary

The validator docs trio (`VALIDATOR_ONBOARDING.md` / `VALIDATOR_GUIDE.md` / `VALIDATORS.md`) was still **PoA-era**: 'contact the chain admin to register', 2 GiB RAM minimum, no mention of `StakingOp::RegisterValidator` tx, no mention of the v2.2.11 unlimited-candidates change.

Voyager DPoS has been live on mainnet since **h=579,047 (2026-04-25)** and the 100-candidate cap was lifted in **v2.2.11** (#664). The docs now match that reality.

## Changes

### `VALIDATOR_ONBOARDING.md` — full deep guide (rewritten)

- **TOC + GitHub-native callouts** (`> [!NOTE]` / `IMPORTANT` / `WARNING` / `CAUTION` / `TIP`) for visual structure
- **Chain comparison table** (BNB / Sentrix / Polkadot / Cosmos / Solana / Avalanche) so prospective operators see where Sentrix sits
- **5-minute quickstart** up top for experienced operators
- **Hardware sizing** corrected to 8 GiB RAM + 8 GiB swap floor (was 2 GiB)
- **Keystore mechanics** updated for v2.2.10 hardening (rpassword no-echo, confirm-twice on rekey, atomic backup+rename, `Zeroizing<String>`)
- **§8 'Register as a validator (permissionless)'** — full tx shape + verification queries, replaces the old `email-to-validators@` flow
- **7-question FAQ section** addressing the most-asked questions

### `VALIDATOR_GUIDE.md` — cheat-sheet (rewritten)

Quickstart, hardware table, systemd template, verify / monitor / troubleshoot, security checklist, see-also links. Cross-links to the deep guide.

### `VALIDATORS.md` — current-set + parameters reference (rewritten)

- Active set table (Treasury / Foundation / Core / Beacon)
- **Active-set rules table** including `MAX_CANDIDATES = usize::MAX` (post v2.2.11)
- Permissionless register tx shape
- Admin path retained for emergency / pre-Voyager bootstrap, marked with `> [!CAUTION]`
- Live-node guard reference (v2.2.11+)
- Block production economics at ~2.5 s block time

## Style notes

No emojis (per operator style); cosmetics via GitHub markdown alerts (`> [!NOTE]` etc.) which render with native icons + color in the GitHub UI.

## Test plan

- [x] All three docs render cleanly in GitHub markdown preview
- [x] Cross-links between the three resolve
- [x] No internal-VPS / no Claude / no founder-private leaks
- [ ] CI green (link-check workflow will catch any broken anchors)