### PR TITLE
chore(forks): bake EVM activation heights into constants (mainnet h=1748900)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-proto"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "prost",
  "prost-build",

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -18,8 +18,7 @@ use std::sync::Arc;
 // live in `crate::tokenomics` now — re-export so existing import
 // paths (`crate::blockchain::MAX_SUPPLY` etc.) still resolve.
 pub use crate::tokenomics::{
-    BLOCK_REWARD, HALVING_INTERVAL, HALVING_INTERVAL_V2, MAX_SUPPLY, MAX_SUPPLY_V2,
-    max_supply_srx,
+    BLOCK_REWARD, HALVING_INTERVAL, HALVING_INTERVAL_V2, MAX_SUPPLY, MAX_SUPPLY_V2, max_supply_srx,
 };
 
 // Chain parameter consts + chain-id accessor live in `crate::chain_params`
@@ -27,8 +26,7 @@ pub use crate::tokenomics::{
 // MAX_TX_PER_BLOCK, CHAIN_ID, HASH_VERSION, CHAIN_WINDOW_SIZE, get_chain_id}`
 // import paths still resolve unchanged.
 pub use crate::chain_params::{
-    BLOCK_TIME_SECS, CHAIN_ID, CHAIN_WINDOW_SIZE, HASH_VERSION, MAX_TX_PER_BLOCK,
-    get_chain_id,
+    BLOCK_TIME_SECS, CHAIN_ID, CHAIN_WINDOW_SIZE, HASH_VERSION, MAX_TX_PER_BLOCK, get_chain_id,
 };
 
 // Fork-height accessors live in `crate::fork_heights` now — re-export so
@@ -42,7 +40,6 @@ pub use crate::fork_heights::{
     warn_if_jail_consensus_armed,
 };
 
-
 // Mempool consts live in `crate::mempool` now (next to the only code
 // that uses them) — re-export so `crate::blockchain::MAX_MEMPOOL_SIZE`
 // etc. still resolve for any path that was relying on it.
@@ -52,8 +49,8 @@ pub use crate::mempool::{MAX_MEMPOOL_PER_SENDER, MAX_MEMPOOL_SIZE, MEMPOOL_MAX_A
 // `crate::address` now — re-export so the existing import paths
 // (`crate::blockchain::is_valid_sentrix_address` etc.) still resolve.
 pub use crate::address::{
-    ECOSYSTEM_FUND_ADDRESS, TOTAL_PREMINE, ZERO_ADDRESS,
-    is_spendable_sentrix_address, is_valid_sentrix_address,
+    ECOSYSTEM_FUND_ADDRESS, TOTAL_PREMINE, ZERO_ADDRESS, is_spendable_sentrix_address,
+    is_valid_sentrix_address,
 };
 
 // ── Blockchain struct ────────────────────────────────────
@@ -422,14 +419,15 @@ impl Blockchain {
         // the block being constructed, so the deterministic is_downtime_at
         // window check needs the about-to-be-applied height.
         let active_set = self.stake_registry.active_set.clone();
-        let evidence = self.slashing.compute_jail_evidence(&active_set, next_height);
+        let evidence = self
+            .slashing
+            .compute_jail_evidence(&active_set, next_height);
         if evidence.is_empty() {
             return None;
         }
 
         // Compute epoch metadata for the bundle
-        let epoch =
-            sentrix_staking::epoch::EpochManager::epoch_for_height(next_height);
+        let epoch = sentrix_staking::epoch::EpochManager::epoch_for_height(next_height);
         let epoch_length = sentrix_staking::epoch::EPOCH_LENGTH;
         let epoch_start_block = epoch.saturating_mul(epoch_length);
         let epoch_end_block = next_height; // boundary block IS the end
@@ -517,7 +515,6 @@ impl Blockchain {
         self.total_minted
     }
 
-
     // Memory estimate reflects the in-memory window, not the full historical chain
     pub fn get_memory_estimate(&self) -> String {
         let window_blocks = self.chain.len();
@@ -529,7 +526,6 @@ impl Blockchain {
         )
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -699,10 +695,7 @@ mod tests {
         assert_eq!(total, MAX_SUPPLY_V2);
         // Sanity: discrete actual is within ~5B sentri of the cap.
         let actual_total = premine + total_mined;
-        assert!(
-            actual_total <= MAX_SUPPLY_V2,
-            "discrete sum exceeds cap"
-        );
+        assert!(actual_total <= MAX_SUPPLY_V2, "discrete sum exceeds cap");
         assert!(
             MAX_SUPPLY_V2 - actual_total <= 5_000_000_000,
             "discrete asymptote gap > 5B sentri (= 50 SRX)"
@@ -2055,9 +2048,7 @@ mod tests {
              — {CHAIN_WINDOW_SIZE}-block window should have evicted it"
         );
         let fetched = bc.get_block_any(evicted_height).unwrap_or_else(|| {
-            panic!(
-                "get_block_any should have fetched evicted block {evicted_height} from MDBX"
-            )
+            panic!("get_block_any should have fetched evicted block {evicted_height} from MDBX")
         });
         assert_eq!(
             fetched.index, evicted_height,
@@ -2132,17 +2123,21 @@ mod tests {
     /// behaviour (TxEnv.value forced to ZERO). Pins the regression that
     /// caused 3 mainnet halts on 2026-05-01 — flat-shipping the
     /// envelope-value plumbing in v2.1.49 produced 2v2 split-brain
-    /// divergence on every value-bearing EVM tx. Default disabled keeps
-    /// chain stable until the divergence RCA lands. Operator activates
-    /// post-RCA via halt-all + simul-start with `EVM_VALUE_TRANSFER_HEIGHT`.
+    /// EVM value-transfer gate is now baked in at mainnet activation
+    /// height 1_748_900 (activated 2026-05-13, closes #580). Test pins
+    /// the constant: pre-fork heights stay inactive, post-fork active.
     #[test]
-    fn test_evm_value_transfer_disabled_by_default() {
+    fn test_evm_value_transfer_default_matches_mainnet_activation() {
         let _guard = env_test_lock();
         unsafe {
             std::env::remove_var("EVM_VALUE_TRANSFER_HEIGHT");
         }
+        // Pre-activation: inactive.
         assert!(!Blockchain::is_evm_value_transfer_height(0));
-        assert!(!Blockchain::is_evm_value_transfer_height(u64::MAX - 1));
+        assert!(!Blockchain::is_evm_value_transfer_height(1_748_899));
+        // At + post-activation: active.
+        assert!(Blockchain::is_evm_value_transfer_height(1_748_900));
+        assert!(Blockchain::is_evm_value_transfer_height(u64::MAX - 1));
     }
 
     /// EVM value-transfer gate: when set, activates exactly at the
@@ -2422,7 +2417,10 @@ mod tests {
             1,
             h0_hash,
             vec![sentrix_primitives::transaction::Transaction::new_coinbase(
-                "v1".into(), 0, 1, 1_700_000_000,
+                "v1".into(),
+                0,
+                1,
+                1_700_000_000,
             )],
             "v1".into(),
         ));
@@ -2437,13 +2435,17 @@ mod tests {
             2,
             h1_hash,
             vec![sentrix_primitives::transaction::Transaction::new_coinbase(
-                "v1".into(), 0, 2, 1_700_000_000,
+                "v1".into(),
+                0,
+                2,
+                1_700_000_000,
             )],
             "v1".into(),
         ));
         let _ = bc.update_trie_for_block();
         assert_eq!(
-            bc.accounts.get_balance(PROTOCOL_TREASURY), 750,
+            bc.accounts.get_balance(PROTOCOL_TREASURY),
+            750,
             "post-activation blocks must not rebase — let coinbase + ClaimRewards drive treasury"
         );
 

--- a/crates/sentrix-core/src/fork_heights.rs
+++ b/crates/sentrix-core/src/fork_heights.rs
@@ -68,7 +68,7 @@ const ADD_SELF_STAKE_HEIGHT_DEFAULT: u64 = u64::MAX;
 /// hash, validator-pair B the other. Until RCA lands
 /// (`audits/2026-05-01-evm-value-transfer-divergence.md`), default
 /// disabled mirrors v2.1.48 behaviour.
-const EVM_VALUE_TRANSFER_HEIGHT_DEFAULT: u64 = u64::MAX;
+const EVM_VALUE_TRANSFER_HEIGHT_DEFAULT: u64 = 1_748_900;
 
 /// Audit H3 (2026-05-06): EVM gas-fix fork. Pre-fork the write-path
 /// EVM tx flow let revm internally deduct `gas_used × INITIAL_BASE_FEE`
@@ -78,7 +78,7 @@ const EVM_VALUE_TRANSFER_HEIGHT_DEFAULT: u64 = u64::MAX;
 /// `cfg.disable_base_fee = true` on the write path too so revm skips
 /// gas accounting; Pass-1 native `tx.fee` (10K sentri flat) is the
 /// entire fee.
-const EVM_GAS_FIX_HEIGHT_DEFAULT: u64 = u64::MAX;
+const EVM_GAS_FIX_HEIGHT_DEFAULT: u64 = 1_748_900;
 
 /// state_root v2 drift fix (2026-05-07, post-halt #5 RCA). Pre-fork
 /// `update_trie_for_block` derives `touched_addrs` from `tx.from` /

--- a/crates/sentrix-core/src/fork_heights.rs
+++ b/crates/sentrix-core/src/fork_heights.rs
@@ -1,10 +1,14 @@
 //! Fork-height accessors — every consensus-fork activation height the
 //! chain reads at runtime, plus the corresponding compile-time defaults.
 //!
-//! All readers default to `u64::MAX` (disabled). Operators activate a
-//! fork by setting the matching env var to a real height in every
-//! validator's process environment and halt-all + simultaneous-start
-//! the cluster — a mismatch produces a state divergence.
+//! Each reader returns its compile-time default unless the matching env
+//! var is set, which then takes precedence. Most defaults remain
+//! `u64::MAX` (un-activated on mainnet); the ones that have already
+//! activated on mainnet carry the real activation height as their
+//! default so a fresh validator (or any rebuild from main) computes
+//! the same state_root past the fork. Mismatched activation heights
+//! across validators = state divergence — change defaults only after
+//! the fork has actually crossed on mainnet.
 //!
 //! Extracted from `crate::blockchain` so this concern lives in one
 //! file (was scattered across ~200 lines mid-blockchain.rs). The
@@ -12,7 +16,7 @@
 //! working bit-identically: `crate::blockchain::get_*_height` still
 //! resolves, no caller had to change.
 
-// ── Compile-time defaults (all u64::MAX = disabled, mainnet-safe) ──────
+// ── Compile-time defaults — see module doc for activated-vs-disabled. ──
 
 /// Voyager DPoS fork activation. Pre-fork: PoA round-robin. Post-fork:
 /// stake-weighted BFT consensus.
@@ -61,13 +65,13 @@ const ADD_SELF_STAKE_HEIGHT_DEFAULT: u64 = u64::MAX;
 /// envelope value and moves SRX between EOAs / forwards into payable
 /// contract calls.
 ///
-/// Why gated: shipped flat in v2.1.49, recurred the eager-write
-/// divergence pattern that v2.1.48's FinalizeBlock guard was meant to
-/// close. Three 2v2 split-brain halts on 2026-05-01 (h≈1180k / 1191k /
-/// 1192k) all followed the same shape — validator-pair A finalizes one
-/// hash, validator-pair B the other. Until RCA lands
-/// (`audits/2026-05-01-evm-value-transfer-divergence.md`), default
-/// disabled mirrors v2.1.48 behaviour.
+/// **Activated on mainnet at h=1,748,900 on 2026-05-13** (closes #580
+/// after the 5-step audit in `audits/2026-05-01-evm-value-transfer-divergence.md`).
+/// The original 2026-05-01 split-brain halts were resolved by the
+/// state_root v2 + extended-touch + strict-justification forks shipped
+/// in v2.1.85+. Verified end-to-end via WSRX deposit at h=1,749,380.
+/// Constant must match the runtime fork — fresh validators that compute
+/// state_root past 1,748,900 with a different default would diverge.
 const EVM_VALUE_TRANSFER_HEIGHT_DEFAULT: u64 = 1_748_900;
 
 /// Audit H3 (2026-05-06): EVM gas-fix fork. Pre-fork the write-path
@@ -78,6 +82,10 @@ const EVM_VALUE_TRANSFER_HEIGHT_DEFAULT: u64 = 1_748_900;
 /// `cfg.disable_base_fee = true` on the write path too so revm skips
 /// gas accounting; Pass-1 native `tx.fee` (10K sentri flat) is the
 /// entire fee.
+///
+/// **Activated on mainnet at h=1,748,900 on 2026-05-13**, paired with
+/// `EVM_VALUE_TRANSFER_HEIGHT_DEFAULT`. Constraint: GAS_FIX ≤ VALUE_TRANSFER —
+/// equal-height activation is the safe form.
 const EVM_GAS_FIX_HEIGHT_DEFAULT: u64 = 1_748_900;
 
 /// state_root v2 drift fix (2026-05-07, post-halt #5 RCA). Pre-fork
@@ -231,11 +239,11 @@ pub fn get_add_self_stake_height() -> u64 {
         .unwrap_or(ADD_SELF_STAKE_HEIGHT_DEFAULT)
 }
 
-/// Read EVM value-transfer fork height from env, default `u64::MAX`
-/// (disabled — matches v2.1.48 EVM behaviour). Post-fork: Pass-2 EVM
-/// apply path threads envelope value into `TxEnv.value` so revm
-/// performs real SRX transfers between EOAs and into payable contract
-/// calls.
+/// Read EVM value-transfer fork height from env. Default 1,748,900 —
+/// matches mainnet activation 2026-05-13 so a fresh validator built
+/// from main computes consistent state_root past the fork. Post-fork
+/// the Pass-2 EVM apply path threads envelope value into `TxEnv.value`.
+/// Testnet sets `EVM_VALUE_TRANSFER_HEIGHT=3409717` in env to override.
 pub fn get_evm_value_transfer_height() -> u64 {
     std::env::var("EVM_VALUE_TRANSFER_HEIGHT")
         .ok()
@@ -244,9 +252,9 @@ pub fn get_evm_value_transfer_height() -> u64 {
 }
 
 /// Audit H3 EVM gas-fix fork height (2026-05-06). See
-/// [`EVM_GAS_FIX_HEIGHT_DEFAULT`] for context. Default `u64::MAX`
-/// keeps the supply-leak behaviour unchanged on chains that haven't
-/// activated.
+/// [`EVM_GAS_FIX_HEIGHT_DEFAULT`] for context. Default 1,748,900 —
+/// matches mainnet activation 2026-05-13 (paired with VALUE_TRANSFER).
+/// Testnet sets `EVM_GAS_FIX_HEIGHT=3787000` in env to override.
 pub fn get_evm_gas_fix_height() -> u64 {
     std::env::var("EVM_GAS_FIX_HEIGHT")
         .ok()


### PR DESCRIPTION
## Why

Mainnet activated `EVM_VALUE_TRANSFER_HEIGHT` + `EVM_GAS_FIX_HEIGHT` at h=1,748,900 on 2026-05-13. The activation was applied via env-var override on the running v2.2.11 binary — chain has crossed the fork height; activation is permanent.

Without baking the constants into source, a fresh validator (or any future rebuild from main) would default to `u64::MAX` and compute different state_root starting at h=1,748,900 → fork. This commit ensures source matches the mainnet runtime contract.

## What

```rust
const EVM_VALUE_TRANSFER_HEIGHT_DEFAULT: u64 = 1_748_900;
const EVM_GAS_FIX_HEIGHT_DEFAULT: u64 = 1_748_900;
```

## Testnet

Stays env-driven (`EVM_VALUE_TRANSFER_HEIGHT=3409717`, `EVM_GAS_FIX_HEIGHT=3787000` in `/opt/sentrix-testnet-docker/env/*.env`) because mainnet vs testnet target heights differ ~2M blocks. Constants follow mainnet only; env override wins on testnet by reader-fallback semantics.

## Verify

- Mainnet RPC `web3_clientVersion` already reports `Sentrix/2.2.11/Rust` with active gates.
- Verified end-to-end via WSRX deposit at h=1,749,380 (tx `0x0b3187c4...`).
- Cargo.lock unchanged in shape (only patch resolver bump from the cargo build during prep).

## Follow-up

None — this PR is the in-source record of the activation event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default activation heights for specific EVM fork features to mainnet block height 1,748,900 (previously effectively disabled).

* **Tests**
  * Adjusted unit tests to reflect the new default activation behavior and formatting updates.

* **Documentation**
  * Updated in-code documentation to state the new mainnet activation height and note testnet override options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/676)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->