### PR TITLE
fix(#683): gossip mempool admits to peers via libp2p

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -3372,6 +3372,33 @@ async fn cmd_start(
         let mut bc = shared.write().await;
         bc.set_event_emitter(Some(event_bus.clone()));
     }
+
+    // libp2p tx-gossip pump — every mempool admit fires
+    // emit_tx_for_gossip; this task forwards to the libp2p gossipsub
+    // `txs` topic so peer mempools see the tx. Without it,
+    // public-RPC fullnode admits never reach validator mempools and
+    // user txs only land when the round-robin upstream happens to be
+    // a validator. Closes #683.
+    let lp2p_for_tx_gossip = lp2p.clone();
+    let mut tx_gossip_rx = event_bus.tx_for_gossip.subscribe();
+    tokio::spawn(async move {
+        loop {
+            match tx_gossip_rx.recv().await {
+                Ok(tx) => lp2p_for_tx_gossip.broadcast_transaction(&tx).await,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(
+                        "tx-gossip pump lagged {} txs — increase EventBus capacity",
+                        n
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    tracing::info!("tx-gossip pump shutting down (channel closed)");
+                    return;
+                }
+            }
+        }
+    });
+
     let app = create_router_with_bus(shared.clone(), event_bus.clone());
     let api_addr = format!("{}:{}", get_api_host(), get_api_port());
     println!("REST API listening on http://{}", api_addr);

--- a/crates/sentrix-core/src/mempool.rs
+++ b/crates/sentrix-core/src/mempool.rs
@@ -188,8 +188,17 @@ impl Blockchain {
         // Notify WebSocket subscribers — eth_subscribe(newPendingTransactions).
         // Non-blocking, infallible by trait contract. Fires only on
         // successful admission; rejections above already returned Err.
+        // Also fires the full-tx gossip channel so the libp2p layer
+        // propagates the tx to peers — without this, public-RPC fullnode
+        // admits never reach validator mempools and txs only land when
+        // the round-robin upstream happens to be a validator. Closes #683.
         if let Some(emitter) = &self.event_emitter {
             emitter.emit_pending_tx(&txid_for_event);
+            // Re-borrow the just-inserted tx (pos is preserved because
+            // we just called insert(pos, tx)).
+            if let Some(admitted) = self.mempool.get(pos) {
+                emitter.emit_tx_for_gossip(admitted);
+            }
         }
 
         Ok(())

--- a/crates/sentrix-primitives/src/events.rs
+++ b/crates/sentrix-primitives/src/events.rs
@@ -69,6 +69,14 @@ pub trait EventEmitter: Send + Sync + std::fmt::Debug {
     /// Note: this fires on admission only, NOT on rejection.
     fn emit_pending_tx(&self, _txid: &str) {}
 
+    /// Called when a tx is admitted to the mempool — the FULL tx body,
+    /// not just the txid. The libp2p layer subscribes to this and
+    /// gossipsub-broadcasts the tx to peers so it reaches validator
+    /// mempools (otherwise public-RPC fullnode admits would never
+    /// propagate, and txs would only land when the round-robin
+    /// upstream happens to be a validator). See sentrix#683.
+    fn emit_tx_for_gossip(&self, _tx: &crate::transaction::Transaction) {}
+
     /// Sentrix-native: called after every BFT-finalized block.
     /// Equivalent to `emit_new_head` on the protocol-native side
     /// but exposes finalization-specific fields (justification

--- a/crates/sentrix-rpc/src/events.rs
+++ b/crates/sentrix-rpc/src/events.rs
@@ -221,6 +221,11 @@ pub struct EventBus {
     pub token_ops: broadcast::Sender<TokenOpEvent>,
     pub staking_ops: broadcast::Sender<StakingOpEvent>,
     pub jail: broadcast::Sender<JailEvent>,
+    /// Full-Tx channel for the libp2p gossip pump. Subscribed by
+    /// `bin/sentrix/main.rs` after the LibP2pNode boots; every admit
+    /// to mempool fires here so peers learn about the tx and validators
+    /// can include it in a block. Closes sentrix#683.
+    pub tx_for_gossip: broadcast::Sender<sentrix_primitives::transaction::Transaction>,
 }
 
 impl EventBus {
@@ -241,6 +246,7 @@ impl EventBus {
             token_ops: broadcast::channel(capacity).0,
             staking_ops: broadcast::channel(capacity).0,
             jail: broadcast::channel(capacity).0,
+            tx_for_gossip: broadcast::channel(capacity).0,
         }
     }
 }
@@ -271,6 +277,13 @@ impl EventEmitter for EventBus {
                 format!("0x{}", txid)
             },
         });
