### PR TITLE
test(#580): regression tests for value-transfer recipient credit + state_root determinism

### DIFF
--- a/crates/sentrix-core/tests/evm_e2e_harness.rs
+++ b/crates/sentrix-core/tests/evm_e2e_harness.rs
@@ -413,3 +413,54 @@ fn test_h3_pre_fork_supply_leak_documented() {
         "pre-fork: drop must exceed value + fee due to wei-side gas leak"
     );
 }
+
+/// #580 — recipient credit. The H3 supply test above pins the SENDER side
+/// of a value-bearing EVM tx; this pins the RECIPIENT side. Both fork
+/// gates active → recipient.balance must equal exactly the value sent
+/// (whole-sentri aligned, no rounding loss on the credit path).
+#[test]
+fn test_580_value_transfer_credits_recipient_exactly() {
+    let (_dir, _mdbx, mut bc) = setup_evm_active_chain_with_h3(true);
+    let (sk, pk) = deterministic_keypair(5);
+    let sender_str = format!("0x{}", hex::encode(evm_address(&pk).as_slice()));
+    bc.accounts.credit(&sender_str, 100_000_000_000).unwrap();
+
+    let value = 100_000_000u64; // 1 SRX
+    let recipient_str = format!("0x{}", hex::encode([0xab_u8; 20]));
+    let recipient_before = bc.accounts.get_balance(&recipient_str);
+
+    submit_evm_value_transfer(&mut bc, &sk, &pk, value, 0);
+
+    let recipient_after = bc.accounts.get_balance(&recipient_str);
+    assert_eq!(
+        recipient_after - recipient_before,
+        value,
+        "recipient credited exactly value (got {}, expected {})",
+        recipient_after - recipient_before,
+        value,
+    );
+}
+
+/// #580 — determinism. Two fresh chains applying the same value-bearing
+/// EVM tx must reach identical state_root. This is the consensus
+/// invariant the gate-removal hinges on; if it fails, value transfers
+/// would fork the chain on activation.
+#[test]
+fn test_580_value_transfer_state_root_deterministic_across_runs() {
+    let run = || -> String {
+        let (_dir, _mdbx, mut bc) = setup_evm_active_chain_with_h3(true);
+        let (sk, pk) = deterministic_keypair(6);
+        let sender_str = format!("0x{}", hex::encode(evm_address(&pk).as_slice()));
+        bc.accounts.credit(&sender_str, 100_000_000_000).unwrap();
+        submit_evm_value_transfer(&mut bc, &sk, &pk, 100_000_000, 0);
+        bc.trie_root_at(1).map(hex::encode).unwrap_or_default()
+    };
+
+    let r1 = run();
+    let r2 = run();
+    assert!(!r1.is_empty(), "trie root must be set after block apply");
+    assert_eq!(
+        r1, r2,
+        "state_root for value-transfer block must be deterministic across runs",
+    );
+}


### PR DESCRIPTION
## Why

Closes the test-coverage gap blocking EVM_VALUE_TRANSFER_HEIGHT + EVM_GAS_FIX_HEIGHT activation on mainnet (#580).

The existing `test_h3_post_fork_supply_invariant_holds_on_value_transfer` pins one side of a value-bearing EVM tx (sender debit = value + fee EXACT) but leaves two consensus invariants untested:

1. **Recipient credit** — the recipient must receive exactly `value` (whole-sentri aligned, no rounding loss on the credit path)
2. **State_root determinism** — two fresh chains applying the same value-bearing tx must reach identical state_root

If either fails, flipping the gates on mainnet would fork the chain.

## What

Two new tests in `crates/sentrix-core/tests/evm_e2e_harness.rs`:

- `test_580_value_transfer_credits_recipient_exactly` — asserts `recipient_after - recipient_before == value`
- `test_580_value_transfer_state_root_deterministic_across_runs` — runs the same value transfer on two fresh chains, asserts `trie_root_at(1)` matches

Both reuse the existing `setup_evm_active_chain_with_h3(true)` + `submit_evm_value_transfer` helpers.

## Verify

```
cargo test -p sentrix-core --test evm_e2e_harness test_580_
```

Both green local on this branch (0.21s, post-compile).

## Follow-up

Pre-condition for the `EVM_VALUE_TRANSFER_HEIGHT` + `EVM_GAS_FIX_HEIGHT` gate-removal PR — once that PR lands and gates flip on mainnet, these tests pin the runtime contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test cases validating EVM value transfer accuracy on compatible chains, ensuring recipients are credited with exact amounts without loss and verifying deterministic blockchain state generation across independent execution instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/674)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->