### PR TITLE
docs: add Integration Cookbook for dApp developers

### DIFF
--- a/docs/operations/INTEGRATION_COOKBOOK.md
+++ b/docs/operations/INTEGRATION_COOKBOOK.md
@@ -1,0 +1,248 @@
+# Integration Cookbook
+
+Code recipes for integrating Sentrix Chain into a dApp, indexer, or backend. Sentrix is EVM-compatible (chain ID `7119` mainnet / `7120` testnet) and works with the standard Ethereum tooling — `viem`, `wagmi`, `ethers`, `hardhat`, `foundry`. This page collects the snippets so you can copy-paste against the canonical RPC URLs without hand-rolling the chain config.
+
+For UI-only walkthroughs (MetaMask + Remix), see [DEVELOPER_QUICKSTART.md](DEVELOPER_QUICKSTART.md) and [SMART_CONTRACT_GUIDE.md](SMART_CONTRACT_GUIDE.md). For native-side integration (REST, gRPC, WebSocket), see [API_REFERENCE.md](API_REFERENCE.md) and [GRPC.md](GRPC.md).
+
+## Network reference
+
+| Network | Chain ID | JSON-RPC | WSS | Explorer |
+|---|---|---|---|---|
+| Mainnet | `7119` | `https://rpc.sentrixchain.com/rpc` | `wss://rpc.sentrixchain.com/ws` | [scan.sentrixchain.com](https://scan.sentrixchain.com) |
+| Testnet | `7120` | `https://testnet-rpc.sentrixchain.com/rpc` | `wss://testnet-rpc.sentrixchain.com/ws` | [scan.sentrixchain.com](https://scan.sentrixchain.com) |
+
+JSON-RPC also responds at the bare host (POST to `https://rpc.sentrixchain.com`) — both paths reach the same node.
+
+---
+
+## viem
+
+`viem 2.50.4+` ships Sentrix chains in `viem/chains` — `import { sentrix, sentrixTestnet }` resolves with the correct `id`, `rpcUrls`, `blockExplorers`, and `nativeCurrency` already wired.
+
+```ts
+import { createPublicClient, http } from 'viem'
+import { sentrix, sentrixTestnet } from 'viem/chains'
+
+const client = createPublicClient({
+  chain: sentrix,                                  // or sentrixTestnet
+  transport: http(),                               // uses the chain's default RPC
+})
+
+const blockNumber = await client.getBlockNumber()
+const balance = await client.getBalance({ address: '0x...' })
+```
+
+For a custom RPC override (e.g. private endpoint):
+
+```ts
+const client = createPublicClient({
+  chain: sentrix,
+  transport: http('https://your-private-rpc.example.com'),
+})
+```
+
+## wagmi
+
+`wagmi` consumes viem's chain definitions, so the same `sentrix` / `sentrixTestnet` exports work directly.
+
+```ts
+import { http, createConfig } from 'wagmi'
+import { sentrix, sentrixTestnet } from 'viem/chains'
+import { injected, walletConnect } from 'wagmi/connectors'
+
+export const config = createConfig({
+  chains: [sentrix, sentrixTestnet],
+  connectors: [
+    injected(),                                    // MetaMask + any EIP-1193 wallet
+    walletConnect({ projectId: 'YOUR_PROJECT_ID' }),
+  ],
+  transports: {
+    [sentrix.id]: http(),
+    [sentrixTestnet.id]: http(),
+  },
+})
+```
+
+In a React component:
+
+```tsx
+import { useAccount, useBalance, useReadContract } from 'wagmi'
+
+function Balance() {
+  const { address } = useAccount()
+  const { data: balance } = useBalance({ address })
+  return <div>{balance?.formatted} {balance?.symbol}</div>
+}
+```
+
+Frameworks built on wagmi (RainbowKit, Web3Modal, ConnectKit) work transparently — they read the chain registry from wagmi's config.
+
+## ethers v6
+
+ethers does not ship Sentrix chain definitions yet. Define them manually:
+
+```ts
+import { JsonRpcProvider, Network } from 'ethers'
+
+const sentrixTestnet = new Network('sentrix-testnet', 7120n)
+const provider = new JsonRpcProvider(
+  'https://testnet-rpc.sentrixchain.com/rpc',
+  sentrixTestnet,
+  { staticNetwork: sentrixTestnet },               // avoid auto-detect roundtrip
+)
+
+const blockNumber = await provider.getBlockNumber()
+const balance = await provider.getBalance('0x...')
+```
+
+For mainnet replace the URL with `https://rpc.sentrixchain.com/rpc` and the chain ID with `7119n`.
+
+## Canonical contracts (npm)
+
+`@sentrix-labs/canonical-contracts` ships as-const ABIs + per-chain addresses for WSRX, Multicall3, SentrixSafe, and TokenFactory. Install:
+
+```sh
+npm install @sentrix-labs/canonical-contracts
+```
+
+Use with viem:
+
+```ts
+import { WSRX_ABI, WSRX_ADDRESS } from '@sentrix-labs/canonical-contracts'
+import { createPublicClient, http } from 'viem'
+import { sentrix } from 'viem/chains'
+
+const client = createPublicClient({ chain: sentrix, transport: http() })
+
+const totalSupply = await client.readContract({
+  address: WSRX_ADDRESS[sentrix.id],               // 0x4693… on mainnet
+  abi: WSRX_ABI,
+  functionName: 'totalSupply',
+})
+```
+
+ABIs are typed `as const`, so viem / wagmi infer the full call / event surface without manual type annotations.
+
+## Hardhat
+
+Add Sentrix to `hardhat.config.ts`:
+
+```ts
+import { HardhatUserConfig } from 'hardhat/config'
+import '@nomicfoundation/hardhat-toolbox'
+
+const config: HardhatUserConfig = {
+  solidity: '0.8.24',
+  networks: {
+    sentrix: {
+      url: 'https://rpc.sentrixchain.com/rpc',
+      chainId: 7119,
+      accounts: [process.env.PRIVATE_KEY!],
+    },
+    sentrixTestnet: {
+      url: 'https://testnet-rpc.sentrixchain.com/rpc',
+      chainId: 7120,
+      accounts: [process.env.PRIVATE_KEY!],
+    },
+  },
+}
+export default config
+```
+
+Deploy:
+
+```sh
+npx hardhat run scripts/deploy.ts --network sentrixTestnet
+```
+
+For a fuller starter project (Hardhat + viem + sample contracts + Sourcify verification), clone [dApp Starter](https://github.com/SentrisCloud/dapp-starter).
+
+## Foundry
+
+Set the RPC + chain via env or `foundry.toml`:
+
+```toml
+[rpc_endpoints]
+sentrix         = "https://rpc.sentrixchain.com/rpc"
+sentrix_testnet = "https://testnet-rpc.sentrixchain.com/rpc"
+```
+
+Deploy with `forge create`:
+
+```sh
+forge create --rpc-url sentrix_testnet \
+             --private-key $PRIVATE_KEY \
+             src/MyContract.sol:MyContract
+```
+
+Or with `forge script`:
+
+```sh
+forge script script/Deploy.s.sol \
+  --rpc-url sentrix_testnet \
+  --private-key $PRIVATE_KEY \
+  --broadcast
+```
+
+`cast` works for ad-hoc queries:
+
+```sh
+cast block-number --rpc-url https://rpc.sentrixchain.com/rpc
+cast balance 0x... --rpc-url https://rpc.sentrixchain.com/rpc
+cast call 0x... 'totalSupply()(uint256)' --rpc-url https://rpc.sentrixchain.com/rpc
+```
+
+## SDKs (first-party)
+
+For projects that need the Sentrix-specific surface (native REST, BFT subscriptions, gRPC, staking ops) on top of EVM:
+
+| SDK | Repo | When to use |
+|---|---|---|
+| `@sentriscloud/sdk-ts` | [SentrisCloud/sdk-ts](https://github.com/SentrisCloud/sdk-ts) | TypeScript projects — typed wrappers over EVM JSON-RPC, native REST, and WebSocket subscription helpers. |
+| `sentrix-chain` (Rust) | [SentrisCloud/sdk-rs](https://github.com/SentrisCloud/sdk-rs), [crates.io](https://crates.io/crates/sentrix-chain) | Rust projects — typed clients for native REST, EVM (via alloy), gRPC (via tonic), and secp256k1 wallet/signing. |
+| `sentrix-grpc-wasm` | [SentrisCloud/sentrix-grpc-wasm](https://github.com/SentrisCloud/sentrix-grpc-wasm) | Browser dApps that need gRPC-Web without a Node middleman. |
+
+EVM-only dApps generally do not need a Sentrix SDK — `viem` or `ethers` is enough.
+
+## WebSocket subscriptions
+
+Sentrix exposes both standard `eth_subscribe` channels and Sentrix-specific `sentrix_subscribe` channels (`sentrix_finalized`, `sentrix_validatorSet`, `sentrix_tokenOps`, `sentrix_stakingOps`, `sentrix_jail`). See [WEBSOCKET_SUBSCRIPTIONS.md](WEBSOCKET_SUBSCRIPTIONS.md) for the full channel catalog.
+
+Quick sample with viem:
+
+```ts
+import { createPublicClient, webSocket } from 'viem'
+import { sentrix } from 'viem/chains'
+
+const client = createPublicClient({
+  chain: sentrix,
+  transport: webSocket('wss://rpc.sentrixchain.com/ws'),
+})
+
+const unwatch = client.watchBlocks({
+  onBlock: (block) => console.log('new block', block.number),
+})
+```
+
+## Common gotchas
+
+- **`eth_getTransactionByHash` returns a chain-native shape** (with `EVM:` data prefix and Sentrix-specific fields) instead of the strict Ethereum JSON-RPC envelope. Standard ethers/viem decoders crash on it; use `cast` for ad-hoc inspection or the typed SDK helpers. Tracked in [sentrix#680](https://github.com/sentrix-labs/sentrix/issues/680).
+- **`eth_call` against a past block tag** historically returned `-32004` on older nodes; fixed in `v2.2.15+`. If your indexer queries `eth_call` with `blockNumber` (rather than `latest`), make sure the node is `>= 2.2.15`.
+- **EVM transactions with non-zero `msg.value`** require the chain to be past `EVM_VALUE_TRANSFER_HEIGHT` (mainnet `1,748,900`, activated 2026-05-13). Pre-fork, payable internal-call chains reverted at 27k gas. Detail in [sentrix#580](https://github.com/sentrix-labs/sentrix/issues/580).
+- **Block time is ~1–2 s on mainnet**; finality is BFT — a block is final the moment it carries a 2/3+1 stake-weighted precommit set. Polling `eth_blockNumber` once per second is fine; tighter polling wastes round-trips.
+
+## Where to go next
+
+- **Deploy a contract end-to-end (UI flow)** — [SMART_CONTRACT_GUIDE.md](SMART_CONTRACT_GUIDE.md)
+- **Verify a deployed contract** — [CONTRACT_VERIFICATION.md](CONTRACT_VERIFICATION.md)
+- **Stream finalised blocks over gRPC** — [GRPC.md](GRPC.md)
+- **Query native REST endpoints** — [API_ENDPOINTS.md](API_ENDPOINTS.md), [API_REFERENCE.md](API_REFERENCE.md)
+- **Listen to BFT / staking events** — [WEBSOCKET_SUBSCRIPTIONS.md](WEBSOCKET_SUBSCRIPTIONS.md)
+- **Run your own RPC node** — [VALIDATOR_ONBOARDING.md](VALIDATOR_ONBOARDING.md) (the fullnode shape lives in the same binary)
+
+## See also
+
+- [Sentrix Chain repo](https://github.com/sentrix-labs/sentrix) — core node implementation.
+- [Canonical contracts repo](https://github.com/sentrix-labs/canonical-contracts) — WSRX, Multicall3, SentrixSafe, TokenFactory.
+- [dApp Starter](https://github.com/SentrisCloud/dapp-starter) — Hardhat + viem template, deploys WSRX wrap + ERC-20 example.
+- [Awesome Sentrix](https://github.com/sentrix-labs/awesome-sentrix) — curated index of every Sentrix-related resource.

--- a/docs/operations/VALIDATORS.md
+++ b/docs/operations/VALIDATORS.md
@@ -2,7 +2,7 @@
 
 Sentrix runs **Voyager DPoS + BFT** with a permissionless, uncapped
 candidate set and a top-21 active set rotated by total stake. Block
-time targets ~2.5 s. Block producer at height `h` = `active_set[h %
+time target is `1 s` (mainnet observed ~1–2 s, testnet ~1 s). Block producer at height `h` = `active_set[h %
 active_set.len()]`.
 
 > [!NOTE]
@@ -38,7 +38,7 @@ mainnet's current registry.)
 | `MIN_BFT_VALIDATORS` | 4 (Voyager activation floor) | `sentrix-staking/staking.rs` |
 | `MIN_ACTIVE_VALIDATORS` | 1 (chain can produce with 1 active) | `sentrix-core/authority.rs` |
 | Commission range | 0 – 10,000 bp (0 – 100%) | `sentrix-staking/staking.rs` |
-| Unbonding period | 201,600 blocks (~7 days at 3 s) | `sentrix-staking/staking.rs` |
+| Unbonding period | 201,600 blocks (~56 hours at 1 s blocks) | `sentrix-staking/staking.rs` |
 
 ## Add a validator (permissionless path, current)
 
@@ -120,11 +120,11 @@ Status shown in `validator list` (v2.2.11+):
 
 ## Block production economics
 
-At ~2.5 s block time and 21 active validators in round-robin, each
+At ~1.5 s observed block time and 21 active validators in round-robin, each
 active validator produces roughly:
 
-- **3,433 blocks/day** (24 × 3,600 / 2.5 / 21 ≈ 3,432.5)
-- **~3,433 SRX/day** in block reward (1 SRX per block, pre-halving)
+- **2,743 blocks/day** (24 × 3,600 / 1.5 / 21 ≈ 2,742.9)
+- **~2,743 SRX/day** in block reward (1 SRX per block, pre-halving)
 - Plus `commission_rate × validator_pool_share` of delegated rewards
 - Plus a share of tx fees in produced blocks
 

--- a/docs/operations/VALIDATOR_ONBOARDING.md
+++ b/docs/operations/VALIDATOR_ONBOARDING.md
@@ -20,6 +20,22 @@ fleet" required.
 
 ---
 
+## Choose your participation path
+
+Before going further, decide whether you actually need to run a validator. Three ways to participate in Sentrix consensus economics, ranked by hands-on commitment:
+
+| Path | What you do | Stake | Hardware | Risk | Reward |
+|---|---|---|---|---|---|
+| **Run a validator** (this guide) | Operate a node 24/7, sign every assigned block, keep the keystore safe, respond to incidents. | **≥ 15,000 SRX self-stake** + any delegated stake | One server matching the spec in §4 | Slashing (20% on double-sign), jailing (liveness <70%) | Block reward + tx fees + commission on delegations |
+| **Delegate to a validator** | Pick an active validator from `/staking/validators`, submit `StakingOp::Delegate { validator, amount }`. Claim accrued rewards with `StakingOp::ClaimRewards` when convenient. | Any amount (no minimum) | None | Slashing follows the validator you delegated to | Block reward share net of validator commission |
+| **Wait for staking SaaS** | Stake through a third-party provider that runs the hardware for you. | Provider-defined | None | Custodial — you trust the provider | Provider-defined |
+
+Today only paths 1 and 2 exist on Sentrix — no staking SaaS providers yet. If you can't commit ≥ 99.5% uptime + the §4 spec, **delegate instead**. Validator slashing applies to the wallet that signed the bad block — not to the delegators behind that validator's stake, but their delegated rewards stop accruing while the validator is jailed. Both paths benefit from the same emission curve.
+
+The rest of this doc assumes you've picked Path 1.
+
+---
+
 ## Table of contents
 
 1. [What you're signing up for](#1-what-youre-signing-up-for)
@@ -46,7 +62,7 @@ Sentrix runs **Voyager DPoS + BFT** on mainnet, live since h=579,047
 (2026-04-25). Stake-weighted, **uncapped candidate set** (cap was
 lifted v2.2.11), 21 active validators rotate based on stake rank,
 3-phase BFT round (propose / prevote / precommit) per block, 2/3+1 of
-stake-weighted active set finalises. Block time targets ~2.5 s.
+stake-weighted active set finalises. Block-time target is `BLOCK_TIME_SECS = 1` second; mainnet ranges ~1–2 s in steady state, testnet typically ~1 s.
 
 > [!IMPORTANT]
 > - Node uptime expectation: **>99.5%**. The in-chain liveness tracker
@@ -81,7 +97,7 @@ stake-weighted active set finalises. Block time targets ~2.5 s.
 | Candidate set | unlimited (any address with ≥ `MIN_SELF_STAKE`) |
 | `MIN_SELF_STAKE` | 15,000 SRX |
 | Permissionless | yes — no whitelist, no admin approval |
-| Block time | ~2.5 s target |
+| Block time | 1 s target; mainnet ~1–2 s observed, testnet ~1 s |
 | Finality | BFT supermajority (2/3+1 stake-weighted) |
 
 The small active set is deliberate — BFT supermajority round-trips
@@ -121,7 +137,7 @@ That's the whole permissionless flow. No email, no DM, no approval.
 
 ## 4. Hardware + network
 
-Mainnet reference at h ≈ 1.74M (2026-05):
+Mainnet reference (observed at recent steady state):
 
 | Resource | Minimum | Comfortable |
 |---|---|---|
@@ -492,6 +508,107 @@ removal) per the slashing parameters.
 **No.** Lost password = lost validator. Bonded SRX is unrecoverable
 without the signing key. Treat keystore + password like a hardware
 wallet seed.
+
+</details>
+
+<details>
+<summary><strong>What counts as "double-signing" and how do I avoid it?</strong></summary>
+
+Double-signing = signing two different blocks at the same `(height,
+round)`. The on-chain `last-sign.json` guard ships in v2.1.85+ and
+refuses to re-sign a different hash for the same `(h, r)`, so the
+binary itself blocks the slashing condition. The two ways you can
+still trip it: (a) running the same keystore on two hosts at once
+(both have their own `last-sign.json`, neither sees the other's
+signature), (b) restoring an old `chain.db` snapshot that rewinds
+past a height you've already signed (and manually removing
+`last-sign.json` to "fix" the boot error). Rule: one keystore, one
+running process, never delete `last-sign.json` to bypass a guard
+error.
+
+</details>
+
+<details>
+<summary><strong>Can I migrate my validator to a new host?</strong></summary>
+
+Yes — keystore + chain.db move together. (1) Stop the old host's
+service. (2) `scp` the keystore, `last-sign.json`, and chain.db
+to the new host. (3) Set up the systemd unit + env file on the new
+host. (4) Start. The old host **must not start again** with the
+same keystore, ever — that's the double-sign trap above. Best
+practice is to rename the old keystore file to `*.archived` on the
+old host before bringing the new host up.
+
+</details>
+
+<details>
+<summary><strong>What's the difference between validator and fullnode?</strong></summary>
+
+A **validator** signs blocks. It bonds ≥ 15,000 SRX, sits in the
+active-set rotation, and faces slashing / jailing. It should NOT
+serve public RPC.
+
+A **fullnode** follows the chain but doesn't sign. It serves public
+JSON-RPC / REST / gRPC / WSS to dApps and explorers, replays new
+blocks via libp2p, and can be load-balanced. No stake required, no
+slashing risk.
+
+The reference deployment runs both: validators behind a firewall,
+fullnodes as the public-RPC frontline. If you only want to operate
+infrastructure (not earn validator rewards), run a fullnode — it's
+the same binary with a different config.
+
+</details>
+
+<details>
+<summary><strong>How do I monitor for jail risk before it happens?</strong></summary>
+
+The liveness tracker fires `JAIL_THRESHOLD = 70% missed-in-window`.
+Alert before that:
+
+- `/sentrix_status` returns `liveness_window_signed` and
+  `liveness_window_total`. Alert at `signed/total < 0.85` for
+  early warning.
+- Prometheus exporter exports the per-validator missed-count gauge
+  (`sentrix_validator_missed_blocks_in_window`).
+- Grafana dashboard panel shows the trend — see
+  `OBSERVABILITY.md` for the JSON.
+
+If you breach 0.85, find the cause (host CPU, disk, network) before
+0.70 fires.
+
+</details>
+
+<details>
+<summary><strong>Can I change my commission rate after registering?</strong></summary>
+
+Yes — submit `StakingOp::UpdateValidator { commission_rate: new_bp
+}`. The new rate applies to blocks produced from that height
+forward; previously-accrued rewards in the accumulator pay out at
+the rate that was active when they accrued. Delegators see the
+change on next claim. There's no cool-down or rate-limit on
+updates today, but spamming changes erodes trust — communicate
+ahead with your delegators.
+
+</details>
+
+<details>
+<summary><strong>How long from RegisterValidator to producing blocks?</strong></summary>
+
+Two thresholds:
+
+- **Candidate** — instant on `RegisterValidator` apply. The tx
+  finalizing puts you in the candidate pool.
+- **Active** — next time you're ranked in the top-21 by total
+  stake. If the active set has fewer than 21 today, you go active
+  in the next epoch boundary. If the active set is full, you're
+  active when one of the bottom-stake actives unbonds, gets jailed,
+  or gets out-staked by you.
+
+On testnet that's typically minutes (small active set, churn).
+On mainnet today the active set is small (4 reference validators),
+so a fresh registration with ≥ 15,000 SRX self-stake enters
+active immediately on the next epoch tick.
 
 </details>
 


### PR DESCRIPTION
## Summary

Cross-chain docs audit surfaced one specific gap: existing dev docs (`DEVELOPER_QUICKSTART.md`, `SMART_CONTRACT_GUIDE.md`) cover the **UI-only flow** (MetaMask + Remix), but there's no doc-side walkthrough for the **actual integration code** a serious dApp will write — viem, wagmi, ethers, hardhat, foundry. This PR adds that file as the entry point for programmatic integrations.

## What lands

`docs/operations/INTEGRATION_COOKBOOK.md` (~250 lines) with:

* **viem 2.50.4+** quickstart leveraging the already-shipped \`sentrix\` / \`sentrixTestnet\` exports from \`viem/chains\`
* **wagmi config** snippet + React component example (useAccount, useBalance)
* **ethers v6** manual-chain snippet for projects not yet on viem
* **\`@sentrix-labs/canonical-contracts\` npm** example (WSRX_ABI + WSRX_ADDRESS into a viem readContract)
* **hardhat.config.ts**, **forge create**, **forge script**, **cast** snippets
* **SDK table** — when to reach for sdk-ts / sdk-rs / sentrix-grpc-wasm vs when viem/ethers is enough
* **WebSocket subscriptions** sample with viem
* **Common gotchas** distilled from real bug reports (\`eth_getTransactionByHash\` shape, \`eth_call\` past-block before v2.2.15, EVM value-transfer fork height, block-time framing)
* **Next-steps cross-links** to the other operations docs

## What this file is NOT

Not a competitor to \`DEVELOPER_QUICKSTART.md\` or \`SMART_CONTRACT_GUIDE.md\` — those keep their UI-flow focus. \`INTEGRATION_COOKBOOK.md\` is for the copy-paste-code audience that already knows what Solidity / TypeScript / Rust looks like.

## Test plan

- [x] No code change; docs only
- [x] Every URL + chain ID + contract address verified against canonical sources (memory: viem 2.50.4 ships chains, canonical-contracts npm @1.1.0, EVM_VALUE_TRANSFER_HEIGHT mainnet 1,748,900)
- [ ] CI green (lychee link-check, commitlint, gitleaks)