+    }
+
+    fn emit_tx_for_gossip(&self, tx: &sentrix_primitives::transaction::Transaction) {
+        // No receivers (e.g. CLI tools without libp2p) → silent drop;
+        // gossip is best-effort. The libp2p task in main.rs subscribes
+        // and forwards to gossipsub `txs` topic.
+        let _ = self.tx_for_gossip.send(tx.clone());
     }
 
     fn emit_finalized(&self, height: u64, hash: &str, justification_signers: usize) {
@@ -358,6 +371,56 @@ mod tests {
         assert_eq!(event.gas_limit, "0x1c9c380"); // 30M
         assert!(event.state_root.starts_with("0x"));
         assert_eq!(event.state_root.len(), 66); // 0x + 64 hex
+    }
+
+    /// Pin the gossip-pump contract: `emit_tx_for_gossip` MUST publish
+    /// the full Tx body to `tx_for_gossip` so the libp2p subscriber in
+    /// bin/sentrix/main.rs can broadcast it. Closes #683.
+    #[test]
+    fn emit_tx_for_gossip_publishes_full_tx() {
+        let bus = EventBus::with_capacity(8);
+        let mut rx = bus.tx_for_gossip.subscribe();
+        let tx = sentrix_primitives::transaction::Transaction {
+            txid: "deadbeef".to_string(),
+            from_address: "0x0000000000000000000000000000000000000001".to_string(),
+            to_address: "0x0000000000000000000000000000000000000002".to_string(),
+            amount: 1_000_000,
+            fee: 10_000,
+            nonce: 7,
+            data: String::new(),
+            timestamp: 1_700_000_000,
+            chain_id: 7119,
+            signature: String::new(),
+            public_key: String::new(),
+        };
+        bus.emit_tx_for_gossip(&tx);
+        let received = rx.try_recv().expect("tx_for_gossip channel must have a tx");
+        assert_eq!(received.txid, "deadbeef");
+        assert_eq!(received.amount, 1_000_000);
+        assert_eq!(received.nonce, 7);
+    }
+
+    /// No subscribers must NOT cause emit to fail or block consensus.
+    #[test]
+    fn emit_tx_for_gossip_no_subscribers_is_silent() {
+        let bus = EventBus::with_capacity(8);
+        let tx = sentrix_primitives::transaction::Transaction {
+            txid: "noop".to_string(),
+            from_address: "0xfrom".to_string(),
+            to_address: "0xto".to_string(),
+            amount: 0,
+            fee: 0,
+            nonce: 0,
+            data: String::new(),
+            timestamp: 0,
+            chain_id: 7119,
+            signature: String::new(),
+            public_key: String::new(),
+        };
+        // No panic, no error — the broadcast::send Err(no receivers) is
+        // intentionally swallowed. Block production must never depend
+        // on subscriber liveness.
+        bus.emit_tx_for_gossip(&tx);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #683.

## Problem

`LibP2pNode::broadcast_transaction` defined at `crates/sentrix-network/src/libp2p_node.rs:319` had **zero callers** in the entire codebase. Every `add_to_mempool` admit (native REST POST /transactions, eth_sendRawTransaction, sentrix_*) added the tx to the RECEIVING node's local mempool only — never propagated.

Mainnet round-robin (`10.20.0.6:8557`, `10.20.0.6:8561`, `10.20.0.4:8545`) means 1-of-3 chance the tx hits a validator and lands; otherwise it sits on a fullnode mempool until eviction. User-facing symptom: faucet logs 'Sent' but recipient balance stays 0.

## Fix

Wire the gossip pump:

| Layer | Change |
|---|---|
| `sentrix-primitives::EventEmitter` | New trait method `emit_tx_for_gossip(&Transaction)` (default no-op) |
| `sentrix-rpc::EventBus` | New `tx_for_gossip` broadcast channel + trait impl |
| `sentrix-core::mempool` | After successful admit, fire `emit_tx_for_gossip(admitted_tx)` |
| `bin/sentrix/main.rs` | Spawn pump task: subscribe `event_bus.tx_for_gossip` → `lp2p.broadcast_transaction` |

## Tests

- 2 new unit tests in `sentrix-rpc::events` pin the gossip-pump contract + the no-subscribers-silent invariant
- 0 failures across `sentrix-primitives`, `sentrix-rpc`, `sentrix-core` after wire change
- `cargo build --release` clean

## Live mesh test

Operator-driven step (not in PR): build via bullseye for vps6, halt-all + simul-start across all 4 vals + 2 fullnodes, then:

```bash
NONCE=$(cast nonce $ADDR --rpc-url http://10.20.0.4:8545/rpc)
for i in 1 2 3; do
  cast send $RECIP --value 1000 \
    --rpc-url https://rpc.sentrixchain.com/rpc \
    --private-key "0x$PK" --async --nonce $((NONCE+i-1))
done
# expect: all 3 land within ~10s
```

## Workaround currently in production

Faucet `MAINNET_REST_URL` switched from `https://rpc.sentrixchain.com` to `http://10.20.0.4:8545` (vps3 direct) — bypasses the bug since the validator IS the receiver. Remove this once the PR deploys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled transaction gossip propagation across the network layer. Transactions accepted into the mempool are now automatically broadcast to connected peers, ensuring distributed transaction visibility and network synchronization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/684)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->