### PR TITLE
docs: add README to each workspace crate

### DIFF
--- a/crates/sentrix-bft/README.md
+++ b/crates/sentrix-bft/README.md
@@ -1,0 +1,49 @@
+# sentrix-bft
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-bft.svg)](https://crates.io/crates/sentrix-bft)
+[![docs.rs](https://docs.rs/sentrix-bft/badge.svg)](https://docs.rs/sentrix-bft)
+
+Tendermint-style BFT consensus engine for Sentrix Chain.
+
+## Why this crate exists
+
+The validator main loop in [`sentrix-labs/sentrix`](https://github.com/sentrix-labs/sentrix) drives a 3-phase state machine — Propose, Prevote, Precommit — and needs a self-contained module that owns vote collection, round timeouts, and the last-signed-vote guard. Splitting the engine out of the binary lets `sentrix-wire` reference the message types without pulling the libp2p stack, and lets tests run the state machine deterministically without touching the network.
+
+The crate depends on [sentrix-primitives](../sentrix-primitives) for block/transaction types, [sentrix-staking](../sentrix-staking) for active-set lookups, and [sentrix-wallet](../sentrix-wallet) for secp256k1 signing.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-bft = { path = "../sentrix-bft" }
+```
+
+```rust
+use sentrix_bft::{BftEngine, BftAction, BftPhase};
+
+// Build the engine for a given (height, round) and feed it messages.
+// The driver calls `BftEngine::tick()` on the propose/prevote/precommit
+// timeouts and dispatches the resulting `BftAction`s to the network layer.
+let mut engine = BftEngine::new(/* validators, our_address, ... */);
+match engine.phase() {
+    BftPhase::Propose => { /* proposer broadcasts a Proposal */ }
+    BftPhase::Prevote => { /* collect 2f+1 prevotes */ }
+    BftPhase::Precommit => { /* collect 2f+1 precommits → finalize */ }
+    _ => {}
+}
+```
+
+Key re-exports: `BftEngine`, `BftAction`, `BftPhase`, `BftRoundState`, `VoteCollector`,
+`Proposal`, `Prevote`, `Precommit`, `RoundStatus`, `BlockJustification`,
+`supermajority_threshold`.
+
+## Round advancement
+
+Round advancement is timeout-only — votes and `RoundStatus` messages never trigger an
+eager round jump. This is the 2026-04-17 fix for the validator-leapfrog stall where
+vote-triggered catch-up would clear collected votes on every round bump. Constants:
+`PROPOSE_TIMEOUT_MS = 10000`, `MAX_ROUND = 100`.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-codec/README.md
+++ b/crates/sentrix-codec/README.md
@@ -1,0 +1,44 @@
+# sentrix-codec
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-codec.svg)](https://crates.io/crates/sentrix-codec)
+[![docs.rs](https://docs.rs/sentrix-codec/badge.svg)](https://docs.rs/sentrix-codec)
+
+Centralised bincode + hex encoding helpers for the Sentrix workspace.
+
+## Why this crate exists
+
+Eight files across the workspace were calling `bincode::serialize` / `bincode::deserialize`
+directly, and `hex::encode` / `hex::decode` were used even more widely. A future format
+change — bincode 1.x → 2.x, endianness, size limits — would have required hunting every
+call site and patching them in lockstep. This crate is the single chokepoint so that
+migration touches one file.
+
+Consumed across most chain crates ([sentrix-core](../sentrix-core),
+[sentrix-storage](../sentrix-storage), [sentrix-rpc](../sentrix-rpc), etc.). Wraps
+bincode 1.3 with the workspace's default config (little-endian, varint ints, no byte
+limit) — same on-the-wire bytes as direct `bincode::serialize` calls.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-codec = { path = "../sentrix-codec" }
+```
+
+```rust
+use sentrix_codec::{encode, decode, hex_encode, hex_decode, hex_decode_fixed};
+
+let bytes = encode(&("hello", 42u64)).unwrap();
+let back: (String, u64) = decode(&bytes).unwrap();
+
+let hex_str = hex_encode([0xde, 0xad, 0xbe, 0xef]);          // "deadbeef"
+let raw = hex_decode("0xdeadbeef").unwrap();                  // accepts 0x prefix
+let arr: [u8; 4] = hex_decode_fixed("deadbeef").unwrap();     // length-checked
+```
+
+Errors come back as `CodecError::Encode` / `CodecError::Decode` so callers can match
+without a bincode dependency themselves.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-core/README.md
+++ b/crates/sentrix-core/README.md
@@ -1,0 +1,49 @@
+# sentrix-core
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-core.svg)](https://crates.io/crates/sentrix-core)
+[![docs.rs](https://docs.rs/sentrix-core/badge.svg)](https://docs.rs/sentrix-core)
+
+Blockchain orchestration for Sentrix Chain — state machine, block execution, mempool, genesis.
+
+## Why this crate exists
+
+This is where the workspace's leaf crates ([sentrix-primitives](../sentrix-primitives),
+[sentrix-trie](../sentrix-trie), [sentrix-staking](../sentrix-staking),
+[sentrix-evm](../sentrix-evm), [sentrix-bft](../sentrix-bft),
+[sentrix-storage](../sentrix-storage)) are wired together into one `Blockchain` type.
+The validator binary and [sentrix-rpc](../sentrix-rpc) / [sentrix-grpc](../sentrix-grpc)
+both depend on this crate; they hold `Arc<RwLock<Blockchain>>` and read/write through it.
+
+Modules cover block production, block execution (revm + state-trie writeback), the
+mempool, authority + genesis loading, fork-height activations, and chain query helpers
+the RPC layer fans out to.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-core = { path = "../sentrix-core" }
+```
+
+```rust
+use sentrix_core::{Blockchain, Genesis, Storage};
+
+// Load genesis from disk (or use `Genesis::mainnet()` for the embedded
+// mainnet genesis), open MDBX storage, then construct the blockchain
+// the validator main loop and the RPC stack both share.
+let genesis = Genesis::from_path("genesis.toml")?;
+let _storage = Storage::open("data/chain.db")?;
+let mut blockchain = Blockchain::new_with_genesis(
+    "0x...admin_address".to_string(),
+    &genesis,
+);
+```
+
+Key re-exports: `Blockchain`, `Genesis`, `GenesisError`, `Storage`. Submodules:
+`block_executor`, `block_producer`, `mempool`, `authority`, `chain_params`,
+`chain_queries`, `state_export`, `fork_heights`, `tokenomics`, `token_ops`, `vm`,
+`parallel`.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-evm/README.md
+++ b/crates/sentrix-evm/README.md
@@ -1,0 +1,43 @@
+# sentrix-evm
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-evm.svg)](https://crates.io/crates/sentrix-evm)
+[![docs.rs](https://docs.rs/sentrix-evm/badge.svg)](https://docs.rs/sentrix-evm)
+
+EVM execution layer for Sentrix Chain, built on revm 38.
+
+## Why this crate exists
+
+Block execution and `eth_call` both need to run EVM bytecode against Sentrix account
+state. This crate provides the revm Database adapter that bridges Sentrix's account
+store to revm, plus the execution helpers, gas constants, log/bloom encoding, and
+receipt storage keys. [sentrix-core](../sentrix-core) drives transaction execution
+through here; [sentrix-rpc](../sentrix-rpc) reuses the same path for `eth_call` and
+`eth_estimateGas`.
+
+Precompile addresses are imported from [sentrix-precompiles](../sentrix-precompiles)
+so SDKs and tooling can reference them without depending on this stack.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-evm = { path = "../sentrix-evm" }
+```
+
+```rust
+use sentrix_evm::{SentrixEvmDb, execute_tx, TxReceipt, commit_state_to_account_db};
+
+// Adapter wraps the account store as a revm Database, then runs the tx and
+// writes the resulting state back. Used by block_executor in sentrix-core.
+let mut db = SentrixEvmDb::new(/* &mut account_db */);
+let receipt: TxReceipt = execute_tx(&mut db, /* tx, block_env, ... */)?;
+commit_state_to_account_db(/* state, &mut account_db */);
+```
+
+Key re-exports: `SentrixEvmDb`, `execute_tx`, `execute_call`, `execute_tx_with_state`,
+`execute_call_with_state`, `commit_state_to_account_db`, `TxReceipt`, `StoredReceipt`,
+`StoredLog`, `LogsBloom`, `compute_logs_bloom`, `BLOCK_GAS_LIMIT`, `INITIAL_BASE_FEE`.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-grpc/README.md
+++ b/crates/sentrix-grpc/README.md
@@ -1,0 +1,49 @@
+# sentrix-grpc
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-grpc.svg)](https://crates.io/crates/sentrix-grpc)
+[![docs.rs](https://docs.rs/sentrix-grpc/badge.svg)](https://docs.rs/sentrix-grpc)
+
+Tonic gRPC supplement transport for Sentrix Chain — parallel to the JSON-RPC `eth_*` interface.
+
+## Why this crate exists
+
+JSON-RPC stays the ecosystem-facing contract for wallets and dApps; gRPC is the
+side-car for SentrisCloud internal monitoring, the Rust SDK, and clients that prefer
+a binary protocol over WebSocket polling. Both transports share the same
+`Arc<RwLock<Blockchain>>` and the same `EventBus` — gRPC is just another reader.
+
+Generated proto types live in the sibling [sentrix-proto](../sentrix-proto) crate (its
+own crates.io semver). This crate carries only server-side handlers and the chain-state
+plumbing that depends on [sentrix-core](../sentrix-core), [sentrix-rpc](../sentrix-rpc),
+and [sentrix-staking](../sentrix-staking).
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-grpc = { path = "../sentrix-grpc" }
+```
+
+```rust
+use sentrix_grpc::{SentrixServiceImpl, server_factory, SharedState};
+
+// In the validator main: spawn the gRPC server next to the axum JSON-RPC
+// router, sharing the same Blockchain handle and EventBus.
+let svc = server_factory(shared_state.clone(), event_bus.clone());
+tokio::spawn(async move {
+    tonic::transport::Server::builder()
+        .add_service(svc)
+        .serve("0.0.0.0:50051".parse().unwrap())
+        .await
+        .ok();
+});
+```
+
+Implemented RPCs: `GetBlock`, `GetBalance`, `GetValidatorSet`, `GetSupply`,
+`GetMempool`, and server-streaming `StreamEvents` (subscribes to the same broadcast
+bus the WebSocket `eth_subscribe` path uses). `BroadcastTx` is currently
+`Status::unimplemented` pending the proto↔chain `Transaction` marshalling.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-network/README.md
+++ b/crates/sentrix-network/README.md
@@ -1,0 +1,46 @@
+# sentrix-network
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-network.svg)](https://crates.io/crates/sentrix-network)
+[![docs.rs](https://docs.rs/sentrix-network/badge.svg)](https://docs.rs/sentrix-network)
+
+P2P networking for Sentrix Chain — libp2p gossipsub + kademlia + request-response.
+
+## Why this crate exists
+
+The validator binary needs a peer-to-peer transport for block propagation, transaction
+gossip, BFT vote dissemination, and chain sync. This crate owns the libp2p
+`NetworkBehaviour` composition, the Kademlia DHT for peer discovery, gossipsub topics
+for blocks / txs / BFT phases, and the request-response codec used for `GetBlocks`
+and handshakes.
+
+Wire-format types (request/response enums, gossipsub envelopes, protocol version
+string, topic constants) live in [sentrix-wire](../sentrix-wire) so SDKs and monitoring
+tools can reference them without pulling libp2p as a transitive dep. This crate brings
+in `sentrix-wire` + [sentrix-bft](../sentrix-bft) + [sentrix-core](../sentrix-core) to
+turn those types into an actual node.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-network = { path = "../sentrix-network" }
+```
+
+```rust
+use sentrix_network::{LibP2pNode, NodeEvent};
+use tokio::sync::mpsc;
+
+// Validator main loop owns the receiver; LibP2pNode is constructed with the
+// matching sender so the swarm task can forward inbound NodeEvents
+// (NewBlock, NewTransaction, BftProposal/Prevote/Precommit) into the engine.
+let (event_tx, mut event_rx) = mpsc::channel::<NodeEvent>(4096);
+let _node = LibP2pNode::new(/* keypair, blockchain, event_tx, ... */).await?;
+
+while let Some(event) = event_rx.recv().await {
+    // dispatch NodeEvent::NewBlock / NewTransaction / Bft* to the engine
+}
+```
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-precompiles/README.md
+++ b/crates/sentrix-precompiles/README.md
@@ -1,0 +1,46 @@
+# sentrix-precompiles
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-precompiles.svg)](https://crates.io/crates/sentrix-precompiles)
+[![docs.rs](https://docs.rs/sentrix-precompiles/badge.svg)](https://docs.rs/sentrix-precompiles)
+
+Sentrix-reserved EVM precompile addresses (staking, slashing).
+
+## Why this crate exists
+
+Standard Ethereum precompiles `0x01`–`0x09` are handled by revm's `EthPrecompiles`
+inside [sentrix-evm](../sentrix-evm). Sentrix's own chain-specific precompiles —
+DPoS staking, slashing-evidence — need stable on-chain addresses that contract
+authors can hard-code, and that future SDKs or governance tooling can reference
+without depending on the full EVM stack.
+
+Splitting these addresses into a tiny standalone crate keeps the contract surface
+stable and lets external tooling import the canonical constants from one place.
+Depends only on `alloy-primitives`.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-precompiles = { path = "../sentrix-precompiles" }
+```
+
+```rust
+use sentrix_precompiles::{STAKING_PRECOMPILE, SLASHING_PRECOMPILE, is_sentrix_precompile};
+
+// Reserved addresses (handler wire-up gated on a future fork height):
+//   STAKING_PRECOMPILE   = 0x...0100
+//   SLASHING_PRECOMPILE  = 0x...0101
+assert!(is_sentrix_precompile(&STAKING_PRECOMPILE));
+```
+
+## Status
+
+As of v2.1.80, both addresses are **reserved + advertised but unwired**. A contract
+calling `0x0100` or `0x0101` today receives revm's default empty-success — not a real
+handler response. `is_sentrix_precompile(...) == true` does NOT mean a handler exists.
+Wiring real handlers will gate behind a fork height so historical chain.db state stays
+reproducible. Never change an address — introduce a new one.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-primitives/README.md
+++ b/crates/sentrix-primitives/README.md
@@ -1,0 +1,49 @@
+# sentrix-primitives
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-primitives.svg)](https://crates.io/crates/sentrix-primitives)
+[![docs.rs](https://docs.rs/sentrix-primitives/badge.svg)](https://docs.rs/sentrix-primitives)
+
+Core types and error handling for Sentrix Chain.
+
+## Why this crate exists
+
+Every other crate in the workspace needs `Block`, `Transaction`, `Account`,
+`AccountDB`, address derivation, and the canonical `SentrixError` / `SentrixResult`
+types. Keeping them in a leaf crate with zero internal dependencies (only `thiserror`,
+`serde`, `secp256k1`, `sha2`, `sha3`, `hex`) means everyone else can depend on it
+without creating cycles.
+
+This is the bottom of the dependency graph — [sentrix-bft](../sentrix-bft),
+[sentrix-staking](../sentrix-staking), [sentrix-evm](../sentrix-evm),
+[sentrix-trie](../sentrix-trie), [sentrix-core](../sentrix-core), and
+[sentrix-wire](../sentrix-wire) all consume types from here.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-primitives = { path = "../sentrix-primitives" }
+```
+
+```rust
+use sentrix_primitives::{
+    Account, AccountDB, Block, Transaction, SentrixError, SentrixResult,
+    derive_address, merkle_root, sha256_hex, SENTRI_PER_SRX,
+};
+
+// `AccountDB` is the workspace's canonical balance + nonce + code store.
+// `derive_address` turns a secp256k1 pubkey into the chain's 0x-prefixed
+// 20-byte address (Keccak-256 of the uncompressed pubkey, last 20 bytes).
+let mut accounts = AccountDB::new();
+accounts.credit(&caller_supplied_address, 1_000 * SENTRI_PER_SRX)?;
+let bal = accounts.get_balance(&caller_supplied_address);
+```
+
+Re-exported submodules: `account`, `address`, `block`, `error`, `events`,
+`justification`, `merkle`, `transaction`. Tested with a `proptest` invariant
+sweep that asserts `total_supply()` and `total_burned` track across random op
+sequences — catches supply-leak classes at the unit level.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-prom-exporter/README.md
+++ b/crates/sentrix-prom-exporter/README.md
@@ -1,0 +1,49 @@
+# sentrix-prom-exporter
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-prom-exporter.svg)](https://crates.io/crates/sentrix-prom-exporter)
+[![docs.rs](https://docs.rs/sentrix-prom-exporter/badge.svg)](https://docs.rs/sentrix-prom-exporter)
+
+Standalone Prometheus exporter that polls per-validator `/sentrix_status` endpoints and exposes labelled gauges for Grafana.
+
+## Why this crate exists
+
+The chain binary doesn't emit a native `/metrics` endpoint yet, so the Grafana
+dashboards need a side-car that scrapes the existing JSON `/sentrix_status` endpoint
+on each validator and re-publishes the numbers as Prometheus metrics with
+`{validator, network}` labels. The key metric is `sentrix_chain_tip_hash_short` — the
+first 8 hex chars of the tip hash decoded to u32 — which makes cluster-divergence a
+one-line PromQL query:
+`count(count by (sentrix_chain_tip_hash_short) (sentrix_chain_tip_hash_short)) > 1`.
+
+Runs as its own binary, no chain crate deps. Reads `SENTRIX_TARGETS` env (format
+`name:network:url,...`), `SENTRIX_PROBE_INTERVAL_SEC` (default 15), and
+`SENTRIX_EXPORTER_BIND` (default `0.0.0.0:9101`).
+
+## Usage
+
+```bash
+cargo run --release -p sentrix-prom-exporter
+```
+
+```bash
+# systemd unit env (single line in real config):
+SENTRIX_TARGETS=val1:mainnet:http://10.0.0.1:8545,val2:testnet:http://10.0.0.2:9545
+SENTRIX_PROBE_INTERVAL_SEC=15
+SENTRIX_EXPORTER_BIND=0.0.0.0:9101
+```
+
+Exported metrics:
+
+| Metric | Labels |
+|---|---|
+| `sentrix_chain_height` | `validator`, `network` |
+| `sentrix_block_age_seconds` | `validator`, `network` |
+| `sentrix_chain_tip_hash_short` | `validator`, `network` |
+| `sentrix_active_validators` | `network` |
+| `sentrix_mempool_size` | `validator`, `network` |
+| `sentrix_uptime_seconds` | `validator`, `network` |
+| `sentrix_probe_failed_total` | `validator`, `network` |
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-rpc-types/README.md
+++ b/crates/sentrix-rpc-types/README.md
@@ -1,0 +1,50 @@
+# sentrix-rpc-types
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-rpc-types.svg)](https://crates.io/crates/sentrix-rpc-types)
+[![docs.rs](https://docs.rs/sentrix-rpc-types/badge.svg)](https://docs.rs/sentrix-rpc-types)
+
+Pure ETH ↔ Sentrix JSON-RPC type conversions and hex / address validation helpers.
+
+## Why this crate exists
+
+Helpers like `to_hex(u64)`, `parse_hex_u64(Value)`, `normalize_rpc_address`, and
+`normalize_rpc_hash` are needed by both the JSON-RPC server in
+[sentrix-rpc](../sentrix-rpc) and any future Sentrix JSON-RPC client SDK. Keeping them
+in a tiny crate that depends only on `serde_json` means SDK consumers don't pay for
+the axum / tokio / revm transitive deps that come with the server crate.
+
+Every helper here is pure — it operates on strings and primitive integers, never on
+node state. Anything that needs a `Blockchain` reference (e.g. `resolve_block_tag`,
+`log_matches`) stays in the consuming crate.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-rpc-types = { path = "../sentrix-rpc-types" }
+```
+
+```rust
+use sentrix_rpc_types::{to_hex, to_hex_u128, parse_hex_u64, normalize_rpc_address, normalize_rpc_hash};
+use serde_json::json;
+
+assert_eq!(to_hex(255), "0xff");
+assert_eq!(parse_hex_u64(&json!("0x2a")), Some(42));
+assert_eq!(parse_hex_u64(&json!(42)), Some(42));
+
+// normalize_rpc_address takes "0x" + 40 hex chars and returns the lowercased
+// length-validated form; malformed input returns an `&'static str` error.
+let addr = normalize_rpc_address(&caller_supplied_address)?;
+
+// normalize_rpc_hash applies the same shape check for 32-byte hashes.
+let hash = normalize_rpc_hash(&caller_supplied_hash)?;
+```
+
+Address normalisation enforces exactly `0x` + 40 hex characters; hash normalisation
+enforces 32 bytes (64 hex). Malformed inputs return an `&'static str` error suitable
+for JSON-RPC error code `-32602` (Invalid params), so adversarial requests don't
+reach the account store as silent misses.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-rpc/README.md
+++ b/crates/sentrix-rpc/README.md
@@ -1,0 +1,49 @@
+# sentrix-rpc
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-rpc.svg)](https://crates.io/crates/sentrix-rpc)
+[![docs.rs](https://docs.rs/sentrix-rpc/badge.svg)](https://docs.rs/sentrix-rpc)
+
+REST API, JSON-RPC (`eth_*`), WebSocket subscriptions, and block-explorer endpoints for Sentrix Chain.
+
+## Why this crate exists
+
+This is the ecosystem-facing surface — the contract wallets, dApps, and the public
+explorer depend on. It exposes axum routes for the `eth_*` JSON-RPC namespace,
+WebSocket subscriptions (`eth_subscribe` newHeads + logs), the explorer REST
+endpoints, and the Sentrix-specific `/sentrix_status` health endpoint that the
+[sentrix-prom-exporter](../sentrix-prom-exporter) scrapes.
+
+Builds on [sentrix-core](../sentrix-core) for blockchain state,
+[sentrix-evm](../sentrix-evm) for `eth_call` and `eth_estimateGas`,
+[sentrix-rpc-types](../sentrix-rpc-types) for the pure hex/address helpers, and
+[sentrix-trie](../sentrix-trie) for `eth_getProof`. The shared `EventBus` exported
+here is also consumed by [sentrix-grpc](../sentrix-grpc) so gRPC stream subscribers
+and WebSocket subscribers see the same ordering.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-rpc = { path = "../sentrix-rpc" }
+```
+
+```rust
+use sentrix_rpc::{create_router, SharedState, EventBus};
+use std::sync::Arc;
+
+// The validator main builds an Arc<RwLock<Blockchain>>, hands it to the router,
+// and serves the result with axum. Same shared state the gRPC side-car holds.
+let state: SharedState = /* Arc<RwLock<Blockchain>> */;
+let bus = Arc::new(EventBus::new());
+let app = create_router(state, bus);
+axum::serve(listener, app).await?;
+```
+
+Key re-exports: `create_router`, `SharedState`, `EventBus`, `NewHeadEvent`.
+Submodules: `jsonrpc` (the `eth_*` handlers), `routes` (axum routing + CORS),
+`ws` (WebSocket subscriptions), `explorer` + `explorer_api` (block / tx / log
+queries), `events` (broadcast channels).
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-staking/README.md
+++ b/crates/sentrix-staking/README.md
@@ -1,0 +1,46 @@
+# sentrix-staking
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-staking.svg)](https://crates.io/crates/sentrix-staking)
+[![docs.rs](https://docs.rs/sentrix-staking/badge.svg)](https://docs.rs/sentrix-staking)
+
+DPoS staking, epoch management, and slashing for Sentrix Chain.
+
+## Why this crate exists
+
+The BFT engine in [sentrix-bft](../sentrix-bft) needs an active validator set,
+the block executor in [sentrix-core](../sentrix-core) needs to settle stake /
+delegate / unbond transitions, and the slashing detector needs a place to
+record downtime + double-sign evidence. Isolating that surface here keeps the
+state machine testable and lets the gRPC layer ([sentrix-grpc](../sentrix-grpc))
+expose `GetValidatorSet` without dragging in the EVM stack.
+
+Depends only on [sentrix-primitives](../sentrix-primitives), `serde`, `sha2`,
+and `tracing`. No I/O — callers persist the registry via
+[sentrix-storage](../sentrix-storage).
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-staking = { path = "../sentrix-staking" }
+```
+
+```rust
+use sentrix_staking::{StakeRegistry, EpochManager, SlashingEngine, MIN_SELF_STAKE, MIN_BFT_VALIDATORS};
+
+// StakeRegistry owns validators + delegations + active_set. The block
+// executor mutates it during staking ops; the BFT engine reads active_set
+// + voting power; epoch boundaries rotate the set.
+let mut registry = StakeRegistry::default();
+let epoch = EpochManager::epoch_for_height(123_456);
+
+// Slashing decisions go through SlashingEngine, which records evidence
+// and decrements the offender's stake at the next epoch boundary.
+```
+
+Key re-exports: `StakeRegistry`, `EpochManager`, `SlashingEngine`,
+`MIN_SELF_STAKE`, `MIN_BFT_VALIDATORS`.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-storage/README.md
+++ b/crates/sentrix-storage/README.md
@@ -1,0 +1,62 @@
+# sentrix-storage
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-storage.svg)](https://crates.io/crates/sentrix-storage)
+[![docs.rs](https://docs.rs/sentrix-storage/badge.svg)](https://docs.rs/sentrix-storage)
+
+libmdbx-backed persistence layer for Sentrix Chain blocks, transactions, trie nodes, and metadata.
+
+## Why this crate exists
+
+The chain was originally on `sled`; libmdbx (used by Reth and Erigon) gives ACID
+transactions with proper commit/rollback semantics, ordered B+ tree iteration, and
+memory-mapped reads — important for a chain.db that grows past a few GB. This crate
+wraps libmdbx in a typed `MdbxStorage` + `WriteBatch` API and defines the table
+layout the rest of the workspace persists into.
+
+[sentrix-trie](../sentrix-trie) writes its node + leaf + root tables here;
+[sentrix-core](../sentrix-core) uses `ChainStorage` for blocks, hash→height index,
+tx index, and the metadata key-value pairs that drive recovery.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-storage = { path = "../sentrix-storage" }
+```
+
+```rust
+use std::path::Path;
+use sentrix_storage::{MdbxStorage, ChainStorage, height_key, key_to_height};
+
+// MdbxStorage is the raw typed wrapper around the libmdbx env;
+// ChainStorage layers block-aware semantics on top of it.
+let storage = MdbxStorage::open(Path::new("data/chain.db"))?;
+
+// Write transaction — atomic across multiple `put` / `delete` calls.
+let batch = storage.begin_write()?;
+batch.put("trie_nodes", &node_hash, &serialized_node)?;
+batch.commit()?;
+
+// Read path (auto-managed RO txn per call).
+if let Some(bytes) = storage.get("trie_nodes", &node_hash)? {
+    // ...
+}
+```
+
+## Tables
+
+| Table | Key | Value |
+|---|---|---|
+| `blocks` | height (BE u64) | `Block` (bincode) |
+| `block_hashes` | hash | height |
+| `state` | name | chain state JSON (backward compat) |
+| `tx_index` | tx_hash | block_height |
+| `trie_nodes` | node_hash | `TrieNode` |
+| `trie_values` | leaf_key | value bytes |
+| `trie_roots` | height | root_hash |
+| `trie_committed_roots` | height | root_hash |
+| `meta` | name | metadata bytes |
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-trie/README.md
+++ b/crates/sentrix-trie/README.md
@@ -1,0 +1,51 @@
+# sentrix-trie
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-trie.svg)](https://crates.io/crates/sentrix-trie)
+[![docs.rs](https://docs.rs/sentrix-trie/badge.svg)](https://docs.rs/sentrix-trie)
+
+256-level Binary Sparse Merkle Tree with MDBX persistence for Sentrix Chain state.
+
+## Why this crate exists
+
+The chain commits `state_root` into every block header, so the block executor needs
+an authenticated key-value store that can produce inclusion proofs (for
+`eth_getProof`) and recompute deterministic roots after each transaction. The BSMT
+implementation here writes nodes through to [sentrix-storage](../sentrix-storage) and
+keeps a hot LRU in front (`TrieCache`) so the trie hot path doesn't hammer mdbx for
+every read.
+
+Used by [sentrix-core](../sentrix-core) for account state writeback, and by
+[sentrix-rpc](../sentrix-rpc) for `eth_getProof`. Criterion microbenches under
+`benches/trie_insert.rs` gate consensus-touching PRs against the main-branch baseline.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-trie = { path = "../sentrix-trie" }
+```
+
+```rust
+use sentrix_trie::{SentrixTrie, MerkleProof, account_value_bytes, address_to_key};
+
+// SentrixTrie is the main API — insert/get/prove/commit. Keys are 256-bit
+// (typically hashed addresses or storage slots); values are arbitrary bytes.
+let mut trie = SentrixTrie::open(/* storage handle */)?;
+let key = address_to_key("0x...");
+let value = account_value_bytes(/* Account */);
+trie.insert(&key, &value)?;
+let root = trie.commit(height)?;
+
+// MerkleProof generates inclusion / non-inclusion proofs for the RPC layer.
+// `verify_membership(&root)` checks the proof matches the trie that committed
+// to `root`; `verify_nonmembership(&root)` proves a key is absent.
+let proof: MerkleProof = trie.prove(&key)?;
+assert!(proof.verify_membership(&root));
+```
+
+Key re-exports: `SentrixTrie`, `TrieNode`, `NodeHash`, `MerkleProof`,
+`account_value_bytes`, `account_value_decode`, `address_to_key`.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-wallet/README.md
+++ b/crates/sentrix-wallet/README.md
@@ -1,0 +1,51 @@
+# sentrix-wallet
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-wallet.svg)](https://crates.io/crates/sentrix-wallet)
+[![docs.rs](https://docs.rs/sentrix-wallet/badge.svg)](https://docs.rs/sentrix-wallet)
+
+Key generation, address derivation, signing, and encrypted keystore for Sentrix Chain.
+
+## Why this crate exists
+
+Both the validator binary and the CLI tooling need to load a secp256k1 secret key,
+derive the 20-byte chain address from its pubkey (Keccak-256 of the uncompressed
+pubkey, last 20 bytes), sign transactions / votes, and read AES-256-GCM encrypted
+keystore files. Centralising that surface here keeps the crypto in one audited
+place, with `zeroize` on secret material and `subtle` for constant-time comparison
+of authentication tags.
+
+Keystores support two KDFs: Argon2id (v2, the default for new files) and PBKDF2
+(v1, kept for backwards compatibility with older keystore files). Consumed by
+[sentrix-bft](../sentrix-bft) for vote signing and by
+[sentrix-wire](../sentrix-wire) tests for the multiaddr-advertisement signature
+path.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-wallet = { path = "../sentrix-wallet" }
+```
+
+```rust
+use sentrix_wallet::{Wallet, Keystore};
+
+// Generate a new wallet, or import via `Wallet::from_private_key(hex)`.
+let wallet = Wallet::generate();
+let pubkey = wallet.get_public_key()?;
+let address = Wallet::derive_address(&pubkey);  // "0x..." 42-char hex
+
+// Save into an encrypted keystore file (Argon2id by default).
+let keystore = Keystore::encrypt(&wallet, "passphrase")?;
+keystore.save("validator.keystore.json")?;
+
+// Load + decrypt later.
+let loaded = Keystore::load("validator.keystore.json")?;
+let wallet2 = loaded.decrypt("passphrase")?;
+```
+
+Key re-exports: `Wallet`, `Keystore`.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.

--- a/crates/sentrix-wire/README.md
+++ b/crates/sentrix-wire/README.md
@@ -1,0 +1,60 @@
+# sentrix-wire
+
+[![crates.io](https://img.shields.io/crates/v/sentrix-wire.svg)](https://crates.io/crates/sentrix-wire)
+[![docs.rs](https://docs.rs/sentrix-wire/badge.svg)](https://docs.rs/sentrix-wire)
+
+Sentrix libp2p wire protocol types — request/response enums, gossipsub envelopes, protocol version + topic constants. No libp2p dependency.
+
+## Why this crate exists
+
+Wire types are part of the on-network protocol surface — every peer running a
+Sentrix binary has to agree on the bincode layout of `SentrixRequest` /
+`SentrixResponse` and the gossipsub topic names. Keeping those types in a crate
+that depends only on [sentrix-primitives](../sentrix-primitives) +
+[sentrix-bft](../sentrix-bft) (no libp2p, no async runtime, no framing) lets
+downstream SDKs, monitoring tools, and light clients reference them without
+pulling the full libp2p stack. The actual codec + behaviour lives in
+[sentrix-network](../sentrix-network).
+
+Stability rules: adding a variant bumps `SENTRIX_PROTOCOL` and rolls out
+testnet-first; renaming / reordering variants is an immediate wire break
+(bincode is position-dependent); removing a variant requires a hard fork at a
+pinned height.
+
+## Usage
+
+```toml
+[dependencies]
+sentrix-wire = { path = "../sentrix-wire" }
+```
+
+```rust
+use sentrix_wire::{
+    SentrixRequest, SentrixResponse, MultiaddrAdvertisement,
+    SENTRIX_PROTOCOL, BLOCKS_TOPIC, TXS_TOPIC,
+    BFT_PROPOSAL_TOPIC, BFT_PREVOTE_TOPIC, BFT_PRECOMMIT_TOPIC,
+    VALIDATOR_ADVERTS_TOPIC, MAX_MESSAGE_BYTES,
+};
+
+// Handshake on connection open — peers exchange chain_id for network partitioning.
+let req = SentrixRequest::Handshake {
+    host: "198.51.100.10".into(),
+    port: 30303,
+    height: 1_700_000,
+    chain_id: 7119,
+};
+
+// Variant name for diagnostics / metrics labels.
+assert_eq!(req.variant_name(), "Handshake");
+
+// Current protocol identifier: `/sentrix/2.2.0`.
+let _ = SENTRIX_PROTOCOL;
+```
+
+Also defines `MultiaddrAdvertisement` — the signed gossipsub message validators
+broadcast for L1 peer auto-discovery, with cross-chain replay protection
+(mainnet 7119 vs testnet 7120) baked into the signing payload.
+
+## License
+
+BUSL-1.1 — same as the rest of the Sentrix Chain workspace. Transitions to a permissive open-source license after the Change Date.


### PR DESCRIPTION
## Summary

16 READMEs (one per workspace crate, excl. \`sentrix-proto\` which already has one). Each follows the \`sentrix-proto\` template: title + crates.io/docs.rs badges, \"Why this crate exists\" framing, install + brief usage example, BUSL-1.1 license footer.

Prep work for publishing the workspace crates to crates.io. Each crate will still need its own version bump + \`cargo publish\` pass; this PR just lands the registry landing-page content.

## Verification

Usage examples spot-checked against actual \`pub fn\` surface in each crate's \`lib.rs\` / \`src/*.rs\`. Three crates had fabricated method names in initial drafts (caught + fixed):

- **sentrix-wallet**: \`Wallet::address()\` / \`secret_key()\` → \`derive_address(&pk)\` / \`get_public_key()\`; \`Keystore::save_to_file/load_from_file\` → \`save/load\`; \`Keystore::encrypt\` takes \`&Wallet\`, not \`&secret_key\`.
- **sentrix-core**: \`Genesis::load_from_file\` → \`Genesis::from_path\`; \`Blockchain::new(genesis, storage)\` → \`Blockchain::new_with_genesis(admin, &genesis)\`.
- **sentrix-network**: dropped \`node.next_event()\` (doesn't exist) in favour of the actual \`mpsc::Sender<NodeEvent>\` constructor pattern.
- **sentrix-rpc-types**: pre-commit hook caught a real (compromised v1 founder) wallet address baked into the example; replaced with a prose-only API contract description.

## Risk tier

- [x] **🟢 Low** — docs only, no code or chain logic changes.

## Test plan

- \`cargo build --workspace\` still passes (no Cargo.toml changes).
- Spot-check each crate's README renders properly in the GitHub tree.
- No leak / no AI tooling references / BUSL-1.1 license footer uniform across all 16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added README documentation for core platform components including consensus engine, blockchain infrastructure, EVM layer, networking, storage, RPC interfaces, staking, and utility modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->