### PR TITLE
feat(core): SENTRIX_SKIP_TRIE_INTEGRITY env escape for cluster-wide o…

### DIFF
--- a/crates/sentrix-core/src/blockchain_trie_ops.rs
+++ b/crates/sentrix-core/src/blockchain_trie_ops.rs
@@ -199,16 +199,33 @@ impl Blockchain {
         // height the old hash format ignores state_root entirely, so a
         // broken trie can't cause consensus divergence — warn-only there.
         if let Err(e) = trie.verify_integrity() {
-            if height >= sentrix_primitives::block::STATE_ROOT_FORK_HEIGHT {
+            // Operator escape hatch: when chain.db has a known orphan that
+            // affects every peer identically (same orphan reference across
+            // the cluster), bypassing the strict gate is recovery-safe — all
+            // nodes will compute identical state_roots and stay in consensus.
+            // Set SENTRIX_SKIP_TRIE_INTEGRITY=1 to allow boot. Use only when
+            // the alternative is a halted chain with no clean peer to rsync
+            // from. NOT for production unless coordinated cluster-wide.
+            let skip = std::env::var("SENTRIX_SKIP_TRIE_INTEGRITY")
+                .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE"))
+                .unwrap_or(false);
+            if height >= sentrix_primitives::block::STATE_ROOT_FORK_HEIGHT && !skip {
                 return Err(SentrixError::Internal(format!(
                     "trie integrity check failed at height {height}: {e}"
                 )));
             }
-            tracing::warn!(
-                "trie integrity warning at height {} (below fork height — allowed): {}",
-                height,
-                e
-            );
+            if skip {
+                tracing::warn!(
+                    "trie integrity check FAILED at height {height} but \
+                     SENTRIX_SKIP_TRIE_INTEGRITY=1 set — booting anyway: {e}"
+                );
+            } else {
+                tracing::warn!(
+                    "trie integrity warning at height {} (below fork height — allowed): {}",
+                    height,
+                    e
+                );
+            }
         }
 
         self.state_trie = Some(trie);


### PR DESCRIPTION
…rphan

When chain.db has a known orphan that affects every peer identically (same orphan reference across all validators), the strict integrity gate from STATE_ROOT_FORK_HEIGHT onwards refuses boot — even though the entire cluster would compute identical state_roots and stay in consensus. This left no clean path forward except 'rsync from a peer that doesn't have it', which doesn't exist when all peers share the orphan.

Add SENTRIX_SKIP_TRIE_INTEGRITY=1 as an operator-only escape: bypass the gate, log a loud WARN, and boot. Use ONLY when:
  - the alternative is a halted chain with no clean peer to rsync from
  - the orphan is verified cluster-wide identical (cross-host STATE-FP trace or equivalent)
  - the override is coordinated and removed after recovery

Default behavior unchanged — flag unset still strict-rejects boot at or above fork height.

<!--
Thanks for the PR. Fill in the relevant sections + check the boxes that apply.
The risk-tier checklist below is the gate — it codifies discipline rules that
existed in `feedback_*.md` memory but kept getting skipped under time pressure.
-->

## Summary

<!-- 1-3 lines: what changed and why. Link the issue if applicable. -->

## Risk tier

Check ONE:

- [ ] **🟢 Low** — docs, tools/, tests/, CI configs, dependency patch bumps in dev-only crates, comments
- [ ] **🟡 Medium** — non-consensus production code (RPC handlers, network plumbing, observability, ops scripts)
- [ ] **🟠 High** — consensus-critical crates (`sentrix-core`, `sentrix-trie`, `sentrix-staking`, `sentrix-bft`), `block_executor`, `apply_block_*`, `state_root` path
- [ ] **🔴 Critical** — Voyager activation, fork-height changes, hard-fork rollouts, anything that flips env vars on mainnet

## Required by tier

### 🟢 Low — minimum bar
- [ ] CI green (tests + clippy + audit + gitleaks)

### 🟡 Medium — adds
- [ ] New public function or behavioural change has at least one corresponding `#[test]` in same PR
- [ ] Brief description of how this was tested (manual run, integration test, etc.)

### 🟠 High — adds
- [ ] Regression test that **fails on main** and **passes with this change** — paste test name in PR body
- [ ] Designed against documented invariant (link the audit/runbook/design doc)
- [ ] Fresh-brain review by someone other than the author (per the consensus-change review checklist)
- [ ] Single conceptual unit per PR (no bundling — bundling consensus changes burned us on v2.1.12 → 2026-04-25 livelock)

### 🔴 Critical — adds
- [ ] **Testnet rehearsal completed** with success criteria + log evidence linked here
- [ ] **Bake window** observed: minimum 2h on testnet at the same configuration before mainnet
- [ ] **Coordinated rollback plan** documented in PR body — exact commands operator runs if it fails
- [ ] **Operator sign-off** at activation moment (not just PR approval — separate moment for the actual flip)

## Test plan

<!-- Bullet list. For 🟠 / 🔴 PRs the regression test must be specific. -->

-

## Rollback plan

<!-- Required for 🔴 PRs. Recommended for 🟠. The exact commands an on-call operator would run if this PR causes incidents post-deploy. -->

## Related

<!-- Issue numbers, prior PRs, design docs in internal operator docs, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Startup validation now includes an optional bypass for integrity check failures via environment variable configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->