### PR TITLE
fix(core): B3 reconcile skips missing trie nodes instead of crashing …

### DIFF
--- a/crates/sentrix-core/src/storage.rs
+++ b/crates/sentrix-core/src/storage.rs
@@ -365,8 +365,11 @@ impl Storage {
     /// premine / genesis accounts that pre-date the first trie touch.
     /// We must not zero those out.
     ///
-    /// Trie-lookup errors (`Err(_)`) propagate: a corrupted trie is a
-    /// hard-fail, not silent fallback.
+    /// Trie-lookup errors (`Err(_)`) are logged and skipped: a missing
+    /// or corrupted trie node for one address no longer aborts boot.
+    /// The address is treated as having no trie leaf (blob value
+    /// preserved); the next block touching that account rewrites the
+    /// trie entry and closes the gap.
     fn reconcile_accounts_from_trie(bc: &mut Blockchain) -> SentrixResult<(usize, usize)> {
         // Build the candidate address set first — sorted + deduped so
         // the reconcile order is deterministic across runs (helps debug
@@ -409,17 +412,41 @@ impl Storage {
 
         // Phase 1: read all trie leaves into a buffer. This avoids
         // holding the trie borrow while we mutate accounts in phase 2.
+        //
+        // 2026-05-20: a missing trie node here used to crash boot. Testnet
+        // hit this with one address having a dangling reference to node
+        // 314e57bd... at h=5003961; the other 99.99% of the trie was
+        // healthy and the chain had been producing for 5 hours. Refusing
+        // to boot turned one stale leaf into an unrecoverable validator.
+        // Fail-soft now: log the gap, skip the address (existing phase-2
+        // logic treats a `None` leaf as "trie has no opinion, keep the
+        // blob"), and let the next block apply rewrite the entry.
         let mut trie_values: Vec<(String, Option<(u64, u64)>)> = Vec::with_capacity(addrs.len());
+        let mut trie_gaps: usize = 0;
         for addr in &addrs {
             let key = address_to_key(addr);
-            let leaf = trie.get(&key).map_err(|e| {
-                SentrixError::Internal(format!(
-                    "B3 reconcile: trie lookup for {addr} failed at h={}: {e}",
-                    bc.chain.last().map(|b| b.index).unwrap_or(0)
-                ))
-            })?;
+            let leaf = match trie.get(&key) {
+                Ok(leaf) => leaf,
+                Err(e) => {
+                    tracing::warn!(
+                        "B3 reconcile: trie lookup for {addr} failed at h={}: {e} — \
+                         skipping reconcile for this address (will rewrite on next touch)",
+                        bc.chain.last().map(|b| b.index).unwrap_or(0)
+                    );
+                    trie_gaps += 1;
+                    None
+                }
+            };
             let decoded = leaf.and_then(|bytes| account_value_decode(&bytes));
             trie_values.push((addr.clone(), decoded));
+        }
+        if trie_gaps > 0 {
+            tracing::warn!(
+                "B3 reconcile: skipped {trie_gaps}/{} addresses due to missing trie nodes \
+                 at h={}; chain will continue producing — touched accounts repair themselves",
+                addrs.len(),
+                bc.chain.last().map(|b| b.index).unwrap_or(0)
+            );
         }
 
         // Phase 2: apply repairs.


### PR DESCRIPTION
…boot

The trie-reconcile pass at boot used to propagate any `trie.get` error all the way out of `load_blockchain`, which turned a single dangling trie node into an unbootable validator — even when the other 99.99% of the trie was healthy and the chain was actively producing blocks before the restart.

Hit live on testnet 2026-05-20 during the v2.2.12 RPC swap. One address (0x044daee895f2bb2ffecd4dd2e771f5ce405ab0ea at h=5003961) had a dangling reference to node 314e57bd...; the validator had been up for 5 hours serving that exact state without complaint, but the next boot crashed on phase-1 trie scan. All four testnet validators were stuck because they share the same trie shape.

The reconcile already has well-defined behavior for "no trie leaf for this address" — phase-2 keeps the blob view as canonical. Treat a failed `trie.get` the same way: log the gap, count it, surface a summary warning if any were skipped, then continue. Touched accounts will rewrite the trie node on next apply, so the gap closes on its own without operator intervention.

This is strictly a fail-soft on a previously fatal path. Healthy chains never hit it; the only behavioral change is that broken state loads instead of refusing to load.

<!--
Thanks for the PR. Fill in the relevant sections + check the boxes that apply.
The risk-tier checklist below is the gate — it codifies discipline rules that
existed in `feedback_*.md` memory but kept getting skipped under time pressure.
-->

## Summary

<!-- 1-3 lines: what changed and why. Link the issue if applicable. -->

## Risk tier

Check ONE:

- [ ] **🟢 Low** — docs, tools/, tests/, CI configs, dependency patch bumps in dev-only crates, comments
- [ ] **🟡 Medium** — non-consensus production code (RPC handlers, network plumbing, observability, ops scripts)
- [x] **🟠 High** — consensus-critical crates (`sentrix-core`, `sentrix-trie`, `sentrix-staking`, `sentrix-bft`), `block_executor`, `apply_block_*`, `state_root` path
- [ ] **🔴 Critical** — Voyager activation, fork-height changes, hard-fork rollouts, anything that flips env vars on mainnet

## Required by tier

### 🟢 Low — minimum bar
- [x] CI green (tests + clippy + audit + gitleaks)

### 🟡 Medium — adds
- [ ] New public function or behavioural change has at least one corresponding `#[test]` in same PR
- [ ] Brief description of how this was tested (manual run, integration test, etc.)

### 🟠 High — adds
- [ ] Regression test that **fails on main** and **passes with this change** — paste test name in PR body
- [ ] Designed against documented invariant (link the audit/runbook/design doc)
- [ ] Fresh-brain review by someone other than the author (per the consensus-change review checklist)
- [ ] Single conceptual unit per PR (no bundling — bundling consensus changes burned us on v2.1.12 → 2026-04-25 livelock)

### 🔴 Critical — adds
- [ ] **Testnet rehearsal completed** with success criteria + log evidence linked here
- [ ] **Bake window** observed: minimum 2h on testnet at the same configuration before mainnet
- [ ] **Coordinated rollback plan** documented in PR body — exact commands operator runs if it fails
- [ ] **Operator sign-off** at activation moment (not just PR approval — separate moment for the actual flip)

## Test plan

<!-- Bullet list. For 🟠 / 🔴 PRs the regression test must be specific. -->

-

## Rollback plan

<!-- Required for 🔴 PRs. Recommended for 🟠. The exact commands an on-call operator would run if this PR causes incidents post-deploy. -->

## Related

<!-- Issue numbers, prior PRs, design docs in internal operator docs, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup is more resilient: individual trie/account lookup failures no longer abort initialization. The system logs warnings for each skipped address and leaves cached account values unchanged until they can be updated.
  * Emits an aggregate warning after scanning when any addresses were skipped due to missing or corrupted trie nodes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->