### PR TITLE
docs(evm): correct stale revm 37 module doc to revm 38

### DIFF
--- a/crates/sentrix-evm/src/lib.rs
+++ b/crates/sentrix-evm/src/lib.rs
@@ -1,4 +1,4 @@
-//! sentrix-evm — EVM execution layer (revm 37) for Sentrix blockchain.
+//! sentrix-evm — EVM execution layer (revm 38) for Sentrix blockchain.
 //!
 //! Provides:
 //! - `SentrixEvmDb` — revm Database adapter bridging Sentrix account state


### PR DESCRIPTION
Single-line fix. `crates/sentrix-evm/src/lib.rs:1` lagged behind the workspace's revm = "38" pin. Cargo.toml, README, and CHANGELOG already correct.

Risk tier: 🟢 Low — docstring only, no code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to reference the latest dependency version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->