### PR TITLE
fix(docker): qualify cargo build with -p sentrix-node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,9 @@ COPY . .
 
 # Build the validator binary specifically — the workspace has 19 crates
 # but we only ship `sentrix-node` (bin/sentrix) as the running validator.
-RUN cargo build --release --bin sentrix
+# `-p sentrix-node` qualifier is required since the workspace refactor
+# (#651-#663) split the binary out of the default-run set.
+RUN cargo build --release --bin sentrix -p sentrix-node
 
 # ── Runtime ────────────────────────────────────────────────────────────────
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Why

`cargo build --release --bin sentrix` errors with `no bin target named sentrix in default-run packages` since the workspace refactor (#651-#663) split the binary out of the default-run set. Hit this during mainnet recovery 2026-05-13 when rebuilding v2.2.11 — fell back to a direct `docker run` invocation with the qualifier added manually. This locks the fix in.

## What

Add `-p sentrix-node` to the build command, with a comment explaining the workspace-refactor history so future readers don't strip it.

## Verify

`docker build --target builder -t sentrix-builder:test .` should now succeed end-to-end (no `exit 101` at the cargo step).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Docker build configuration to ensure the release binary is built correctly with the current crate layout. Runtime functionality remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/675)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->