### PR TITLE
fix(bft): v2.2.20 engine resume handles round=0 step>=1 stuck state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "bincode",
  "hex",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "anyhow",
  "axum",
@@ -5327,7 +5327,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5346,7 +5346,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "anyhow",
  "axum",
@@ -5389,14 +5389,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "hex",
  "proptest",
@@ -5411,7 +5411,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5469,14 +5469,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5486,7 +5486,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "bincode",
  "blake3",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.19"
+version = "2.2.20"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.19"
+version = "2.2.20"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1777,25 +1777,45 @@ async fn cmd_start(
                     // halt where chain can't advance until operator manually
                     // clears /var/lib/sentrix/last-sign.json. See v44 incident
                     // 2026-05-07 for the failure mode.
+                    //
+                    // v2.2.20: extended to also handle the (round=0, step>=1)
+                    // case. Original condition `state.round > 0` skipped the
+                    // common nil-precommit-at-round-0 stuck pattern: cluster
+                    // loses quorum during rolling restart → vals precommit nil
+                    // at round 0 → last-sign.json persists (h, 0, 2) → restart
+                    // → engine boots at round 0 → guard rejects (h, 0, 0)
+                    // because <= (h, 0, 2) → empty sig → cluster stalls until
+                    // engine times out 12+ rounds. Now triggers when step>=1
+                    // (vote cast at this round) AND advances to next round.
+                    // 2026-05-29 testnet stall at h=5707944 was this pattern.
                     if let Some(state) = sentrix_bft::last_sign_guard::current_state()
                         && state.height == next_height
-                        && state.round > 0
                     {
-                        let target_round = state.round.saturating_add(1);
-                        // BftEngine::advance_round bumps round + resets the
-                        // vote collector + phase_start. Apply N times to
-                        // skip the prior in-progress round.
-                        for _ in 0..target_round {
-                            bft.advance_round();
+                        // If we cast a vote at this round (step >= Prevote),
+                        // engine must skip past this round entirely. If we
+                        // only proposed (step == Proposal), prevote and
+                        // precommit at the same round are still legal.
+                        let target_round = if state.step >= 1 {
+                            state.round.saturating_add(1)
+                        } else {
+                            state.round
+                        };
+                        if target_round > 0 {
+                            // BftEngine::advance_round bumps round + resets
+                            // the vote collector + phase_start. Apply N times
+                            // to skip the prior in-progress round(s).
+                            for _ in 0..target_round {
+                                bft.advance_round();
+                            }
+                            tracing::info!(
+                                "BFT engine resume: prior sign at (h={}, r={}, s={}) — \
+                                 advanced engine to round {} to bypass guard refusal",
+                                state.height,
+                                state.round,
+                                state.step,
+                                target_round,
+                            );
                         }
-                        tracing::info!(
-                            "BFT engine resume: prior sign at (h={}, r={}, s={}) — \
-                             advanced engine to round {} to bypass guard refusal",
-                            state.height,
-                            state.round,
-                            state.step,
-                            target_round,
-                        );
                     }
 
                     proposed_block = None;


### PR DESCRIPTION
## Why

v2.1.85 added engine-round resume logic so the `LastSignBytes guard` doesn't trap a freshly-booted engine at round 0 when last_signed is at a higher round. The condition `state.round > 0` covered the common case (cluster advanced to high round → restart → resume at high+1) but missed the `(round=0, step>=1)` pattern:

1. Cluster loses quorum during rolling restart
2. Vals cast nil-precommit at round 0
3. `last-sign.json` persists `(h, 0, 2)`
4. Restart → engine boots at round=0
5. Guard rejects any sign at `(h, 0, *)` because `<= (h, 0, 2)`
6. Empty signature broadcast → peers reject → cluster stalls
7. Recovery: engine times out 12+ rounds (~6 min minimum) OR operator manually wipes `last-sign.json`

**2026-05-29 testnet stall at h=5707944 was exactly this pattern.** Manual recovery required halt-all + reset of `last-sign.json` across all 4 vals + simul-start. This trap does not scale beyond the operator's own validator set — independent operators won't manually reset guard state at 3 AM.

## What

Extend the existing resume condition at `bin/sentrix/src/main.rs:1780` to also trigger when `state.step >= 1` (any vote cast at this round, regardless of round number).

```rust
// Before
&& state.round > 0
// → only triggered after engine had advanced rounds

// After (no extra clause — fall through to step-aware target_round)
let target_round = if state.step >= 1 {
    state.round.saturating_add(1)  // skip this round
} else {
    state.round                     // can still vote at same round
};
if target_round > 0 { /* advance N times */ }
```

Logic:
- `step == 0 (Proposal)`: prevote+precommit at same round are still legal per the guard's `(r, s)` tuple comparison
- `step >= 1 (Prevote or Precommit)`: must skip past this round entirely

## Why this doesn't bypass equivocation protection

The guard's check semantics are unchanged: any sign attempt at `(h, r, s) <= persisted_tuple` is still rejected. This fix only changes WHERE the engine STARTS — we don't sit at a trapped state. The engine still must respect the guard at every signing point.

Equivocation risk: zero. We don't allow signing anything that wasn't already allowable; we just don't waste 6 minutes of timeouts walking the engine through trapped rounds.

## Test plan

- [x] `cargo check --release -p sentrix-node` clean with `-D warnings`
- [x] `cargo fmt --check` clean
- [ ] After mainnet restart: verify boot logs show `BFT engine resume: ... advanced engine to round 1` if any val had `(h, 0, step>=1)` persisted
- [ ] Ship to testnet, simulate the v2026-05-29 stall pattern (manually set `last-sign.json` to `{h, 0, 2}` before restart), verify no manual reset needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker support for running a Sentrix fullnode with environment configuration template and docker-compose orchestration file.
  * Configured API and P2P port mappings with built-in health monitoring.
  * Enhanced validator initialization logic during startup and recovery sequences.

* **Chores**
  * Released version 2.2.20.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->