### PR TITLE
chore: bump workspace 2.2.14 -> 2.2.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5237,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "bincode",
  "hex",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "bincode",
  "hex",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -5392,14 +5392,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "hex",
  "proptest",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5472,14 +5472,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "bincode",
  "blake3",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5540,7 +5540,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.14"
+version = "2.2.15"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"


### PR DESCRIPTION
PRs #705 + #707 (`eth_call` historical tags + `logsBloom` 256-byte fix) merged into main without a version bump. Post-merge `main` carries more RPC changes than the 2.2.14 binary already running on mainnet — two distinct binaries with the same version string.

Bump to 2.2.15 so the RPC-complete binary is distinguishable. This is the version for the next mainnet upgrade.

## Test plan
- [x] `cargo update -w` regenerated Cargo.lock cleanly (19 workspace crates -> 2.2.15)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped workspace version from 2.2.14 to 2.2.15.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->