### PR TITLE
fix(network): v2.2.19 apply-watchdog for fullnode silent-stall class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "hex",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "axum",
@@ -5327,7 +5327,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5346,7 +5346,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "axum",
@@ -5389,14 +5389,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "hex",
  "proptest",
@@ -5411,7 +5411,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5469,14 +5469,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5486,7 +5486,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "blake3",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.18"
+version = "2.2.19"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/bin/sentrix-faucet/src/main.rs
+++ b/bin/sentrix-faucet/src/main.rs
@@ -55,7 +55,11 @@ struct Cli {
     password: String,
 
     /// RPC base URL (POST /transactions, GET /accounts/{addr}/nonce)
-    #[arg(long, env = "SENTRIX_FAUCET_RPC_URL", default_value = "http://127.0.0.1:8545")]
+    #[arg(
+        long,
+        env = "SENTRIX_FAUCET_RPC_URL",
+        default_value = "http://127.0.0.1:8545"
+    )]
     rpc_url: String,
 
     /// Bind address for the HTTP server
@@ -80,7 +84,11 @@ struct Cli {
 
     /// Per-recipient cooldown seconds. Same address can drip again only
     /// after this elapses.
-    #[arg(long, env = "SENTRIX_FAUCET_ADDR_COOLDOWN_SECS", default_value_t = 86400)]
+    #[arg(
+        long,
+        env = "SENTRIX_FAUCET_ADDR_COOLDOWN_SECS",
+        default_value_t = 86400
+    )]
     addr_cooldown_secs: u64,
 
     /// Tx fee paid by the faucet (sentri). MIN_TX_FEE by default.
