### PR TITLE
fix(staking): pay_one_signer iterates sorted delegator keys

### DIFF
--- a/crates/sentrix-staking/src/staking.rs
+++ b/crates/sentrix-staking/src/staking.rs
@@ -873,9 +873,21 @@ impl StakeRegistry {
         }
 
         // Sum of delegations to this validator (denominator for pro-rata).
-        let total_delegated: u64 = self
-            .delegations
-            .values()
+        //
+        // CRITICAL determinism (mirrors the slash() pattern at line 556):
+        // `self.delegations` is `HashMap<String, Vec<DelegationEntry>>`. Its
+        // `.values()` iteration order is randomised per-process via SipHash
+        // seed. The summation itself is commutative so this sum is
+        // order-independent — but we also need a stable iteration below for
+        // the per-share write into `delegator_rewards`, and using the same
+        // sorted-keys pattern in both places keeps the two halves of the
+        // function trivially consistent.
+        let mut delegator_keys: Vec<String> = self.delegations.keys().cloned().collect();
+        delegator_keys.sort();
+
+        let total_delegated: u64 = delegator_keys
+            .iter()
+            .filter_map(|k| self.delegations.get(k))
             .flatten()
             .filter(|e| e.validator == validator_addr)
             .map(|e| e.amount)
@@ -885,10 +897,14 @@ impl StakeRegistry {
         }
 
         // Collect (delegator, amount) pairs first to avoid double-borrow
-        // of self when writing into delegator_rewards.
-        let shares: Vec<(String, u64)> = self
-            .delegations
-            .values()
+        // of self when writing into delegator_rewards. Iterate by sorted
+        // delegator address so the `shares` Vec is byte-identical across
+        // every validator process for the same input — matches slash()
+        // (line 556) and closes a quiet determinism gap that paired with
+        // PR #551 for the slash path but was missed for the reward path.
+        let shares: Vec<(String, u64)> = delegator_keys
+            .iter()
+            .filter_map(|k| self.delegations.get(k))
             .flatten()
             .filter(|e| e.validator == validator_addr)
             .map(|e| {


### PR DESCRIPTION
`pay_one_signer` was the last reward-path function still iterating `self.delegations.values()` directly. `slash()` was hardened in PR #551 to sort by delegator address before iterating, exactly because `HashMap::values()` order is randomised per-process via SipHash seed. The reward-distribution path missed the same treatment.

In practice the per-share math here is already order-independent (each delegator's share is computed from the full delegator_pool and full total_delegated, then summed into `delegator_rewards` via saturating_add, which is associative). So this is NOT a proven cause of the 2026-05-24 STATE-FP `fp` divergence — that drift sits elsewhere (likely in coinbase / total_minted accumulation, still being tracked).

What this commit fixes is the structural asymmetry: two functions in the same crate, doing pro-rata distribution against the same HashMap, should reason about iteration order the same way. Leaving one sorted and the other random invites future regressions where someone adds an order-dependent operation downstream and only one path is safe.

Lifts the same sorted-keys pattern from `slash()` (line 556) into `pay_one_signer`. Cost: one Vec<String> + sort per call. Reward path already does heavier work (u128 multiplications + map writes) so the sort cost is irrelevant at the call frequency (~4 calls per block).

<!--
Thanks for the PR. Fill in the relevant sections + check the boxes that apply.
The risk-tier checklist below is the gate — it codifies discipline rules that
existed in `feedback_*.md` memory but kept getting skipped under time pressure.
-->

## Summary

<!-- 1-3 lines: what changed and why. Link the issue if applicable. -->

## Risk tier

Check ONE:

- [ ] **🟢 Low** — docs, tools/, tests/, CI configs, dependency patch bumps in dev-only crates, comments
- [ ] **🟡 Medium** — non-consensus production code (RPC handlers, network plumbing, observability, ops scripts)
- [x] **🟠 High** — consensus-critical crates (`sentrix-core`, `sentrix-trie`, `sentrix-staking`, `sentrix-bft`), `block_executor`, `apply_block_*`, `state_root` path
- [ ] **🔴 Critical** — Voyager activation, fork-height changes, hard-fork rollouts, anything that flips env vars on mainnet

## Required by tier

### 🟢 Low — minimum bar
- [ ] CI green (tests + clippy + audit + gitleaks)

### 🟡 Medium — adds
- [ ] New public function or behavioural change has at least one corresponding `#[test]` in same PR
- [ ] Brief description of how this was tested (manual run, integration test, etc.)

### 🟠 High — adds
- [ ] Regression test that **fails on main** and **passes with this change** — paste test name in PR body
- [ ] Designed against documented invariant (link the audit/runbook/design doc)
- [ ] Fresh-brain review by someone other than the author (per the consensus-change review checklist)
- [ ] Single conceptual unit per PR (no bundling — bundling consensus changes burned us on v2.1.12 → 2026-04-25 livelock)

### 🔴 Critical — adds
- [ ] **Testnet rehearsal completed** with success criteria + log evidence linked here
- [ ] **Bake window** observed: minimum 2h on testnet at the same configuration before mainnet
- [ ] **Coordinated rollback plan** documented in PR body — exact commands operator runs if it fails
- [ ] **Operator sign-off** at activation moment (not just PR approval — separate moment for the actual flip)

## Test plan

<!-- Bullet list. For 🟠 / 🔴 PRs the regression test must be specific. -->

-

## Rollback plan

<!-- Required for 🔴 PRs. Recommended for 🟠. The exact commands an on-call operator would run if this PR causes incidents post-deploy. -->

## Related

<!-- Issue numbers, prior PRs, design docs in internal operator docs, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved nondeterminism in delegator reward distribution that could cause inconsistent state across processes. Staking rewards are now distributed deterministically.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->