### PR TITLE
chore(codec): restore deps.rs badge now that crate is published

### DIFF
--- a/crates/sentrix-codec/README.md
+++ b/crates/sentrix-codec/README.md
@@ -9,6 +9,7 @@
   <a href="https://docs.rs/sentrix-codec"><img src="https://docs.rs/sentrix-codec/badge.svg" alt="docs.rs" /></a>
   <a href="https://github.com/sentrix-labs/sentrix/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/sentrix-labs/sentrix/ci.yml?branch=main&label=CI" alt="CI" /></a>
   <a href="https://codecov.io/gh/sentrix-labs/sentrix"><img src="https://codecov.io/gh/sentrix-labs/sentrix/branch/main/graph/badge.svg" alt="Coverage" /></a>
+  <a href="https://deps.rs/crate/sentrix-codec"><img src="https://deps.rs/crate/sentrix-codec/latest/status.svg" alt="Dependencies" /></a>
   <a href="https://crates.io/crates/sentrix-codec"><img src="https://img.shields.io/crates/d/sentrix-codec.svg?label=downloads" alt="downloads" /></a>
   <a href="https://github.com/sentrix-labs/sentrix/blob/main/crates/sentrix-codec/Cargo.toml"><img src="https://img.shields.io/badge/MSRV-1.95-blue.svg" alt="MSRV 1.95" /></a>
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>


### PR DESCRIPTION
Badge was dropped pre-publish in #730 because deps.rs only indexes published crates and the URL returned 404. Now that v0.1.0 is live on crates.io and deps.rs has data, the badge can come back.

Current rendered status will read 'outdated' because the crate intentionally pins bincode 1.3 instead of 2.x (deliberate design — see the module doc in src/lib.rs). The signal is honest; a future bincode 2.x migration will flip it to 'up to date'.