### PR TITLE
fix(rpc): eth_getTransactionCount accepts any block tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5237,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "bincode",
  "hex",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "bincode",
  "hex",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "anyhow",
  "axum",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "anyhow",
  "axum",
@@ -5392,14 +5392,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "hex",
  "proptest",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5472,14 +5472,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "bincode",
  "blake3",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5540,7 +5540,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.12"
+version = "2.2.14"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.13"
+version = "2.2.14"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -54,15 +54,22 @@ pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) 
             // accepted only the first, the rest piled up rejected
             // mid-block. Live discovery 2026-05-02.
             //
-            // 2026-05-06: extend the same historical-state honesty
-            // pattern Bug A applied to eth_getBalance — specific past
-            // heights return -32004 instead of silently returning
-            // current nonce. `pending` keeps its mempool-aware path.
+            // 2026-05-21: relaxed the historical-state gate for this
+            // method only. Hyperlane relayer + ethers + viem all query
+            // `eth_getTransactionCount(addr, blockN)` against a recent
+            // past block as part of routine nonce bookkeeping — they do
+            // NOT actually care about the historical value, they just
+            // want a nonce they can pass to the next signed tx.
+            // Returning -32004 here breaks every off-the-shelf relayer.
+            //
+            // Unlike eth_getBalance / eth_getCode / eth_getStorageAt /
+            // eth_call (kept strict), a "wrong" nonce is self-correcting:
+            // the chain rejects a tx with a stale nonce, the caller
+            // retries, no protocol-level decision was made on stale data.
+            // So this method serves current nonce regardless of block
+            // tag and trusts the caller to handle the retry loop.
             let block_tag = params.get(1).and_then(|v| v.as_str()).unwrap_or("latest");
             let bc = state.read().await;
-            if block_tag != "pending" {
-                require_latest_state_read(params.get(1), bc.height())?;
-            }
             let mut nonce = bc.accounts.get_nonce(&address);
             if block_tag == "pending" {
                 nonce = nonce.saturating_add(bc.mempool_pending_count(&address));

--- a/crates/sentrix-rpc/src/jsonrpc/helpers.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/helpers.rs
@@ -33,8 +33,10 @@ pub(super) fn resolve_block_tag(v: Option<&Value>, latest: u64) -> Result<u64, &
 }
 
 /// Gate state-read methods (`eth_getBalance`, `eth_getCode`,
-/// `eth_getStorageAt`, `eth_getTransactionCount`, `eth_call`) against
-/// historical-specific block heights.
+/// `eth_getStorageAt`, `eth_call`) against historical-specific block
+/// heights. `eth_getTransactionCount` was removed from this gate
+/// 2026-05-21 — see the comment in eth.rs for why nonces are different
+/// from other state reads.
 ///
 /// Sentrix doesn't yet have MDBX snapshot isolation, so account state
 /// reads always serve current-tip data regardless of the block tag


### PR DESCRIPTION
Discovered 2026-05-21 while standing up the Hyperlane relayer agent for the Base Sepolia ↔ Sentrix Testnet bridge (audit fix H-4). The relayer queries `eth_getTransactionCount(signer, blockN)` against a recent past block in a tight loop. With the strict historical-state gate from 2026-05-06 active, every call returned:

```
{"code": -32004, "message": "historical state reads not yet supported; use 'latest'"}
```

and the relayer's `FallbackProvider` eventually deprioritized the Sentrix RPC host entirely (`reason: "Too many errors"`).

Hyperlane, ethers, viem, and most off-the-shelf EVM tooling all do this — passing a block tag to `eth_getTransactionCount` is part of routine nonce bookkeeping, not an actual historical query.

## Fix

Remove the historical-state gate for `eth_getTransactionCount` only. Serve current nonce regardless of block tag. The `pending` semantics (mempool-aware path) is preserved.

The gate stays on `eth_getBalance` / `eth_getCode` / `eth_getStorageAt` / `eth_call` — those four are the methods where a silently-stale answer (instead of `-32004`) would let a caller make a wrong protocol decision on data that purports to be historical.

A stale nonce is different: the chain rejects any tx that arrives with the wrong nonce, the caller retries, no protocol decision is built on the stale value. So the trade-off is "agent works" vs "honesty about nonce being current-only," and current-only is the right answer because relayers + faucets + dapps already assume it.

## Test plan

- [x] `cargo check -p sentrix-rpc --release` passes with `-D warnings`
- [x] All 10 `require_latest_state_read_*` tests still pass (gate is unchanged)
- [ ] Confirm Hyperlane relayer no longer spams the `-32004` warn after deploy
- [ ] Confirm the pending 0.1 USDC bridge tx auto-relays (sUSDC totalSupply 18.5M → 18.6M)

## Notes

- Bumps workspace 2.2.13 → 2.2.14.
- Companion entry in audit findings: this is the 4th Sentrix RPC compat gap discovered. Bug-class write-up tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `eth_getTransactionCount` RPC method now returns current nonce for all block tags, including historical ones, instead of error responses. This improves client compatibility.

* **Documentation**
  * Updated documentation for state read gating to clarify scope and reflect transaction count behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->