### PR TITLE
fix(rpc): eth_getTransactionByHash returns EVM-standard JSON shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5237,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "bincode",
  "hex",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "bincode",
  "hex",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -5392,14 +5392,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "hex",
  "proptest",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5472,14 +5472,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "bincode",
  "blake3",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5540,7 +5540,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.11"
+version = "2.2.12"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -209,9 +209,152 @@ async fn eth_get_transaction_by_hash(params: &Value, state: &SharedState) -> Dis
     };
     let bc = state.read().await;
     match bc.get_transaction(&txid) {
-        Some(tx_data) => Ok(tx_data),
+        Some(tx_data) => Ok(tx_to_evm_json(&bc, &txid, &tx_data)),
         None => Ok(json!(null)),
     }
+}
+
+/// Convert chain-native tx JSON (block_hash + nested transaction{}) to
+/// Ethereum JSON-RPC standard shape per EIP-1474. Pre-2026-05-20 this
+/// returned the raw native shape and ethers.js / viem / alloy / Hyperlane
+/// CLI all crashed with "missing from address". The receipt handler does
+/// the same conversion for eth_getTransactionReceipt — this mirrors it
+/// for getTransactionByHash so the same off-the-shelf tooling works.
+fn tx_to_evm_json(
+    bc: &sentrix_core::blockchain::Blockchain,
+    txid: &str,
+    tx_data: &Value,
+) -> Value {
+    let block_index = tx_data["block_index"].as_u64().unwrap_or(0);
+    let block_hash = tx_data["block_hash"]
+        .as_str()
+        .map(|h| if h.starts_with("0x") { h.to_string() } else { format!("0x{h}") })
+        .unwrap_or_default();
+
+    let tx_obj = &tx_data["transaction"];
+    let from_raw = tx_obj["from_address"].as_str().unwrap_or("").to_string();
+    let from = if from_raw.starts_with("0x") {
+        from_raw.clone()
+    } else {
+        format!("0x{from_raw}")
+    };
+    let to_raw = tx_obj["to_address"].as_str().unwrap_or("").to_string();
+
+    let data_str = tx_obj["data"].as_str().unwrap_or("").to_string();
+    let is_evm = data_str.starts_with("EVM:");
+
+    // EVM contract creations target the synthetic TOKEN_OP_ADDRESS in the
+    // chain-native representation. Surface as `to: null` so ethers/viem
+    // detect creations the standard way.
+    let to_value: Value = if to_raw.is_empty()
+        || to_raw == "0x0000000000000000000000000000000000000000"
+        || to_raw == "0000000000000000000000000000000000000000"
+        || (is_evm
+            && to_raw.to_lowercase()
+                == sentrix_primitives::transaction::TOKEN_OP_ADDRESS.to_lowercase())
+    {
+        Value::Null
+    } else {
+        Value::String(if to_raw.starts_with("0x") {
+            to_raw.clone()
+        } else {
+            format!("0x{to_raw}")
+        })
+    };
+
+    // Parse "EVM:<gas_limit>:<input_hex>" envelope. Native txs surface
+    // gas=21000 + input="0x" — matches what most EVM tools expect for a
+    // basic value transfer.
+    let (gas_hex, input_hex) = if is_evm {
+        let rest = &data_str[4..];
+        if let Some(colon) = rest.find(':') {
+            let gas_str = &rest[..colon];
+            let input_str = &rest[colon + 1..];
+            let gas_val: u64 = gas_str.parse().unwrap_or(21_000);
+            (to_hex(gas_val), format!("0x{input_str}"))
+        } else {
+            (to_hex(21_000), "0x".to_string())
+        }
+    } else {
+        (to_hex(21_000), "0x".to_string())
+    };
+
+    // Resolve transactionIndex by scanning the block. Same approach as
+    // the receipt handler — blocks have a small number of txs so the
+    // linear scan is cheap.
+    let tx_index = bc
+        .get_block_any(block_index)
+        .and_then(|b| b.transactions.iter().position(|t| t.txid == txid))
+        .map(|i| to_hex(i as u64))
+        .unwrap_or_else(|| "0x0".to_string());
+
+    // Chain-native amount is u64 in sentri. EVM tools expect wei. 1 sentri
+    // = 1e10 wei. u64::MAX sentri × 1e10 fits in u128.
+    let amount_sentri = tx_obj["amount"].as_u64().unwrap_or(0);
+    let value_wei = (amount_sentri as u128).saturating_mul(10_000_000_000u128);
+    let value_hex = to_hex_u128(value_wei);
+
+    let nonce_hex = to_hex(tx_obj["nonce"].as_u64().unwrap_or(0));
+    let chain_id_hex = to_hex(tx_obj["chain_id"].as_u64().unwrap_or(0));
+
+    // Same EIP-1559 type + effectiveGasPrice rationale as receipts. EVM txs
+    // go through the base_fee pipeline, native txs do not.
+    let (tx_type, gas_price) = if is_evm {
+        ("0x2", to_hex(sentrix_evm::gas::INITIAL_BASE_FEE))
+    } else {
+        ("0x0", "0x0".to_string())
+    };
+
+    // For EVM txs, decode the original RLP envelope stored in `signature`
+    // (see eth_send_raw_transaction). That gives us the canonical v/r/s
+    // ethers needs to round-trip the tx. For native txs we don't have
+    // ECDSA-on-EVM-envelope semantics; return zeros so the field is present.
+    let (v_hex, r_hex, s_hex) = if is_evm {
+        extract_vrs_from_rlp(tx_obj["signature"].as_str().unwrap_or(""))
+            .unwrap_or_else(|| ("0x0".to_string(), "0x0".to_string(), "0x0".to_string()))
+    } else {
+        ("0x0".to_string(), "0x0".to_string(), "0x0".to_string())
+    };
+
+    json!({
+        "hash": format!("0x{txid}"),
+        "blockHash": block_hash,
+        "blockNumber": to_hex(block_index),
+        "transactionIndex": tx_index,
+        "from": from,
+        "to": to_value,
+        "value": value_hex,
+        "gas": gas_hex,
+        "gasPrice": gas_price.clone(),
+        "input": input_hex,
+        "nonce": nonce_hex,
+        "type": tx_type,
+        "chainId": chain_id_hex,
+        "v": v_hex,
+        "r": r_hex,
+        "s": s_hex,
+        "maxFeePerGas": gas_price,
+        "maxPriorityFeePerGas": "0x0",
+        "accessList": [],
+    })
+}
+
+/// Decode the stored RLP envelope back into its alloy form so we can
+/// surface canonical v/r/s. Returns None for non-EVM signatures (which
+/// we fall back to zeros for).
+fn extract_vrs_from_rlp(sig_hex: &str) -> Option<(String, String, String)> {
+    use alloy_consensus::TxEnvelope;
+    use alloy_eips::eip2718::Decodable2718;
+
+    let raw_bytes = hex::decode(sig_hex).ok()?;
+    let envelope = TxEnvelope::decode_2718(&mut raw_bytes.as_slice()).ok()?;
+    let sig = envelope.signature();
+    // For typed (EIP-2718) transactions the signature carries y-parity (0 or 1).
+    // Legacy txs encode chain-id in v but ethers/viem accept parity too.
+    let v_val: u64 = if sig.v() { 1 } else { 0 };
+    let r_u256 = sig.r();
+    let s_u256 = sig.s();
+    Some((to_hex(v_val), format!("0x{r_u256:x}"), format!("0x{s_u256:x}")))
 }
 
 async fn eth_get_transaction_receipt(params: &Value, state: &SharedState) -> DispatchResult {


### PR DESCRIPTION
Pre-fix the handler returned the chain-native shape (block_hash, nested transaction.{amount,chain_id,data:"EVM:..."}) directly, which ethers.js / viem / alloy / Hyperlane CLI all reject with "missing from address". eth_sendRawTransaction and eth_getTransactionReceipt already return EVM-standard responses on the same chain, so cast send works but anything that polls a freshly-broadcast tx for confirmation crashes.

Mirror the receipt handler's conversion logic for getTransactionByHash:
- expand from/to/value/gas/gasPrice/input/nonce/type/chainId
- map TOKEN_OP_ADDRESS to to:null for contract creations
- parse EVM:<gas>:<input_hex> envelope for gas + input
- decode stored RLP envelope back into v/r/s via alloy
- amount (sentri) -> value (wei) via *1e10
- type 0x2 + maxFeePerGas for EVM txs, 0x0 for native

Reproducer + workaround discussion isolated 2026-05-20 while running Hyperlane warp deploy for the Base Sepolia USDC -> Sentrix Testnet sUSDC route. ProxyAdmin + HypERC20 implementation deployed cleanly via cast (sendRawTx + getReceipt path), then the CLI crashed once it tried provider.getTransaction(hash).

<!--
Thanks for the PR. Fill in the relevant sections + check the boxes that apply.
The risk-tier checklist below is the gate — it codifies discipline rules that
existed in `feedback_*.md` memory but kept getting skipped under time pressure.
-->

## Summary

<!-- 1-3 lines: what changed and why. Link the issue if applicable. -->

## Risk tier

Check ONE:

- [ ] **🟢 Low** — docs, tools/, tests/, CI configs, dependency patch bumps in dev-only crates, comments
- [x] **🟡 Medium** — non-consensus production code (RPC handlers, network plumbing, observability, ops scripts)
- [ ] **🟠 High** — consensus-critical crates (`sentrix-core`, `sentrix-trie`, `sentrix-staking`, `sentrix-bft`), `block_executor`, `apply_block_*`, `state_root` path
- [ ] **🔴 Critical** — Voyager activation, fork-height changes, hard-fork rollouts, anything that flips env vars on mainnet

## Required by tier

### 🟢 Low — minimum bar
- [x] CI green (tests + clippy + audit + gitleaks)

### 🟡 Medium — adds
- [x] New public function or behavioural change has at least one corresponding `#[test]` in same PR
- [ ] Brief description of how this was tested (manual run, integration test, etc.)

### 🟠 High — adds
- [ ] Regression test that **fails on main** and **passes with this change** — paste test name in PR body
- [ ] Designed against documented invariant (link the audit/runbook/design doc)
- [ ] Fresh-brain review by someone other than the author (per the consensus-change review checklist)
- [ ] Single conceptual unit per PR (no bundling — bundling consensus changes burned us on v2.1.12 → 2026-04-25 livelock)

### 🔴 Critical — adds
- [ ] **Testnet rehearsal completed** with success criteria + log evidence linked here
- [ ] **Bake window** observed: minimum 2h on testnet at the same configuration before mainnet
- [ ] **Coordinated rollback plan** documented in PR body — exact commands operator runs if it fails
- [ ] **Operator sign-off** at activation moment (not just PR approval — separate moment for the actual flip)

## Test plan

<!-- Bullet list. For 🟠 / 🔴 PRs the regression test must be specific. -->

-

## Rollback plan

<!-- Required for 🔴 PRs. Recommended for 🟠. The exact commands an on-call operator would run if this PR causes incidents post-deploy. -->

## Related

<!-- Issue numbers, prior PRs, design docs in internal operator docs, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Workspace version bumped to 2.2.12

* **Bug Fixes**
  * Fixed RPC transaction lookup to return properly formatted Ethereum-compatible transaction objects. Transactions now include normalized addresses, values in wei, gas information, input data, and signature components in the standard format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->