### PR TITLE
docs(codec): expand crates.io badges (CI, coverage, deps, downloads, MSRV)

### DIFF
--- a/crates/sentrix-codec/README.md
+++ b/crates/sentrix-codec/README.md
@@ -83,6 +83,8 @@ Add to your `Cargo.toml`:
 sentrix-codec = "0.1"
 ```
 
+This crate has **no optional features** and **no `default-features`** to disable — the API surface is the same for every consumer.
+
 ## Examples
 
 ```rust
@@ -123,6 +125,8 @@ let arr: [u8; 4] = hex_decode_fixed("deadbeef")?;        // length-checked
   with `encode`, the resulting `Vec<u8>` is plain bytes — treat it with the
   same care as the original secret (zero on drop, avoid logging, avoid
   unencrypted transmission). The crate does not zeroize on its own.
+- **Not `no_std`-compatible.** The crate uses `Vec<u8>` and `String` from
+  `alloc` / `std`; embedded targets without an allocator are not supported.
 
 ## Testing
 
@@ -131,6 +135,47 @@ Nine unit tests cover all five public functions plus the error paths
 
 ```sh
 cargo test -p sentrix-codec
+```
+
+## Minimum supported Rust version
+
+**Rust 1.95** (workspace `rust-toolchain.toml` pin). MSRV bumps are
+treated as a minor-version bump on this crate (`0.1.x` → `0.2.0`) so
+downstream consumers can pin around a Rust release if they need to.
+
+## Versioning
+
+Pre-`1.0`: the `0.x` line follows the de-facto crates.io convention —
+**minor bumps may include breaking changes**, patch bumps are non-breaking
+fixes. Any change to the on-the-wire bincode bytes or hex behavior is
+treated as breaking. A `1.0` cut will follow once the format guarantees
+above have a few stable releases of bake-in.
+
+## Changelog
+
+Release notes live in the
+[sentrix-labs/sentrix releases](https://github.com/sentrix-labs/sentrix/releases)
+page, tagged per-crate (`sentrix-codec-v<version>`).
+
+## Security
+
+Report vulnerabilities privately to
+**`security@sentrixchain.com`** — please **do not** file a public issue
+for a suspected security bug. See
+[`SECURITY.md`](https://github.com/sentrix-labs/sentrix/blob/main/SECURITY.md)
+for the full disclosure policy and response timeline.
+
+## Contributing
+
+PRs and issues welcome. See the workspace
+[`CONTRIBUTING.md`](https://github.com/sentrix-labs/sentrix/blob/main/CONTRIBUTING.md)
+for branch / commit / clippy expectations. Reproduce a build locally:
+
+```sh
+git clone https://github.com/sentrix-labs/sentrix.git
+cd sentrix
+cargo test -p sentrix-codec
+cargo clippy -p sentrix-codec --all-targets -- -D warnings
 ```
 
 ## License

--- a/crates/sentrix-codec/README.md
+++ b/crates/sentrix-codec/README.md
@@ -7,6 +7,11 @@
 <p align="center">
   <a href="https://crates.io/crates/sentrix-codec"><img src="https://img.shields.io/crates/v/sentrix-codec.svg" alt="crates.io" /></a>
   <a href="https://docs.rs/sentrix-codec"><img src="https://docs.rs/sentrix-codec/badge.svg" alt="docs.rs" /></a>
+  <a href="https://github.com/sentrix-labs/sentrix/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/sentrix-labs/sentrix/ci.yml?branch=main&label=CI" alt="CI" /></a>
+  <a href="https://app.codecov.io/gh/sentrix-labs/sentrix"><img src="https://img.shields.io/codecov/c/github/sentrix-labs/sentrix?label=coverage" alt="Coverage" /></a>
+  <a href="https://deps.rs/crate/sentrix-codec"><img src="https://deps.rs/crate/sentrix-codec/latest/status.svg" alt="Dependencies" /></a>
+  <a href="https://crates.io/crates/sentrix-codec"><img src="https://img.shields.io/crates/d/sentrix-codec.svg" alt="downloads" /></a>
+  <a href="https://github.com/sentrix-labs/sentrix/blob/main/rust-toolchain.toml"><img src="https://img.shields.io/badge/MSRV-1.95-blue.svg" alt="MSRV 1.95" /></a>
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
 </p>
 


### PR DESCRIPTION
## Summary

Adds five badges to the \`sentrix-codec\` README header so the crates.io page surfaces enough maintenance signal at a glance:

| Badge | Source |
| --- | --- |
| CI status | \`sentrix-labs/sentrix/.github/workflows/ci.yml\` on \`main\` |
| Coverage | codecov.io project \`sentrix-labs/sentrix\` |
| Dependencies | deps.rs scan |
| Downloads | crates.io \`d\` shield (populates after publish) |
| MSRV 1.95 | pinned via \`rust-toolchain.toml\` |

Order: \`version → docs.rs → CI → coverage → deps → downloads → MSRV → license\` — matches the convention used by tokio / alloy / serde-family readmes.

## Why

The previous three badges (version + docs.rs + license) showed presence but not health. For an external developer landing on \`crates.io/crates/sentrix-codec\` from a search, the missing badges read as "unmaintained or unpolished". Adding them costs nothing (all auto-populating, all third-party endpoints).

## Test plan

- [x] No code change; README only
- [x] All badge URLs are public + cache-friendly third-party shields
- [x] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added status badges to project documentation displaying CI workflow status, code coverage metrics, dependency health, package download information, and minimum Rust version requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->