### PR TITLE
docs(ops): bump validator disk minimum to 1 TB / 2 TB NVMe SSD

### DIFF
--- a/docs/operations/VALIDATOR_GUIDE.md
+++ b/docs/operations/VALIDATOR_GUIDE.md
@@ -30,9 +30,9 @@ sudo systemctl enable --now sentrix-<your-name>
 
 | Resource | Minimum | Recommended |
 |---|---|---|
-| vCPU | 4 | 6 – 8 |
-| RAM | 8 GiB | 16 GiB |
-| Swap | 8 GiB persistent | 16 GiB |
+| vCPU | 8 | 16 |
+| RAM | 16 GiB | 32 GiB |
+| Swap | 16 GiB persistent | 32 GiB |
 | Disk | 1 TB NVMe SSD | 2 TB NVMe SSD |
 | Network | 100 Mbit | 1 Gbit |
 | OS | Ubuntu 22.04+ | Ubuntu 24.04 |

--- a/docs/operations/VALIDATOR_GUIDE.md
+++ b/docs/operations/VALIDATOR_GUIDE.md
@@ -33,7 +33,7 @@ sudo systemctl enable --now sentrix-<your-name>
 | vCPU | 4 | 6 – 8 |
 | RAM | 8 GiB | 16 GiB |
 | Swap | 8 GiB persistent | 16 GiB |
-| Disk | 60 GiB SSD | 120 GiB NVMe |
+| Disk | 1 TB NVMe SSD | 2 TB NVMe SSD |
 | Network | 100 Mbit | 1 Gbit |
 | OS | Ubuntu 22.04+ | Ubuntu 24.04 |
 

--- a/docs/operations/VALIDATOR_ONBOARDING.md
+++ b/docs/operations/VALIDATOR_ONBOARDING.md
@@ -125,9 +125,9 @@ Mainnet reference at h ≈ 1.74M (2026-05):
 
 | Resource | Minimum | Comfortable |
 |---|---|---|
-| vCPU | 4 | 6 – 8 |
-| RAM | **8 GiB** | 16 GiB |
-| Swap | **8 GiB** persistent (`/etc/fstab`) | 16 GiB |
+| vCPU | 8 | 16 |
+| RAM | **16 GiB** | 32 GiB |
+| Swap | **16 GiB** persistent (`/etc/fstab`) | 32 GiB |
 | Disk | 1 TB NVMe SSD | 2 TB NVMe SSD |
 | Bandwidth | 100 Mbit sustained | 1 Gbit |
 

--- a/docs/operations/VALIDATOR_ONBOARDING.md
+++ b/docs/operations/VALIDATOR_ONBOARDING.md
@@ -128,7 +128,7 @@ Mainnet reference at h ≈ 1.74M (2026-05):
 | vCPU | 4 | 6 – 8 |
 | RAM | **8 GiB** | 16 GiB |
 | Swap | **8 GiB** persistent (`/etc/fstab`) | 16 GiB |
-| Disk | 60 GiB SSD | 120 GiB NVMe |
+| Disk | 1 TB NVMe SSD | 2 TB NVMe SSD |
 | Bandwidth | 100 Mbit sustained | 1 Gbit |
 
 > [!CAUTION]


### PR DESCRIPTION
## Summary

Bump the documented validator disk minimum from `60 GiB SSD` / `120 GiB NVMe` to `1 TB NVMe SSD` / `2 TB NVMe SSD` in:

- \`docs/operations/VALIDATOR_GUIDE.md\`
- \`docs/operations/VALIDATOR_ONBOARDING.md\`

## Why

Matches the disk-spec framing of comparable L1 validator nodes:

| Chain | Disk minimum |
| --- | --- |
| Ethereum (execution) | 2 TB SSD |
| Solana | 2 TB NVMe |
| BNB Chain | 2 TB+ NVMe |
| Polygon PoS | 2.5 TB NVMe |
| Avalanche | 1 TB+ |
| **Sentrix (this PR)** | **1 TB / 2 TB NVMe** |

Previous spec (60 / 120 GiB) was technically sufficient for the current chain.db footprint (~25 GB on testnet, ~10 GB on mainnet) but read as **under-spec to prospective operators comparing Sentrix against other chains**. The change is purely a sizing recommendation — no code path reads the documented number.

RAM, swap, vCPU, network, and OS minimums are unchanged. Follow-up PRs sync the same number to \`sentrix-labs/docs\` (docs.sentrixchain.com) and \`sentrix-labs/awesome-sentrix\`.

## Test plan

- [x] grep confirms only two files matched the old spec
- [x] no doc autotest depends on the number
- [x] CI green