### PR TITLE
chore: add .github/CODEOWNERS — solo-operator default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owner for everything in the repo. CODEOWNERS auto-requests
+# review from listed owners when a PR touches matching paths. Solo
+# operator pattern — everything owned by satyakwok until co-maintainers
+# join, at which point split per-area (e.g. consensus/ contracts/ etc.).
+* @satyakwok


### PR DESCRIPTION
Adds CODEOWNERS so PRs that touch any path auto-request review from @satyakwok. Single-line glob `* @satyakwok` covers the whole repo for now; once co-maintainers join, split per-area (e.g. `crates/sentrix-bft/ @other-eng`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository code ownership configuration to define default code ownership and automate review requests for pull requests affecting specified paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/679)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->