### PR TITLE
fix(codec): MSRV badge link target + drop premature deps.rs badge

### DIFF
--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sentrix-codec"
 version = "0.1.0"
 edition.workspace = true
+rust-version = "1.95"
 license = "MIT OR Apache-2.0"
 description = "Centralised bincode + hex encoding helpers — a stable wrapper around bincode 1.3 and hex 0.4 with a single error type."
 repository.workspace = true

--- a/crates/sentrix-codec/README.md
+++ b/crates/sentrix-codec/README.md
@@ -9,9 +9,8 @@
   <a href="https://docs.rs/sentrix-codec"><img src="https://docs.rs/sentrix-codec/badge.svg" alt="docs.rs" /></a>
   <a href="https://github.com/sentrix-labs/sentrix/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/sentrix-labs/sentrix/ci.yml?branch=main&label=CI" alt="CI" /></a>
   <a href="https://app.codecov.io/gh/sentrix-labs/sentrix"><img src="https://img.shields.io/codecov/c/github/sentrix-labs/sentrix?label=coverage" alt="Coverage" /></a>
-  <a href="https://deps.rs/crate/sentrix-codec"><img src="https://deps.rs/crate/sentrix-codec/latest/status.svg" alt="Dependencies" /></a>
   <a href="https://crates.io/crates/sentrix-codec"><img src="https://img.shields.io/crates/d/sentrix-codec.svg" alt="downloads" /></a>
-  <a href="https://github.com/sentrix-labs/sentrix/blob/main/rust-toolchain.toml"><img src="https://img.shields.io/badge/MSRV-1.95-blue.svg" alt="MSRV 1.95" /></a>
+  <a href="https://github.com/sentrix-labs/sentrix/blob/main/crates/sentrix-codec/Cargo.toml"><img src="https://img.shields.io/badge/MSRV-1.95-blue.svg" alt="MSRV 1.95" /></a>
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
 </p>
 
@@ -139,9 +138,10 @@ cargo test -p sentrix-codec
 
 ## Minimum supported Rust version
 
-**Rust 1.95** (workspace `rust-toolchain.toml` pin). MSRV bumps are
-treated as a minor-version bump on this crate (`0.1.x` → `0.2.0`) so
-downstream consumers can pin around a Rust release if they need to.
+**Rust 1.95** (declared via `rust-version` in this crate's `Cargo.toml`).
+MSRV bumps are treated as a minor-version bump on this crate (`0.1.x`
+→ `0.2.0`) so downstream consumers can pin around a Rust release if
+they need to.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

PR #729 was merged before the third commit landed in the PR diff, so two broken badges shipped to main:

- **MSRV badge** linked to \`rust-toolchain.toml\` which does not exist (404). Repointed to the crate's own \`Cargo.toml\` where \`rust-version = \"1.95\"\` is now declared.
- **deps.rs badge** 404'd because \`sentrix-codec\` is not on crates.io yet — deps.rs only indexes published versions. Dropped the badge; can be reintroduced in a post-publish polish PR once \`https://deps.rs/crate/sentrix-codec\` actually resolves.

This is a cherry-pick of the lost commit from PR #729.

## Test plan

- [x] No code change; README + Cargo.toml metadata only
- [x] \`cargo check -p sentrix-codec\` clean (verified locally)
- [x] All remaining badge URLs return 200 (verified)
- [x] CI green