### PR TITLE
ci(publish-proto): pin crates-io-auth-action to v1.0.4 SHA

### DIFF
--- a/.github/workflows/publish-sentrix-proto.yml
+++ b/.github/workflows/publish-sentrix-proto.yml
@@ -57,7 +57,9 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler
 
       - name: Mint short-lived crates.io token via OIDC
-        uses: rust-lang/crates-io-auth-action@v1
+        # Pinned to v1.0.4 commit SHA — verified via
+        # `gh api /repos/rust-lang/crates-io-auth-action/tags`
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth
 
       - name: Verify package


### PR DESCRIPTION
Followup to CodeRabbit review on #669.

The OIDC auth step used the mutable \`@v1\` tag while other actions in the workflow were SHA-pinned. This pins it.

SHA \`bbd81622f20ce9e2dd9622e3218b975523e45bbe\` verified via:
\`\`\`
gh api /repos/rust-lang/crates-io-auth-action/tags
\`\`\`
→ \`v1.0.4\` resolves to that commit.

(Note: CodeRabbit's suggested SHA in the review was \`bbd8162625f8c1f7fb0e1b1a5d4a8e7e5e2f3d4c\` which is fabricated — they share a prefix, easy to misread, but the real one is the verified value above.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow authentication configuration with pinned version reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/671)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->