### PR TITLE
fix(proto): gate transport behind cargo feature for wasm32 support (v0.1.1)

### DIFF
--- a/crates/sentrix-proto/Cargo.toml
+++ b/crates/sentrix-proto/Cargo.toml
@@ -3,7 +3,7 @@ name = "sentrix-proto"
 # Independent semver — proto crate evolves on its own cadence, decoupled from
 # the chain workspace version. Pre-1.0 alpha while the schema is still
 # settling; bump to 1.0.0 when sentrix.v1 is stable.
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,8 +15,20 @@ readme = "README.md"
 [lib]
 path = "src/lib.rs"
 
+[features]
+# `transport` pulls tonic's hyper-based transport stack (for client + server
+# Channels). It depends on tokio-net / mio which DON'T compile on
+# `wasm32-unknown-unknown`, so it's opt-out via `default-features = false`
+# for browser consumers. Native (server, native client) keeps it on.
+default = ["transport"]
+transport = ["tonic/transport"]
+
 [dependencies]
-tonic = { version = "0.14", features = ["transport"] }
+# `default-features = false` so consumers control whether `transport` ships;
+# `codegen` is the only feature needed to materialise the generated types
+# and stubs (prost integration is provided by the separate `tonic-prost`
+# crate).
+tonic = { version = "0.14", default-features = false, features = ["codegen"] }
 prost = "0.14"
 tonic-prost = "0.14"
 

--- a/crates/sentrix-proto/README.md
+++ b/crates/sentrix-proto/README.md
@@ -15,8 +15,18 @@ The chain server (`crates/sentrix-grpc` in [`sentrix-labs/sentrix`](https://gith
 
 ```toml
 [dependencies]
+# Native (server, native client) — default features include `transport`:
 sentrix-proto = "0.1"
+
+# Browser / WASM target — disable `transport` so tokio-net / mio aren't pulled in:
+# sentrix-proto = { version = "0.1", default-features = false }
 ```
+
+### Cargo features
+
+| Feature | Default | What it adds |
+|---|---|---|
+| `transport` | yes | Generated server stubs + tonic's hyper-based transport (Channel, Server). Needed for native server / native client; OFF for `wasm32`. |
 
 ```rust
 use sentrix_proto::sentrix_client::SentrixClient;

--- a/crates/sentrix-proto/build.rs
+++ b/crates/sentrix-proto/build.rs
@@ -12,9 +12,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut config = prost_build::Config::new();
     config.protoc_arg("--experimental_allow_proto3_optional");
 
+    // The `transport` cargo feature gates whether the generated code may
+    // reference `tonic::transport::*` (Channel / Server). WASM consumers
+    // disable the feature so the generated module compiles without
+    // tokio-net / mio dependencies. tonic-build emits transport-using
+    // code only when both client/server stubs AND transport bindings are
+    // requested.
+    let with_transport = std::env::var_os("CARGO_FEATURE_TRANSPORT").is_some();
+
     tonic_prost_build::configure()
-        .build_server(true)
         .build_client(true)
+        // Server stubs require the hyper-based transport stack (Server::builder),
+        // so they're gated behind the same feature.
+        .build_server(with_transport)
+        .build_transport(with_transport)
         .compile_with_config(config, &["proto/sentrix.proto"], &["proto"])?;
+
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_TRANSPORT");
     Ok(())
 }


### PR DESCRIPTION
## Why

\`sentrix-proto\` v0.1.0 (just published 2026-05-13 16:45 UTC) pulled in \`tonic/transport\` unconditionally. The transport stack propagates a tokio-net / mio dep that doesn't compile on \`wasm32-unknown-unknown\` — browser consumers (\`sentrix-grpc-wasm\`, \`sentrix-explorer-v2\`) hit:

\`\`\`
compile_error!("This wasm target is unsupported by mio. If using Tokio, disable the net feature.");
\`\`\`

This blocks the 3 A4 PRs (sdk-rs#23, sentrix-grpc-wasm#17, sentrix-explorer-v2#32).

## What

- \`[features]\` block in \`crates/sentrix-proto/Cargo.toml\` with default-on \`transport\` feature
- \`build.rs\` reads \`CARGO_FEATURE_TRANSPORT\` env var and passes matching \`build_transport()\` + \`build_server()\` flags to tonic-prost-build, so the generated module's \`tonic::transport::*\` references only appear when the feature is on
- \`tonic\` dep switched to \`default-features = false, features = ["codegen"]\` (plus \`transport\` activated by feature)
- README updated with the WASM consumption pattern

## Compatibility

- Native consumers (chain server's \`sentrix-grpc\`, sdk-rs's \`grpc\` feature) keep working with no change — default still includes transport
- WASM consumers use \`sentrix-proto = { version = "0.1", default-features = false }\`
- Semver-compat (additive feature change), bumped 0.1.0 → 0.1.1

## After this merges

Re-trigger the publish workflow:
\`\`\`
gh workflow run publish-sentrix-proto.yml -R sentrix-labs/sentrix
\`\`\`
(Or manual \`cargo publish -p sentrix-proto\` if Trusted Publisher isn't set up yet.)

Then the 3 A4 PRs should go green after their CIs re-run with the new \`sentrix-proto = "0.1.1"\` resolved from crates.io.

## Test plan

- [x] Local: \`cargo check -p sentrix-proto\` (default features) clean
- [x] Local: \`cargo check -p sentrix-proto --no-default-features\` (wasm-equivalent) clean
- [x] Local: \`cargo check -p sentrix-grpc\` (chain server consumer) clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `transport` feature (enabled by default), allowing selective inclusion of transport support for different deployment scenarios.

* **Documentation**
  * Updated dependency configuration examples with guidance for native and WASM builds.
  * Added Cargo features table documenting available features and their defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/670)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->