### PR TITLE
test(codec): cover Display/Error impls + encode error path → 100% lines

### DIFF
--- a/crates/sentrix-codec/src/lib.rs
+++ b/crates/sentrix-codec/src/lib.rs
@@ -156,4 +156,45 @@ mod tests {
         let err: Result<[u8; 4], _> = hex_decode_fixed("deadbe");
         assert!(matches!(err, Err(CodecError::Decode(_))));
     }
+
+    #[test]
+    fn test_hex_decode_fixed_with_prefix() {
+        let bytes: [u8; 4] = hex_decode_fixed("0xdeadbeef").unwrap();
+        assert_eq!(bytes, [0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn test_display_encode_error() {
+        let e = CodecError::Encode("oops".into());
+        assert_eq!(format!("{e}"), "codec encode error: oops");
+    }
+
+    #[test]
+    fn test_display_decode_error() {
+        let e = CodecError::Decode("bad bytes".into());
+        assert_eq!(format!("{e}"), "codec decode error: bad bytes");
+    }
+
+    #[test]
+    fn test_error_trait_object() {
+        // Verify CodecError implements std::error::Error so it composes
+        // with `?` in any `Result<_, Box<dyn Error>>` chain.
+        let e: Box<dyn std::error::Error> = Box::new(CodecError::Decode("x".into()));
+        assert!(e.to_string().contains("decode"));
+    }
+
+    #[test]
+    fn test_encode_error_path() {
+        // bincode 1.3 serialization is near-infallible for owned data, so
+        // force the error arm via a custom Serialize that always returns Err.
+        struct AlwaysFails;
+        impl Serialize for AlwaysFails {
+            fn serialize<S: serde::Serializer>(&self, _: S) -> Result<S::Ok, S::Error> {
+                Err(serde::ser::Error::custom("forced encode failure"))
+            }
+        }
+        let err = encode(&AlwaysFails).unwrap_err();
+        assert!(matches!(err, CodecError::Encode(_)));
+        assert!(format!("{err}").contains("forced encode failure"));
+    }
 }


### PR DESCRIPTION
## Why

\`sentrix-codec\` was at 92.5% line coverage (62/67). Five lines uncovered:
- \`Display\` impl arms for both \`CodecError\` variants
- \`std::error::Error\` marker impl
- bincode encode-error closure (line 50)

## What

Adds 5 tests:
- \`test_hex_decode_fixed_with_prefix\` — was only testing the no-prefix path
- \`test_display_encode_error\` / \`test_display_decode_error\` — exercise the \`fmt\` arms
- \`test_error_trait_object\` — boxes into \`dyn std::error::Error\` to verify trait impl
- \`test_encode_error_path\` — forces bincode 1.3 ser error via a custom \`Serialize\` that always returns \`Err\` (bincode 1.3 is near-infallible for owned data, so this is the only way to trigger that arm)

## Result

```
                          Functions    Lines       Regions
sentrix-codec/src/lib.rs  24/24=100%   94/94=100%  165/171=96.5%
```

Remaining 6 region misses are generic-monomorphization corners (each \`Serialize\`/\`DeserializeOwned\` instantiation has its own closure) that can't be hit without instantiating every type in the workspace.

## Test plan

- [x] \`cargo llvm-cov --package sentrix-codec\` shows 100% lines + 100% functions
- [x] \`cargo test --package sentrix-codec\` — 14/14 passing
- [x] \`cargo fmt --check\` clean