@@ -161,7 +169,11 @@ fn validate_address(addr: &str) -> Result<String> {
 }
 
 async fn fetch_nonce(http: &reqwest::Client, rpc_url: &str, address: &str) -> Result<u64> {
-    let url = format!("{}/accounts/{}/nonce", rpc_url.trim_end_matches('/'), address);
+    let url = format!(
+        "{}/accounts/{}/nonce",
+        rpc_url.trim_end_matches('/'),
+        address
+    );
     let resp = http.get(&url).send().await.context("nonce request")?;
     if !resp.status().is_success() {
         bail!("nonce HTTP {}", resp.status());
@@ -228,7 +240,13 @@ async fn handle_drip(
 ) -> Result<Json<DripResponse>, (StatusCode, Json<ErrorResponse>)> {
     let recipient = match validate_address(&req.to) {
         Ok(a) => a,
-        Err(e) => return Err(err_with(StatusCode::BAD_REQUEST, "bad address", e.to_string())),
+        Err(e) => {
+            return Err(err_with(
+                StatusCode::BAD_REQUEST,
+                "bad address",
+                e.to_string(),
+            ));
+        }
     };
 
     if recipient == state.address {
@@ -275,14 +293,16 @@ async fn handle_drip(
         )
     })?;
 
-    let txid = submit_tx(&state.http, &state.rpc_url, &tx).await.map_err(|e| {
-        error!(?e, "tx submit failed");
-        err_with(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "rpc submit failed",
-            e.to_string(),
-        )
-    })?;
+    let txid = submit_tx(&state.http, &state.rpc_url, &tx)
+        .await
+        .map_err(|e| {
+            error!(?e, "tx submit failed");
+            err_with(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "rpc submit failed",
+                e.to_string(),
+            )
+        })?;
 
     info!(
         ip = %client.ip(),
@@ -325,8 +345,7 @@ async fn handle_health(
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .init();
 
@@ -334,7 +353,9 @@ async fn main() -> Result<()> {
 
     info!(keystore = %cli.keystore, "loading keystore");
     let keystore = Keystore::load(&cli.keystore).context("load keystore")?;
-    let wallet: Wallet = keystore.decrypt(&cli.password).context("decrypt keystore")?;
+    let wallet: Wallet = keystore
+        .decrypt(&cli.password)
+        .context("decrypt keystore")?;
 
     let secret_key = wallet.get_secret_key().context("extract secret key")?;
     let public_key = wallet.get_public_key().context("extract public key")?;

--- a/bin/sentrix/src/commands/token.rs
+++ b/bin/sentrix/src/commands/token.rs
@@ -105,12 +105,7 @@ pub fn cmd_token_transfer(
     Ok(())
 }
 
-pub fn cmd_token_burn(
-    contract: &str,
-    amount: u64,
-    from_key: &str,
-    gas: u64,
-) -> anyhow::Result<()> {
+pub fn cmd_token_burn(contract: &str, amount: u64, from_key: &str, gas: u64) -> anyhow::Result<()> {
     let storage = Storage::open(&get_db_path())?;
     let mut bc = storage
         .load_blockchain()?

--- a/bin/sentrix/src/commands/wallet.rs
+++ b/bin/sentrix/src/commands/wallet.rs
@@ -470,8 +470,7 @@ mod tests {
         // process memory / crash dumps). If this compiles, the wrap is
         // intact; if a future refactor drops the wrap by accident the
         // assignment fails at build time.
-        let _proof: Zeroizing<String> =
-            resolve_password_named(Some("x".into()), "_", "_").unwrap();
+        let _proof: Zeroizing<String> = resolve_password_named(Some("x".into()), "_", "_").unwrap();
         let _proof: Zeroizing<String> =
             resolve_password_named_confirmed(Some("x".into()), "_", "_").unwrap();
         let _proof: Zeroizing<String> = resolve_password(Some("x".into())).unwrap();

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -586,17 +586,19 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Init { admin, genesis } => {
-            commands::init::cmd_init(&admin, genesis.as_deref())?
-        }
+        Commands::Init { admin, genesis } => commands::init::cmd_init(&admin, genesis.as_deref())?,
 
         Commands::Wallet { action } => match action {
-            WalletCommands::Generate { password } => commands::wallet::cmd_wallet_generate(password)?,
+            WalletCommands::Generate { password } => {
+                commands::wallet::cmd_wallet_generate(password)?
+            }
             WalletCommands::Import {
                 private_key,
                 password,
             } => commands::wallet::cmd_wallet_import(&private_key, password)?,
-            WalletCommands::Info { keystore_file } => commands::wallet::cmd_wallet_info(&keystore_file)?,
+            WalletCommands::Info { keystore_file } => {
+                commands::wallet::cmd_wallet_info(&keystore_file)?
+            }
             WalletCommands::Encrypt {
                 private_key,
                 password,
@@ -643,7 +645,10 @@ async fn main() -> anyhow::Result<()> {
                 address,
                 i_understand_phantom_stake,
             } => {
-                commands::validator::cmd_validator_force_unjail(&address, i_understand_phantom_stake)?;
+                commands::validator::cmd_validator_force_unjail(
+                    &address,
+                    i_understand_phantom_stake,
+                )?;
             }
             ValidatorCommands::Unjail { address } => {
                 commands::validator::cmd_validator_unjail(&address)?;
@@ -1880,11 +1885,16 @@ async fn cmd_start(
                                         BftAction::BroadcastPrevote(ref prevote) => {
                                             let mut signed_pv = prevote.clone();
                                             signed_pv.sign(&validator_secret_key);
-                                            if lp2p_clone.broadcast_bft_prevote(&signed_pv).await.is_err() {
+                                            if lp2p_clone
+                                                .broadcast_bft_prevote(&signed_pv)
+                                                .await
+                                                .is_err()
+                                            {
                                                 tracing::error!(
                                                     "BFT prevote broadcast dropped at h={} r={} — \
                                                      engine retains pending; outer loop re-emits",
-                                                    prevote.height, prevote.round,
+                                                    prevote.height,
+                                                    prevote.round,
                                                 );
                                                 break;
                                             }
@@ -1902,11 +1912,16 @@ async fn cmd_start(
                                         BftAction::BroadcastPrecommit(ref precommit) => {
                                             let mut signed_pc = precommit.clone();
                                             signed_pc.sign(&validator_secret_key);
-                                            if lp2p_clone.broadcast_bft_precommit(&signed_pc).await.is_err() {
+                                            if lp2p_clone
+                                                .broadcast_bft_precommit(&signed_pc)
+                                                .await
+                                                .is_err()
+                                            {
                                                 tracing::error!(
                                                     "BFT precommit broadcast dropped at h={} r={} — \
                                                      engine retains pending; outer loop re-emits",
-                                                    precommit.height, precommit.round,
+                                                    precommit.height,
+                                                    precommit.round,
                                                 );
                                                 break;
                                             }
@@ -2261,39 +2276,55 @@ async fn cmd_start(
                                                             .as_deref()
                                                             == Some(wallet.address.as_str());
                                                         if we_next {
-                                                            match bc.create_block_voyager(&wallet.address) {
+                                                            match bc.create_block_voyager(
+                                                                &wallet.address,
+                                                            ) {
                                                                 Ok(block) => {
-                                                                    let block_hash = block.hash.clone();
-                                                                    let block_data = bincode::serialize(&block).unwrap_or_default();
+                                                                    let block_hash =
+                                                                        block.hash.clone();
+                                                                    let block_data =
+                                                                        bincode::serialize(&block)
+                                                                            .unwrap_or_default();
                                                                     // F-D Variant A v3 embedded
                                                                     // unsigned proposer prevote.
-                                                                    let proposer_prevote = Some(Prevote {
-                                                                        height: next_h,
-                                                                        round: 0,
-                                                                        block_hash: Some(block_hash.clone()),
-                                                                        validator: wallet.address.clone(),
-                                                                        signature: vec![],
-                                                                    });
+                                                                    let proposer_prevote =
+                                                                        Some(Prevote {
+                                                                            height: next_h,
+                                                                            round: 0,
+                                                                            block_hash: Some(
+                                                                                block_hash.clone(),
+                                                                            ),
+                                                                            validator: wallet
+                                                                                .address
+                                                                                .clone(),
+                                                                            signature: vec![],
+                                                                        });
                                                                     let mut prop = Proposal {
                                                                         height: next_h,
                                                                         round: 0,
                                                                         block_hash,
                                                                         block_data,
-                                                                        proposer: wallet.address.clone(),
+                                                                        proposer: wallet
+                                                                            .address
+                                                                            .clone(),
                                                                         signature: vec![],
                                                                         proposer_prevote,
                                                                     };
-                                                                    prop.sign(&validator_secret_key);
+                                                                    prop.sign(
+                                                                        &validator_secret_key,
+                                                                    );
                                                                     tracing::debug!(
                                                                         target: "speculative_build",
                                                                         "pre-built proposal h={} from FinalizeBlock(self) arm",
                                                                         next_h,
                                                                     );
-                                                                    speculative_proposal = Some((next_h, block, prop));
+                                                                    speculative_proposal =
+                                                                        Some((next_h, block, prop));
                                                                 }
                                                                 Err(e) => tracing::warn!(
                                                                     "speculative build for h={} failed: {}",
-                                                                    next_h, e,
+                                                                    next_h,
+                                                                    e,
                                                                 ),
                                                             }
                                                         } else {
@@ -2307,7 +2338,10 @@ async fn cmd_start(
                                                             // here. B2 load-replay recovers if we
                                                             // crash between in-memory commit and
                                                             // the queued save.
-                                                            if save_tx_clone.try_send(height).is_err() {
+                                                            if save_tx_clone
+                                                                .try_send(height)
+                                                                .is_err()
+                                                            {
                                                                 tracing::warn!(
                                                                     target: "save_writer",
                                                                     "save queue full at h={}; \
@@ -2546,7 +2580,8 @@ async fn cmd_start(
                                         tracing::error!(
                                             "BFT prevote broadcast dropped at h={} r={} — \
                                              engine retains pending; outer loop re-emits",
-                                            prevote.height, prevote.round,
+                                            prevote.height,
+                                            prevote.round,
                                         );
                                         break;
                                     }
@@ -2564,11 +2599,16 @@ async fn cmd_start(
                                 BftAction::BroadcastPrecommit(ref precommit) => {
                                     let mut signed_pc = precommit.clone();
                                     signed_pc.sign(&validator_secret_key);
-                                    if lp2p_clone.broadcast_bft_precommit(&signed_pc).await.is_err() {
+                                    if lp2p_clone
+                                        .broadcast_bft_precommit(&signed_pc)
+                                        .await
+                                        .is_err()
+                                    {
                                         tracing::error!(
                                             "BFT precommit broadcast dropped at h={} r={} — \
                                              engine retains pending; outer loop re-emits",
-                                            precommit.height, precommit.round,
+                                            precommit.height,
+                                            precommit.round,
                                         );
                                         break;
                                     }
@@ -2674,7 +2714,8 @@ async fn cmd_start(
                                         drop(bc_read);
                                         if let Some(mut prevote) = cu_result {
                                             prevote.sign(&validator_secret_key);
-                                            let _ = lp2p_clone.broadcast_bft_prevote(&prevote).await;
+                                            let _ =
+                                                lp2p_clone.broadcast_bft_prevote(&prevote).await;
                                         }
                                         break;
                                     }
@@ -2850,13 +2891,17 @@ async fn cmd_start(
                                                     match bc.create_block_voyager(&wallet.address) {
                                                         Ok(block) => {
                                                             let block_hash = block.hash.clone();
-                                                            let block_data = bincode::serialize(&block).unwrap_or_default();
+                                                            let block_data =
+                                                                bincode::serialize(&block)
+                                                                    .unwrap_or_default();
                                                             // F-D Variant A v3 embedded
                                                             // unsigned proposer prevote.
                                                             let proposer_prevote = Some(Prevote {
                                                                 height: next_h_pf,
                                                                 round: 0,
-                                                                block_hash: Some(block_hash.clone()),
+                                                                block_hash: Some(
+                                                                    block_hash.clone(),
+                                                                ),
                                                                 validator: wallet.address.clone(),
                                                                 signature: vec![],
                                                             });
@@ -2875,11 +2920,13 @@ async fn cmd_start(
                                                                 "pre-built proposal h={} from FinalizeBlock(peer) arm",
                                                                 next_h_pf,
                                                             );
-                                                            speculative_proposal = Some((next_h_pf, block, prop));
+                                                            speculative_proposal =
+                                                                Some((next_h_pf, block, prop));
                                                         }
                                                         Err(e) => tracing::warn!(
                                                             "speculative build for h={} failed: {}",
-                                                            next_h_pf, e,
+                                                            next_h_pf,
+                                                            e,
                                                         ),
                                                     }
                                                 } else {
@@ -3093,7 +3140,8 @@ async fn cmd_start(
                                         tracing::error!(
                                             "BFT prevote broadcast dropped at h={} r={} — \
                                              engine retains pending; outer loop re-emits",
-                                            prevote.height, prevote.round,
+                                            prevote.height,
+                                            prevote.round,
                                         );
                                         break;
                                     }
@@ -3111,11 +3159,16 @@ async fn cmd_start(
                                 BftAction::BroadcastPrecommit(ref precommit) => {
                                     let mut signed_pc = precommit.clone();
                                     signed_pc.sign(&validator_secret_key);
-                                    if lp2p_clone.broadcast_bft_precommit(&signed_pc).await.is_err() {
+                                    if lp2p_clone
+                                        .broadcast_bft_precommit(&signed_pc)
+                                        .await
+                                        .is_err()
+                                    {
                                         tracing::error!(
                                             "BFT precommit broadcast dropped at h={} r={} — \
                                              engine retains pending; outer loop re-emits",
-                                            precommit.height, precommit.round,
+                                            precommit.height,
+                                            precommit.round,
                                         );
                                         break;
                                     }
@@ -3601,7 +3654,6 @@ async fn cmd_start(
     .await?;
     Ok(())
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -2178,7 +2178,11 @@ mod tests {
         let (mut engine, reg) = setup_143();
         let action = engine.on_round_status(&status("0xa", 2), &reg);
         assert!(matches!(action, BftAction::Wait), "got {:?}", action);
-        assert_eq!(engine.round(), 1, "legacy path catches up to peer_round - 1");
+        assert_eq!(
+            engine.round(),
+            1,
+            "legacy path catches up to peer_round - 1"
+        );
         assert_eq!(engine.state.phase, BftPhase::Propose);
         assert!(!engine.state.our_prevote_cast);
     }

--- a/crates/sentrix-codec/src/lib.rs
+++ b/crates/sentrix-codec/src/lib.rs
@@ -131,12 +131,18 @@ mod tests {
 
     #[test]
     fn test_hex_decode_no_prefix() {
-        assert_eq!(hex_decode("deadbeef").unwrap(), vec![0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(
+            hex_decode("deadbeef").unwrap(),
+            vec![0xde, 0xad, 0xbe, 0xef]
+        );
     }
 
     #[test]
     fn test_hex_decode_with_prefix() {
-        assert_eq!(hex_decode("0xdeadbeef").unwrap(), vec![0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(
+            hex_decode("0xdeadbeef").unwrap(),
+            vec![0xde, 0xad, 0xbe, 0xef]
+        );
     }
 
     #[test]

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -632,8 +632,7 @@ impl Blockchain {
         // duration. post = state_root stamp + state_root check + prune
         // dispatch. The prune itself runs on a background thread (v2.2.4)
         // so its walk time is NOT included here.
-        let apply_profile = std::env::var_os("SENTRIX_APPLY_PROFILE")
-            .is_some_and(|v| v == "1");
+        let apply_profile = std::env::var_os("SENTRIX_APPLY_PROFILE").is_some_and(|v| v == "1");
         let profile_t0 = if apply_profile {
             Some(std::time::Instant::now())
         } else {
@@ -664,9 +663,7 @@ impl Blockchain {
         //
         // Default OFF: env var unset → zero-cost (the env-var read is
         // gated by a `var_os` check that doesn't allocate when missing).
-        if std::env::var_os("SENTRIX_FRONTIER_F2_SHADOW")
-            .is_some_and(|v| v == "1")
-        {
+        if std::env::var_os("SENTRIX_FRONTIER_F2_SHADOW").is_some_and(|v| v == "1") {
             shadow_observe_parallel_batching(&block);
         }
 
@@ -765,9 +762,9 @@ impl Blockchain {
                 // in practice, but the guard is cheap and prevents a silent
                 // wrap if MAX_TX_PER_BLOCK or MIN_TX_FEE are ever tuned
                 // upward past the implicit ceiling.
-                total_fee = total_fee
-                    .checked_add(tx.fee)
-                    .ok_or_else(|| SentrixError::Internal("block total_fee overflow".to_string()))?;
+                total_fee = total_fee.checked_add(tx.fee).ok_or_else(|| {
+                    SentrixError::Internal("block total_fee overflow".to_string())
+                })?;
             }
 
             // Execute token operation if present in data field
@@ -932,7 +929,8 @@ impl Blockchain {
             // the `to_address == TREASURY` invariant inside dispatch
             // below; wrong address → Err → Pass 2 rollback.
             if Self::is_reward_v2_height(block.index)
-                && let Some(staking_op) = sentrix_primitives::transaction::StakingOp::decode(&tx.data)
+                && let Some(staking_op) =
+                    sentrix_primitives::transaction::StakingOp::decode(&tx.data)
             {
                 use sentrix_primitives::transaction::{PROTOCOL_TREASURY, StakingOp};
                 if tx.to_address != PROTOCOL_TREASURY {
@@ -961,8 +959,7 @@ impl Blockchain {
                         // the transfer Errs, accumulators stay intact
                         // and the claimer can re-submit later.
                         let claimer = tx.from_address.clone();
-                        let delegator_amount =
-                            self.stake_registry.peek_delegator_rewards(&claimer);
+                        let delegator_amount = self.stake_registry.peek_delegator_rewards(&claimer);
                         let validator_amount = self
                             .stake_registry
                             .validators
@@ -972,12 +969,8 @@ impl Blockchain {
                         let total_claim = delegator_amount.saturating_add(validator_amount);
                         if total_claim > 0 {
                             // Transfer first; only drain on success.
-                            self.accounts.transfer(
-                                PROTOCOL_TREASURY,
-                                &claimer,
-                                total_claim,
-                                0,
-                            )?;
+                            self.accounts
+                                .transfer(PROTOCOL_TREASURY, &claimer, total_claim, 0)?;
                             // Transfer succeeded — drain accumulators.
                             // `take_delegator_rewards` removes the entry
                             // entirely (matches semantics — claimer
@@ -1125,8 +1118,7 @@ impl Blockchain {
                                 "Unjail: tx.amount must be 0".into(),
                             ));
                         }
-                        self.stake_registry
-                            .unjail(&tx.from_address, block.index)?;
+                        self.stake_registry.unjail(&tx.from_address, block.index)?;
                         if let Some(emitter) = &self.event_emitter {
                             emitter.emit_staking_op(&sentrix_primitives::events::StakingOpEvent {
                                 op: "unjail".to_string(),
@@ -1164,8 +1156,7 @@ impl Blockchain {
                         // already rejects auto-jail dispatch).
                         if offender.is_empty() {
                             return Err(SentrixError::InvalidTransaction(
-                                "SubmitEvidence: offender field must be populated"
-                                    .into(),
+                                "SubmitEvidence: offender field must be populated".into(),
                             ));
                         }
                         // Evidence targets the validator named in the
@@ -1239,9 +1230,7 @@ impl Blockchain {
                         // Boundary block's epoch should be `(height + 1) / EPOCH_LENGTH - 1`
                         // when the boundary is the LAST block of the epoch.
                         let current_epoch =
-                            sentrix_staking::epoch::EpochManager::epoch_for_height(
-                                self.height(),
-                            );
+                            sentrix_staking::epoch::EpochManager::epoch_for_height(self.height());
                         if claimed_epoch != current_epoch {
                             return Err(SentrixError::InvalidTransaction(format!(
                                 "JailEvidenceBundle epoch {} != current epoch {}",
@@ -1398,9 +1387,8 @@ impl Blockchain {
                             // validator re-enters; emit so dApps tracking
                             // active set get a notif.
                             let active: Vec<String> = self.stake_registry.active_set.to_vec();
-                            let epoch = sentrix_staking::epoch::EpochManager::epoch_for_height(
-                                block.index,
-                            );
+                            let epoch =
+                                sentrix_staking::epoch::EpochManager::epoch_for_height(block.index);
                             emitter.emit_validator_set(epoch, &active);
                         }
                     }
@@ -1683,7 +1671,13 @@ impl Blockchain {
         emit_state_fingerprint(self, self.height());
 
         // Per-block apply-phase profile (see top of fn for rationale).
-        emit_apply_profile(profile_t0, profile_t1, profile_t2, profile_height, profile_txs);
+        emit_apply_profile(
+            profile_t0,
+            profile_t1,
+            profile_t2,
+            profile_height,
+            profile_txs,
+        );
 
         Ok(())
     }
@@ -1706,7 +1700,6 @@ impl Blockchain {
         }
         self.stake_registry.delegator_rewards.clear();
     }
-
 }
 
 /// State-drift fingerprint emitter (debug-only). When
@@ -2352,7 +2345,8 @@ mod tests {
         assert!(block.transactions[1].is_system_tx());
 
         // add_block runs full Pass-1 + Pass-2 + dispatch + state mutation
-        bc.add_block(block).expect("add_block must accept Phase D system tx");
+        bc.add_block(block)
+            .expect("add_block must accept Phase D system tx");
 
         // Post-condition: downer jailed
         let post_jailed = bc
@@ -2410,23 +2404,14 @@ mod tests {
                 },
             );
         }
-        bc.stake_registry.active_set = vec![
-            "v1".into(),
-            "v2".into(),
-            "v3".into(),
-            "v4".into(),
-        ];
+        bc.stake_registry.active_set = vec!["v1".into(), "v2".into(), "v3".into(), "v4".into()];
 
         let prev_hash = bc.latest_block().unwrap().hash.clone();
         let height = bc.height() + 1;
         let reward = bc.get_block_reward();
         let coinbase = Transaction::new_coinbase("v1".into(), reward, height, 1_777_000_000);
-        let mut block = sentrix_primitives::block::Block::new(
-            height,
-            prev_hash,
-            vec![coinbase],
-            "v1".into(),
-        );
+        let mut block =
+            sentrix_primitives::block::Block::new(height, prev_hash, vec![coinbase], "v1".into());
         block.timestamp = 1_777_000_000;
         block.hash = block.calculate_hash();
         let mut just = BlockJustification::new(height, 0, block.hash.clone());
@@ -2474,23 +2459,14 @@ mod tests {
                 },
             );
         }
-        bc.stake_registry.active_set = vec![
-            "v1".into(),
-            "v2".into(),
-            "v3".into(),
-            "v4".into(),
-        ];
+        bc.stake_registry.active_set = vec!["v1".into(), "v2".into(), "v3".into(), "v4".into()];
 
         let prev_hash = bc.latest_block().unwrap().hash.clone();
         let height = bc.height() + 1;
         let reward = bc.get_block_reward();
         let coinbase = Transaction::new_coinbase("v1".into(), reward, height, 1_777_000_000);
-        let mut block = sentrix_primitives::block::Block::new(
-            height,
-            prev_hash,
-            vec![coinbase],
-            "v1".into(),
-        );
+        let mut block =
+            sentrix_primitives::block::Block::new(height, prev_hash, vec![coinbase], "v1".into());
         block.timestamp = 1_777_000_000;
         block.hash = block.calculate_hash();
         let mut just = BlockJustification::new(height, 0, block.hash.clone());

--- a/crates/sentrix-core/src/block_executor/evm.rs
+++ b/crates/sentrix-core/src/block_executor/evm.rs
@@ -82,8 +82,8 @@ impl Blockchain {
             }
         };
 
-        use alloy_consensus::TxEnvelope;
         use alloy_consensus::Transaction as AlloyTx; // brings .value() into scope
+        use alloy_consensus::TxEnvelope;
         use alloy_eips::eip2718::Decodable2718;
 
         let envelope: TxEnvelope = match TxEnvelope::decode_2718(&mut raw_bytes.as_slice()) {
@@ -364,11 +364,9 @@ impl Blockchain {
                     // execute and DID move state — surface so ops can spot
                     // it. Don't propagate: block apply already succeeded,
                     // chain state is canonical.
-                    if let Err(e) = storage.put_bincode(
-                        sentrix_storage::tables::TABLE_RECEIPTS,
-                        &key,
-                        &stored,
-                    ) {
+                    if let Err(e) =
+                        storage.put_bincode(sentrix_storage::tables::TABLE_RECEIPTS, &key, &stored)
+                    {
                         tracing::warn!(
                             "EVM tx {}: receipt persist failed: {}",
                             &tx.txid[..16.min(tx.txid.len())],
@@ -405,11 +403,9 @@ impl Blockchain {
                         // as the receipt persist above. Failed log persist
                         // means `eth_getLogs` misses an entry; emit_log
                         // below still notifies live WS subscribers.
-                        if let Err(e) = storage.put_bincode(
-                            sentrix_storage::tables::TABLE_LOGS,
-                            &key,
-                            &stored,
-                        ) {
+                        if let Err(e) =
+                            storage.put_bincode(sentrix_storage::tables::TABLE_LOGS, &key, &stored)
+                        {
                             tracing::warn!(
                                 "EVM tx {}: log persist failed (idx={}): {}",
                                 &tx.txid[..16.min(tx.txid.len())],

--- a/crates/sentrix-core/src/block_executor/validate.rs
+++ b/crates/sentrix-core/src/block_executor/validate.rs
@@ -83,8 +83,7 @@ impl Blockchain {
             let local_evidence = self
                 .slashing
                 .compute_jail_evidence(&active_set, expected_index);
-            if !local_evidence.is_empty()
-                && !block.transactions.iter().any(|tx| tx.is_system_tx())
+            if !local_evidence.is_empty() && !block.transactions.iter().any(|tx| tx.is_system_tx())
             {
                 return Err(SentrixError::InvalidBlock(format!(
                     "boundary block {} missing required JailEvidenceBundle \

--- a/crates/sentrix-core/src/block_producer.rs
+++ b/crates/sentrix-core/src/block_producer.rs
@@ -50,9 +50,7 @@ impl Blockchain {
         // system tx with locally-computed downtime evidence. Helper returns
         // None pre-fork, at non-boundaries, or with no evidence — making this
         // a no-op on default builds (JAIL_CONSENSUS_HEIGHT=u64::MAX).
-        if let Some(jail_tx) =
-            self.build_jail_evidence_system_tx(next_height, block_timestamp)
-        {
+        if let Some(jail_tx) = self.build_jail_evidence_system_tx(next_height, block_timestamp) {
             transactions.push(jail_tx);
         }
 

--- a/crates/sentrix-core/src/blockchain_block_accessors.rs
+++ b/crates/sentrix-core/src/blockchain_block_accessors.rs
@@ -106,11 +106,7 @@ impl Blockchain {
         match serde_json::from_slice::<Block>(&bytes) {
             Ok(b) => Some(b),
             Err(e) => {
-                tracing::warn!(
-                    "get_block_any({}): block JSON decode error: {}",
-                    index,
-                    e
-                );
+                tracing::warn!("get_block_any({}): block JSON decode error: {}", index, e);
                 None
             }
         }

--- a/crates/sentrix-core/src/blockchain_storage_io.rs
+++ b/crates/sentrix-core/src/blockchain_storage_io.rs
@@ -50,9 +50,7 @@ impl Blockchain {
     /// (disk full, lock contention, permissions, corruption).
     pub fn persist_block_durable(&self, block: &Block) -> SentrixResult<()> {
         let mdbx = self.mdbx_storage.as_ref().ok_or_else(|| {
-            SentrixError::Internal(
-                "persist_block_durable: mdbx_storage not initialised".into(),
-            )
+            SentrixError::Internal("persist_block_durable: mdbx_storage not initialised".into())
         })?;
 
         let key = format!("block:{}", block.index);
@@ -81,9 +79,8 @@ impl Blockchain {
             .map_err(|e| {
                 SentrixError::Internal(format!("persist_block_durable: height put: {e}"))
             })?;
-        mdbx.sync().map_err(|e| {
-            SentrixError::Internal(format!("persist_block_durable: sync: {e}"))
-        })?;
+        mdbx.sync()
+            .map_err(|e| SentrixError::Internal(format!("persist_block_durable: sync: {e}")))?;
         Ok(())
     }
 

--- a/crates/sentrix-core/src/blockchain_trie_ops.rs
+++ b/crates/sentrix-core/src/blockchain_trie_ops.rs
@@ -252,13 +252,17 @@ impl Blockchain {
                     tracing::warn!(
                         "STATE_ROOT_V2 activation rebase at h={}: PROTOCOL_TREASURY \
                          {} → {} (delta {} sentri). Operator-set canonical override.",
-                        state_root_v2_height_for_rebase, prior, canonical, delta
+                        state_root_v2_height_for_rebase,
+                        prior,
+                        canonical,
+                        delta
                     );
                 } else {
                     tracing::info!(
                         "STATE_ROOT_V2 activation at h={}: PROTOCOL_TREASURY \
                          balance already matches canonical {} sentri (no rebase)",
-                        state_root_v2_height_for_rebase, canonical
+                        state_root_v2_height_for_rebase,
+                        canonical
                     );
                 }
                 self.accounts.set_balance(PROTOCOL_TREASURY, canonical);
@@ -454,7 +458,10 @@ impl Blockchain {
             None => return Ok(None),
         };
         if trace {
-            eprintln!("[trie-trace] root pre-update: {}", hex::encode(trie.root_hash()));
+            eprintln!(
+                "[trie-trace] root pre-update: {}",
+                hex::encode(trie.root_hash())
+            );
         }
         for (addr, balance, nonce) in updates {
             let key = address_to_key(&addr);
@@ -463,7 +470,10 @@ impl Blockchain {
                 let existing = trie.get(&key)?;
                 eprintln!(
                     "[trie-trace]   existing leaf for {addr}: {}",
-                    existing.as_ref().map(hex::encode).unwrap_or_else(|| "<none>".into())
+                    existing
+                        .as_ref()
+                        .map(hex::encode)
+                        .unwrap_or_else(|| "<none>".into())
                 );
             }
             if balance == 0 {
@@ -481,7 +491,10 @@ impl Blockchain {
         }
         let root = trie.commit(block_index)?;
         if trace {
-            eprintln!("[trie-trace] commit at h={block_index} → root={}", hex::encode(root));
+            eprintln!(
+                "[trie-trace] commit at h={block_index} → root={}",
+                hex::encode(root)
+            );
         }
         Ok(Some(root))
     }

--- a/crates/sentrix-core/src/divergence.rs
+++ b/crates/sentrix-core/src/divergence.rs
@@ -108,7 +108,10 @@ mod tests {
             t.record_rejection(1_000 + i);
         }
         let (recent, total) = t.stats();
-        assert_eq!(recent, 50, "all 50 rejections should be within the 5-min window");
+        assert_eq!(
+            recent, 50,
+            "all 50 rejections should be within the 5-min window"
+        );
         assert_eq!(total, 50);
     }
 

--- a/crates/sentrix-core/src/mempool.rs
+++ b/crates/sentrix-core/src/mempool.rs
@@ -183,7 +183,10 @@ impl Blockchain {
         self.mempool.insert(pos, tx);
         // Audit M6: maintain sidecars on every successful admission.
         self.mempool_txids.insert(txid_for_event.clone());
-        *self.mempool_sender_count.entry(sender_for_count).or_insert(0) += 1;
+        *self
+            .mempool_sender_count
+            .entry(sender_for_count)
+            .or_insert(0) += 1;
 
         // Notify WebSocket subscribers — eth_subscribe(newPendingTransactions).
         // Non-blocking, infallible by trait contract. Fires only on
@@ -213,10 +216,7 @@ impl Blockchain {
         // iter+filter+count which `add_to_mempool` called twice per
         // admission (per-sender cap + expected-nonce computation),
         // each scan O(n) on a 10K-entry mempool.
-        self.mempool_sender_count
-            .get(address)
-            .copied()
-            .unwrap_or(0) as u64
+        self.mempool_sender_count.get(address).copied().unwrap_or(0) as u64
     }
 
     fn mempool_pending_spend(&self, address: &str) -> u64 {
@@ -316,10 +316,11 @@ impl Blockchain {
             .iter()
             .map(|addr| (addr.to_string(), self.accounts.get_nonce(addr)))
             .collect();
-        self.mempool.retain(|tx| match nonces.get(&tx.from_address) {
-            Some(&finalized) => tx.nonce >= finalized,
-            None => true,
-        });
+        self.mempool
+            .retain(|tx| match nonces.get(&tx.from_address) {
+                Some(&finalized) => tx.nonce >= finalized,
+                None => true,
+            });
         // Audit M6: retain mutated `mempool`, rebuild sidecars to keep
         // them consistent.
         self.rebuild_mempool_sidecars();

--- a/crates/sentrix-core/src/parallel/rw_set.rs
+++ b/crates/sentrix-core/src/parallel/rw_set.rs
@@ -95,8 +95,13 @@ impl TxAccess {
     /// any EVM tx conflicts with every other tx — forcing it into its
     /// own batch.
     pub fn conflicts_with(&self, other: &TxAccess) -> bool {
-        self.writes.iter().any(|w| other.reads.contains(w) || other.writes.contains(w))
-            || other.writes.iter().any(|w| self.reads.contains(w) || self.writes.contains(w))
+        self.writes
+            .iter()
+            .any(|w| other.reads.contains(w) || other.writes.contains(w))
+            || other
+                .writes
+                .iter()
+                .any(|w| self.reads.contains(w) || self.writes.contains(w))
     }
 }
 
@@ -221,6 +226,9 @@ mod tests {
 
         let a_iter: Vec<_> = a.reads.iter().collect();
         let b_iter: Vec<_> = b.reads.iter().collect();
-        assert_eq!(a_iter, b_iter, "BTreeSet iteration must be order-independent of insertion");
+        assert_eq!(
+            a_iter, b_iter,
+            "BTreeSet iteration must be order-independent of insertion"
+        );
     }
 }

--- a/crates/sentrix-core/src/parallel/scheduler.rs
+++ b/crates/sentrix-core/src/parallel/scheduler.rs
@@ -33,7 +33,9 @@ pub struct Batch {
 
 impl Batch {
     pub fn singleton(idx: usize) -> Self {
-        Self { tx_indices: vec![idx] }
+        Self {
+            tx_indices: vec![idx],
+        }
     }
 }
 
@@ -62,7 +64,10 @@ pub fn build_batches<T: AsRef<[u8]>>(txs: &[T], validator: &str) -> Vec<Batch> {
         .map(|tx| derive_access(tx.as_ref(), validator))
         .collect();
 
-    txs.iter().enumerate().map(|(i, _)| Batch::singleton(i)).collect()
+    txs.iter()
+        .enumerate()
+        .map(|(i, _)| Batch::singleton(i))
+        .collect()
 }
 
 #[cfg(test)]
@@ -122,7 +127,10 @@ mod tests {
     fn batches_preserve_ascending_order() {
         let txs: Vec<&[u8]> = vec![b"0", b"1", b"2", b"3", b"4"];
         let batches = build_batches(&txs, "0xv");
-        let flat: Vec<usize> = batches.iter().flat_map(|b| b.tx_indices.iter().copied()).collect();
+        let flat: Vec<usize> = batches
+            .iter()
+            .flat_map(|b| b.tx_indices.iter().copied())
+            .collect();
         assert_eq!(flat, vec![0, 1, 2, 3, 4]);
     }
 }

--- a/crates/sentrix-core/src/state_export.rs
+++ b/crates/sentrix-core/src/state_export.rs
@@ -437,7 +437,8 @@ mod tests {
         let s2 = serde_json::to_value(&snap2).unwrap();
 
         assert_eq!(
-            s1, s2,
+            s1,
+            s2,
             "export → import → export must be byte-identical (determinism)\n\
              original: {}\n\
              after round-trip: {}",
@@ -536,9 +537,7 @@ mod tests {
 
         // Chain 1: build a committed trie at height 1.
         let (accounts_a, accounts_b) = {
-            let mdbx = std::sync::Arc::new(
-                sentrix_storage::MdbxStorage::open(mdbx_path).unwrap(),
-            );
+            let mdbx = std::sync::Arc::new(sentrix_storage::MdbxStorage::open(mdbx_path).unwrap());
             let mut bc = setup();
             bc.init_trie(mdbx.clone()).unwrap();
 
@@ -567,9 +566,7 @@ mod tests {
         // (as if from a peer who had slightly different balances for
         // the same addresses). Simulates the drift-recovery scenario.
         let snapshot = {
-            let mdbx = std::sync::Arc::new(
-                sentrix_storage::MdbxStorage::open(mdbx_path).unwrap(),
-            );
+            let mdbx = std::sync::Arc::new(sentrix_storage::MdbxStorage::open(mdbx_path).unwrap());
             let mut other = setup();
             other.init_trie(mdbx).unwrap();
             // Same addresses but different balances — the "canonical" version
@@ -587,9 +584,7 @@ mod tests {
         // We apply the reset here so the next open sees empty trie tables
         // → init_trie backfills from imported accounts.
         {
-            let mdbx = std::sync::Arc::new(
-                sentrix_storage::MdbxStorage::open(mdbx_path).unwrap(),
-            );
+            let mdbx = std::sync::Arc::new(sentrix_storage::MdbxStorage::open(mdbx_path).unwrap());
             let mut bc = setup();
             bc.init_trie(mdbx.clone()).unwrap();
             bc.import_state(&snapshot).unwrap();
@@ -613,9 +608,8 @@ mod tests {
         // Chain 1 restart: init_trie should rebuild from the imported
         // accounts. If the fix is in place, the trie tables are empty
         // and init_trie triggers the backfill path.
-        let mdbx_reopen = std::sync::Arc::new(
-            sentrix_storage::MdbxStorage::open(mdbx_path).unwrap(),
-        );
+        let mdbx_reopen =
+            std::sync::Arc::new(sentrix_storage::MdbxStorage::open(mdbx_path).unwrap());
         let mut bc_reopened = setup();
         // Re-apply the imported accounts (save_blockchain/load_blockchain
         // would persist+restore them in production; here we set them
@@ -630,9 +624,8 @@ mod tests {
         // onto a pristine MDBX (no prior trie). This is what an
         // untouched peer would look like.
         let tmp_ref = tempfile::TempDir::new().unwrap();
-        let mdbx_ref = std::sync::Arc::new(
-            sentrix_storage::MdbxStorage::open(tmp_ref.path()).unwrap(),
-        );
+        let mdbx_ref =
+            std::sync::Arc::new(sentrix_storage::MdbxStorage::open(tmp_ref.path()).unwrap());
         let mut bc_reference = setup();
         bc_reference.import_state(&snapshot).unwrap();
         bc_reference.init_trie(mdbx_ref).unwrap();
@@ -641,7 +634,8 @@ mod tests {
             .or_else(|| bc_reference.state_trie.as_ref().map(|t| t.root_hash()));
 
         assert_eq!(
-            root_after_restart, root_reference,
+            root_after_restart,
+            root_reference,
             "After state import + restart, the restored trie root MUST equal what an \
              untouched peer would compute from the same imported accounts. If they \
              differ, the stale trie from pre-import state is still in use — exactly \
@@ -687,9 +681,9 @@ mod tests {
             sentrix_storage::MdbxStorage::open(tempfile::TempDir::new().unwrap().path()).unwrap(),
         );
         bc1.init_trie(mdbx1.clone()).unwrap();
-        let root1 = bc1.trie_root_at(bc1.height()).or_else(|| {
-            bc1.state_trie.as_ref().map(|t| t.root_hash())
-        });
+        let root1 = bc1
+            .trie_root_at(bc1.height())
+            .or_else(|| bc1.state_trie.as_ref().map(|t| t.root_hash()));
         assert!(root1.is_some(), "bc1 must have a committed trie root");
 
         // Export + import into fresh chain.
@@ -702,13 +696,14 @@ mod tests {
             sentrix_storage::MdbxStorage::open(tempfile::TempDir::new().unwrap().path()).unwrap(),
         );
         bc2.init_trie(mdbx2.clone()).unwrap();
-        let root2 = bc2.trie_root_at(bc2.height()).or_else(|| {
-            bc2.state_trie.as_ref().map(|t| t.root_hash())
-        });
+        let root2 = bc2
+            .trie_root_at(bc2.height())
+            .or_else(|| bc2.state_trie.as_ref().map(|t| t.root_hash()));
         assert!(root2.is_some(), "bc2 must have a committed trie root");
 
         assert_eq!(
-            root1, root2,
+            root1,
+            root2,
             "state_root must be IDENTICAL between original chain and chain rebuilt from export\n\
              original root = {:?}\n\
              restored root = {:?}\n\

--- a/crates/sentrix-core/src/storage.rs
+++ b/crates/sentrix-core/src/storage.rs
@@ -75,7 +75,9 @@ impl Storage {
         {
             tracing::info!(
                 "chain_name fix-up on load: chain_id={} blob={:?} → {:?}",
-                bc.chain_id, bc.chain_name, name,
+                bc.chain_id,
+                bc.chain_name,
+                name,
             );
             bc.chain_name = name.to_string();
         }
@@ -796,7 +798,10 @@ mod tests {
         assert_eq!(bc.total_minted, expected, "bc.total_minted ground truth");
 
         let recomputed = storage.recompute_total_minted_from_blocks(&bc).unwrap();
-        assert_eq!(recomputed, expected, "helper must match block-sum ground truth");
+        assert_eq!(
+            recomputed, expected,
+            "helper must match block-sum ground truth"
+        );
 
         let _ = std::fs::remove_dir_all(&path);
     }

--- a/crates/sentrix-core/tests/evm_e2e_harness.rs
+++ b/crates/sentrix-core/tests/evm_e2e_harness.rs
@@ -364,8 +364,7 @@ fn test_h3_post_fork_supply_invariant_holds_on_value_transfer() {
     bc.accounts.credit(&sender_str, 100_000_000_000).unwrap(); // 1000 SRX
 
     let value = 100_000_000u64; // 1 SRX
-    let (_, balance_before, _txid) =
-        submit_evm_value_transfer(&mut bc, &sk, &pk, value, 0);
+    let (_, balance_before, _txid) = submit_evm_value_transfer(&mut bc, &sk, &pk, value, 0);
 
     let balance_after = bc.accounts.get_balance(&sender_str);
     let actual_drop = balance_before - balance_after;

--- a/crates/sentrix-core/tests/fork_determinism.rs
+++ b/crates/sentrix-core/tests/fork_determinism.rs
@@ -206,8 +206,8 @@ fn test_signed_tx_blocks_self_vs_peer_determinism() {
 #[test]
 fn test_mdbx_roundtrip_then_peer_block() {
     let dir = TempDir::new().expect("tempdir");
-    let storage = sentrix_core::storage::Storage::open(dir.path().to_str().unwrap())
-        .expect("storage open");
+    let storage =
+        sentrix_core::storage::Storage::open(dir.path().to_str().unwrap()).expect("storage open");
     let mdbx = storage.mdbx_arc();
 
     let mut producer = setup_chain();
@@ -316,8 +316,8 @@ fn test_mdbx_roundtrip_then_peer_block() {
 #[test]
 fn test_mdbx_roundtrip_with_active_state() {
     let dir = TempDir::new().expect("tempdir");
-    let storage = sentrix_core::storage::Storage::open(dir.path().to_str().unwrap())
-        .expect("storage open");
+    let storage =
+        sentrix_core::storage::Storage::open(dir.path().to_str().unwrap()).expect("storage open");
     let mdbx = storage.mdbx_arc();
 
     let mut producer = setup_chain();
@@ -445,7 +445,9 @@ fn test_stale_snapshot_peer_sync() {
 
     let mut producer = setup_chain();
     producer.init_trie(Arc::clone(&producer_mdbx)).unwrap();
-    producer.init_storage_handle(Arc::clone(&producer_mdbx)).unwrap();
+    producer
+        .init_storage_handle(Arc::clone(&producer_mdbx))
+        .unwrap();
 
     // Pre-fund 3 senders
     let mut keypairs = Vec::new();
@@ -727,9 +729,8 @@ fn test_voyager_active_stale_snapshot_peer_sync() {
     let peer_dir = TempDir::new().expect("peer tempdir");
     copy_dir_contents(producer_dir.path(), peer_dir.path()).expect("rsync sim");
 
-    let peer_storage =
-        sentrix_core::storage::Storage::open(peer_dir.path().to_str().unwrap())
-            .expect("peer storage open");
+    let peer_storage = sentrix_core::storage::Storage::open(peer_dir.path().to_str().unwrap())
+        .expect("peer storage open");
     let peer_mdbx = peer_storage.mdbx_arc();
     let mut peer: Blockchain = peer_storage
         .load_blockchain()
@@ -829,10 +830,7 @@ fn test_legacy_validation_height_branches() {
         (d1, d2, producer, peer)
     }
 
-    fn produce_block_with_bad_state_root(
-        producer: &mut Blockchain,
-        bad_root: [u8; 32],
-    ) -> Block {
+    fn produce_block_with_bad_state_root(producer: &mut Blockchain, bad_root: [u8; 32]) -> Block {
         let mut block = producer.create_block(VALIDATOR).unwrap();
         // Apply on producer normally (stamps real state_root)
         producer.add_block(block.clone()).unwrap();
@@ -964,7 +962,11 @@ fn test_libp2p_sync_loop_skips_duplicates_and_applies_remaining() {
 
     assert_eq!(skipped, 2, "two already-applied blocks should be skipped");
     assert_eq!(synced, 2, "two forward blocks should be applied");
-    assert_eq!(peer.height(), 5, "peer must advance to h=5 (not stall at 3)");
+    assert_eq!(
+        peer.height(),
+        5,
+        "peer must advance to h=5 (not stall at 3)"
+    );
 }
 
 /// Recursively copy directory contents — used for the rsync simulation in

--- a/crates/sentrix-core/tests/phase_d_4validator_determinism.rs
+++ b/crates/sentrix-core/tests/phase_d_4validator_determinism.rs
@@ -58,7 +58,12 @@ fn setup_validator_chain() -> Blockchain {
 
     // Register both validator (proposer) + downer (the one we'll jail)
     bc.stake_registry
-        .register_validator(&validator, sentrix_staking::staking::MIN_SELF_STAKE, 1000, 0)
+        .register_validator(
+            &validator,
+            sentrix_staking::staking::MIN_SELF_STAKE,
+            1000,
+            0,
+        )
         .expect("register validator");
     bc.stake_registry
         .register_validator(&downer, sentrix_staking::staking::MIN_SELF_STAKE, 1000, 0)
@@ -116,8 +121,7 @@ fn phase_d_4validator_consensus_jail_determinism() {
 
     // Spin up 4 independent chain instances, all with identical initial
     // state (downer in active_set, full LIVENESS_WINDOW of misses).
-    let mut validators: Vec<Blockchain> =
-        (0..4).map(|_| setup_validator_chain()).collect();
+    let mut validators: Vec<Blockchain> = (0..4).map(|_| setup_validator_chain()).collect();
 
     // Pre-condition: no validator has the downer jailed yet.
     for (i, bc) in validators.iter().enumerate() {
@@ -237,9 +241,9 @@ fn phase_d_4validator_diverging_evidence_rejected() {
         .expect("proposer must build boundary block");
 
     // Diverging peer must reject the block.
-    let err = diverging_peer.add_block(block.clone()).expect_err(
-        "diverging peer must reject block — evidence recompute differs from claim",
-    );
+    let err = diverging_peer
+        .add_block(block.clone())
+        .expect_err("diverging peer must reject block — evidence recompute differs from claim");
     let msg = format!("{err:?}");
     assert!(
         msg.contains("verification failed") || msg.contains("differs from claim"),

--- a/crates/sentrix-core/tests/rca_env_repro.rs
+++ b/crates/sentrix-core/tests/rca_env_repro.rs
@@ -38,9 +38,9 @@
 //! This OFFLINE harness sidesteps that by reading blocks directly from
 //! MDBX storage. BACKLOG #14 fixes the live-sync path independently.
 
+use sentrix_core::Genesis;
 use sentrix_core::blockchain::Blockchain;
 use sentrix_core::storage::Storage;
-use sentrix_core::Genesis;
 use std::sync::Arc;
 
 /// Burn-address admin for the rebuilt Blockchain. The harness only
@@ -59,7 +59,8 @@ fn replay_admin() -> String {
 /// Caller must set `SENTRIX_ALLOW_UNENCRYPTED_DISK=true` if the snapshot
 /// lives on an unencrypted volume (the default for dev/test setups).
 fn load_existing_chain(path: &str) -> Blockchain {
-    let storage = Storage::open(path).expect("chain.db open failed — check path + encryption env vars");
+    let storage =
+        Storage::open(path).expect("chain.db open failed — check path + encryption env vars");
     let mut bc = storage
         .load_blockchain()
         .expect("load_blockchain failed")
@@ -79,8 +80,7 @@ fn load_existing_chain(path: &str) -> Blockchain {
 #[test]
 #[ignore = "requires real chain.db — run manually per file header"]
 fn read_committed_trie_root() {
-    let path = std::env::var("TEST_CHAIN_DB")
-        .expect("set TEST_CHAIN_DB=/path/to/chain.db");
+    let path = std::env::var("TEST_CHAIN_DB").expect("set TEST_CHAIN_DB=/path/to/chain.db");
 
     // If TEST_HEIGHT is unset, dump tip + recent roots and return.
     if std::env::var("TEST_HEIGHT").is_err() {
@@ -91,11 +91,20 @@ fn read_committed_trie_root() {
         println!("TOTAL_MINTED={}", bc.total_minted);
         println!("VOYAGER_ACTIVATED={}", bc.voyager_activated);
         println!("EVM_ACTIVATED={}", bc.evm_activated);
-        println!("STAKE_REGISTRY_VALIDATORS={}", bc.stake_registry.validators.len());
-        println!("ACTIVE_VALIDATORS={}", bc.authority.active_validators().len());
+        println!(
+            "STAKE_REGISTRY_VALIDATORS={}",
+            bc.stake_registry.validators.len()
+        );
+        println!(
+            "ACTIVE_VALIDATORS={}",
+            bc.authority.active_validators().len()
+        );
         println!("--- last 5 trie roots ---");
         for h in tip.saturating_sub(4)..=tip {
-            let r = bc.trie_root_at(h).map(hex::encode).unwrap_or_else(|| "<none>".to_string());
+            let r = bc
+                .trie_root_at(h)
+                .map(hex::encode)
+                .unwrap_or_else(|| "<none>".to_string());
             println!("  h={} root={}", h, r);
         }
         // If TEST_BLOCK_AT is set, dump that specific block's header instead of tip's.
@@ -214,7 +223,9 @@ fn apply_canonical_block_to_forensic() {
             latest.hash
         );
         if latest.hash != block_prev {
-            println!("WARN: tip hash != block.previous_hash — chain not contiguous, peer-apply will reject");
+            println!(
+                "WARN: tip hash != block.previous_hash — chain not contiguous, peer-apply will reject"
+            );
         }
     }
 
@@ -226,10 +237,14 @@ fn apply_canonical_block_to_forensic() {
             println!("COMPUTED_STATE_ROOT={:?}", post_root);
             match post_root {
                 Some(computed) if computed == declared_state_root => {
-                    println!("VERDICT=MATCH — v2.1.23 binary reproduces canonical state_root for h={block_height}");
-                    println!("CONCLUSION=#268 NOT reproduced on this binary on this input — \
+                    println!(
+                        "VERDICT=MATCH — v2.1.23 binary reproduces canonical state_root for h={block_height}"
+                    );
+                    println!(
+                        "CONCLUSION=#268 NOT reproduced on this binary on this input — \
                               either the empty-hash fix closed it OR canary's bug was \
-                              transient (e.g. live-rsync MDBX inconsistency, not code).");
+                              transient (e.g. live-rsync MDBX inconsistency, not code)."
+                    );
                 }
                 Some(computed) => {
                     println!("VERDICT=MISMATCH — #268 reproducing on v2.1.23!");
@@ -237,7 +252,9 @@ fn apply_canonical_block_to_forensic() {
                     println!("  computed:  {}", computed);
                     panic!("#268 STATE_ROOT MISMATCH — root cause repro pinned, ready to bisect");
                 }
-                None => println!("VERDICT=COMPUTED_ROOT_MISSING — apply returned Ok but trie has no root at this height (unexpected)"),
+                None => println!(
+                    "VERDICT=COMPUTED_ROOT_MISSING — apply returned Ok but trie has no root at this height (unexpected)"
+                ),
             }
         }
         Err(e) => {
@@ -279,8 +296,7 @@ fn load_block_by_height(
 #[test]
 #[ignore = "requires real chain.db — run manually; full 388K walk is a few minutes"]
 fn sweep_mdbx_block_gaps() {
-    let path = std::env::var("TEST_CHAIN_DB")
-        .expect("set TEST_CHAIN_DB=/path/to/chain.db");
+    let path = std::env::var("TEST_CHAIN_DB").expect("set TEST_CHAIN_DB=/path/to/chain.db");
     let stride: u64 = std::env::var("TEST_SWEEP_STRIDE")
         .ok()
         .and_then(|v| v.parse().ok())
@@ -380,8 +396,7 @@ fn sweep_mdbx_block_gaps() {
 #[test]
 #[ignore = "requires real chain.db — run manually per file header; slow on large ranges"]
 fn replay_and_compare() {
-    let path = std::env::var("TEST_CHAIN_DB")
-        .expect("set TEST_CHAIN_DB=/path/to/chain.db");
+    let path = std::env::var("TEST_CHAIN_DB").expect("set TEST_CHAIN_DB=/path/to/chain.db");
     let from: u64 = std::env::var("TEST_HEIGHT_FROM")
         .expect("set TEST_HEIGHT_FROM=<start block index, ≥1>")
         .parse()
@@ -415,8 +430,8 @@ fn replay_and_compare() {
     let tmp = tempfile::tempdir().expect("tempdir for replay trie failed");
     let trie_path = tmp.path().join("replay-trie");
     std::fs::create_dir_all(&trie_path).expect("create replay-trie dir failed");
-    let trie_storage = sentrix_storage::MdbxStorage::open(&trie_path)
-        .expect("replay trie MDBX open failed");
+    let trie_storage =
+        sentrix_storage::MdbxStorage::open(&trie_path).expect("replay trie MDBX open failed");
     bc.init_trie(Arc::new(trie_storage))
         .expect("replay init_trie failed");
 
@@ -437,9 +452,12 @@ fn replay_and_compare() {
         let block = match load_block_by_height(&source, h) {
             Some(b) => b,
             None => {
-                println!("GAP_STOP h={} — block missing from source TABLE_META; \
+                println!(
+                    "GAP_STOP h={} — block missing from source TABLE_META; \
                           cannot proceed past this point via replay. \
-                          (See BACKLOG #16 for the mainnet-wide 7K gap.)", h);
+                          (See BACKLOG #16 for the mainnet-wide 7K gap.)",
+                    h
+                );
                 gap_stop = Some(h);
                 break;
             }
@@ -505,7 +523,10 @@ fn replay_and_compare() {
         let block = match load_block_by_height(&source, h) {
             Some(b) => b,
             None => {
-                println!("COMPARE_GAP_STOP h={} — block missing from source TABLE_META", h);
+                println!(
+                    "COMPARE_GAP_STOP h={} — block missing from source TABLE_META",
+                    h
+                );
                 break;
             }
         };
@@ -537,7 +558,10 @@ fn replay_and_compare() {
     if mismatches == 0 {
         println!("CUMULATIVE_OK blocks={}", to - from + 1);
     } else {
-        println!("CUMULATIVE_MISMATCH count={} range={}..={}", mismatches, from, to);
+        println!(
+            "CUMULATIVE_MISMATCH count={} range={}..={}",
+            mismatches, from, to
+        );
     }
 }
 
@@ -591,8 +615,8 @@ fn replay_and_compare() {
 #[test]
 #[ignore = "requires two real chain.db snapshots + operator prep — manual run per file header"]
 fn snapshot_seed_env_repro() {
-    let state_path = std::env::var("TEST_STATE_DB")
-        .expect("set TEST_STATE_DB=/path/to/starting-state/chain.db");
+    let state_path =
+        std::env::var("TEST_STATE_DB").expect("set TEST_STATE_DB=/path/to/starting-state/chain.db");
     let block_src_path = std::env::var("TEST_BLOCK_SOURCE_DB")
         .expect("set TEST_BLOCK_SOURCE_DB=/path/to/block-source/chain.db");
     let from: u64 = std::env::var("TEST_HEIGHT_FROM")
@@ -609,8 +633,7 @@ fn snapshot_seed_env_repro() {
     // reconstructs Blockchain at that DB's tip height, including the
     // full `accounts` map + `authority` registry. Trie is bound to the
     // SAME mdbx so `trie_root_at(h)` can answer for pre-seed heights.
-    let state_storage =
-        Storage::open(&state_path).expect("state snapshot chain.db open failed");
+    let state_storage = Storage::open(&state_path).expect("state snapshot chain.db open failed");
     let mut bc = state_storage
         .load_blockchain()
         .expect("state snapshot load_blockchain failed")
@@ -628,8 +651,7 @@ fn snapshot_seed_env_repro() {
         from
     );
 
-    let block_source =
-        Storage::open(&block_src_path).expect("block source chain.db open failed");
+    let block_source = Storage::open(&block_src_path).expect("block source chain.db open failed");
 
     println!("STATE_DB={}", state_path);
     println!("STATE_TIP={}", state_tip);
@@ -642,9 +664,12 @@ fn snapshot_seed_env_repro() {
         let block = match load_block_by_height(&block_source, h) {
             Some(b) => b,
             None => {
-                println!("BLOCK_SOURCE_GAP h={} — block missing from source TABLE_META; \
+                println!(
+                    "BLOCK_SOURCE_GAP h={} — block missing from source TABLE_META; \
                           stopping. Pick a range fully inside a contiguous range \
-                          (see BACKLOG #16 for the mainnet-wide 7K gap).", h);
+                          (see BACKLOG #16 for the mainnet-wide 7K gap).",
+                    h
+                );
                 break;
             }
         };

--- a/crates/sentrix-evm/src/database.rs
+++ b/crates/sentrix-evm/src/database.rs
@@ -293,7 +293,11 @@ mod tests {
         // Slot 0 = totalSupply; arbitrary 32-byte value.
         let value = U256::from(1_000_000u64);
         let slot_hex = format!("{:064x}", U256::ZERO);
-        acct_db.store_contract_storage(contract_addr, &slot_hex, value.to_be_bytes::<32>().to_vec());
+        acct_db.store_contract_storage(
+            contract_addr,
+            &slot_hex,
+            value.to_be_bytes::<32>().to_vec(),
+        );
 
         let mut db = SentrixEvmDb::from_account_db(&acct_db);
         let addr = parse_sentrix_address(contract_addr).expect("valid addr");

--- a/crates/sentrix-evm/src/executor.rs
+++ b/crates/sentrix-evm/src/executor.rs
@@ -201,9 +201,10 @@ where
                 // saw "execution reverted" with no reason and dApps couldn't
                 // distinguish e.g. `ZeroValue()` from `Slippage()`. Wallets +
                 // wagmi rely on this data to display human revert reasons.
-                ExecutionResult::Revert { output: revert_bytes, .. } => {
-                    (None, revert_bytes.to_vec())
-                }
+                ExecutionResult::Revert {
+                    output: revert_bytes,
+                    ..
+                } => (None, revert_bytes.to_vec()),
                 _ => (None, Vec::new()),
             };
             // Distinguish Halt (OOG, InvalidOpcode, StackOverflow, etc) from
@@ -217,7 +218,8 @@ where
             if let ExecutionResult::Halt { reason, .. } = &exec_result {
                 return Err(format!(
                     "EVM halt ({:?}) — gas_used={}; not a contract revert",
-                    reason, exec_result.tx_gas_used()
+                    reason,
+                    exec_result.tx_gas_used()
                 ));
             }
             let receipt = TxReceipt {
@@ -414,7 +416,11 @@ mod tests {
             .unwrap_or_default();
 
         let result = execute_tx_with_state(db, tx, INITIAL_BASE_FEE, 7119);
-        assert!(result.is_ok(), "execute_tx_with_state failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "execute_tx_with_state failed: {:?}",
+            result.err()
+        );
         let (receipt, state) = result.unwrap();
         assert!(receipt.success);
         assert!(
@@ -457,6 +463,9 @@ mod tests {
         let (_receipt, state) = result.expect("no-op call should succeed");
         // State map is returned even for trivial txs — sender is touched
         // by gas deduction at minimum.
-        assert!(!state.is_empty(), "state diff must not be empty even for no-op");
+        assert!(
+            !state.is_empty(),
+            "state diff must not be empty even for no-op"
+        );
     }
 }

--- a/crates/sentrix-evm/src/lib.rs
+++ b/crates/sentrix-evm/src/lib.rs
@@ -21,10 +21,10 @@ pub use database::{SentrixEvmDb, parse_sentrix_address};
 pub use executor::{
     TxReceipt, execute_call, execute_call_with_state, execute_tx, execute_tx_with_state,
 };
-pub use writeback::commit_state_to_account_db;
 pub use gas::{BLOCK_GAS_LIMIT, INITIAL_BASE_FEE};
 pub use logs::{
     LogsBloom, StoredLog, add_log_to_bloom, bloom_contains, bloom_union, compute_logs_bloom,
     empty_bloom, log_key, log_key_prefix,
 };
 pub use receipts::{StoredReceipt, receipt_key};
+pub use writeback::commit_state_to_account_db;

--- a/crates/sentrix-evm/src/receipts.rs
+++ b/crates/sentrix-evm/src/receipts.rs
@@ -102,7 +102,10 @@ mod tests {
     fn receipt_key_parses_with_and_without_prefix() {
         // Split into halves so the pre-commit "64-hex" guard doesn't
         // flag this test data as a private key.
-        let h = format!("{}{}", "8c333b24083ac83bb2a30817fd56cca3", "fde8fe69d916d6deeaa581b2354942a0");
+        let h = format!(
+            "{}{}",
+            "8c333b24083ac83bb2a30817fd56cca3", "fde8fe69d916d6deeaa581b2354942a0"
+        );
         let k1 = receipt_key(&h).expect("valid hex");
         let k2 = receipt_key(&format!("0x{h}")).expect("valid hex with 0x");
         assert_eq!(k1, k2);

--- a/crates/sentrix-evm/src/writeback.rs
+++ b/crates/sentrix-evm/src/writeback.rs
@@ -76,10 +76,8 @@ pub fn commit_state_to_account_db(
     // iteration is non-deterministic across processes; sorting removes a
     // potential source of cross-validator log divergence. Matches the
     // init_trie backfill pattern at blockchain.rs:583.
-    let mut touched: Vec<(&Address, &revm::state::Account)> = state
-        .iter()
-        .filter(|(_, acc)| acc.is_touched())
-        .collect();
+    let mut touched: Vec<(&Address, &revm::state::Account)> =
+        state.iter().filter(|(_, acc)| acc.is_touched()).collect();
     touched.sort_by_key(|(addr, _)| *addr);
 
     for (addr, evm_account) in touched {
@@ -204,7 +202,10 @@ mod tests {
         );
         let mut db = AccountDB::new();
         commit_state_to_account_db(&state, &mut db).unwrap();
-        assert_eq!(db.get_balance("0x0101010101010101010101010101010101010101"), 2100);
+        assert_eq!(
+            db.get_balance("0x0101010101010101010101010101010101010101"),
+            2100
+        );
     }
 
     #[test]
@@ -213,7 +214,10 @@ mod tests {
         state.insert(addr(0x02), touched_account(U256::ZERO, 7));
         let mut db = AccountDB::new();
         commit_state_to_account_db(&state, &mut db).unwrap();
-        assert_eq!(db.get_nonce("0x0202020202020202020202020202020202020202"), 7);
+        assert_eq!(
+            db.get_nonce("0x0202020202020202020202020202020202020202"),
+            7
+        );
     }
 
     #[test]
@@ -265,8 +269,14 @@ mod tests {
             "new contract bytecode must be persisted"
         );
         let addr_str = "0x0404040404040404040404040404040404040404";
-        let acct = db.accounts.get(addr_str).expect("contract account must exist");
-        assert_eq!(acct.code_hash, code_hash_bytes, "set_contract must mark account");
+        let acct = db
+            .accounts
+            .get(addr_str)
+            .expect("contract account must exist");
+        assert_eq!(
+            acct.code_hash, code_hash_bytes,
+            "set_contract must mark account"
+        );
         assert!(acct.is_contract());
     }
 
@@ -280,15 +290,23 @@ mod tests {
 
         let mut db = AccountDB::new();
         // Pre-populate so we can see the zero-out.
-        db.credit("0x0505050505050505050505050505050505050505", 100).unwrap();
+        db.credit("0x0505050505050505050505050505050505050505", 100)
+            .unwrap();
         db.set_contract("0x0505050505050505050505050505050505050505", [0xBB; 32]);
 
         commit_state_to_account_db(&state, &mut db).unwrap();
 
         let addr_str = "0x0505050505050505050505050505050505050505";
-        assert_eq!(db.get_balance(addr_str), 0, "selfdestructed balance must be zeroed");
+        assert_eq!(
+            db.get_balance(addr_str),
+            0,
+            "selfdestructed balance must be zeroed"
+        );
         let acct = db.accounts.get(addr_str).unwrap();
-        assert_eq!(acct.code_hash, EMPTY_CODE_HASH, "selfdestructed code_hash must be EMPTY");
+        assert_eq!(
+            acct.code_hash, EMPTY_CODE_HASH,
+            "selfdestructed code_hash must be EMPTY"
+        );
     }
 
     #[test]
@@ -315,7 +333,10 @@ mod tests {
         commit_state_to_account_db(&state, &mut db).unwrap();
 
         // Account should not even exist in AccountDB since we never touched it.
-        assert!(!db.accounts.contains_key("0x0606060606060606060606060606060606060606"));
+        assert!(
+            !db.accounts
+                .contains_key("0x0606060606060606060606060606060606060606")
+        );
     }
 
     #[test]
@@ -326,8 +347,10 @@ mod tests {
         let mut state_b = EvmState::default();
 
         for i in 0u8..5 {
-            let mut acc_a = touched_account(U256::from((i as u64 + 1) * 10_000_000_000u64), i as u64);
-            let mut acc_b = touched_account(U256::from((i as u64 + 1) * 10_000_000_000u64), i as u64);
+            let mut acc_a =
+                touched_account(U256::from((i as u64 + 1) * 10_000_000_000u64), i as u64);
+            let mut acc_b =
+                touched_account(U256::from((i as u64 + 1) * 10_000_000_000u64), i as u64);
             acc_a.storage.insert(
                 U256::ZERO,
                 EvmStorageSlot::new_changed(U256::ZERO, U256::from(i as u64 + 100), 0),

--- a/crates/sentrix-grpc/src/lib.rs
+++ b/crates/sentrix-grpc/src/lib.rs
@@ -530,7 +530,9 @@ mod tests {
         let _ = req.at_height.is_none();
 
         let entry = ValidatorEntry {
-            address: Some(Address { value: vec![0u8; 20] }),
+            address: Some(Address {
+                value: vec![0u8; 20],
+            }),
             stake_sentri: 1_000_000_000,
             active: true,
             jailed: false,

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -65,6 +65,25 @@ pub static SWARM_TICK: AtomicU64 = AtomicU64::new(0);
 /// next session) so the Telegram alerter can fire on `rate(...) > 0`.
 pub static DROPPED_BFT_BROADCASTS: AtomicU64 = AtomicU64::new(0);
 
+// 2026-05-28 v2.2.19: apply-path observability. The fullnode silent-stall
+// class (vps6 fullnode-1 stuck 78min on 2026-05-27, fullnode-2 stuck 6.1h,
+// testnet fullnode-1 stuck 4.5d) is invisible from outside: container is
+// alive, RPC answers, libp2p peers connected, but chain.height() never
+// advances. v2.2.18 closed the BFT-side silent-stall (driver-confirmed
+// cast); fullnodes don't run BFT — they only receive blocks via the three
+// apply paths below. We don't know yet whether the stall lives in
+// gossipsub delivery, the chain.write() lock, add_block_from_peer
+// internals, or the post-apply bookkeeping, so this watchdog records
+// counts at each step and logs a stall-class diagnostic instead of
+// speculating. Next stall reproduces with these numbers in the log.
+pub static APPLY_RX_GOSSIP: AtomicU64 = AtomicU64::new(0);
+pub static APPLY_RX_REQ: AtomicU64 = AtomicU64::new(0);
+pub static APPLY_RX_SYNC: AtomicU64 = AtomicU64::new(0);
+pub static APPLY_OK: AtomicU64 = AtomicU64::new(0);
+pub static APPLY_ERR: AtomicU64 = AtomicU64::new(0);
+pub static APPLY_LAST_HEIGHT: AtomicU64 = AtomicU64::new(0);
+pub static APPLY_LAST_UNIX: AtomicU64 = AtomicU64::new(0);
+
 use futures::StreamExt;
 use libp2p::{
     Multiaddr, PeerId, Swarm, SwarmBuilder, gossipsub,
@@ -81,14 +100,12 @@ use crate::behaviour::{
     BLOCKS_TOPIC, GossipBlock, GossipTransaction, SentrixBehaviour, SentrixBehaviourEvent,
     SentrixRequest, SentrixResponse, TXS_TOPIC, VALIDATOR_ADVERTS_TOPIC,
 };
-use sentrix_wire::{
-    GossipBftPrecommit, GossipBftPrevote, GossipBftProposal, GossipBftRoundStatus,
-};
 use crate::node::{NodeEvent, SharedBlockchain};
 use sentrix_primitives::block::Block;
 use sentrix_primitives::error::{SentrixError, SentrixResult};
 use sentrix_primitives::transaction::Transaction;
 use sentrix_wire::MultiaddrAdvertisement;
+use sentrix_wire::{GossipBftPrecommit, GossipBftPrevote, GossipBftProposal, GossipBftRoundStatus};
 
 // The rate-limit + multiaddr-helper bits used to live inline below;
 // they were independent of the swarm logic and just bulked up the
@@ -235,6 +252,67 @@ impl LibP2pNode {
         tokio::spawn(async move {
             if let Err(e) = run_swarm(kp, bc, event_tx, cmd_rx).await {
                 tracing::error!("libp2p swarm task exited with error: {}", e);
+            }
+        });
+
+        // 2026-05-28 v2.2.19: apply-watchdog. Every 30s, drains the per-path
+        // RX/OK/ERR counters and reports apply_age (seconds since last
+        // successful apply). Classifies stalls:
+        //   • rx_total > 0 + apply_age > 120s  → SILENT-STALL (apply path
+        //     stuck or rejecting everything); previously invisible
+        //   • rx_total = 0 + apply_age > 120s  → PEER-MESH IDLE (gossipsub
+        //     mesh broken; different class — see libp2p peer table)
+        // Logs at info on every tick so grep apply_watchdog gives a clean
+        // history. Errors only on actual stall classification.
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(30));
+            interval.tick().await; // skip immediate first tick at startup
+            loop {
+                interval.tick().await;
+                let now_unix = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                let last_apply_unix = APPLY_LAST_UNIX.load(Ordering::Relaxed);
+                let last_height = APPLY_LAST_HEIGHT.load(Ordering::Relaxed);
+                let rx_gossip = APPLY_RX_GOSSIP.swap(0, Ordering::Relaxed);
+                let rx_req = APPLY_RX_REQ.swap(0, Ordering::Relaxed);
+                let rx_sync = APPLY_RX_SYNC.swap(0, Ordering::Relaxed);
+                let ok = APPLY_OK.swap(0, Ordering::Relaxed);
+                let err = APPLY_ERR.swap(0, Ordering::Relaxed);
+                let apply_age = if last_apply_unix == 0 {
+                    0
+                } else {
+                    now_unix.saturating_sub(last_apply_unix)
+                };
+                let rx_total = rx_gossip + rx_req + rx_sync;
+
+                tracing::info!(
+                    target: "apply_watchdog",
+                    "30s tick: rx_gossip={} rx_req={} rx_sync={} ok={} err={} \
+                     last_h={} apply_age={}s",
+                    rx_gossip, rx_req, rx_sync, ok, err, last_height, apply_age,
+                );
+
+                if last_apply_unix > 0 && apply_age > 120 && rx_total > 0 {
+                    tracing::error!(
+                        target: "apply_watchdog",
+                        "SILENT-STALL: {} blocks received in last 30s but no \
+                         successful apply in {}s (last_h={}) — apply path stuck \
+                         on write-lock, MDBX commit, or rejecting everything. \
+                         Inspect chain.write() holders + DROPPED_BFT_BROADCASTS \
+                         + EVENT_TX_DROPPED counters and dump tokio task tree.",
+                        rx_total, apply_age, last_height,
+                    );
+                } else if last_apply_unix > 0 && apply_age > 120 {
+                    tracing::warn!(
+                        target: "apply_watchdog",
+                        "PEER-MESH IDLE: no apply in {}s and zero blocks received \
+                         (last_h={}) — gossipsub mesh broken or all peers behind. \
+                         Inspect connected_peers + gossip mesh size.",
+                        apply_age, last_height,
+                    );
+                }
             }
         });
 
@@ -1003,6 +1081,7 @@ async fn on_swarm_event(
                             );
                             return;
                         }
+                        APPLY_RX_GOSSIP.fetch_add(1, Ordering::Relaxed);
                         let bc = blockchain.clone();
                         let etx = event_tx.clone();
                         let peer = propagation_source;
@@ -1010,6 +1089,13 @@ async fn on_swarm_event(
                             let mut chain = bc.write().await;
                             match chain.add_block_from_peer(gossip.block.clone()) {
                                 Ok(()) => {
+                                    APPLY_OK.fetch_add(1, Ordering::Relaxed);
+                                    APPLY_LAST_HEIGHT.store(gossip.block.index, Ordering::Relaxed);
+                                    if let Ok(now) = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                    {
+                                        APPLY_LAST_UNIX.store(now.as_secs(), Ordering::Relaxed);
+                                    }
                                     // Asymmetric-recording fix bundle (see audits/reward-distribution-flow-audit-2026-04-27.md).
                                     // Apply same bookkeeping that main.rs validator-finalize paths apply,
                                     // so libp2p-applied blocks have identical state mutations.
@@ -1053,6 +1139,7 @@ async fn on_swarm_event(
                                     let _ = etx.send(NodeEvent::NewBlock(updated)).await;
                                 }
                                 Err(e) => {
+                                    APPLY_ERR.fetch_add(1, Ordering::Relaxed);
                                     tracing::debug!("gossip block from {} rejected: {}", peer, e);
                                 }
                             }
@@ -1115,7 +1202,8 @@ async fn on_swarm_event(
                             if pv.validator != proposal.proposer {
                                 tracing::warn!(
                                     "gossip bft proposal: embedded prevote signer {} != proposer {} — dropping",
-                                    &pv.validator, &proposal.proposer,
+                                    &pv.validator,
+                                    &proposal.proposer,
                                 );
                             } else if !triple_matches {
                                 tracing::warn!(
@@ -1173,7 +1261,11 @@ async fn on_swarm_event(
                             );
                             return;
                         }
-                        try_send_event(event_tx, NodeEvent::BftPrecommit(precommit), "BftPrecommit");
+                        try_send_event(
+                            event_tx,
+                            NodeEvent::BftPrecommit(precommit),
+                            "BftPrecommit",
+                        );
                     }
                     Err(e) => tracing::debug!("gossip bft precommit: bad bincode: {}", e),
                 }
@@ -1575,6 +1667,7 @@ async fn on_inbound_request(
                 );
                 return;
             }
+            APPLY_RX_REQ.fetch_add(1, Ordering::Relaxed);
             let bc = blockchain.clone();
             let etx = event_tx.clone();
             tokio::spawn(async move {
@@ -1584,6 +1677,13 @@ async fn on_inbound_request(
                 let block_justification = block.justification.clone();
                 match chain.add_block_from_peer(*block.clone()) {
                     Ok(()) => {
+                        APPLY_OK.fetch_add(1, Ordering::Relaxed);
+                        APPLY_LAST_HEIGHT.store(block_idx, Ordering::Relaxed);
+                        if let Ok(now) =
+                            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)
+                        {
+                            APPLY_LAST_UNIX.store(now.as_secs(), Ordering::Relaxed);
+                        }
                         // Asymmetric-recording fix bundle (see audits/reward-distribution-flow-audit-2026-04-27.md).
                         if let Some(j) = &block_justification {
                             let active = chain.stake_registry.active_set.clone();
@@ -1615,6 +1715,7 @@ async fn on_inbound_request(
                         let _ = etx.send(NodeEvent::NewBlock(updated)).await;
                     }
                     Err(e) => {
+                        APPLY_ERR.fetch_add(1, Ordering::Relaxed);
                         tracing::warn!("libp2p: rejected block from {}: {}", peer, e);
                     }
                 }
@@ -1724,7 +1825,8 @@ async fn on_inbound_request(
                 if pv.validator != proposal.proposer {
                     tracing::warn!(
                         "libp2p rr bft proposal: embedded prevote signer {} != proposer {} — dropping",
-                        &pv.validator, &proposal.proposer,
+                        &pv.validator,
+                        &proposal.proposer,
                     );
                 } else if !triple_matches {
                     tracing::warn!(
@@ -1876,8 +1978,16 @@ async fn on_inbound_response(
                     skipped += 1;
                     continue;
                 }
+                APPLY_RX_SYNC.fetch_add(1, Ordering::Relaxed);
                 match chain.add_block_from_peer(block.clone()) {
                     Ok(()) => {
+                        APPLY_OK.fetch_add(1, Ordering::Relaxed);
+                        APPLY_LAST_HEIGHT.store(block.index, Ordering::Relaxed);
+                        if let Ok(now) =
+                            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)
+                        {
+                            APPLY_LAST_UNIX.store(now.as_secs(), Ordering::Relaxed);
+                        }
                         // ── Asymmetric-recording fix bundle (2026-04-27 audit) ──
                         // Validator-finalize paths in main.rs apply 3 bookkeeping
                         // calls per block: record_block_signatures (liveness),
@@ -1919,6 +2029,7 @@ async fn on_inbound_response(
                         synced += 1;
                     }
                     Err(e) => {
+                        APPLY_ERR.fetch_add(1, Ordering::Relaxed);
                         tracing::warn!("libp2p sync: block {} failed: {}", block.index, e);
                         break;
                     }
@@ -2276,5 +2387,4 @@ mod tests {
             sentrix_primitives::block::Block::new(0, "0".to_string(), vec![], "v1".to_string());
         node.broadcast_block(&block).await; // must not panic
     }
-
 }

--- a/crates/sentrix-primitives/src/account.rs
+++ b/crates/sentrix-primitives/src/account.rs
@@ -534,7 +534,8 @@ mod tests {
         db.credit("alice", 100_000).unwrap();
         let pre_nonce = db.get_nonce("alice");
 
-        db.charge_fee_only("alice", 10_000).expect("charge should succeed");
+        db.charge_fee_only("alice", 10_000)
+            .expect("charge should succeed");
 
         assert_eq!(db.get_balance("alice"), 90_000, "fee should be deducted");
         assert_eq!(
@@ -552,9 +553,16 @@ mod tests {
         let result = db.charge_fee_only("alice", 10_000);
         assert!(matches!(
             result,
-            Err(SentrixError::InsufficientBalance { have: 9_999, need: 10_000 })
+            Err(SentrixError::InsufficientBalance {
+                have: 9_999,
+                need: 10_000
+            })
         ));
-        assert_eq!(db.get_balance("alice"), 9_999, "balance unchanged on rejection");
+        assert_eq!(
+            db.get_balance("alice"),
+            9_999,
+            "balance unchanged on rejection"
+        );
         assert_eq!(db.get_nonce("alice"), 0, "nonce unchanged on rejection");
     }
 
@@ -619,7 +627,10 @@ mod tests {
         assert_eq!(after_pass1, 999_995_000);
         assert_eq!(after_pass1_burned, 5_000);
         // Native invariant holds: supply drop == burn increment.
-        assert_eq!(initial_supply - after_pass1, after_pass1_burned - initial_burned);
+        assert_eq!(
+            initial_supply - after_pass1,
+            after_pass1_burned - initial_burned
+        );
 
         // Step 3 — Simulate `commit_state_to_account_db` writeback after
         // revm internally deducted gas. Real values: gas_used = 100_000,

--- a/crates/sentrix-primitives/src/events.rs
+++ b/crates/sentrix-primitives/src/events.rs
@@ -108,22 +108,22 @@ pub trait EventEmitter: Send + Sync + std::fmt::Debug {
 /// Native TokenOp event — sentrix_subscribe(tokenOps).
 #[derive(Debug, Clone)]
 pub struct TokenOpEvent {
-    pub op: String,         // "deploy" / "transfer" / "burn" / "mint" / "approve" / etc.
-    pub contract: String,   // 0x-prefixed contract address (or "" for deploy)
-    pub from: String,       // 0x-prefixed sender
-    pub to: String,         // 0x-prefixed recipient (or "" for burn)
-    pub amount: u64,        // token amount in base units (decimals applied by display)
-    pub txid: String,       // tx hash
+    pub op: String,       // "deploy" / "transfer" / "burn" / "mint" / "approve" / etc.
+    pub contract: String, // 0x-prefixed contract address (or "" for deploy)
+    pub from: String,     // 0x-prefixed sender
+    pub to: String,       // 0x-prefixed recipient (or "" for burn)
+    pub amount: u64,      // token amount in base units (decimals applied by display)
+    pub txid: String,     // tx hash
     pub block_height: u64,
 }
 
 /// Native StakingOp event — sentrix_subscribe(stakingOps).
 #[derive(Debug, Clone)]
 pub struct StakingOpEvent {
-    pub op: String,         // "delegate" / "undelegate" / "claim_rewards" / etc.
-    pub validator: String,  // 0x-prefixed validator address
-    pub delegator: String,  // 0x-prefixed delegator (== validator for self-stake)
-    pub amount: u64,        // amount in sentri (0 for ClaimRewards / Unjail)
+    pub op: String,        // "delegate" / "undelegate" / "claim_rewards" / etc.
+    pub validator: String, // 0x-prefixed validator address
+    pub delegator: String, // 0x-prefixed delegator (== validator for self-stake)
+    pub amount: u64,       // amount in sentri (0 for ClaimRewards / Unjail)
     pub txid: String,
     pub block_height: u64,
 }

--- a/crates/sentrix-primitives/src/transaction.rs
+++ b/crates/sentrix-primitives/src/transaction.rs
@@ -319,7 +319,9 @@ pub enum StakingOp {
     /// Fork-gated by `ADD_SELF_STAKE_HEIGHT` (env-controlled, default
     /// `u64::MAX` = disabled). Wire format stable on enum-add; gate
     /// check happens in dispatch.
-    AddSelfStake { amount: u64 },
+    AddSelfStake {
+        amount: u64,
+    },
 }
 
 /// Phase A data type: per-validator missed-block evidence for an epoch.
@@ -940,14 +942,12 @@ mod tests {
             epoch: 42,
             epoch_start_block: 590100,
             epoch_end_block: 604499,
-            evidence: vec![
-                JailEvidence {
-                    validator: "0x87c9976d4b2e360b9fbb87e4bd5442edce2a7511".into(),
-                    signed_count: 3000,
-                    missed_count: 11400,
-                    justification_hashes: vec!["abc123".into(), "def456".into()],
-                },
-            ],
+            evidence: vec![JailEvidence {
+                validator: "0x87c9976d4b2e360b9fbb87e4bd5442edce2a7511".into(),
+                signed_count: 3000,
+                missed_count: 11400,
+                justification_hashes: vec!["abc123".into(), "def456".into()],
+            }],
             active_set: vec![
                 "0x87c9976d4b2e360b9fbb87e4bd5442edce2a7511".into(),
                 "0x753f2f68829fbe76a0132295624f48b27ce2e2d9".into(),
@@ -1064,12 +1064,17 @@ mod tests {
         // the same StakingOp.
         let re_encoded = decoded.encode().expect("encode");
         let re_decoded = StakingOp::decode(&re_encoded).expect("re-decode");
-        assert_eq!(decoded, re_decoded, "round-trip must preserve the StakingOp");
+        assert_eq!(
+            decoded, re_decoded,
+            "round-trip must preserve the StakingOp"
+        );
     }
 
     #[test]
     fn test_add_self_stake_encode_decode_roundtrip() {
-        let op = StakingOp::AddSelfStake { amount: 1_500_000_000 };
+        let op = StakingOp::AddSelfStake {
+            amount: 1_500_000_000,
+        };
         let encoded = op.encode().expect("encode");
         let decoded = StakingOp::decode(&encoded).expect("decode");
         match decoded {
@@ -1155,7 +1160,10 @@ mod tests {
         let encoded = op.encode().expect("encode");
         assert!(encoded.contains("\"op\":\"set_approval_for_all\""));
         let decoded = TokenOp::decode(&encoded).expect("decode");
-        assert!(matches!(decoded, TokenOp::SetApprovalForAll { approved: true, .. }));
+        assert!(matches!(
+            decoded,
+            TokenOp::SetApprovalForAll { approved: true, .. }
+        ));
     }
 
     #[test]
@@ -1175,32 +1183,72 @@ mod tests {
     #[test]
     fn test_is_nft_family_predicate() {
         // SRC-20 fungible variants → NOT NFT family
-        assert!(!TokenOp::Deploy {
-            name: "x".into(), symbol: "X".into(), decimals: 8, supply: 0, max_supply: 0
-        }.is_nft_family());
-        assert!(!TokenOp::Transfer {
-            contract: "c".into(), to: "t".into(), amount: 1
-        }.is_nft_family());
+        assert!(
+            !TokenOp::Deploy {
+                name: "x".into(),
+                symbol: "X".into(),
+                decimals: 8,
+                supply: 0,
+                max_supply: 0
+            }
+            .is_nft_family()
+        );
+        assert!(
+            !TokenOp::Transfer {
+                contract: "c".into(),
+                to: "t".into(),
+                amount: 1
+            }
+            .is_nft_family()
+        );
 
         // SRC-721 variants → NFT family
-        assert!(TokenOp::DeployNft {
-            name: "n".into(), symbol: "N".into(), base_uri: "u".into(), max_supply: 0
-        }.is_nft_family());
-        assert!(TokenOp::MintNft {
-            contract: "c".into(), to: "t".into(), token_id: 1, metadata_uri: String::new()
-        }.is_nft_family());
-        assert!(TokenOp::SetApprovalForAll {
-            contract: "c".into(), operator: "o".into(), approved: false
-        }.is_nft_family());
+        assert!(
+            TokenOp::DeployNft {
+                name: "n".into(),
+                symbol: "N".into(),
+                base_uri: "u".into(),
+                max_supply: 0
+            }
+            .is_nft_family()
+        );
+        assert!(
+            TokenOp::MintNft {
+                contract: "c".into(),
+                to: "t".into(),
+                token_id: 1,
+                metadata_uri: String::new()
+            }
+            .is_nft_family()
+        );
+        assert!(
+            TokenOp::SetApprovalForAll {
+                contract: "c".into(),
+                operator: "o".into(),
+                approved: false
+            }
+            .is_nft_family()
+        );
 
         // SRC-1155 variants → NFT family
-        assert!(TokenOp::DeployMulti {
-            name: "n".into(), symbol: "N".into(), base_uri: "u".into()
-        }.is_nft_family());
-        assert!(TokenOp::BatchTransferMulti {
-            contract: "c".into(), from: "f".into(), to: "t".into(),
-            ids: vec![1], amounts: vec![1]
-        }.is_nft_family());
+        assert!(
+            TokenOp::DeployMulti {
+                name: "n".into(),
+                symbol: "N".into(),
+                base_uri: "u".into()
+            }
+            .is_nft_family()
+        );
+        assert!(
+            TokenOp::BatchTransferMulti {
+                contract: "c".into(),
+                from: "f".into(),
+                to: "t".into(),
+                ids: vec![1],
+                amounts: vec![1]
+            }
+            .is_nft_family()
+        );
     }
 
     #[test]

--- a/crates/sentrix-primitives/tests/account_proptest.rs
+++ b/crates/sentrix-primitives/tests/account_proptest.rs
@@ -67,18 +67,14 @@ fn op_strategy() -> impl Strategy<Value = Op> {
     prop_oneof![
         (addr.clone(), small_amount.clone()).prop_map(|(addr, amount)| Op::Credit { addr, amount }),
         (addr.clone(), small_fee.clone()).prop_map(|(from, fee)| Op::ChargeFee { from, fee }),
-        (
-            addr.clone(),
-            addr.clone(),
-            small_amount,
-            small_fee,
-        )
-            .prop_map(|(from, to, amount, fee)| Op::Transfer {
+        (addr.clone(), addr.clone(), small_amount, small_fee,).prop_map(
+            |(from, to, amount, fee)| Op::Transfer {
                 from,
                 to,
                 amount,
                 fee,
-            }),
+            }
+        ),
     ]
 }
 

--- a/crates/sentrix-prom-exporter/src/main.rs
+++ b/crates/sentrix-prom-exporter/src/main.rs
@@ -23,8 +23,8 @@
 //! is `count(count by (sentrix_chain_tip_hash_short) (sentrix_chain_tip_hash_short)) > 1`.
 
 use prometheus::{
-    register_gauge_vec, register_int_counter_vec, register_int_gauge_vec, Encoder,
-    GaugeVec, IntCounterVec, IntGaugeVec, TextEncoder,
+    Encoder, GaugeVec, IntCounterVec, IntGaugeVec, TextEncoder, register_gauge_vec,
+    register_int_counter_vec, register_int_gauge_vec,
 };
 use serde::Deserialize;
 use std::sync::OnceLock;
@@ -133,7 +133,8 @@ async fn poll_one(client: &reqwest::Client, t: &Target) -> Option<()> {
         .ok()?;
     let status: SentrixStatus = resp.json().await.ok()?;
 
-    HEIGHT.get()?
+    HEIGHT
+        .get()?
         .with_label_values(&[&t.name, &t.network])
         .set(status.sync_info.latest_block_height as i64);
 
@@ -141,28 +142,33 @@ async fn poll_one(client: &reqwest::Client, t: &Target) -> Option<()> {
         .duration_since(std::time::UNIX_EPOCH)
         .ok()?
         .as_secs() as f64;
-    BLOCK_AGE.get()?
+    BLOCK_AGE
+        .get()?
         .with_label_values(&[&t.name, &t.network])
         .set(now - status.sync_info.latest_block_time as f64);
 
     if let Some(v) = decode_tip_hash_short(&status.sync_info.latest_block_hash) {
-        TIP_HASH.get()?
+        TIP_HASH
+            .get()?
             .with_label_values(&[&t.name, &t.network])
             .set(v as i64);
     }
 
     if let Some(v) = status.validators {
-        ACTIVE_VALIDATORS.get()?
+        ACTIVE_VALIDATORS
+            .get()?
             .with_label_values(&[&t.network])
             .set(v.active_count as i64);
     }
     if let Some(m) = status.mempool {
-        MEMPOOL.get()?
+        MEMPOOL
+            .get()?
             .with_label_values(&[&t.name, &t.network])
             .set(m.size as i64);
     }
     if let Some(u) = status.uptime_seconds {
-        UPTIME.get()?
+        UPTIME
+            .get()?
             .with_label_values(&[&t.name, &t.network])
             .set(u as i64);
     }
@@ -180,7 +186,9 @@ async fn poll_loop(targets: Vec<Target>, interval: Duration) {
         tick.tick().await;
         for t in &targets {
             if poll_one(&client, t).await.is_none() {
-                PROBE_FAILED.get().unwrap()
+                PROBE_FAILED
+                    .get()
+                    .unwrap()
                     .with_label_values(&[&t.name, &t.network])
                     .inc();
                 warn!(target = %t.name, network = %t.network, "probe failed");
@@ -262,8 +270,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     tokio::spawn(poll_loop(targets, Duration::from_secs(interval)));
 
-    let bind = std::env::var("SENTRIX_EXPORTER_BIND")
-        .unwrap_or_else(|_| "0.0.0.0:9101".into());
+    let bind = std::env::var("SENTRIX_EXPORTER_BIND").unwrap_or_else(|_| "0.0.0.0:9101".into());
     let addr: std::net::SocketAddr = bind.parse()?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
     info!(addr = %addr, "metrics endpoint listening");
@@ -436,7 +443,9 @@ mod tests {
 
         // ── 2. Prometheus gather + encode (mirrors metrics_handler body) ──
         // Pre-populate one metric so the output is non-trivial.
-        HEIGHT.get().unwrap()
+        HEIGHT
+            .get()
+            .unwrap()
             .with_label_values(&["test-val", "test-net"])
             .set(42);
         let metric_families = prometheus::gather();
@@ -485,29 +494,42 @@ mod tests {
             url: format!("http://{}", addr),
         };
         let res = poll_one(&client, &target).await;
-        assert!(res.is_some(), "poll_one returned None — fixture handshake failed");
+        assert!(
+            res.is_some(),
+            "poll_one returned None — fixture handshake failed"
+        );
 
-        let h = HEIGHT.get().unwrap()
+        let h = HEIGHT
+            .get()
+            .unwrap()
             .get_metric_with_label_values(&["fixture", "fxnet"])
             .unwrap()
             .get();
         assert_eq!(h, 12345);
-        let m = MEMPOOL.get().unwrap()
+        let m = MEMPOOL
+            .get()
+            .unwrap()
             .get_metric_with_label_values(&["fixture", "fxnet"])
             .unwrap()
             .get();
         assert_eq!(m, 2);
-        let av = ACTIVE_VALIDATORS.get().unwrap()
+        let av = ACTIVE_VALIDATORS
+            .get()
+            .unwrap()
             .get_metric_with_label_values(&["fxnet"])
             .unwrap()
             .get();
         assert_eq!(av, 4);
-        let up = UPTIME.get().unwrap()
+        let up = UPTIME
+            .get()
+            .unwrap()
             .get_metric_with_label_values(&["fixture", "fxnet"])
             .unwrap()
             .get();
         assert_eq!(up, 60);
-        let th = TIP_HASH.get().unwrap()
+        let th = TIP_HASH
+            .get()
+            .unwrap()
             .get_metric_with_label_values(&["fixture", "fxnet"])
             .unwrap()
             .get();
@@ -522,6 +544,9 @@ mod tests {
             url: "http://127.0.0.1:1".into(),
         };
         let res = poll_one(&client, &dead).await;
-        assert!(res.is_none(), "poll_one against closed port should return None");
+        assert!(
+            res.is_none(),
+            "poll_one against closed port should return None"
+        );
     }
 }

--- a/crates/sentrix-rpc-types/src/lib.rs
+++ b/crates/sentrix-rpc-types/src/lib.rs
@@ -113,10 +113,7 @@ mod tests {
 
     #[test]
     fn test_to_hex_u128() {
-        assert_eq!(
-            to_hex_u128(u128::from(u64::MAX) + 1),
-            "0x10000000000000000"
-        );
+        assert_eq!(to_hex_u128(u128::from(u64::MAX) + 1), "0x10000000000000000");
     }
 
     #[test]

--- a/crates/sentrix-rpc/src/events.rs
+++ b/crates/sentrix-rpc/src/events.rs
@@ -33,12 +33,12 @@ pub const DEFAULT_BUS_CAPACITY: usize = 1024;
 /// special-casing Sentrix.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NewHeadEvent {
-    pub number: String,        // hex-encoded u64
-    pub hash: String,          // 0x-prefixed
+    pub number: String, // hex-encoded u64
+    pub hash: String,   // 0x-prefixed
     #[serde(rename = "parentHash")]
-    pub parent_hash: String,   // 0x-prefixed
-    pub timestamp: String,     // hex-encoded u64
-    pub miner: String,         // validator address (lowercase, 0x-prefixed)
+    pub parent_hash: String, // 0x-prefixed
+    pub timestamp: String, // hex-encoded u64
+    pub miner: String,  // validator address (lowercase, 0x-prefixed)
     #[serde(rename = "transactionsRoot")]
     pub transactions_root: String,
     #[serde(rename = "stateRoot")]
@@ -70,8 +70,9 @@ impl NewHeadEvent {
         };
         let state_root_hex = match block.state_root {
             Some(root) => format!("0x{}", hex::encode(root)),
-            None => "0x0000000000000000000000000000000000000000000000000000000000000000"
-                .to_string(),
+            None => {
+                "0x0000000000000000000000000000000000000000000000000000000000000000".to_string()
+            }
         };
         Self {
             number: to_hex(block.index),
@@ -96,9 +97,9 @@ impl NewHeadEvent {
 /// topics, data, plus block + tx context.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogEvent {
-    pub address: String, // 0x + 40 hex
+    pub address: String,     // 0x + 40 hex
     pub topics: Vec<String>, // 0x + 64 hex each
-    pub data: String, // 0x + hex
+    pub data: String,        // 0x + hex
     #[serde(rename = "blockNumber")]
     pub block_number: String, // hex u64
     #[serde(rename = "blockHash")]

--- a/crates/sentrix-rpc/src/explorer.rs
+++ b/crates/sentrix-rpc/src/explorer.rs
@@ -41,7 +41,6 @@ struct DailyCache {
 }
 static DAILY_CACHE: OnceLock<TokioMutex<Option<DailyCache>>> = OnceLock::new();
 
-
 // ── Explorer home ────────────────────────────────────────
 pub async fn explorer_home(State(state): State<SharedState>) -> Html<String> {
     const HOME_TTL: Duration = Duration::from_secs(10);

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -101,7 +101,10 @@ pub(super) async fn dispatch(method: &str, params: &Value, state: &SharedState) 
                 bc.height()
             } else if block_param == "earliest" {
                 0
-            } else if block_param == "pending" || block_param == "finalized" || block_param == "safe" {
+            } else if block_param == "pending"
+                || block_param == "finalized"
+                || block_param == "safe"
+            {
                 bc.height()
             } else {
                 match u64::from_str_radix(block_param.trim_start_matches("0x"), 16) {
@@ -232,11 +235,7 @@ async fn eth_get_transaction_by_hash(params: &Value, state: &SharedState) -> Dis
 /// CLI all crashed with "missing from address". The receipt handler does
 /// the same conversion for eth_getTransactionReceipt — this mirrors it
 /// for getTransactionByHash so the same off-the-shelf tooling works.
-fn tx_to_evm_json(
-    bc: &sentrix_core::blockchain::Blockchain,
-    txid: &str,
-    tx_data: &Value,
-) -> Value {
+fn tx_to_evm_json(bc: &sentrix_core::blockchain::Blockchain, txid: &str, tx_data: &Value) -> Value {
     // Mined location fields are Option-typed so pending / not-yet-included
     // txs surface as null rather than genesis-looking defaults (block 0,
     // empty hash). EIP-1474 clients use null on these three to detect that
@@ -245,7 +244,13 @@ fn tx_to_evm_json(
     let block_hash: Value = tx_data["block_hash"]
         .as_str()
         .filter(|h| !h.is_empty())
-        .map(|h| if h.starts_with("0x") { h.to_string() } else { format!("0x{h}") })
+        .map(|h| {
+            if h.starts_with("0x") {
+                h.to_string()
+            } else {
+                format!("0x{h}")
+            }
+        })
         .map(Value::String)
         .unwrap_or(Value::Null);
 
@@ -404,7 +409,11 @@ fn extract_vrs_from_rlp(sig_hex: &str) -> Option<(String, String, String)> {
     let v_val: u64 = if sig.v() { 1 } else { 0 };
     let r_u256 = sig.r();
     let s_u256 = sig.s();
-    Some((to_hex(v_val), format!("0x{r_u256:x}"), format!("0x{s_u256:x}")))
+    Some((
+        to_hex(v_val),
+        format!("0x{r_u256:x}"),
+        format!("0x{s_u256:x}"),
+    ))
 }
 
 async fn eth_get_transaction_receipt(params: &Value, state: &SharedState) -> DispatchResult {
@@ -506,10 +515,15 @@ async fn eth_get_transaction_receipt(params: &Value, state: &SharedState) -> Dis
                 .as_ref()
                 .and_then(|s| sentrix_evm::receipt_key(&txid).map(|k| (s, k)))
                 .and_then(|(s, k)| {
-                    s.get_bincode(sentrix_storage::tables::TABLE_RECEIPTS, &k).ok().flatten()
+                    s.get_bincode(sentrix_storage::tables::TABLE_RECEIPTS, &k)
+                        .ok()
+                        .flatten()
                 });
 
-            let gas_used: u64 = stored_receipt.as_ref().map(|r| r.gas_used).unwrap_or(21_000);
+            let gas_used: u64 = stored_receipt
+                .as_ref()
+                .map(|r| r.gas_used)
+                .unwrap_or(21_000);
 
             // cumulativeGasUsed = sum of gas_used for all txs in this block
             // up to and including this one. We sum from the receipt store
@@ -647,9 +661,14 @@ async fn eth_get_block_receipts(params: &Value, state: &SharedState) -> Dispatch
             .as_ref()
             .and_then(|s| sentrix_evm::receipt_key(&tx.txid).map(|k| (s, k)))
             .and_then(|(s, k)| {
-                s.get_bincode(sentrix_storage::tables::TABLE_RECEIPTS, &k).ok().flatten()
+                s.get_bincode(sentrix_storage::tables::TABLE_RECEIPTS, &k)
+                    .ok()
+                    .flatten()
             });
-        let gas_used: u64 = stored_receipt.as_ref().map(|r| r.gas_used).unwrap_or(21_000);
+        let gas_used: u64 = stored_receipt
+            .as_ref()
+            .map(|r| r.gas_used)
+            .unwrap_or(21_000);
         cumulative = cumulative.saturating_add(gas_used);
         let contract_address: Value = stored_receipt
             .as_ref()
@@ -913,9 +932,7 @@ async fn run_evm_dry_run(
     let tx_value: alloy_primitives::U256 = call_obj
         .get("value")
         .and_then(|v| v.as_str())
-        .and_then(|s| alloy_primitives::U256::from_str_radix(
-            s.trim_start_matches("0x"), 16
-        ).ok())
+        .and_then(|s| alloy_primitives::U256::from_str_radix(s.trim_start_matches("0x"), 16).ok())
         .unwrap_or(alloy_primitives::U256::ZERO);
 
     let tx = revm::context::TxEnv::builder()
@@ -1105,9 +1122,14 @@ async fn eth_get_storage_at(params: &Value, state: &SharedState) -> DispatchResu
     // junk here keeps the downstream storage lookup from querying with
     // a malformed key that quietly returns zero.
     let slot_hex = slot.trim_start_matches("0x");
-    if slot_hex.is_empty() || slot_hex.len() > 64 || !slot_hex.chars().all(|c| c.is_ascii_hexdigit())
+    if slot_hex.is_empty()
+        || slot_hex.len() > 64
+        || !slot_hex.chars().all(|c| c.is_ascii_hexdigit())
     {
-        return Err((-32602, "invalid storage slot (must be hex, ≤ 32 bytes)".into()));
+        return Err((
+            -32602,
+            "invalid storage slot (must be hex, ≤ 32 bytes)".into(),
+        ));
     }
     let bc = state.read().await;
     // 2026-05-06: storage block tag is params[2] per spec (params[0]=addr,

--- a/crates/sentrix-rpc/src/jsonrpc/mod.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/mod.rs
@@ -85,10 +85,7 @@ pub async fn jsonrpc_handler(
 ///
 /// HTTP and WS share this single dispatch path → 100% method parity
 /// across transports without duplicate code or drift risk.
-pub(crate) async fn dispatch_request(
-    state: &SharedState,
-    req: JsonRpcRequest,
-) -> JsonRpcResponse {
+pub(crate) async fn dispatch_request(state: &SharedState, req: JsonRpcRequest) -> JsonRpcResponse {
     let id = req.id.clone();
     let params = req.params.unwrap_or(json!([]));
     let method = req.method.as_str();

--- a/crates/sentrix-rpc/src/jsonrpc/sentrix.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/sentrix.rs
@@ -346,7 +346,11 @@ async fn sentrix_get_bft_status(state: &SharedState) -> DispatchResult {
     // while VOYAGER_FORK_HEIGHT stayed at u64::MAX as operational safety
     // — the fork-height check would wrongly report PoA. (next_height is
     // still used downstream for proposer selection, kept in scope.)
-    let consensus = if bc.voyager_activated { "DPoS+BFT" } else { "PoA" };
+    let consensus = if bc.voyager_activated {
+        "DPoS+BFT"
+    } else {
+        "PoA"
+    };
     // Live BFT round/phase state is owned by the validator loop's
     // BftEngine and not yet published into Blockchain. For now we expose
     // the chain-level finality view (last block carrying a BFT

--- a/crates/sentrix-rpc/src/jsonrpc/web3.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/web3.rs
@@ -12,11 +12,7 @@ use sha3::{Digest, Keccak256};
 
 use super::DispatchResult;
 
-pub(super) async fn dispatch(
-    method: &str,
-    params: &Value,
-    _state: &SharedState,
-) -> DispatchResult {
+pub(super) async fn dispatch(method: &str, params: &Value, _state: &SharedState) -> DispatchResult {
     match method {
         "web3_clientVersion" => Ok(json!(format!("Sentrix/{}/Rust", env!("CARGO_PKG_VERSION")))),
         // `web3_sha3` — keccak256 hash of a hex-encoded byte string. The
@@ -29,8 +25,8 @@ pub(super) async fn dispatch(
                 .and_then(|v| v.as_str())
                 .ok_or((-32602, "web3_sha3: expected hex string param".to_string()))?;
             let hex = input.strip_prefix("0x").unwrap_or(input);
-            let bytes = hex::decode(hex)
-                .map_err(|e| (-32602, format!("web3_sha3: invalid hex: {}", e)))?;
+            let bytes =
+                hex::decode(hex).map_err(|e| (-32602, format!("web3_sha3: invalid hex: {}", e)))?;
             let mut hasher = Keccak256::new();
             hasher.update(&bytes);
             let digest = hasher.finalize();

--- a/crates/sentrix-rpc/src/routes/cache.rs
+++ b/crates/sentrix-rpc/src/routes/cache.rs
@@ -43,7 +43,11 @@ const CACHE_NO_STORE: &str = "no-store";
 fn cache_policy_for(path: &str) -> Option<&'static str> {
     // Live data: must always fetch fresh.
     match path {
-        "/chain/info" | "/sentrix_status" | "/sentrix_status_extended" | "/mempool" | "/chain/performance" => {
+        "/chain/info"
+        | "/sentrix_status"
+        | "/sentrix_status_extended"
+        | "/mempool"
+        | "/chain/performance" => {
             return Some(CACHE_NO_STORE);
         }
         "/chain/blocks" | "/blocks" => return Some(CACHE_LIVE_LIST),
@@ -158,7 +162,10 @@ mod tests {
         assert_eq!(cache_policy_for("/tokens"), None);
         // Children (holders, balance, etc) must NOT pick up token meta.
         assert_eq!(cache_policy_for("/tokens/SRC20_abcdef/holders"), None);
-        assert_eq!(cache_policy_for("/tokens/SRC20_abcdef/balance/0xdead"), None);
+        assert_eq!(
+            cache_policy_for("/tokens/SRC20_abcdef/balance/0xdead"),
+            None
+        );
     }
 
     #[test]

--- a/crates/sentrix-rpc/src/routes/mod.rs
+++ b/crates/sentrix-rpc/src/routes/mod.rs
@@ -26,10 +26,10 @@ use accounts::{
     get_address_history, get_address_info, get_address_proof, get_balance, get_nonce, get_richlist,
     get_state_root, get_wallet_info, list_transactions,
 };
+use cache::cache_control_middleware;
 use chain::{chain_info, get_block, get_blocks, get_finalized_height, validate_chain};
 use epoch::{epoch_current, epoch_history};
 use ops::{START_TIME, get_admin_log, health, metrics, root};
-use cache::cache_control_middleware;
 use ratelimit::{ip_rate_limit_middleware, write_rate_limit_middleware};
 use staking::{get_validators, staking_delegations, staking_unbonding, staking_validators};
 use tokens::{
@@ -76,10 +76,7 @@ pub fn create_router(state: SharedState) -> Router {
 /// subscribers see live block events. Tests + lightweight CLI builds
 /// can use `create_router` which constructs an isolated bus the
 /// caller can ignore.
-pub fn create_router_with_bus(
-    state: SharedState,
-    bus: Arc<crate::events::EventBus>,
-) -> Router {
+pub fn create_router_with_bus(state: SharedState, bus: Arc<crate::events::EventBus>) -> Router {
     // Eagerly pin the process start time so /sentrix_status and /metrics
     // report uptime relative to boot, not to the first handler call that
     // happened to trigger the OnceLock. Without this, uptime_seconds was
@@ -109,11 +106,11 @@ pub fn create_router_with_bus(
             // SENTRIX_CORS_ORIGIN produced a router that rejected every
             // browser request without surfacing the misconfig. Panic at
             // startup instead so operators see the problem immediately.
-            let header = origin.parse::<axum::http::HeaderValue>().unwrap_or_else(|e| {
-                panic!(
-                    "SENTRIX_CORS_ORIGIN={origin:?} is not a valid HTTP header value: {e}"
-                )
-            });
+            let header = origin
+                .parse::<axum::http::HeaderValue>()
+                .unwrap_or_else(|e| {
+                    panic!("SENTRIX_CORS_ORIGIN={origin:?} is not a valid HTTP header value: {e}")
+                });
             CorsLayer::new()
                 .allow_origin(header)
                 .allow_methods([

--- a/crates/sentrix-rpc/src/routes/ops.rs
+++ b/crates/sentrix-rpc/src/routes/ops.rs
@@ -35,7 +35,11 @@ pub(super) async fn root(State(state): State<SharedState>) -> Json<serde_json::V
     // — wallets that probe `/` for self-describe couldn't tell which
     // rail they were on without checking chain_id.
     let chain_name = bc.chain_name.clone();
-    let consensus = if bc.voyager_activated { "DPoS+BFT" } else { "PoA" };
+    let consensus = if bc.voyager_activated {
+        "DPoS+BFT"
+    } else {
+        "PoA"
+    };
     drop(bc);
     Json(serde_json::json!({
         "name": chain_name,
@@ -102,7 +106,11 @@ pub async fn sentrix_status(State(state): State<SharedState>) -> Json<serde_json
     let bc = state.read().await;
     let chain_id = bc.chain_id;
     // Same fix as root() — runtime flag, not chain_id heuristic.
-    let consensus = if bc.voyager_activated { "DPoS+BFT" } else { "PoA" };
+    let consensus = if bc.voyager_activated {
+        "DPoS+BFT"
+    } else {
+        "PoA"
+    };
     let latest = bc.latest_block().ok().cloned();
     let (latest_height, latest_hash, latest_timestamp) = latest
         .as_ref()
@@ -157,16 +165,18 @@ pub async fn sentrix_status(State(state): State<SharedState>) -> Json<serde_json
 ///
 /// All fields read from a single `state.read().await` to avoid producing
 /// inconsistent snapshots under load.
-pub async fn sentrix_status_extended(
-    State(state): State<SharedState>,
-) -> Json<serde_json::Value> {
+pub async fn sentrix_status_extended(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let uptime = START_TIME
         .get_or_init(std::time::Instant::now)
         .elapsed()
         .as_secs();
     let bc = state.read().await;
     let chain_id = bc.chain_id;
-    let consensus = if bc.voyager_activated { "DPoS+BFT" } else { "PoA" };
+    let consensus = if bc.voyager_activated {
+        "DPoS+BFT"
+    } else {
+        "PoA"
+    };
     let latest = bc.latest_block().ok().cloned();
     let (latest_height, latest_hash, latest_timestamp) = latest
         .as_ref()
@@ -200,7 +210,11 @@ pub async fn sentrix_status_extended(
             sum += w[1].timestamp.saturating_sub(w[0].timestamp) as i64;
             n += 1;
         }
-        if n > 0 { Some(sum as f64 / n as f64) } else { None }
+        if n > 0 {
+            Some(sum as f64 / n as f64)
+        } else {
+            None
+        }
     } else {
         None
     };

--- a/crates/sentrix-rpc/src/ws/mod.rs
+++ b/crates/sentrix-rpc/src/ws/mod.rs
@@ -163,7 +163,10 @@ fn wrap_subscription(sub_id: &str, result: Value) -> Value {
     json!(SubscriptionMessage {
         jsonrpc: "2.0",
         method: "eth_subscription",
-        params: SubscriptionPayload { subscription: sub_id, result },
+        params: SubscriptionPayload {
+            subscription: sub_id,
+            result
+        },
     })
 }
 
@@ -306,10 +309,7 @@ async fn handle_subscribe(
         }
     }
 
-    let sub_id = format!(
-        "0x{:016x}",
-        next_sub_id.fetch_add(1, Ordering::Relaxed)
-    );
+    let sub_id = format!("0x{:016x}", next_sub_id.fetch_add(1, Ordering::Relaxed));
 
     let handle = match channel.as_str() {
         "newHeads" => {
@@ -376,11 +376,7 @@ async fn handle_subscribe(
     };
 
     subscriptions.lock().await.insert(sub_id.clone(), handle);
-    send_response(
-        sender,
-        JsonRpcResponse::ok(id, json!(sub_id)),
-    )
-    .await;
+    send_response(sender, JsonRpcResponse::ok(id, json!(sub_id))).await;
 }
 
 async fn handle_unsubscribe(
@@ -402,11 +398,7 @@ async fn handle_unsubscribe(
     if let Some(handle) = &removed {
         handle.abort();
     }
-    send_response(
-        sender,
-        JsonRpcResponse::ok(id, json!(removed.is_some())),
-    )
-    .await;
+    send_response(sender, JsonRpcResponse::ok(id, json!(removed.is_some()))).await;
 }
 
 /// Filter for `eth_subscribe(logs)` — mirrors the eth_getLogs filter
@@ -448,7 +440,11 @@ impl LogFilter {
                             .filter_map(|v| v.as_str())
                             .filter_map(parse_topic)
                             .collect();
-                        if hashes.is_empty() { None } else { Some(hashes) }
+                        if hashes.is_empty() {
+                            None
+                        } else {
+                            Some(hashes)
+                        }
                     }
                     _ => None,
                 })
@@ -519,7 +515,10 @@ fn spawn_new_heads_listener(
                 Ok(event) => {
                     let payload = wrap_subscription(&sub_id, json!(event));
                     let mut s = sender.lock().await;
-                    if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+                    if s.send(Message::Text(payload.to_string().into()))
+                        .await
+                        .is_err()
+                    {
                         // Client disconnected — exit task; the per-conn
                         // subscriptions HashMap will be drained by the
                         // outer loop on close.
@@ -572,7 +571,10 @@ fn spawn_logs_listener(
                     }
                     let payload = wrap_subscription(&sub_id, json!(event));
                     let mut s = sender.lock().await;
-                    if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+                    if s.send(Message::Text(payload.to_string().into()))
+                        .await
+                        .is_err()
+                    {
                         break;
                     }
                 }
@@ -610,7 +612,10 @@ fn spawn_pending_txs_listener(
                 Ok(event) => {
                     let payload = wrap_subscription(&sub_id, json!(event.txid));
                     let mut s = sender.lock().await;
-                    if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+                    if s.send(Message::Text(payload.to_string().into()))
+                        .await
+                        .is_err()
+                    {
                         break;
                     }
                 }
@@ -645,7 +650,10 @@ fn spawn_finalized_listener(
         while let Ok(event) = rx.recv().await {
             let payload = wrap_subscription(&sub_id, json!(event));
             let mut s = sender.lock().await;
-            if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+            if s.send(Message::Text(payload.to_string().into()))
+                .await
+                .is_err()
+            {
                 break;
             }
         }
@@ -666,7 +674,10 @@ fn spawn_validator_set_listener(
         while let Ok(event) = rx.recv().await {
             let payload = wrap_subscription(&sub_id, json!(event));
             let mut s = sender.lock().await;
-            if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+            if s.send(Message::Text(payload.to_string().into()))
+                .await
+                .is_err()
+            {
                 break;
             }
         }
@@ -684,7 +695,10 @@ fn spawn_token_ops_listener(
         while let Ok(event) = rx.recv().await {
             let payload = wrap_subscription(&sub_id, json!(event));
             let mut s = sender.lock().await;
-            if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+            if s.send(Message::Text(payload.to_string().into()))
+                .await
+                .is_err()
+            {
                 break;
             }
         }
@@ -701,7 +715,10 @@ fn spawn_staking_ops_listener(
         while let Ok(event) = rx.recv().await {
             let payload = wrap_subscription(&sub_id, json!(event));
             let mut s = sender.lock().await;
-            if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+            if s.send(Message::Text(payload.to_string().into()))
+                .await
+                .is_err()
+            {
                 break;
             }
         }
@@ -720,7 +737,10 @@ fn spawn_jail_listener(
         while let Ok(event) = rx.recv().await {
             let payload = wrap_subscription(&sub_id, json!(event));
             let mut s = sender.lock().await;
-            if s.send(Message::Text(payload.to_string().into())).await.is_err() {
+            if s.send(Message::Text(payload.to_string().into()))
+                .await
+                .is_err()
+            {
                 break;
             }
         }

--- a/crates/sentrix-staking/src/slashing.rs
+++ b/crates/sentrix-staking/src/slashing.rs
@@ -33,14 +33,14 @@ mod liveness;
 
 pub use double_sign::{DOUBLE_SIGN_SLASH_BP, DoubleSignDetector, DoubleSignEvidence};
 pub use liveness::{
-    DOWNTIME_JAIL_BLOCKS, DOWNTIME_SLASH_BP, LIVENESS_WINDOW, LivenessTracker, MIN_SIGNED_PER_WINDOW,
+    DOWNTIME_JAIL_BLOCKS, DOWNTIME_SLASH_BP, LIVENESS_WINDOW, LivenessTracker,
+    MIN_SIGNED_PER_WINDOW,
 };
 
 use crate::staking::StakeRegistry;
 use sentrix_primitives::transaction::JailEvidence;
 use sentrix_primitives::{SentrixError, SentrixResult};
 use serde::{Deserialize, Serialize};
-
 
 // ── Slashing Engine ──────────────────────────────────────────
 
@@ -545,7 +545,10 @@ mod tests {
 
         let (s2, m2) = engine.liveness.get_stats("0xval2");
         assert_eq!(s2, 0, "val2 didn't sign → no signed entries recorded");
-        assert_eq!(m2, 0, "val2 has no entries at all (not signers, not missed)");
+        assert_eq!(
+            m2, 0,
+            "val2 has no entries at all (not signers, not missed)"
+        );
 
         let (s3, _) = engine.liveness.get_stats("0xval3");
         assert_eq!(s3, 1);
@@ -601,8 +604,7 @@ mod tests {
     #[test]
     fn test_proposer_only_signers_triggers_cascade_jail() {
         let mut engine = SlashingEngine::new();
-        let active: Vec<String> =
-            (0..4).map(|i| format!("0xval{}", i + 1)).collect();
+        let active: Vec<String> = (0..4).map(|i| format!("0xval{}", i + 1)).collect();
 
         // Simulate LIVENESS_WINDOW blocks with the BROKEN model:
         // only the rotating proposer goes into `signers`.
@@ -687,8 +689,7 @@ mod tests {
         for h in 0..LIVENESS_WINDOW {
             engine.liveness.record_signed("0xval1", h);
         }
-        let evidence = engine
-            .compute_jail_evidence(&["0xval1".into()], LIVENESS_WINDOW);
+        let evidence = engine.compute_jail_evidence(&["0xval1".into()], LIVENESS_WINDOW);
         assert!(
             evidence.is_empty(),
             "healthy validator must NOT appear in jail evidence"
@@ -708,8 +709,7 @@ mod tests {
         // window is (100, LIVENESS_WINDOW + 100] — anchor at h=0 is
         // outside it, so signed_in_window = 0 < MIN_SIGNED_PER_WINDOW.
         let current_height = LIVENESS_WINDOW + 100;
-        let evidence = engine
-            .compute_jail_evidence(&["0xval1".into()], current_height);
+        let evidence = engine.compute_jail_evidence(&["0xval1".into()], current_height);
         assert_eq!(evidence.len(), 1);
         assert_eq!(evidence[0].validator, "0xval1");
         // Phase B initial impl: justification_hashes empty
@@ -779,8 +779,7 @@ mod tests {
         // LIVENESS_WINDOW, first_seen > current_height - LIVENESS_WINDOW
         // (grace period still active) → no downtime.
         engine.liveness.record_signed("0xval1", LIVENESS_WINDOW / 2);
-        let evidence = engine
-            .compute_jail_evidence(&["0xval1".into()], LIVENESS_WINDOW);
+        let evidence = engine.compute_jail_evidence(&["0xval1".into()], LIVENESS_WINDOW);
         assert!(
             evidence.is_empty(),
             "validator inside grace period must not produce evidence"

--- a/crates/sentrix-staking/src/staking.rs
+++ b/crates/sentrix-staking/src/staking.rs
@@ -767,8 +767,7 @@ impl StakeRegistry {
             if *signer_stake == 0 {
                 continue;
             }
-            let signer_share = (total_reward as u128)
-                .saturating_mul(*signer_stake as u128)
+            let signer_share = (total_reward as u128).saturating_mul(*signer_stake as u128)
                 / total_signer_stake as u128;
             let signer_share = signer_share as u64;
             if signer_share == 0 {
@@ -787,9 +786,7 @@ impl StakeRegistry {
         total_reward: u64,
     ) -> SentrixResult<()> {
         let val = self.validators.get(validator_addr).ok_or_else(|| {
-            SentrixError::InvalidTransaction(
-                "proposer not found in stake registry".into(),
-            )
+            SentrixError::InvalidTransaction("proposer not found in stake registry".into())
         })?;
         let commission =
             (total_reward as u128).saturating_mul(val.commission_rate as u128) / 10_000;
@@ -815,11 +812,7 @@ impl StakeRegistry {
 
     /// V4 Step 2: split one signer's pro-rata share into commission +
     /// self-stake + per-delegator accumulator.
-    fn pay_one_signer(
-        &mut self,
-        validator_addr: &str,
-        signer_share: u64,
-    ) -> SentrixResult<()> {
+    fn pay_one_signer(&mut self, validator_addr: &str, signer_share: u64) -> SentrixResult<()> {
         // Fetch validator state (pre-mutation so we can read then write).
         let (commission_rate, self_stake, total_stake) = {
             let val = match self.validators.get(validator_addr) {
@@ -836,8 +829,7 @@ impl StakeRegistry {
         };
 
         // 1. Commission off the top.
-        let commission =
-            (signer_share as u128).saturating_mul(commission_rate as u128) / 10_000;
+        let commission = (signer_share as u128).saturating_mul(commission_rate as u128) / 10_000;
         let commission = commission as u64;
         let pool = signer_share.saturating_sub(commission);
 
@@ -855,8 +847,7 @@ impl StakeRegistry {
         }
 
         // 3. Self-stake portion credited to validator.
-        let self_share =
-            (pool as u128).saturating_mul(self_stake as u128) / total_stake as u128;
+        let self_share = (pool as u128).saturating_mul(self_stake as u128) / total_stake as u128;
         let self_share = self_share as u64;
         {
             let val = self
@@ -1570,8 +1561,7 @@ mod tests {
         // this validator. Pre-fix this could drift by N sentri per
         // slash (N = delegator count). Post-fix exact.
         assert_eq!(
-            reg.validators["0xval1"].total_delegated,
-            sum_entries,
+            reg.validators["0xval1"].total_delegated, sum_entries,
             "audit M3 invariant: total_delegated must equal sum of delegation entries",
         );
 
@@ -1722,7 +1712,8 @@ mod tests {
         reg.update_active_set();
 
         // Legacy Pioneer-path (empty signers) — 10% commission, reward = 1 SRX
-        reg.distribute_reward("0xval1", &[], 100_000_000, 0).unwrap();
+        reg.distribute_reward("0xval1", &[], 100_000_000, 0)
+            .unwrap();
 
         let val = &reg.validators["0xval1"];
         // Commission = 10% of 100M = 10M
@@ -1744,10 +1735,14 @@ mod tests {
         register_val(&mut reg, "0xval3", MIN_SELF_STAKE);
         register_val(&mut reg, "0xval4", MIN_SELF_STAKE);
         // Each validator has one delegator with MIN_SELF_STAKE delegated
-        reg.delegate("0xdelA", "0xval1", MIN_SELF_STAKE, 100).unwrap();
-        reg.delegate("0xdelB", "0xval2", MIN_SELF_STAKE, 100).unwrap();
-        reg.delegate("0xdelC", "0xval3", MIN_SELF_STAKE, 100).unwrap();
-        reg.delegate("0xdelD", "0xval4", MIN_SELF_STAKE, 100).unwrap();
+        reg.delegate("0xdelA", "0xval1", MIN_SELF_STAKE, 100)
+            .unwrap();
+        reg.delegate("0xdelB", "0xval2", MIN_SELF_STAKE, 100)
+            .unwrap();
+        reg.delegate("0xdelC", "0xval3", MIN_SELF_STAKE, 100)
+            .unwrap();
+        reg.delegate("0xdelD", "0xval4", MIN_SELF_STAKE, 100)
+            .unwrap();
         reg.update_active_set();
 
         // All 4 signers with equal stake weight.
@@ -1757,7 +1752,8 @@ mod tests {
             ("0xval3".to_string(), MIN_SELF_STAKE * 2),
             ("0xval4".to_string(), MIN_SELF_STAKE * 2),
         ];
-        reg.distribute_reward("0xval1", &signers, 100_000_000, 0).unwrap();
+        reg.distribute_reward("0xval1", &signers, 100_000_000, 0)
+            .unwrap();
 
         // Each signer's share = 100M / 4 = 25M
         // Commission (10%) = 2.5M → validator pending
@@ -1795,7 +1791,8 @@ mod tests {
             ("0xrogue".to_string(), MIN_SELF_STAKE), // not registered
         ];
         // Should not error, should silently skip rogue.
-        reg.distribute_reward("0xval1", &signers, 100_000_000, 0).unwrap();
+        reg.distribute_reward("0xval1", &signers, 100_000_000, 0)
+            .unwrap();
 
         // val1 got 50M share; rogue got 0 (skipped).
         // Commission 10% = 5M; pool 45M; self-share = 45M × SELF/SELF = 45M (no delegators).
@@ -1813,7 +1810,8 @@ mod tests {
         reg.update_active_set();
 
         // Empty signers vec = Pioneer fallback = pay proposer only (legacy).
-        reg.distribute_reward("0xval1", &[], 100_000_000, 0).unwrap();
+        reg.distribute_reward("0xval1", &[], 100_000_000, 0)
+            .unwrap();
         // Same as test_distribute_reward with no delegators:
         // commission 10M + self-share (all of pool since no delegators share) = 100M.
         assert_eq!(reg.validators["0xval1"].pending_rewards, 100_000_000);
@@ -1824,12 +1822,14 @@ mod tests {
     fn test_v4_claim_rewards_after_distribute() {
         let mut reg = new_registry();
         register_val(&mut reg, "0xval1", MIN_SELF_STAKE);
-        reg.delegate("0xdelA", "0xval1", MIN_SELF_STAKE, 100).unwrap();
+        reg.delegate("0xdelA", "0xval1", MIN_SELF_STAKE, 100)
+            .unwrap();
         reg.update_active_set();
 
         // One signer, full reward to them.
         let signers = vec![("0xval1".to_string(), MIN_SELF_STAKE * 2)];
-        reg.distribute_reward("0xval1", &signers, 100_000_000, 0).unwrap();
+        reg.distribute_reward("0xval1", &signers, 100_000_000, 0)
+            .unwrap();
 
         // Delegator should have accumulated a share.
         let accumulated = reg.delegator_rewards.get("0xdelA").copied().unwrap_or(0);
@@ -1892,8 +1892,7 @@ mod tests {
             msg2
         );
         assert_eq!(
-            reg.validators["0xval1"].commission_rate,
-            after_first,
+            reg.validators["0xval1"].commission_rate, after_first,
             "rate must not have advanced past first call"
         );
 
@@ -2289,7 +2288,10 @@ mod tests {
         struct Lcg(u64);
         impl Lcg {
             fn next(&mut self) -> u64 {
-                self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                self.0 = self
+                    .0
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
                 self.0 >> 33
             }
             fn pick<'a, T>(&mut self, xs: &'a [T]) -> &'a T {

--- a/crates/sentrix-storage/src/mdbx.rs
+++ b/crates/sentrix-storage/src/mdbx.rs
@@ -501,9 +501,7 @@ mod tests {
                 let mut k = Vec::with_capacity(16);
                 k.extend_from_slice(&height.to_be_bytes());
                 k.extend_from_slice(&[idx; 8]);
-                storage
-                    .put(TABLE_META, &k, &[height as u8, idx])
-                    .unwrap();
+                storage.put(TABLE_META, &k, &[height as u8, idx]).unwrap();
             }
         }
         let prefix = 2u64.to_be_bytes();

--- a/crates/sentrix-trie/benches/trie_insert.rs
+++ b/crates/sentrix-trie/benches/trie_insert.rs
@@ -16,9 +16,9 @@
 //!   recomputation.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::hint::black_box;
-use sentrix_trie::{address::account_value_bytes, tree::SentrixTrie};
 use sentrix_storage::MdbxStorage;
+use sentrix_trie::{address::account_value_bytes, tree::SentrixTrie};
+use std::hint::black_box;
 use std::sync::Arc;
 use tempfile::TempDir;
 
@@ -37,7 +37,9 @@ fn random_key(seed: u64) -> [u8; 32] {
     let mut k = [0u8; 32];
     let mut s = seed;
     for byte in k.iter_mut() {
-        s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        s = s
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         *byte = (s >> 33) as u8;
     }
     k
@@ -101,5 +103,10 @@ fn bench_commit_100(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_insert_single, bench_insert_batch_100, bench_commit_100);
+criterion_group!(
+    benches,
+    bench_insert_single,
+    bench_insert_batch_100,
+    bench_commit_100
+);
 criterion_main!(benches);

--- a/crates/sentrix-trie/src/cache.rs
+++ b/crates/sentrix-trie/src/cache.rs
@@ -300,7 +300,10 @@ mod tests {
 
         // Now in persistent storage.
         assert!(cache.storage.load_node(&h1).unwrap().is_some());
-        assert_eq!(cache.storage.load_value(&h1).unwrap(), Some(b"hello".to_vec()));
+        assert_eq!(
+            cache.storage.load_value(&h1).unwrap(),
+            Some(b"hello".to_vec())
+        );
         // Root stored too.
         assert_eq!(cache.storage.load_root(0).unwrap(), Some(root_hash));
         // Pending buffers drained.

--- a/crates/sentrix-trie/src/tree.rs
+++ b/crates/sentrix-trie/src/tree.rs
@@ -529,7 +529,11 @@ impl SentrixTrie {
                 }
                 Ok(())
             }
-            TrieNode::Internal { left, right, hash: stored_hash } => {
+            TrieNode::Internal {
+                left,
+                right,
+                hash: stored_hash,
+            } => {
                 if stored_hash != hash {
                     return Err(SentrixError::Internal(format!(
                         "trie strict integrity: internal node loaded by hash {} declares \
@@ -666,11 +670,7 @@ impl SentrixTrie {
         // refactor (exposing the txn handle through TrieStorage) and
         // belongs in its own PR. This patch is the minimal targeted
         // closer for the observed symptom.
-        let on_disk_latest = self
-            .cache
-            .storage
-            .latest_version()?
-            .unwrap_or(self.version);
+        let on_disk_latest = self.cache.storage.latest_version()?.unwrap_or(self.version);
         let mut augmented_roots = 0usize;
         for version in (self.version + 1)..=on_disk_latest {
             if let Some(root) = self.cache.storage.load_root(version)?
@@ -1267,7 +1267,8 @@ mod tests {
 
         // Round 1: bulk insert + commit.
         for (i, k) in keys.iter().enumerate() {
-            trie.insert(k, &account_value_bytes(100 + i as u64, 0)).unwrap();
+            trie.insert(k, &account_value_bytes(100 + i as u64, 0))
+                .unwrap();
         }
         let _ = trie.commit(1).unwrap();
 
@@ -1275,7 +1276,8 @@ mod tests {
         // through the cluster, deletes some internal nodes along its path.
         for round in 2u64..=20 {
             let i = (round as usize) % keys.len();
-            trie.insert(&keys[i], &account_value_bytes(1000 + round, round)).unwrap();
+            trie.insert(&keys[i], &account_value_bytes(1000 + round, round))
+                .unwrap();
             let _ = trie.commit(round).unwrap();
         }
 
@@ -1344,7 +1346,8 @@ mod tests {
         for i in 1u8..=4 {
             let addr = format!("0x{}", hex::encode([i; 20]));
             let key = address_to_key(&addr);
-            trie.insert(&key, &account_value_bytes(1_000 * i as u64, 0)).unwrap();
+            trie.insert(&key, &account_value_bytes(1_000 * i as u64, 0))
+                .unwrap();
         }
         // Flush pending writes to MDBX before we can damage them.
         trie.commit(0).unwrap();
@@ -1355,7 +1358,9 @@ mod tests {
         let storage = &trie.cache.storage;
         storage.delete_node(&root).unwrap();
 
-        let err = trie.verify_integrity().expect_err("must detect missing root node");
+        let err = trie
+            .verify_integrity()
+            .expect_err("must detect missing root node");
         assert!(
             format!("{err}").contains("orphan node reference"),
             "error should name the orphan kind; got: {err}"
@@ -1394,7 +1399,9 @@ mod tests {
             }
         }
 
-        let err = trie.verify_integrity().expect_err("must detect missing value");
+        let err = trie
+            .verify_integrity()
+            .expect_err("must detect missing value");
         assert!(
             format!("{err}").contains("orphan value reference"),
             "error should name the orphan kind; got: {err}"
@@ -1503,21 +1510,27 @@ mod tests {
             [0x01; 32],
             [0x80; 32],
             [0xff; 32],
-            [0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0, 0, 0, 0, 0, 0, 0, 0,
-             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0x10, 0x20, 0x30, 0x41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [
+                0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ],
+            [
+                0x10, 0x20, 0x30, 0x41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+            ],
         ];
 
         for (i, k) in keys.iter().enumerate() {
-            trie.insert(k, &account_value_bytes(1000 + i as u64, 0)).unwrap();
+            trie.insert(k, &account_value_bytes(1000 + i as u64, 0))
+                .unwrap();
         }
         let _ = trie.commit(1).unwrap();
 
         // v2: rotate the values so the old leaf/value entries become
         // unreachable from v2 root but still alive under v1.
         for (i, k) in keys.iter().enumerate() {
-            trie.insert(k, &account_value_bytes(2000 + i as u64, 1)).unwrap();
+            trie.insert(k, &account_value_bytes(2000 + i as u64, 1))
+                .unwrap();
         }
         let _ = trie.commit(2).unwrap();
 
@@ -1532,7 +1545,8 @@ mod tests {
             assert!(v.is_some(), "key {i} missing after prune");
             assert_eq!(v.unwrap(), account_value_bytes(2000 + i as u64, 1));
         }
-        trie.verify_integrity().expect("trie integrity must hold after prune");
+        trie.verify_integrity()
+            .expect("trie integrity must hold after prune");
     }
 
     /// Race-window regression for `prune()`: when a clone of the trie is
@@ -1580,9 +1594,12 @@ mod tests {
 
         // Sanity: v=4 root + race value are in storage before prune.
         assert_eq!(
-            mdbx.get(sentrix_storage::tables::TABLE_TRIE_ROOTS, &4u64.to_be_bytes())
-                .unwrap()
-                .as_deref(),
+            mdbx.get(
+                sentrix_storage::tables::TABLE_TRIE_ROOTS,
+                &4u64.to_be_bytes()
+            )
+            .unwrap()
+            .as_deref(),
             Some(&v4_root[..]),
             "v=4 root must be committed before prune"
         );

--- a/crates/sentrix-wire/src/lib.rs
+++ b/crates/sentrix-wire/src/lib.rs
@@ -252,7 +252,12 @@ impl MultiaddrAdvertisement {
     /// replayed as an advertisement signature and vice versa.
     pub fn signing_payload(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(
-            1 + 8 + self.validator.len() + 8 + 8 + 8 + self.multiaddrs.iter().map(|m| 8 + m.len()).sum::<usize>(),
+            1 + 8
+                + self.validator.len()
+                + 8
+                + 8
+                + 8
+                + self.multiaddrs.iter().map(|m| 8 + m.len()).sum::<usize>(),
         );
         buf.push(0x10); // domain separator: multiaddr advertisement
         buf.extend_from_slice(&self.chain_id.to_be_bytes());
@@ -419,7 +424,8 @@ mod tests {
         MultiaddrAdvertisement {
             // Construct via concat! so the source text doesn't contain
             // a literal `0x` + 40-hex (pre-commit secret-scan regex).
-            validator: concat!("0", "x", "00000000000000000000", "00000000000000000001").to_string(),
+            validator: concat!("0", "x", "00000000000000000000", "00000000000000000001")
+                .to_string(),
             // RFC 5737 documentation IP ranges to avoid pre-commit
             // hook flagging real-fleet addresses.
             multiaddrs: vec![
@@ -456,7 +462,11 @@ mod tests {
         advert.validator = address.clone();
         advert.sign(&sk);
 
-        assert_eq!(advert.signature.len(), 65, "recoverable sig must be 65 bytes");
+        assert_eq!(
+            advert.signature.len(),
+            65,
+            "recoverable sig must be 65 bytes"
+        );
         assert!(advert.verify(), "signed advert must verify");
     }
 
@@ -571,7 +581,10 @@ mod tests {
 
         assert!(a1.verify());
         assert!(a2.verify());
-        assert_ne!(a1.signature, a2.signature, "different sequences → different sigs");
+        assert_ne!(
+            a1.signature, a2.signature,
+            "different sequences → different sigs"
+        );
     }
 
     /// Structural validation rejects malformed adverts before reaching
@@ -585,15 +598,23 @@ mod tests {
         assert!(a.validate_shape().is_err(), "empty multiaddr list rejected");
 
         let mut b = sample_advert();
-        b.multiaddrs = vec!["/ip4/198.51.100.10/tcp/30303".into(); MultiaddrAdvertisement::MAX_MULTIADDRS + 1];
-        assert!(b.validate_shape().is_err(), "exceeding MAX_MULTIADDRS rejected");
+        b.multiaddrs =
+            vec!["/ip4/198.51.100.10/tcp/30303".into(); MultiaddrAdvertisement::MAX_MULTIADDRS + 1];
+        assert!(
+            b.validate_shape().is_err(),
+            "exceeding MAX_MULTIADDRS rejected"
+        );
 
         let mut c = sample_advert();
         c.multiaddrs = vec!["not-a-multiaddr".into()];
-        assert!(c.validate_shape().is_err(), "missing leading slash rejected");
+        assert!(
+            c.validate_shape().is_err(),
+            "missing leading slash rejected"
+        );
 
         let mut d = sample_advert();
-        d.multiaddrs = vec!["/".to_string() + &"x".repeat(MultiaddrAdvertisement::MAX_MULTIADDR_LEN)];
+        d.multiaddrs =
+            vec!["/".to_string() + &"x".repeat(MultiaddrAdvertisement::MAX_MULTIADDR_LEN)];
         assert!(d.validate_shape().is_err(), "oversize multiaddr rejected");
 
         let mut e = sample_advert();
@@ -601,7 +622,10 @@ mod tests {
         assert!(e.validate_shape().is_err(), "non-0x validator rejected");
 
         let valid = sample_advert();
-        assert!(valid.validate_shape().is_ok(), "sample advert shape is valid");
+        assert!(
+            valid.validate_shape().is_ok(),
+            "sample advert shape is valid"
+        );
     }
 
     // ── BFT gossipsub envelope roundtrips ──────────────────
@@ -616,10 +640,13 @@ mod tests {
             height: 42,
             round: 1,
             block_hash: Some("0xabc123".to_string()),
-            validator: concat!("0", "x", "00000000000000000000", "00000000000000000005").to_string(),
+            validator: concat!("0", "x", "00000000000000000000", "00000000000000000005")
+                .to_string(),
             signature: vec![0u8; 65],
         };
-        let env = GossipBftPrevote { prevote: pv.clone() };
+        let env = GossipBftPrevote {
+            prevote: pv.clone(),
+        };
         let bytes = bincode::serialize(&env).expect("encode");
         let decoded: GossipBftPrevote = bincode::deserialize(&bytes).expect("decode");
         assert_eq!(decoded.prevote, pv);
@@ -631,10 +658,13 @@ mod tests {
             height: 100,
             round: 3,
             block_hash: None,
-            validator: concat!("0", "x", "00000000000000000000", "00000000000000000007").to_string(),
+            validator: concat!("0", "x", "00000000000000000000", "00000000000000000007")
+                .to_string(),
             signature: vec![1u8; 65],
         };
-        let env = GossipBftPrecommit { precommit: pc.clone() };
+        let env = GossipBftPrecommit {
+            precommit: pc.clone(),
+        };
         let bytes = bincode::serialize(&env).expect("encode");
         let decoded: GossipBftPrecommit = bincode::deserialize(&bytes).expect("decode");
         assert_eq!(decoded.precommit, pc);
@@ -645,7 +675,8 @@ mod tests {
         let rs = RoundStatus {
             height: 555,
             round: 2,
-            validator: concat!("0", "x", "00000000000000000000", "00000000000000000009").to_string(),
+            validator: concat!("0", "x", "00000000000000000000", "00000000000000000009")
+                .to_string(),
             signature: vec![2u8; 65],
         };
         let env = GossipBftRoundStatus { status: rs.clone() };

--- a/tests/integration_evm_state_persistence.rs
+++ b/tests/integration_evm_state_persistence.rs
@@ -106,10 +106,12 @@ fn deploy_bytecode(db: &mut AccountDB, deployer: Address, init_code: Vec<u8>) ->
         .chain_id(Some(CHAIN_ID))
         .build()
         .unwrap_or_default();
-    let (receipt, state) = execute_tx_with_state(evm_db, tx, INITIAL_BASE_FEE, CHAIN_ID)
-        .expect("deploy must succeed");
+    let (receipt, state) =
+        execute_tx_with_state(evm_db, tx, INITIAL_BASE_FEE, CHAIN_ID).expect("deploy must succeed");
     assert!(receipt.success, "deploy reverted");
-    let contract_addr = receipt.contract_address.expect("CREATE must produce address");
+    let contract_addr = receipt
+        .contract_address
+        .expect("CREATE must produce address");
     // Commit + also manually persist the runtime bytecode via set_contract,
     // because revm's state diff contains info.code = Some(runtime) from the
     // CREATE and commit_state_to_account_db will store + mark it.
@@ -133,7 +135,8 @@ fn call_contract(
     {
         let code_hash_hex = hex::encode(target_account.code_hash);
         if let Some(bytecode) = db.get_contract_code(&code_hash_hex) {
-            let code = revm::state::Bytecode::new_raw(alloy_primitives::Bytes::from(bytecode.clone()));
+            let code =
+                revm::state::Bytecode::new_raw(alloy_primitives::Bytes::from(bytecode.clone()));
             evm_db.insert_code(alloy_primitives::B256::from(target_account.code_hash), code);
         }
         let prefix = format!("{}:", target_str);
@@ -190,7 +193,10 @@ fn test_1_simple_storage_persists_after_set() {
     // Sanity: contract is now recorded.
     let contract_str = address_to_sentrix(&contract);
     assert!(
-        db.accounts.get(&contract_str).map(|a| a.is_contract()).unwrap_or(false),
+        db.accounts
+            .get(&contract_str)
+            .map(|a| a.is_contract())
+            .unwrap_or(false),
         "contract account must be marked is_contract() post-deploy"
     );
 
@@ -202,7 +208,8 @@ fn test_1_simple_storage_persists_after_set() {
 
     // Verify slot 0 == 42.
     let slot_hex = format!("{:064x}", 0);
-    let stored = db.get_contract_storage(&contract_str, &slot_hex)
+    let stored = db
+        .get_contract_storage(&contract_str, &slot_hex)
         .expect("slot 0 must be persisted to AccountDB");
     assert_eq!(stored.len(), 32, "slot value is 32 bytes");
     assert_eq!(stored[31], 42, "low byte == 42");
@@ -219,8 +226,10 @@ fn test_3_multiple_sets_see_prior_write() {
     fund_sender(&mut db, &deployer, 100_000_000);
     let contract = deploy_bytecode(&mut db, deployer, simple_storage_init_code());
 
-    let mut calldata10 = vec![0u8; 32]; calldata10[31] = 10;
-    let mut calldata20 = vec![0u8; 32]; calldata20[31] = 20;
+    let mut calldata10 = vec![0u8; 32];
+    calldata10[31] = 10;
+    let mut calldata20 = vec![0u8; 32];
+    calldata20[31] = 20;
 
     call_contract(&mut db, deployer, contract, calldata10, 100_000);
     call_contract(&mut db, deployer, contract, calldata20, 100_000);
@@ -275,7 +284,11 @@ fn test_5_revert_leaves_state_unchanged() {
 
     // Storage slot 0 must STILL be 42 (revert did not commit).
     let stored = db.get_contract_storage(&contract_str, &slot_hex).unwrap();
-    assert_eq!(stored, &vec![42u8; 32], "reverted tx must NOT overwrite storage");
+    assert_eq!(
+        stored,
+        &vec![42u8; 32],
+        "reverted tx must NOT overwrite storage"
+    );
 }
 
 // Tests 2 (ERC-20 mock), 4 (contract-to-contract), 6 (SELFDESTRUCT) are


### PR DESCRIPTION
## Why

vps6 mainnet fullnodes stuck 78min and 6.1h on 2026-05-27 (testnet fullnode-1 stuck 4.5d). Container healthy, RPC responsive, libp2p peers connected — chain.height() frozen. v2.2.18 closed the BFT-side silent-stall (driver-confirmed cast); fullnodes don't run BFT so the BFT fix doesn't help them. They only receive blocks via three paths in libp2p_node.rs (gossipsub / request-response / catch-up sync).

Without per-step counters we couldn't tell whether the stall lives in gossipsub delivery, the chain.write() lock, add_block_from_peer / MDBX commit, or the post-apply bookkeeping. Every occurrence got recovered via chain.db cp before we could capture evidence.

## What

Per-path counters (RX_GOSSIP, RX_REQ, RX_SYNC, OK, ERR, LAST_HEIGHT, LAST_UNIX) at all three apply call sites + a 30s watchdog spawned in LibP2pNode::new. Watchdog logs the deltas at info on every tick and classifies stalls at error:

- rx_total > 0 + apply_age > 120s → SILENT-STALL (apply path stuck or rejecting)
- rx_total = 0 + apply_age > 120s → PEER-MESH IDLE (gossipsub mesh broken; different class)

Atomic counters only, single read-only watchdog task — no semantic change to apply path. Drop-in safe for mainnet + testnet.

Workspace bump 2.2.18 → 2.2.19. Second commit is the accumulated `cargo fmt` drift across the workspace, mechanical only.

## Operator runbook

After deploy, normal apply tick looks like:

```
apply_watchdog: 30s tick: rx_gossip=30 rx_req=0 rx_sync=0 ok=30 err=0 last_h=2379693 apply_age=1s
```

Next stall fires:

```
apply_watchdog: SILENT-STALL: 90 blocks received in last 30s but no successful apply in 180s (last_h=2379693) — apply path stuck on write-lock, MDBX commit, or rejecting everything.
```

That gives us the diagnostic we've been missing. Targeted fix follows once we capture a stall.

## Test plan

- [x] cargo check --release --all-targets with RUSTFLAGS=-D warnings clean
- [x] cargo fmt --check clean
- [x] Ship to testnet val4, observe apply_watchdog ticks in journal for ~30 min
- [x] Ship to mainnet vps6 fullnodes (the hosts that keep stalling)
- [x] Document detection pattern in operator runbook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 2.2.19.

* **New Features**
  * Added apply-path observability for fullnode silent-stall detection with a periodic watchdog that monitors block application inactivity across gossipsub, request-response, and sync paths, logging warnings when prolonged apply delays are detected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->