### PR TITLE
chore(codec): publish-prep for crates.io v0.1.0

### DIFF
--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "sentrix-codec"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license = "MIT OR Apache-2.0"
-description = "Centralised encoding: bincode + hex wrappers for Sentrix"
+description = "Centralised bincode + hex encoding helpers — a stable wrapper around bincode 1.3 and hex 0.4 with a single error type."
 repository.workspace = true
+authors = ["Sentrix Labs <support@sentrixchain.com>"]
+keywords = ["bincode", "hex", "serialization", "encoding"]
+categories = ["encoding"]
 
 [dependencies]
 bincode = "1.3"

--- a/crates/sentrix-codec/README.md
+++ b/crates/sentrix-codec/README.md
@@ -1,43 +1,132 @@
-# sentrix-codec
+<p align="center">
+  <img src="https://cdn.jsdelivr.net/gh/sentrix-labs/brand-kit@master/png-transparent/sentrix-256.png" alt="Sentrix" width="120" />
+</p>
 
-[![crates.io](https://img.shields.io/crates/v/sentrix-codec.svg)](https://crates.io/crates/sentrix-codec)
-[![docs.rs](https://docs.rs/sentrix-codec/badge.svg)](https://docs.rs/sentrix-codec)
+<h1 align="center">sentrix-codec</h1>
 
-Centralised bincode + hex encoding helpers for the Sentrix workspace.
+<p align="center">
+  <a href="https://crates.io/crates/sentrix-codec"><img src="https://img.shields.io/crates/v/sentrix-codec.svg" alt="crates.io" /></a>
+  <a href="https://docs.rs/sentrix-codec"><img src="https://docs.rs/sentrix-codec/badge.svg" alt="docs.rs" /></a>
+  <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
+</p>
+
+Centralized serialization and hex encoding helpers for the Sentrix workspace.
+
+## What it is
+
+A thin, stable wrapper around `bincode 1.3` and `hex 0.4`. Five pure functions
+and one error type — `encode` / `decode` for bincode, `hex_encode` /
+`hex_decode` / `hex_decode_fixed` for hex, all returning `Result<_, CodecError>`.
+
+No I/O, no `unsafe`, no panics on the production path. Pulls in only the three
+crates it wraps (`bincode`, `hex`, `serde`).
 
 ## Why this crate exists
 
-Eight files across the workspace were calling `bincode::serialize` / `bincode::deserialize`
-directly, and `hex::encode` / `hex::decode` were used even more widely. A future format
-change — bincode 1.x → 2.x, endianness, size limits — would have required hunting every
-call site and patching them in lockstep. This crate is the single chokepoint so that
-migration touches one file.
+A workspace that calls `bincode::serialize` and `hex::decode` from dozens of
+call sites turns any format change — bincode 1.x → 2.x, hex prefix rules, byte
+limits — into a workspace-wide grep-and-patch. This crate is the chokepoint:
+edit the encoder once, every consumer follows in one step.
 
-Consumed across most chain crates ([sentrix-core](../sentrix-core),
-[sentrix-storage](../sentrix-storage), [sentrix-rpc](../sentrix-rpc), etc.). Wraps
-bincode 1.3 with the workspace's default config (little-endian, varint ints, no byte
-limit) — same on-the-wire bytes as direct `bincode::serialize` calls.
+The same logic applies outside Sentrix: any Rust project that wants to commit
+to one bincode config (and stop re-implementing the `0x`-prefix-tolerant
+`hex_decode` everyone eventually writes) can use it the same way.
+
+## Format guarantees
+
+- **bincode**: `1.3` default config — little-endian, variable-length integer
+  encoding, no byte-length limit. Output is byte-identical to a direct
+  `bincode::serialize(val)` call against the same crate version.
+- **hex encode**: lowercase, no `0x` prefix (matches `hex::encode`).
+- **hex decode**: tolerates a leading `0x` prefix; fails on non-hex characters
+  or odd length.
+- **hex decode fixed**: tolerates `0x`, then requires exactly `2 * N`
+  characters; fails with a length-mismatch error otherwise.
+
+These are stable for the `0.x` line. Any breaking change to the on-the-wire
+bytes will be a major version bump.
+
+## API
+
+```rust
+// bincode
+pub fn encode<T: Serialize>(val: &T) -> Result<Vec<u8>, CodecError>;
+pub fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, CodecError>;
+
+// hex
+pub fn hex_encode<T: AsRef<[u8]>>(bytes: T) -> String;
+pub fn hex_decode(s: &str) -> Result<Vec<u8>, CodecError>;
+pub fn hex_decode_fixed<const N: usize>(s: &str) -> Result<[u8; N], CodecError>;
+
+// error
+pub enum CodecError {
+    Encode(String),
+    Decode(String),
+}
+```
+
+`CodecError` implements `std::error::Error` and `Display`. Pattern-match on the
+variants if you need to distinguish encode vs decode failures without taking a
+direct dependency on `bincode` yourself.
 
 ## Usage
 
+Add to your `Cargo.toml`:
+
 ```toml
 [dependencies]
-sentrix-codec = { path = "../sentrix-codec" }
+sentrix-codec = "0.1"
 ```
+
+## Examples
 
 ```rust
 use sentrix_codec::{encode, decode, hex_encode, hex_decode, hex_decode_fixed};
+use serde::{Serialize, Deserialize};
 
-let bytes = encode(&("hello", 42u64)).unwrap();
-let back: (String, u64) = decode(&bytes).unwrap();
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct Block {
+    height: u64,
+    data: Vec<u8>,
+}
 
-let hex_str = hex_encode([0xde, 0xad, 0xbe, 0xef]);          // "deadbeef"
-let raw = hex_decode("0xdeadbeef").unwrap();                  // accepts 0x prefix
-let arr: [u8; 4] = hex_decode_fixed("deadbeef").unwrap();     // length-checked
+// bincode round-trip
+let b = Block { height: 42, data: vec![1, 2, 3] };
+let bytes = encode(&b)?;
+let back: Block = decode(&bytes)?;
+assert_eq!(b, back);
+
+// hex helpers
+let s = hex_encode([0xde, 0xad, 0xbe, 0xef]);           // "deadbeef"
+let v = hex_decode("0xdeadbeef")?;                       // accepts 0x prefix
+let arr: [u8; 4] = hex_decode_fixed("deadbeef")?;        // length-checked
+# Ok::<(), sentrix_codec::CodecError>(())
 ```
 
-Errors come back as `CodecError::Encode` / `CodecError::Decode` so callers can match
-without a bincode dependency themselves.
+## Safety and security notes
+
+- **`#![forbid(unsafe_code)]`** — the crate cannot contain `unsafe` blocks;
+  enforced at compile time.
+- **No I/O.** All functions are pure — no filesystem, network, environment, or
+  process access. The crate has no side channels of its own.
+- **No panics on the production path.** Every fallible operation returns
+  `CodecError`; the workspace lint config denies `unwrap_used`, `expect_used`,
+  and `panic`.
+- **Length-checked decode.** `hex_decode_fixed` validates the byte length
+  before copying into the output array.
+- **Secrets caveat.** If you serialize a private key or other signing material
+  with `encode`, the resulting `Vec<u8>` is plain bytes — treat it with the
+  same care as the original secret (zero on drop, avoid logging, avoid
+  unencrypted transmission). The crate does not zeroize on its own.
+
+## Testing
+
+Nine unit tests cover all five public functions plus the error paths
+(non-hex input, odd-length input, wrong fixed length, garbage bincode bytes).
+
+```sh
+cargo test -p sentrix-codec
+```
 
 ## License
 

--- a/crates/sentrix-codec/src/lib.rs
+++ b/crates/sentrix-codec/src/lib.rs
@@ -1,37 +1,34 @@
-//! sentrix-codec — centralised encoding helpers for Sentrix.
+//! sentrix-codec — centralised encoding helpers.
 //!
-//! Why this crate exists:
-//!   - 8 files across the workspace call `bincode::serialize` /
-//!     `bincode::deserialize` directly. If we ever need to change bincode
-//!     config (e.g. bincode 1.x → 2.x migration, endianness, size limit),
-//!     every call site needs to be found and updated.
-//!   - `hex::encode` / `hex::decode` is used even more widely.
-//!
-//! This crate is the single chokepoint. Future format migrations edit
-//! ONE file (this one) instead of scanning the whole workspace.
-//!
-//! Extracted during the 45-crate split, Tier 1 item #2. See
-//! `internal design doc`.
+//! A small, stable wrapper around `bincode 1.3` and `hex 0.4` that gives
+//! consumers a single import surface and one error type (`CodecError`) for
+//! both serialization and hex conversion.
 //!
 //! # Design
 //!
-//! We stay with bincode 1.3 for now (matches the existing workspace
-//! pin). Migration to bincode 2.x (which has a different API surface)
-//! would happen here first with unit-tests confirming byte-identical
-//! output for the fixed serialization formats. Not part of this PR.
+//! Bincode is pinned to 1.3 (the workspace stays on 1.x for now). A future
+//! migration to bincode 2.x — which has a different API surface — would
+//! happen here first with byte-equality tests so every consumer follows in
+//! one step instead of a workspace-wide grep.
 
-#![allow(missing_docs)]
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 use serde::{Serialize, de::DeserializeOwned};
 
 // ── bincode ──────────────────────────────────────────────────────────
 
-/// Error type returned by this crate's encode/decode helpers.
-/// Wraps `bincode::Error` but doesn't leak the underlying crate, so
-/// callers can match on `CodecError::*` without a bincode dep themselves.
+/// Error type returned by every function in this crate. Implements
+/// `std::error::Error` so it composes with `?` in any `Result` chain.
 #[derive(Debug)]
 pub enum CodecError {
+    /// Serialization failed (returned by [`encode`]). The wrapped string
+    /// is the underlying `bincode` error message — opaque to callers, fine
+    /// for logging or surfacing to a user.
     Encode(String),
+    /// Deserialization or hex-decoding failed (returned by [`decode`],
+    /// [`hex_decode`], and [`hex_decode_fixed`]). The wrapped string is the
+    /// underlying error message from `bincode` or `hex`.
     Decode(String),
 }
 
@@ -46,36 +43,39 @@ impl std::fmt::Display for CodecError {
 
 impl std::error::Error for CodecError {}
 
-/// Serialize a value to `Vec<u8>` using bincode 1.3 default config
-/// (little-endian, varint ints, no byte limit). Matches the behaviour
-/// of `bincode::serialize(..)` already in use across the workspace —
-/// this is a direct wrapper, not a new format.
+/// Serialize a value to `Vec<u8>` using `bincode 1.3` default config
+/// (little-endian, varint integers, no byte-length limit). Output is
+/// byte-identical to a direct `bincode::serialize(val)` call.
 pub fn encode<T: Serialize>(val: &T) -> Result<Vec<u8>, CodecError> {
     bincode::serialize(val).map_err(|e| CodecError::Encode(e.to_string()))
 }
 
-/// Deserialize a value from bytes using bincode 1.3 default config.
+/// Deserialize a value from bytes using `bincode 1.3` default config.
+/// Returns [`CodecError::Decode`] on malformed input or type mismatch.
 pub fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, CodecError> {
     bincode::deserialize(bytes).map_err(|e| CodecError::Decode(e.to_string()))
 }
 
 // ── hex ──────────────────────────────────────────────────────────────
 
-/// Hex-encode bytes as lowercase string (no `0x` prefix — matches the
-/// existing `hex::encode` behaviour that the workspace expects).
+/// Hex-encode bytes as a lowercase string with no `0x` prefix. Matches
+/// `hex::encode` exactly — kept here so consumers don't take a direct
+/// dependency on the `hex` crate.
 pub fn hex_encode<T: AsRef<[u8]>>(bytes: T) -> String {
     hex::encode(bytes)
 }
 
-/// Hex-decode a string (tolerates a leading `0x` prefix). Returns
-/// `CodecError::Decode` on invalid hex or odd length.
+/// Hex-decode a string into a `Vec<u8>`. Tolerates a leading `0x` prefix
+/// (`"deadbeef"` and `"0xdeadbeef"` both decode to the same bytes).
+/// Returns [`CodecError::Decode`] on non-hex characters or odd length.
 pub fn hex_decode(s: &str) -> Result<Vec<u8>, CodecError> {
     let stripped = s.strip_prefix("0x").unwrap_or(s);
     hex::decode(stripped).map_err(|e| CodecError::Decode(e.to_string()))
 }
 
-/// Hex-decode into a fixed-size byte array. Errors if the input isn't
-/// exactly `N` bytes (2*N hex chars after optional `0x` prefix).
+/// Hex-decode a string into a fixed-size `[u8; N]`. Tolerates a leading
+/// `0x` prefix and then requires exactly `2 * N` hex characters. Returns
+/// [`CodecError::Decode`] on a length mismatch or non-hex input.
 pub fn hex_decode_fixed<const N: usize>(s: &str) -> Result<[u8; N], CodecError> {
     let bytes = hex_decode(s)?;
     if bytes.len() != N {


### PR DESCRIPTION
## Summary

Prepares \`sentrix-codec\` for first crates.io publish at \`v0.1.0\`. No functional code change — just metadata, doc-hygiene, and README restructure.

## Changes

**Cargo.toml**
- Override version → \`0.1.0\` (decoupled from chain workspace \`2.2.17\`; codec's semver should track its own API, not the chain release cadence)
- \`authors = [\"Sentrix Labs <support@sentrixchain.com>\"]\` (live mailbox)
- \`keywords\` + \`categories\` for crates.io search discoverability

**src/lib.rs**
- Drop internal workspace jargon (\"45-crate split\", \"Tier 1 item #2\", \"internal design doc\") from the module doc — meaningless to external readers
- Add \`#![forbid(unsafe_code)]\` + \`#![deny(missing_docs)]\` as compile-time enforced guarantees
- Document \`CodecError::Encode\` / \`CodecError::Decode\` variants

**README.md**
- Restructured: What it is / Why / Format guarantees / API / Usage / Examples / Safety and security notes / Testing / License
- Removed relative-path \`[X](../sentrix-Y)\` links (broken on crates.io page)
- Added Sentrix logo + centered badge layout matching the org \`.github/profile\` README pattern

## Verification

\`\`\`
cargo test -p sentrix-codec --lib        # 9 passed; 0 failed
cargo clippy -p sentrix-codec -- -D warnings   # clean
cargo publish --dry-run -p sentrix-codec       # 8 files, 9.5 KB compressed
\`\`\`

## After merge

Operator runs \`cargo publish -p sentrix-codec\` locally (needs crates.io token via \`cargo login\`). First crates.io publish is **irreversible** — \`cargo yank\` only hides from the resolver; the tarball stays downloadable forever.

## Test plan

- [x] cargo test passes (9 tests)
- [x] cargo clippy strict passes
- [x] cargo publish --dry-run passes
- [ ] CI green