### PR TITLE
fix(bft,network): driver-confirmed prevote/precommit cast (no more silent stall on dropped try_send)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "hex",
@@ -5238,7 +5238,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-codec"
-version = "2.2.15"
+version = "0.1.0"
 dependencies = [
  "bincode",
  "hex",
@@ -5247,7 +5247,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -5375,14 +5375,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "hex",
  "proptest",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5455,14 +5455,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5472,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5487,7 +5487,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "blake3",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.15"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.17"
+version = "2.2.18"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1880,7 +1880,15 @@ async fn cmd_start(
                                         BftAction::BroadcastPrevote(ref prevote) => {
                                             let mut signed_pv = prevote.clone();
                                             signed_pv.sign(&validator_secret_key);
-                                            lp2p_clone.broadcast_bft_prevote(&signed_pv).await;
+                                            if lp2p_clone.broadcast_bft_prevote(&signed_pv).await.is_err() {
+                                                tracing::error!(
+                                                    "BFT prevote broadcast dropped at h={} r={} — \
+                                                     engine retains pending; outer loop re-emits",
+                                                    prevote.height, prevote.round,
+                                                );
+                                                break;
+                                            }
+                                            bft.mark_prevote_cast();
                                             let bc = shared_clone.read().await;
                                             let our_stake = bc
                                                 .stake_registry
@@ -1894,7 +1902,15 @@ async fn cmd_start(
                                         BftAction::BroadcastPrecommit(ref precommit) => {
                                             let mut signed_pc = precommit.clone();
                                             signed_pc.sign(&validator_secret_key);
-                                            lp2p_clone.broadcast_bft_precommit(&signed_pc).await;
+                                            if lp2p_clone.broadcast_bft_precommit(&signed_pc).await.is_err() {
+                                                tracing::error!(
+                                                    "BFT precommit broadcast dropped at h={} r={} — \
+                                                     engine retains pending; outer loop re-emits",
+                                                    precommit.height, precommit.round,
+                                                );
+                                                break;
+                                            }
+                                            bft.mark_precommit_cast();
                                             let bc = shared_clone.read().await;
                                             let our_stake = bc
                                                 .stake_registry
@@ -2025,7 +2041,7 @@ async fn cmd_start(
                                                 drop(bc_read);
                                                 if let Some(mut prevote) = cu_result {
                                                     prevote.sign(&validator_secret_key);
-                                                    lp2p_clone
+                                                    let _ = lp2p_clone
                                                         .broadcast_bft_prevote(&prevote)
                                                         .await;
                                                 }
@@ -2526,7 +2542,15 @@ async fn cmd_start(
                                 BftAction::BroadcastPrevote(ref prevote) => {
                                     let mut signed_pv = prevote.clone();
                                     signed_pv.sign(&validator_secret_key);
-                                    lp2p_clone.broadcast_bft_prevote(&signed_pv).await;
+                                    if lp2p_clone.broadcast_bft_prevote(&signed_pv).await.is_err() {
+                                        tracing::error!(
+                                            "BFT prevote broadcast dropped at h={} r={} — \
+                                             engine retains pending; outer loop re-emits",
+                                            prevote.height, prevote.round,
+                                        );
+                                        break;
+                                    }
+                                    bft.mark_prevote_cast();
                                     let bc = shared_clone.read().await;
                                     let our_stake = bc
                                         .stake_registry
@@ -2540,7 +2564,15 @@ async fn cmd_start(
                                 BftAction::BroadcastPrecommit(ref precommit) => {
                                     let mut signed_pc = precommit.clone();
                                     signed_pc.sign(&validator_secret_key);
-                                    lp2p_clone.broadcast_bft_precommit(&signed_pc).await;
+                                    if lp2p_clone.broadcast_bft_precommit(&signed_pc).await.is_err() {
+                                        tracing::error!(
+                                            "BFT precommit broadcast dropped at h={} r={} — \
+                                             engine retains pending; outer loop re-emits",
+                                            precommit.height, precommit.round,
+                                        );
+                                        break;
+                                    }
+                                    bft.mark_precommit_cast();
                                     let bc = shared_clone.read().await;
                                     let our_stake = bc
                                         .stake_registry
@@ -2642,7 +2674,7 @@ async fn cmd_start(
                                         drop(bc_read);
                                         if let Some(mut prevote) = cu_result {
                                             prevote.sign(&validator_secret_key);
-                                            lp2p_clone.broadcast_bft_prevote(&prevote).await;
+                                            let _ = lp2p_clone.broadcast_bft_prevote(&prevote).await;
                                         }
                                         break;
                                     }
@@ -3057,7 +3089,15 @@ async fn cmd_start(
                                 BftAction::BroadcastPrevote(ref prevote) => {
                                     let mut signed_pv = prevote.clone();
                                     signed_pv.sign(&validator_secret_key);
-                                    lp2p_clone.broadcast_bft_prevote(&signed_pv).await;
+                                    if lp2p_clone.broadcast_bft_prevote(&signed_pv).await.is_err() {
+                                        tracing::error!(
+                                            "BFT prevote broadcast dropped at h={} r={} — \
+                                             engine retains pending; outer loop re-emits",
+                                            prevote.height, prevote.round,
+                                        );
+                                        break;
+                                    }
+                                    bft.mark_prevote_cast();
                                     let bc = shared_clone.read().await;
                                     let our_stake = bc
                                         .stake_registry
@@ -3071,7 +3111,15 @@ async fn cmd_start(
                                 BftAction::BroadcastPrecommit(ref precommit) => {
                                     let mut signed_pc = precommit.clone();
                                     signed_pc.sign(&validator_secret_key);
-                                    lp2p_clone.broadcast_bft_precommit(&signed_pc).await;
+                                    if lp2p_clone.broadcast_bft_precommit(&signed_pc).await.is_err() {
+                                        tracing::error!(
+                                            "BFT precommit broadcast dropped at h={} r={} — \
+                                             engine retains pending; outer loop re-emits",
+                                            precommit.height, precommit.round,
+                                        );
+                                        break;
+                                    }
+                                    bft.mark_precommit_cast();
                                     let bc = shared_clone.read().await;
                                     let our_stake = bc
                                         .stake_registry

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -512,7 +512,13 @@ impl BftEngine {
             return BftAction::Wait;
         }
         self.pending_prevote = Some(prevote.clone());
-        self.state.our_prevote_cast = true;
+        // NOTE: our_prevote_cast is no longer set here. The driver must call
+        // mark_prevote_cast() after the network send actually succeeds —
+        // setting the flag pre-send caused silent-thread-death when the
+        // libp2p cmd_tx try_send dropped the message (h=1392113 2026-05-05,
+        // val4 2026-05-27 ~h=5609246). pending_prevote is kept so the engine
+        // re-emits the same prevote on the next iteration if the driver
+        // failed to broadcast.
         BftAction::BroadcastPrevote(prevote)
     }
 
@@ -535,7 +541,10 @@ impl BftEngine {
             return BftAction::Wait;
         }
         self.pending_precommit = Some(precommit.clone());
-        self.state.our_precommit_cast = true;
+        // NOTE: our_precommit_cast is no longer set here. Same reason as
+        // emit_prevote — driver calls mark_precommit_cast() only after the
+        // network send succeeds, so a dropped try_send no longer leaves the
+        // engine thinking it broadcast when it didn't.
         BftAction::BroadcastPrecommit(precommit)
     }
 
@@ -1040,6 +1049,27 @@ impl BftEngine {
 
     pub fn phase(&self) -> BftPhase {
         self.state.phase
+    }
+
+    /// Called by the driver after a `BroadcastPrevote` action has been
+    /// successfully sent on the network. Marks our prevote as cast so the
+    /// engine does not re-emit it on the next iteration.
+    ///
+    /// If the driver does NOT call this (because the network send dropped),
+    /// the engine state machine sees `our_prevote_cast=false` on the next
+    /// step and re-emits the same prevote via the `pending_prevote` path —
+    /// which is how we self-heal from a dropped `libp2p` `try_send` instead
+    /// of going silently stuck.
+    pub fn mark_prevote_cast(&mut self) {
+        self.state.our_prevote_cast = true;
+    }
+
+    /// Called by the driver after a `BroadcastPrecommit` action has been
+    /// successfully sent on the network. Same contract as
+    /// [`Self::mark_prevote_cast`] — only mark on confirmed send so a
+    /// dropped `try_send` doesn't leave the engine thinking it broadcast.
+    pub fn mark_precommit_cast(&mut self) {
+        self.state.our_precommit_cast = true;
     }
 }
 
@@ -2609,9 +2639,13 @@ mod tests {
                 other
             ),
         }
+        // Driver-confirmed cast: simulate successful broadcast, then assert.
+        // Pre-v2.1.91 the engine self-set this flag inside emit_prevote and a
+        // dropped libp2p try_send left us stuck thinking we'd voted.
+        engine.mark_prevote_cast();
         assert!(
             engine.state.our_prevote_cast,
-            "after on_own_proposal, our_prevote_cast must be set"
+            "after on_own_proposal + driver mark_prevote_cast, flag must be set"
         );
     }
 
@@ -2728,6 +2762,9 @@ mod tests {
             ),
         }
         assert_eq!(engine.state.phase, BftPhase::Prevote);
+        // Driver-confirmed cast (same contract change as
+        // test_finalization_dead_fix_proposer_on_own_proposal_yes_prevotes).
+        engine.mark_prevote_cast();
         assert!(engine.state.our_prevote_cast);
     }
 

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -2883,6 +2883,113 @@ mod tests {
         assert_eq!(direct_retry, first_precommit);
     }
 
+    /// v2.1.91 driver-confirmed cast contract: `emit_prevote` must NOT
+    /// auto-set `our_prevote_cast`. The flag flips to true only when the
+    /// driver explicitly calls `mark_prevote_cast` after a confirmed
+    /// network send. If the driver never calls it (because `libp2p`
+    /// `try_send` dropped on a full channel), the engine stays in a
+    /// retry-ready state instead of going silently stuck.
+    #[test]
+    fn test_v2_1_91_emit_prevote_does_not_auto_mark_cast() {
+        let (_reg, total_stake) = setup_4val();
+        let mut engine = BftEngine::new(100, "0xval001".into(), total_stake);
+
+        let action = engine.on_own_proposal("0xblockhash");
+        assert!(matches!(action, BftAction::BroadcastPrevote(_)));
+        assert!(
+            !engine.state.our_prevote_cast,
+            "emit_prevote MUST NOT auto-mark cast — flag is driver-confirmed"
+        );
+
+        engine.mark_prevote_cast();
+        assert!(
+            engine.state.our_prevote_cast,
+            "after explicit mark_prevote_cast, flag is set"
+        );
+    }
+
+    /// v2.1.91 driver-confirmed cast contract for precommit. Same
+    /// reasoning as the prevote variant — engine must wait for the
+    /// driver's explicit confirmation instead of optimistically marking.
+    #[test]
+    fn test_v2_1_91_emit_precommit_does_not_auto_mark_cast() {
+        let (_reg, total_stake) = setup_4val();
+        let mut engine = BftEngine::new(100, "0xval001".into(), total_stake);
+        let stake = MIN_SELF_STAKE;
+        let block = "0xblockhash";
+
+        // Drive the engine to Precommit via the proposer-self-prevote
+        // + 2-peer-yes pattern from test 5.
+        let our_pv = match engine.on_own_proposal(block) {
+            BftAction::BroadcastPrevote(p) => p,
+            other => panic!("expected own prevote, got {other:?}"),
+        };
+        let _ = engine.on_prevote_weighted(&our_pv, stake);
+        let peer2 = Prevote {
+            height: 100,
+            round: 0,
+            block_hash: Some(block.into()),
+            validator: "0xval002".into(),
+            signature: vec![],
+        };
+        let _ = engine.on_prevote_weighted(&peer2, stake);
+        let peer3 = Prevote {
+            height: 100,
+            round: 0,
+            block_hash: Some(block.into()),
+            validator: "0xval003".into(),
+            signature: vec![],
+        };
+        let action = engine.on_prevote_weighted(&peer3, stake);
+        assert!(matches!(action, BftAction::BroadcastPrecommit(_)));
+
+        assert!(
+            !engine.state.our_precommit_cast,
+            "emit_precommit MUST NOT auto-mark cast — flag is driver-confirmed"
+        );
+
+        engine.mark_precommit_cast();
+        assert!(
+            engine.state.our_precommit_cast,
+            "after explicit mark_precommit_cast, flag is set"
+        );
+    }
+
+    /// v2.1.91 full-cycle regression: simulates the production silent-stall
+    /// scenario where the libp2p `try_send` drops the first send. The
+    /// engine must re-emit the same prevote on the next iteration, the
+    /// driver retries, this time successfully, and only then marks cast.
+    /// Pre-v2.1.91 the engine would have auto-set cast=true on the first
+    /// `on_own_proposal`, and the validator would have sat on the same
+    /// `(h, r)` until manually recovered.
+    #[test]
+    fn test_v2_1_91_dropped_send_then_retry_marks_cast_after_success() {
+        let (_reg, total_stake) = setup_4val();
+        let mut engine = BftEngine::new(100, "0xval001".into(), total_stake);
+
+        let first = match engine.on_own_proposal("0xblockhash") {
+            BftAction::BroadcastPrevote(p) => p,
+            other => panic!("first emit must return BroadcastPrevote, got {other:?}"),
+        };
+        // Driver simulates dropped send: does NOT call mark_prevote_cast.
+        assert!(!engine.state.our_prevote_cast);
+
+        // Engine re-emits same prevote via pending_prevote early-return.
+        let retry = match engine.on_own_proposal("0xblockhash") {
+            BftAction::BroadcastPrevote(p) => p,
+            other => panic!("retry must return BroadcastPrevote, got {other:?}"),
+        };
+        assert_eq!(retry, first, "retry must re-emit the identical prevote");
+        assert!(
+            !engine.state.our_prevote_cast,
+            "retry path also must not auto-mark — still driver-confirmed"
+        );
+
+        // Driver succeeds this time and confirms.
+        engine.mark_prevote_cast();
+        assert!(engine.state.our_prevote_cast);
+    }
+
     #[test]
     fn test_291_conflicting_pending_prevote_blocks_new_vote() {
         let (_reg, total_stake) = setup_4val();

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -248,12 +248,16 @@ impl LibP2pNode {
     /// 2 s, and missed prevotes/precommits trigger a round skip on the
     /// receiver. Losing the occasional message is preferable to
     /// hard-stopping the BFT engine.
-    fn send_swarm_cmd(&self, cmd: SwarmCommand, op: &'static str) {
-        // 2026-05-05 v2.1.65: breadcrumb logs at trace level + a hot
-        // ERROR log on the drop branch so journalctl + the Telegram
-        // alerter both surface it. The drop here is what caused the
-        // silent-thread-death pattern at h=1392113 on 2026-05-05 —
-        // see `DROPPED_BFT_BROADCASTS` doc above for the full story.
+    /// Non-blocking send to the swarm task. Returns `Ok(())` if the message
+    /// was enqueued, `Err(())` if it was dropped (channel full or closed).
+    ///
+    /// BFT-vote callers (prevote/precommit broadcast) MUST inspect the
+    /// return value and revert their engine-state "cast" flag if the send
+    /// dropped, otherwise the engine goes silently stuck (it thinks it
+    /// broadcast and never retries). Best-effort callers (gossip block,
+    /// gossip transaction) can ignore the result — gossipsub re-sends and
+    /// the round skip on peers covers the loss.
+    fn send_swarm_cmd(&self, cmd: SwarmCommand, op: &'static str) -> Result<(), ()> {
         let max_cap = self.cmd_tx.max_capacity();
         let depth_pre = max_cap - self.cmd_tx.capacity();
         tracing::trace!(
@@ -268,17 +272,19 @@ impl LibP2pNode {
                     "[B sent] op={} depth_was={}/{}",
                     op, depth_pre, max_cap,
                 );
+                Ok(())
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                 let total = DROPPED_BFT_BROADCASTS.fetch_add(1, Ordering::Relaxed) + 1;
                 tracing::error!(
                     target: "broadcast_bc",
                     "[B FAIL: channel FULL] libp2p cmd_tx saturated at {}/{} — \
-                     DROPPED {} (total drops since boot: {}). Engine will desync \
-                     from peers if this is a BFT vote — investigate swarm-task \
-                     starvation (memory pressure / I/O wait / blocked .await).",
+                     DROPPED {} (total drops since boot: {}). Engine will \
+                     self-heal via re-emit; investigate swarm-task starvation \
+                     (memory pressure / I/O wait / blocked .await).",
                     max_cap, max_cap, op, total,
                 );
+                Err(())
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                 tracing::error!(
@@ -287,6 +293,7 @@ impl LibP2pNode {
                      (process should be restarting); message lost.",
                     op,
                 );
+                Err(())
             }
         }
     }
@@ -309,7 +316,7 @@ impl LibP2pNode {
 
     /// Broadcast a new block to all peers via gossipsub.
     pub async fn broadcast_block(&self, block: &Block) {
-        self.send_swarm_cmd(
+        let _ = self.send_swarm_cmd(
             SwarmCommand::GossipBlock(Box::new(block.clone())),
             "gossip block",
         );
@@ -317,31 +324,45 @@ impl LibP2pNode {
 
     /// Broadcast a new transaction to all peers via gossipsub.
     pub async fn broadcast_transaction(&self, tx: &Transaction) {
-        self.send_swarm_cmd(SwarmCommand::GossipTx(tx.clone()), "gossip transaction");
+        let _ = self.send_swarm_cmd(SwarmCommand::GossipTx(tx.clone()), "gossip transaction");
     }
 
     /// Broadcast a BFT proposal to all verified peers.
     pub async fn broadcast_bft_proposal(&self, proposal: &sentrix_bft::messages::Proposal) {
-        self.send_swarm_cmd(
+        let _ = self.send_swarm_cmd(
             SwarmCommand::GossipBftProposal(Box::new(proposal.clone())),
             "bft proposal",
         );
     }
 
     /// Broadcast a BFT prevote to all verified peers.
-    pub async fn broadcast_bft_prevote(&self, prevote: &sentrix_bft::messages::Prevote) {
+    /// Broadcast a signed BFT prevote. Returns `Ok(())` on enqueue,
+    /// `Err(())` if the underlying `try_send` dropped — the caller must
+    /// then revert its engine-state flag (e.g. `engine.mark_prevote_cast`
+    /// is skipped on the error path) so the BFT loop re-emits.
+    pub async fn broadcast_bft_prevote(
+        &self,
+        prevote: &sentrix_bft::messages::Prevote,
+    ) -> Result<(), ()> {
         self.send_swarm_cmd(
             SwarmCommand::GossipBftPrevote(Box::new(prevote.clone())),
             "bft prevote",
-        );
+        )
     }
 
     /// Broadcast a BFT precommit to all verified peers.
-    pub async fn broadcast_bft_precommit(&self, precommit: &sentrix_bft::messages::Precommit) {
+    /// Broadcast a signed BFT precommit. Same return contract as
+    /// [`Self::broadcast_bft_prevote`] — `Err(())` means the driver must
+    /// not mark `our_precommit_cast` on the engine; the BFT loop will
+    /// re-emit on the next iteration.
+    pub async fn broadcast_bft_precommit(
+        &self,
+        precommit: &sentrix_bft::messages::Precommit,
+    ) -> Result<(), ()> {
         self.send_swarm_cmd(
             SwarmCommand::GossipBftPrecommit(Box::new(precommit.clone())),
             "bft precommit",
-        );
+        )
     }
 
     /// Broadcast our current BFT round status so peers can sync rounds.
@@ -351,7 +372,7 @@ impl LibP2pNode {
     /// against the on-chain stake registry and dial the advertised
     /// multiaddrs on their next discovery tick.
     pub async fn broadcast_validator_advert(&self, advert: MultiaddrAdvertisement) {
-        self.send_swarm_cmd(
+        let _ = self.send_swarm_cmd(
             SwarmCommand::GossipValidatorAdvert(Box::new(advert)),
             "validator advert",
         );
@@ -389,7 +410,7 @@ impl LibP2pNode {
     }
 
     pub async fn broadcast_bft_round_status(&self, status: &sentrix_bft::messages::RoundStatus) {
-        self.send_swarm_cmd(
+        let _ = self.send_swarm_cmd(
             SwarmCommand::GossipBftRoundStatus(Box::new(status.clone())),
             "bft round status",
         );
@@ -397,7 +418,7 @@ impl LibP2pNode {
 
     /// Re-dial bootstrap peers that may have disconnected.
     pub async fn reconnect_peers(&self, addrs: Vec<Multiaddr>) {
-        self.send_swarm_cmd(SwarmCommand::ReconnectPeers(addrs), "reconnect peers");
+        let _ = self.send_swarm_cmd(SwarmCommand::ReconnectPeers(addrs), "reconnect peers");
     }
 
     /// Ask the swarm to immediately issue a `GetBlocks` to the first
@@ -406,17 +427,17 @@ impl LibP2pNode {
     /// catch up before the next round starts, not wait up to 30s for
     /// the periodic sync interval to fire.
     pub async fn trigger_sync(&self) {
-        self.send_swarm_cmd(SwarmCommand::TriggerSync, "trigger sync");
+        let _ = self.send_swarm_cmd(SwarmCommand::TriggerSync, "trigger sync");
     }
 
     /// Add a known peer to the Kademlia routing table (bootstrap node).
     pub async fn add_kad_peer(&self, peer_id: PeerId, addr: Multiaddr) {
-        self.send_swarm_cmd(SwarmCommand::AddKadPeer(peer_id, addr), "add kad peer");
+        let _ = self.send_swarm_cmd(SwarmCommand::AddKadPeer(peer_id, addr), "add kad peer");
     }
 
     /// Trigger a Kademlia bootstrap (random walk to discover peers).
     pub async fn kad_bootstrap(&self) {
-        self.send_swarm_cmd(SwarmCommand::KadBootstrap, "kad bootstrap");
+        let _ = self.send_swarm_cmd(SwarmCommand::KadBootstrap, "kad bootstrap");
     }
 
     /// Returns the number of currently verified (handshaked) peers.

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -279,9 +279,12 @@ impl LibP2pNode {
                 tracing::error!(
                     target: "broadcast_bc",
                     "[B FAIL: channel FULL] libp2p cmd_tx saturated at {}/{} — \
-                     DROPPED {} (total drops since boot: {}). Engine will \
-                     self-heal via re-emit; investigate swarm-task starvation \
-                     (memory pressure / I/O wait / blocked .await).",
+                     dropped op={} (total drops since boot: {}). Investigate \
+                     swarm-task starvation (memory pressure / I/O wait / \
+                     blocked .await). BFT-vote callers re-emit via the \
+                     engine's pending_* path; best-effort callers (gossip \
+                     block/tx/advert/round-status) rely on the next gossip \
+                     tick to recover.",
                     max_cap, max_cap, op, total,
                 );
                 Err(())

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -130,8 +130,19 @@ enum SwarmCommand {
     // per-peer request-response). Mesh fan-out + IHAVE/IWANT retry
     // replace our manual rebroadcast tick for missed votes on WAN.
     GossipBftProposal(Box<sentrix_bft::messages::Proposal>),
-    GossipBftPrevote(Box<sentrix_bft::messages::Prevote>),
-    GossipBftPrecommit(Box<sentrix_bft::messages::Precommit>),
+    /// BFT prevote with an ack channel — `run_swarm` sends `Ok(())` only
+    /// after `gossipsub.publish` succeeds, so the driver can mark the
+    /// engine cast on actual publication rather than mere enqueue.
+    GossipBftPrevote(
+        Box<sentrix_bft::messages::Prevote>,
+        tokio::sync::oneshot::Sender<Result<(), ()>>,
+    ),
+    /// BFT precommit with an ack channel — same publish-confirmation
+    /// contract as [`Self::GossipBftPrevote`].
+    GossipBftPrecommit(
+        Box<sentrix_bft::messages::Precommit>,
+        tokio::sync::oneshot::Sender<Result<(), ()>>,
+    ),
     GossipBftRoundStatus(Box<sentrix_bft::messages::RoundStatus>),
     /// Add a peer address to Kademlia DHT.
     AddKadPeer(PeerId, Multiaddr),
@@ -339,33 +350,41 @@ impl LibP2pNode {
     }
 
     /// Broadcast a BFT prevote to all verified peers.
-    /// Broadcast a signed BFT prevote. Returns `Ok(())` on enqueue,
-    /// `Err(())` if the underlying `try_send` dropped — the caller must
-    /// then revert its engine-state flag (e.g. `engine.mark_prevote_cast`
-    /// is skipped on the error path) so the BFT loop re-emits.
+    /// Broadcast a signed BFT prevote. Returns `Ok(())` ONLY after
+    /// `run_swarm` has actually `gossipsub.publish`'d the message (not just
+    /// enqueued the command). `Err(())` covers three failure modes:
+    /// `send_swarm_cmd` drop (cmd_tx full or closed), `bincode::serialize`
+    /// failure, or `gossipsub.publish` failure (e.g. `InsufficientPeers`).
+    /// In every error case the driver must skip `engine.mark_prevote_cast`
+    /// so the BFT loop re-emits the same vote on its next iteration.
     pub async fn broadcast_bft_prevote(
         &self,
         prevote: &sentrix_bft::messages::Prevote,
     ) -> Result<(), ()> {
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         self.send_swarm_cmd(
-            SwarmCommand::GossipBftPrevote(Box::new(prevote.clone())),
+            SwarmCommand::GossipBftPrevote(Box::new(prevote.clone()), ack_tx),
             "bft prevote",
-        )
+        )?;
+        ack_rx.await.unwrap_or(Err(()))
     }
 
     /// Broadcast a BFT precommit to all verified peers.
-    /// Broadcast a signed BFT precommit. Same return contract as
-    /// [`Self::broadcast_bft_prevote`] — `Err(())` means the driver must
-    /// not mark `our_precommit_cast` on the engine; the BFT loop will
-    /// re-emit on the next iteration.
+    /// Broadcast a signed BFT precommit. Same publish-confirmation
+    /// contract as [`Self::broadcast_bft_prevote`] — `Ok(())` only after
+    /// `gossipsub.publish` succeeds; `Err(())` on any of cmd_tx-drop /
+    /// serialize-fail / publish-fail. Driver skips `mark_precommit_cast`
+    /// on `Err(())` and the engine re-emits on the next iteration.
     pub async fn broadcast_bft_precommit(
         &self,
         precommit: &sentrix_bft::messages::Precommit,
     ) -> Result<(), ()> {
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         self.send_swarm_cmd(
-            SwarmCommand::GossipBftPrecommit(Box::new(precommit.clone())),
+            SwarmCommand::GossipBftPrecommit(Box::new(precommit.clone()), ack_tx),
             "bft precommit",
-        )
+        )?;
+        ack_rx.await.unwrap_or(Err(()))
     }
 
     /// Broadcast our current BFT round status so peers can sync rounds.
@@ -641,29 +660,44 @@ async fn run_swarm(
                             Err(e) => tracing::warn!("gossip bft proposal serialize failed: {}", e),
                         }
                     }
-                    Some(SwarmCommand::GossipBftPrevote(prevote)) => {
+                    Some(SwarmCommand::GossipBftPrevote(prevote, ack)) => {
                         let topic = gossipsub::IdentTopic::new(BFT_PREVOTE_TOPIC);
                         let env = GossipBftPrevote { prevote: *prevote };
-                        match bincode::serialize(&env) {
-                            Ok(data) => {
-                                if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, data) {
+                        let result = match bincode::serialize(&env) {
+                            Ok(data) => match swarm.behaviour_mut().gossipsub.publish(topic, data) {
+                                Ok(_) => Ok(()),
+                                Err(e) => {
                                     tracing::debug!("gossipsub publish bft prevote failed: {}", e);
+                                    Err(())
                                 }
+                            },
+                            Err(e) => {
+                                tracing::warn!("gossip bft prevote serialize failed: {}", e);
+                                Err(())
                             }
-                            Err(e) => tracing::warn!("gossip bft prevote serialize failed: {}", e),
-                        }
+                        };
+                        // If the driver task dropped the receiver, the ack
+                        // .send returns Err — ignore: the broadcast attempt
+                        // still completed in the log.
+                        let _ = ack.send(result);
                     }
-                    Some(SwarmCommand::GossipBftPrecommit(precommit)) => {
+                    Some(SwarmCommand::GossipBftPrecommit(precommit, ack)) => {
                         let topic = gossipsub::IdentTopic::new(BFT_PRECOMMIT_TOPIC);
                         let env = GossipBftPrecommit { precommit: *precommit };
-                        match bincode::serialize(&env) {
-                            Ok(data) => {
-                                if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, data) {
+                        let result = match bincode::serialize(&env) {
+                            Ok(data) => match swarm.behaviour_mut().gossipsub.publish(topic, data) {
+                                Ok(_) => Ok(()),
+                                Err(e) => {
                                     tracing::debug!("gossipsub publish bft precommit failed: {}", e);
+                                    Err(())
                                 }
+                            },
+                            Err(e) => {
+                                tracing::warn!("gossip bft precommit serialize failed: {}", e);
+                                Err(())
                             }
-                            Err(e) => tracing::warn!("gossip bft precommit serialize failed: {}", e),
-                        }
+                        };
+                        let _ = ack.send(result);
                     }
                     Some(SwarmCommand::GossipBftRoundStatus(status)) => {
                         let topic = gossipsub::IdentTopic::new(BFT_ROUND_STATUS_TOPIC);


### PR DESCRIPTION
## Summary

Closes the silent-stall bug class that has been recurring on testnet (val4 stuck 8h on 2026-05-27 at h=5,609,246; val1 stuck 20min same day at h=5,612,033 — both recovered manually by cp from healthy peer; root cause kept re-arming).

**Root cause**: `libp2p_node::send_swarm_cmd` uses non-blocking `try_send` to avoid the 2026-04-30 h=936906 deadlock. When the bounded cmd channel is full, the message is dropped and logged. But the BFT engine had already set `self.state.our_prevote_cast = true` inside `emit_prevote` *before* the action was returned to the driver — so when the subsequent `broadcast_bft_prevote` `try_send` dropped, the engine state said \"we voted\" and never re-emitted. Validator sat at the same `(h, r)` indefinitely.

The codebase comment trail at `crates/sentrix-network/src/libp2p_node.rs:32-215` already documented this exact pattern. The previously-considered fix was a `swarm_watchdog` (`project_v2_1_91_libp2p_watchdog_workstream`), which the operator rejected as a band-aid. This PR is the surgical alternative.

## Change

* **`sentrix-bft engine.rs`**: `emit_prevote` / `emit_precommit` no longer auto-set `our_*_cast`. `pending_*` is still set, so the engine re-emits the same prevote/precommit on the next iteration via the existing pending-match early-return. Two new public methods — `mark_prevote_cast` / `mark_precommit_cast` — for the driver to call **only after** confirmed network send.
* **`sentrix-network libp2p_node.rs`**: `send_swarm_cmd` returns `Result<(), ()>` (was unit). `broadcast_bft_prevote` / `broadcast_bft_precommit` propagate. Best-effort callers (gossip block / tx / advert / round status, reconnect_peers, trigger_sync, kad_*) keep fire-and-forget via `let _ =` — they self-recover via re-gossip.
* **`bin/sentrix main.rs`**: six BFT cascade arms (3 prevote + 3 precommit across initial-action, peer-message, and timeout loops) now match on the broadcast result. On `Ok`: `engine.mark_*_cast` then weighted self-vote update. On `Err`: log + `break` the cascade; outer BFT loop re-enters engine, hits `pending_*` path, re-emits the same vote. Two `catch_up_round` broadcasts use `let _ =` (catch-up re-fires next tick).
* **engine.rs tests**: two regression tests that asserted `engine.state.our_prevote_cast` after `on_own_proposal` / `on_timeout` were updated to call `engine.mark_prevote_cast()` first (mirrors the new driver contract). \`test_291_*\` regression targets (which already simulated dropped-enqueue + retry) keep passing without modification.
* **Workspace version bump**: 2.2.17 → 2.2.18.

## Why no watchdog

A watchdog is detect+restart — restart loses transient state and re-pays B3 reconcile cost. The bug here is fundamentally a state-machine ordering issue (mark-before-send), which has a deterministic structural fix. Watchdog can stay deferred as a future safety net for unknown silent-stall classes, but it shouldn't paper over a known one.

## Verified locally

\`\`\`
cargo check --workspace --all-targets     clean
cargo clippy --workspace --all-targets -- -D warnings    clean
cargo test -p sentrix-bft                 128 / 128 passing
cargo test -p sentrix-network             32 / 32 passing
\`\`\`

## Test plan

- [x] cargo check workspace clean
- [x] cargo clippy strict (\`-D warnings\`) clean
- [x] sentrix-bft full suite 128/128
- [x] sentrix-network full suite 32/32
- [ ] CI green
- [ ] Testnet bake observation for ≥ 24h after deploy — no silent-stall recoveries needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling for consensus vote broadcasts with improved logging.

* **Bug Fixes**
  * Fixed voting state tracking to prevent marking votes as sent when network broadcasts fail.

* **Chores**
  * Version bump to 2.2.18.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->