### PR TITLE
fix(rpc): null v/r/s for undecodable EVM tx sigs instead of silent zeros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.12"
+version = "2.2.13"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -321,13 +321,33 @@ fn tx_to_evm_json(
 
     // For EVM txs, decode the original RLP envelope stored in `signature`
     // (see eth_send_raw_transaction). That gives us the canonical v/r/s
-    // ethers needs to round-trip the tx. For native txs we don't have
-    // ECDSA-on-EVM-envelope semantics; return zeros so the field is present.
-    let (v_hex, r_hex, s_hex) = if is_evm {
-        extract_vrs_from_rlp(tx_obj["signature"].as_str().unwrap_or(""))
-            .unwrap_or_else(|| ("0x0".to_string(), "0x0".to_string(), "0x0".to_string()))
+    // ethers needs to round-trip the tx.
+    //
+    // 2026-05-21 (audit M-6): if decoding fails for an EVM tx, surface
+    // v/r/s as null in the response instead of silently returning zeros.
+    // Zero-as-fallback risks ethers / viem accepting a forged "signature"
+    // (all-zero r/s parses but ecrecover returns a deterministic junk
+    // address that callers might trust). Null forces explicit "no
+    // recoverable signature" handling, matching how EIP-1474 clients
+    // treat pending / unsigned txs. Log a warn so a stuck decoder path
+    // doesn't go unnoticed.
+    //
+    // For native (non-EVM) txs there is no Ethereum-shaped signature at
+    // all; v/r/s stay null so the response is shape-consistent.
+    let (v_value, r_value, s_value): (Value, Value, Value) = if is_evm {
+        match extract_vrs_from_rlp(tx_obj["signature"].as_str().unwrap_or("")) {
+            Some((v, r, s)) => (Value::String(v), Value::String(r), Value::String(s)),
+            None => {
+                tracing::warn!(
+                    txid,
+                    "eth_getTransactionByHash: failed to decode v/r/s from stored \
+                     EVM-tx signature field; returning null sig"
+                );
+                (Value::Null, Value::Null, Value::Null)
+            }
+        }
     } else {
-        ("0x0".to_string(), "0x0".to_string(), "0x0".to_string())
+        (Value::Null, Value::Null, Value::Null)
     };
 
     let block_number_value: Value = block_index
@@ -348,9 +368,9 @@ fn tx_to_evm_json(
         "nonce": nonce_hex,
         "type": tx_type,
         "chainId": chain_id_hex,
-        "v": v_hex,
-        "r": r_hex,
-        "s": s_hex,
+        "v": v_value,
+        "r": r_value,
+        "s": s_value,
         "maxFeePerGas": gas_price,
         "maxPriorityFeePerGas": "0x0",
         "accessList": [],


### PR DESCRIPTION
Audit M-6 follow-up against #692.

## Problem

`extract_vrs_from_rlp` returns `Option<(String,String,String)>`; the caller used `unwrap_or_else` to substitute `("0x0","0x0","0x0")` on decode failure. All-zero r/s parses as a valid ECDSA point pair and ecrecover returns a deterministic junk address — a caller doing best-effort sender check via the signature could trust that junk.

## Fix

Surface v/r/s as `null` instead of zero strings. EIP-1474 clients already treat null sig fields as "not recoverable" (matches the pending-tx convention), so ethers / viem behave correctly without changes. Log a `warn!` when this path fires — successful decode is the steady state for any tx that came in via `eth_sendRawTransaction`, so a failure here means the stored signature field is corrupted or the wire format drifted.

For native (non-EVM) txs the same null fields apply; there is no Ethereum-shaped signature to surface, and shape-consistency between the two paths simplifies downstream parsers.

## Impact

No behavior change for healthy EVM txs (the steady state). Failed-decode path goes from "silent zeros that look like a valid signature" to "explicit null + warn log".

## Test plan

- [x] `cargo check --release` passes
- [ ] Confirm Sentrix testnet tx returns proper v/r/s post-deploy
- [ ] Confirm null v/r/s + warn log on a deliberately-corrupted signature row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.2.13

* **Bug Fixes**
  * Ethereum transaction signature fields now return null and emit diagnostic warnings when decoding fails, replacing previous silent default fallbacks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->