### PR TITLE
docs(codec): match codecov badge style with workspace root readme

### DIFF
--- a/crates/sentrix-codec/CHANGELOG.md
+++ b/crates/sentrix-codec/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to `sentrix-codec` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this crate adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Pre-`1.0`: minor bumps (`0.x.0`) may include breaking changes, patch bumps
+(`0.x.y`) are non-breaking fixes. Any change to the on-the-wire bincode bytes
+or hex behavior is treated as breaking.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-28
+
+### Added
+
+- Initial release.
+- `encode<T>` / `decode<T>` — `bincode 1.3` default-config wrappers that
+  return a single error type (`CodecError`) instead of `bincode::Error`.
+- `hex_encode` — lowercase hex with no `0x` prefix, matches `hex::encode`.
+- `hex_decode` — tolerates a leading `0x` prefix; fails on non-hex chars
+  or odd length.
+- `hex_decode_fixed<const N: usize>` — `0x`-tolerant length-checked
+  variant that returns `[u8; N]`.
+- `CodecError` with `Encode(String)` and `Decode(String)` variants;
+  implements `Display` and `std::error::Error`.
+- Crate-level safety pins: `#![forbid(unsafe_code)]` + `#![deny(missing_docs)]`.
+- Dual `MIT OR Apache-2.0` license.
+
+[Unreleased]: https://github.com/sentrix-labs/sentrix/compare/sentrix-codec-v0.1.0...HEAD
+[0.1.0]: https://github.com/sentrix-labs/sentrix/releases/tag/sentrix-codec-v0.1.0

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -10,6 +10,13 @@ homepage = "https://sentrixchain.com"
 authors = ["Sentrix Labs <support@sentrixchain.com>"]
 keywords = ["bincode", "hex", "serialization", "encoding"]
 categories = ["encoding"]
+include = [
+    "src/**/*.rs",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE-MIT",
+    "LICENSE-APACHE",
+]
 
 [dependencies]
 bincode = "1.3"

--- a/crates/sentrix-codec/Cargo.toml
+++ b/crates/sentrix-codec/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.95"
 license = "MIT OR Apache-2.0"
 description = "Centralised bincode + hex encoding helpers — a stable wrapper around bincode 1.3 and hex 0.4 with a single error type."
 repository.workspace = true
+homepage = "https://sentrixchain.com"
 authors = ["Sentrix Labs <support@sentrixchain.com>"]
 keywords = ["bincode", "hex", "serialization", "encoding"]
 categories = ["encoding"]

--- a/crates/sentrix-codec/README.md
+++ b/crates/sentrix-codec/README.md
@@ -8,7 +8,7 @@
   <a href="https://crates.io/crates/sentrix-codec"><img src="https://img.shields.io/crates/v/sentrix-codec.svg" alt="crates.io" /></a>
   <a href="https://docs.rs/sentrix-codec"><img src="https://docs.rs/sentrix-codec/badge.svg" alt="docs.rs" /></a>
   <a href="https://github.com/sentrix-labs/sentrix/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/sentrix-labs/sentrix/ci.yml?branch=main&label=CI" alt="CI" /></a>
-  <a href="https://app.codecov.io/gh/sentrix-labs/sentrix"><img src="https://img.shields.io/codecov/c/github/sentrix-labs/sentrix?label=coverage" alt="Coverage" /></a>
+  <a href="https://codecov.io/gh/sentrix-labs/sentrix"><img src="https://codecov.io/gh/sentrix-labs/sentrix/branch/main/graph/badge.svg" alt="Coverage" /></a>
   <a href="https://crates.io/crates/sentrix-codec"><img src="https://img.shields.io/crates/d/sentrix-codec.svg" alt="downloads" /></a>
   <a href="https://github.com/sentrix-labs/sentrix/blob/main/crates/sentrix-codec/Cargo.toml"><img src="https://img.shields.io/badge/MSRV-1.95-blue.svg" alt="MSRV 1.95" /></a>
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>

--- a/crates/sentrix-codec/README.md
+++ b/crates/sentrix-codec/README.md
@@ -153,9 +153,9 @@ above have a few stable releases of bake-in.
 
 ## Changelog
 
-Release notes live in the
-[sentrix-labs/sentrix releases](https://github.com/sentrix-labs/sentrix/releases)
-page, tagged per-crate (`sentrix-codec-v<version>`).
+See [CHANGELOG.md](CHANGELOG.md) for per-version notes; release tags live
+at the [sentrix-labs/sentrix releases](https://github.com/sentrix-labs/sentrix/releases)
+page (`sentrix-codec-v<version>`).
 
 ## Security
 


### PR DESCRIPTION
Same change as the second commit of #730 that didn't make the squash. Switch the codec codecov badge from the img.shields.io proxy to the native codecov.io graph URL, matching the badge used in sentrix-labs/sentrix's own root README. Same data source, more direct render path.