### PR TITLE
fix(codec): set explicit label=downloads on the downloads badge

### DIFF
--- a/crates/sentrix-codec/README.md
+++ b/crates/sentrix-codec/README.md
@@ -9,7 +9,7 @@
   <a href="https://docs.rs/sentrix-codec"><img src="https://docs.rs/sentrix-codec/badge.svg" alt="docs.rs" /></a>
   <a href="https://github.com/sentrix-labs/sentrix/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/sentrix-labs/sentrix/ci.yml?branch=main&label=CI" alt="CI" /></a>
   <a href="https://codecov.io/gh/sentrix-labs/sentrix"><img src="https://codecov.io/gh/sentrix-labs/sentrix/branch/main/graph/badge.svg" alt="Coverage" /></a>
-  <a href="https://crates.io/crates/sentrix-codec"><img src="https://img.shields.io/crates/d/sentrix-codec.svg" alt="downloads" /></a>
+  <a href="https://crates.io/crates/sentrix-codec"><img src="https://img.shields.io/crates/d/sentrix-codec.svg?label=downloads" alt="downloads" /></a>
   <a href="https://github.com/sentrix-labs/sentrix/blob/main/crates/sentrix-codec/Cargo.toml"><img src="https://img.shields.io/badge/MSRV-1.95-blue.svg" alt="MSRV 1.95" /></a>
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
 </p>


### PR DESCRIPTION
The shields.io crates/d/<crate>.svg endpoint renders 'crates.io' as the left label by default. That made the codec readme look like two crates.io badges side by side (version + downloads both labeled 'crates.io'). `?label=downloads` forces the left label to 'downloads' so the row reads version + docs.rs + CI + Coverage + downloads + MSRV + license without visual duplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added a total downloads badge to the project documentation alongside existing version, documentation, CI, and code coverage information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->