### PR TITLE
feat(bft): v2.2.21 BftMetrics observability struct + tracing at hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5234,10 +5234,11 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "bincode",
  "hex",
+ "prometheus",
  "secp256k1 0.31.1",
  "sentrix-primitives",
  "sentrix-staking",
@@ -5261,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5291,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5306,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "anyhow",
  "axum",
@@ -5327,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5346,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5364,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "anyhow",
  "axum",
@@ -5389,14 +5390,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "hex",
  "proptest",
@@ -5411,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5439,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5469,14 +5470,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5486,7 +5487,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5501,7 +5502,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "bincode",
  "blake3",
@@ -5518,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5537,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.20"
+version = "2.2.21"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.20"
+version = "2.2.21"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/crates/sentrix-bft/Cargo.toml
+++ b/crates/sentrix-bft/Cargo.toml
@@ -17,6 +17,7 @@ sha2 = "0.11"
 hex = "0.4"
 sha3 = "0.12"
 tracing = "0.1"
+prometheus = "0.14"
 
 [dev-dependencies]
 bincode = "1.3"

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -22,11 +22,13 @@ pub use timeouts::{
 pub use vote_collector::VoteCollector;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 // errors used by integration callers, not directly in this module
 use crate::messages::{
     BlockJustification, Precommit, Prevote, RoundStatus, supermajority_threshold,
 };
+use crate::metrics::{BftMetrics, phase};
 use sentrix_staking::StakeRegistry;
 
 // ── BFT Engine ───────────────────────────────────────────────
@@ -70,19 +72,77 @@ pub struct BftEngine {
     /// 1-round-drift livelock (issue #143) that the legacy single-peer
     /// "2+ rounds ahead" trigger could not resolve.
     peer_rounds: HashMap<String, (u32, u64)>,
+    /// Observability hook. `None` keeps the legacy hot path untouched
+    /// (tests + bench callers). Validator binary injects via
+    /// `new_with_metrics` and the engine writes to it at every state
+    /// transition. Cheap: `Option<Arc<_>>` clone is one atomic refcount.
+    metrics: Option<Arc<BftMetrics>>,
+    /// Wall-clock anchor for the in-progress round, used to observe round
+    /// duration on advance/commit. Reset on every `advance_round`,
+    /// `new_height`, and `catch_up_round`.
+    round_start: Instant,
 }
 
 impl BftEngine {
     pub fn new(height: u64, our_address: String, total_active_stake: u64) -> Self {
+        let now = Instant::now();
         Self {
             state: BftRoundState::new(height, 0, total_active_stake),
             collector: VoteCollector::new(),
             our_address,
-            phase_start: Instant::now(),
+            phase_start: now,
             pending_prevote: None,
             pending_precommit: None,
             peer_rounds: HashMap::new(),
+            metrics: None,
+            round_start: now,
         }
+    }
+
+    /// Construct with observability injected. Used by the validator binary;
+    /// tests + bench callers stick to [`Self::new`] and skip the metric
+    /// emit on hot paths via `Option`.
+    pub fn new_with_metrics(
+        height: u64,
+        our_address: String,
+        total_active_stake: u64,
+        metrics: Arc<BftMetrics>,
+    ) -> Self {
+        let now = Instant::now();
+        metrics.set_height(height);
+        metrics.set_round(0);
+        tracing::info!(
+            target: "bft::engine",
+            height,
+            our_address = %our_address,
+            "BFT engine constructed with observability hook"
+        );
+        Self {
+            state: BftRoundState::new(height, 0, total_active_stake),
+            collector: VoteCollector::new(),
+            our_address,
+            phase_start: now,
+            pending_prevote: None,
+            pending_precommit: None,
+            peer_rounds: HashMap::new(),
+            metrics: Some(metrics),
+            round_start: now,
+        }
+    }
+
+    /// Test/integration helper: attach metrics after construction. Same
+    /// semantics as `new_with_metrics` but lets call sites that already
+    /// hold an engine bolt observability on.
+    pub fn attach_metrics(&mut self, metrics: Arc<BftMetrics>) {
+        metrics.set_height(self.state.height);
+        metrics.set_round(self.state.round);
+        self.metrics = Some(metrics);
+    }
+
+    /// Read-only accessor for tests + callers that want to publish round
+    /// duration on commit (the engine itself only observes on advance).
+    pub fn metrics(&self) -> Option<&Arc<BftMetrics>> {
+        self.metrics.as_ref()
     }
 
     /// 2026-05-10: accessor for the validator-loop's vote-rebroadcast tick.
@@ -99,21 +159,54 @@ impl BftEngine {
 
     /// Reset for a new height
     pub fn new_height(&mut self, height: u64, total_active_stake: u64) {
+        let prev_height = self.state.height;
         self.state.advance_height(height, total_active_stake);
         self.collector.reset();
-        self.phase_start = Instant::now();
+        let now = Instant::now();
+        self.phase_start = now;
+        self.round_start = now;
         self.pending_prevote = None;
         self.pending_precommit = None;
         self.peer_rounds.clear();
+        if let Some(m) = &self.metrics {
+            m.set_height(height);
+            m.set_round(0);
+        }
+        tracing::info!(
+            target: "bft::engine",
+            from_height = prev_height,
+            to_height = height,
+            total_active_stake,
+            "BFT new height — engine reset"
+        );
     }
 
     /// Advance to next round (timeout or nil)
     pub fn advance_round(&mut self) {
+        let prev_round = self.state.round;
+        let prev_phase = self.state.phase;
+        let dur = self.round_start.elapsed();
         self.state.advance_round();
         self.collector.reset();
-        self.phase_start = Instant::now();
+        let now = Instant::now();
+        self.phase_start = now;
+        self.round_start = now;
         self.pending_prevote = None;
         self.pending_precommit = None;
+        if let Some(m) = &self.metrics {
+            m.inc_round();
+            m.observe_round_duration(dur.as_secs_f64());
+            m.set_round(self.state.round);
+        }
+        tracing::info!(
+            target: "bft::engine",
+            height = self.state.height,
+            prev_round,
+            new_round = self.state.round,
+            ?prev_phase,
+            elapsed_ms = dur.as_millis() as u64,
+            "BFT round advanced"
+        );
     }
 
     /// Round catch-up: if peers are at a higher round, fast-forward.
@@ -282,6 +375,17 @@ impl BftEngine {
         if expected.as_deref() != Some(proposer) {
             return BftAction::Wait; // wrong proposer, ignore
         }
+        if let Some(m) = &self.metrics {
+            m.inc_vote(phase::PROPOSE);
+        }
+        tracing::debug!(
+            target: "bft::engine",
+            height = self.state.height,
+            round = self.state.round,
+            proposer,
+            block_hash,
+            "BFT proposal received from expected proposer"
+        );
 
         // V3 defense-in-depth: refuse proposals from a jailed or
         // tombstoned validator even if `weighted_proposer` returned
@@ -590,6 +694,18 @@ impl BftEngine {
         if self.state.prevotes.contains_key(&prevote.validator) {
             return BftAction::Wait;
         }
+        if let Some(m) = &self.metrics {
+            m.inc_vote(phase::PREVOTE);
+        }
+        tracing::trace!(
+            target: "bft::engine",
+            height = prevote.height,
+            round = prevote.round,
+            validator = %prevote.validator,
+            block_hash = ?prevote.block_hash,
+            stake,
+            "BFT prevote accepted"
+        );
 
         self.state.prevotes.insert(
             prevote.validator.clone(),
@@ -679,6 +795,18 @@ impl BftEngine {
         if self.state.precommits.contains_key(&precommit.validator) {
             return BftAction::Wait;
         }
+        if let Some(m) = &self.metrics {
+            m.inc_vote(phase::PRECOMMIT);
+        }
+        tracing::trace!(
+            target: "bft::engine",
+            height = precommit.height,
+            round = precommit.round,
+            validator = %precommit.validator,
+            block_hash = ?precommit.block_hash,
+            stake,
+            "BFT precommit accepted"
+        );
 
         self.state.precommits.insert(
             precommit.validator.clone(),
@@ -778,6 +906,23 @@ impl BftEngine {
         if let Some(precommit) = &self.pending_precommit {
             return BftAction::BroadcastPrecommit(precommit.clone());
         }
+        let phase_label = match self.state.phase {
+            BftPhase::Propose => phase::PROPOSE,
+            BftPhase::Prevote => phase::PREVOTE,
+            BftPhase::Precommit => phase::PRECOMMIT,
+            BftPhase::Finalize => "finalize",
+        };
+        if let Some(m) = &self.metrics {
+            m.inc_timeout(phase_label);
+        }
+        tracing::warn!(
+            target: "bft::engine",
+            height = self.state.height,
+            round = self.state.round,
+            phase = phase_label,
+            phase_elapsed_ms = self.phase_start.elapsed().as_millis() as u64,
+            "BFT phase timeout — engine taking timeout action"
+        );
         match self.state.phase {
             BftPhase::Propose => {
                 // No proposal received — prevote nil

--- a/crates/sentrix-bft/src/engine.rs
+++ b/crates/sentrix-bft/src/engine.rs
@@ -3287,4 +3287,212 @@ mod tests {
         assert!(engine.pending_precommit.is_none());
         assert_eq!(engine.state.round, 2);
     }
+
+    // ── v2.2.21 observability integration tests ──────────────────────
+    //
+    // These tests pin the contract between BftEngine state transitions
+    // and BftMetrics counters/gauges. Each test uses a fresh private
+    // registry via BftMetrics::for_test so counters don't bleed between
+    // tests. Together they cover every hot-path metric call added in
+    // PR #745 + this PR's wiring.
+
+    use crate::metrics::{BftMetrics, jail_reason, phase};
+
+    fn setup_with_metrics() -> (BftEngine, StakeRegistry, std::sync::Arc<BftMetrics>) {
+        let mut reg = StakeRegistry::new();
+        for i in 0..21 {
+            let addr = format!("0xval{:03}", i);
+            reg.register_validator(&addr, MIN_SELF_STAKE, 1000, 0)
+                .unwrap();
+        }
+        reg.update_active_set();
+        let total_stake: u64 = reg
+            .active_set
+            .iter()
+            .filter_map(|a| reg.get_validator(a))
+            .map(|v| v.total_stake())
+            .sum();
+        let metrics = BftMetrics::for_test();
+        let engine =
+            BftEngine::new_with_metrics(100, "0xval000".into(), total_stake, metrics.clone());
+        (engine, reg, metrics)
+    }
+
+    #[test]
+    fn test_new_with_metrics_sets_initial_gauges() {
+        let (_engine, _reg, m) = setup_with_metrics();
+        assert_eq!(m.current_height.get(), 100);
+        assert_eq!(m.current_round.get(), 0);
+    }
+
+    #[test]
+    fn test_advance_round_increments_counter_and_observes_duration() {
+        let (mut engine, _reg, m) = setup_with_metrics();
+        assert_eq!(m.rounds_total.get(), 0);
+        // Sleep enough that the histogram observation is non-zero (the
+        // smallest bucket boundary is 0.1s; we just need to confirm
+        // the observation count incremented, not the specific bucket).
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        engine.advance_round();
+        assert_eq!(m.rounds_total.get(), 1);
+        assert_eq!(m.current_round.get(), 1);
+        assert_eq!(m.round_duration.get_sample_count(), 1);
+        // Two more for good measure.
+        engine.advance_round();
+        engine.advance_round();
+        assert_eq!(m.rounds_total.get(), 3);
+        assert_eq!(m.current_round.get(), 3);
+        assert_eq!(m.round_duration.get_sample_count(), 3);
+    }
+
+    #[test]
+    fn test_new_height_updates_gauges_and_resets_round() {
+        let (mut engine, _reg, m) = setup_with_metrics();
+        engine.advance_round();
+        engine.advance_round();
+        assert_eq!(m.current_round.get(), 2);
+        engine.new_height(200, 10_000);
+        assert_eq!(m.current_height.get(), 200);
+        assert_eq!(m.current_round.get(), 0);
+    }
+
+    #[test]
+    fn test_on_proposal_increments_propose_vote_counter() {
+        let (mut engine, reg, m) = setup_with_metrics();
+        let proposer = reg.weighted_proposer(100, 0).unwrap();
+        let _ = engine.on_proposal("hash_abc", &proposer, &reg);
+        let cnt = m.votes_received.with_label_values(&[phase::PROPOSE]).get();
+        assert_eq!(cnt, 1);
+    }
+
+    #[test]
+    fn test_on_proposal_wrong_proposer_does_not_count() {
+        let (mut engine, reg, m) = setup_with_metrics();
+        // Pick an address that isn't the round-0 proposer.
+        let real_proposer = reg.weighted_proposer(100, 0).unwrap();
+        let wrong = if real_proposer == "0xval001" {
+            "0xval002"
+        } else {
+            "0xval001"
+        };
+        let _ = engine.on_proposal("hash_abc", wrong, &reg);
+        assert_eq!(
+            m.votes_received.with_label_values(&[phase::PROPOSE]).get(),
+            0,
+        );
+    }
+
+    #[test]
+    fn test_on_prevote_increments_prevote_counter() {
+        let (mut engine, _reg, m) = setup_with_metrics();
+        let pv = Prevote {
+            height: 100,
+            round: 0,
+            block_hash: Some("h".into()),
+            validator: "0xval005".into(),
+            signature: vec![],
+        };
+        let _ = engine.on_prevote_weighted(&pv, MIN_SELF_STAKE);
+        assert_eq!(
+            m.votes_received.with_label_values(&[phase::PREVOTE]).get(),
+            1,
+        );
+    }
+
+    #[test]
+    fn test_on_precommit_increments_precommit_counter() {
+        let (mut engine, _reg, m) = setup_with_metrics();
+        let pc = Precommit {
+            height: 100,
+            round: 0,
+            block_hash: Some("h".into()),
+            validator: "0xval005".into(),
+            signature: vec![],
+        };
+        let _ = engine.on_precommit_weighted(&pc, MIN_SELF_STAKE);
+        assert_eq!(
+            m.votes_received
+                .with_label_values(&[phase::PRECOMMIT])
+                .get(),
+            1,
+        );
+    }
+
+    #[test]
+    fn test_on_timeout_increments_phase_counter() {
+        let (mut engine, _reg, m) = setup_with_metrics();
+        // Engine starts in Propose phase, so on_timeout records a propose-timeout.
+        let _ = engine.on_timeout();
+        assert_eq!(m.timeouts.with_label_values(&[phase::PROPOSE]).get(), 1);
+        // First on_timeout populates pending_prevote (nil); subsequent
+        // calls short-circuit to BroadcastPrevote without reaching the
+        // counter. To exercise the prevote-phase timeout path, clear
+        // pending_prevote first then call timeout from Prevote phase.
+        engine.pending_prevote = None;
+        let _ = engine.on_timeout();
+        assert_eq!(m.timeouts.with_label_values(&[phase::PREVOTE]).get(), 1);
+    }
+
+    #[test]
+    fn test_jail_counter_via_inc_jail_helper() {
+        let m = BftMetrics::for_test();
+        // Engine doesn't drive jail events directly — slashing module does,
+        // but the helper API is part of the BftMetrics surface so we pin it.
+        m.inc_jail(jail_reason::LIVENESS);
+        m.inc_jail(jail_reason::LIVENESS);
+        m.inc_jail(jail_reason::DOUBLE_SIGN);
+        m.inc_jail(jail_reason::MANUAL);
+        assert_eq!(
+            m.jail_events
+                .with_label_values(&[jail_reason::LIVENESS])
+                .get(),
+            2,
+        );
+        assert_eq!(
+            m.jail_events
+                .with_label_values(&[jail_reason::DOUBLE_SIGN])
+                .get(),
+            1,
+        );
+        assert_eq!(
+            m.jail_events
+                .with_label_values(&[jail_reason::MANUAL])
+                .get(),
+            1,
+        );
+    }
+
+    #[test]
+    fn test_attach_metrics_after_construction() {
+        let (mut engine, _reg, _m1) = setup_with_metrics();
+        // Construct without metrics, attach later — same gauge updates apply.
+        let mut engine2 = BftEngine::new(100, "0xval000".into(), 21 * MIN_SELF_STAKE);
+        let m2 = BftMetrics::for_test();
+        engine2.attach_metrics(m2.clone());
+        assert_eq!(m2.current_height.get(), 100);
+        assert_eq!(m2.current_round.get(), 0);
+        engine2.advance_round();
+        assert_eq!(m2.rounds_total.get(), 1);
+        assert_eq!(m2.current_round.get(), 1);
+        // Sanity: the original engine's metrics didn't pick up the second
+        // engine's increments.
+        // (The setup_with_metrics m1 is unused here but proves isolation
+        // works — see metrics::tests::test_for_test_helper_isolates.)
+        engine.advance_round();
+        assert!(engine.metrics().is_some());
+    }
+
+    #[test]
+    fn test_engine_without_metrics_skips_all_calls() {
+        // Legacy hot path: no metric ops, no panics, behaviour identical
+        // to the pre-PR engine.
+        let (mut engine, reg) = setup();
+        assert!(engine.metrics().is_none());
+        engine.advance_round();
+        engine.new_height(101, 10_000);
+        let proposer = reg.weighted_proposer(101, 0).unwrap();
+        let _ = engine.on_proposal("h", &proposer, &reg);
+        let _ = engine.on_timeout();
+        // Reached here without panic — that's the test.
+    }
 }

--- a/crates/sentrix-bft/src/lib.rs
+++ b/crates/sentrix-bft/src/lib.rs
@@ -19,6 +19,7 @@
 pub mod engine;
 pub mod last_sign_guard;
 pub mod messages;
+pub mod metrics;
 
 pub use engine::{BftAction, BftEngine, BftPhase, BftRoundState, VoteCollector};
 pub use engine::{MAX_ROUND, PRECOMMIT_TIMEOUT_MS, PREVOTE_TIMEOUT_MS, PROPOSE_TIMEOUT_MS};
@@ -27,3 +28,4 @@ pub use messages::{
     BftMessage, BlockJustification, Precommit, Prevote, Proposal, RoundStatus,
     supermajority_threshold,
 };
+pub use metrics::{BftMetrics, jail_reason, phase};

--- a/crates/sentrix-bft/src/metrics.rs
+++ b/crates/sentrix-bft/src/metrics.rs
@@ -1,0 +1,245 @@
+//! BFT consensus metrics. Tendermint-style observability for round stall,
+//! timeout, vote, and jail detection.
+//!
+//! # Design
+//!
+//! [`BftMetrics`] is registered against a [`prometheus::Registry`] at
+//! construction. The validator binary creates one instance against the
+//! default registry; tests can construct against a private registry to
+//! avoid global state pollution.
+//!
+//! Metrics are wrapped behind cheap accessors so engine-side call sites stay
+//! one-liners. All counters/gauges use `IntCounter` / `IntGauge` for
+//! per-event throughput; the only `Histogram` is round duration, which needs
+//! distributional summary.
+//!
+//! Phase labels (`propose`/`prevote`/`precommit`) and jail reason labels are
+//! emitted as Prometheus labels so dashboards can break down by phase
+//! without separate counter names per phase.
+//!
+//! # Performance
+//!
+//! Each metric op is one atomic add (counter/gauge) or one histogram
+//! observation (lock-free in `prometheus 0.14`). The optional wrapping in
+//! [`Option<Arc<BftMetrics>>`] on the engine side adds one `if let` —
+//! negligible vs the BFT hot-path work that follows. Hot-path call sites
+//! are noted in `engine.rs`.
+
+use prometheus::{Histogram, HistogramOpts, IntCounter, IntCounterVec, IntGauge, Opts, Registry};
+use std::sync::Arc;
+
+/// Phase label values used by the per-phase counters. Kept as `&'static str`
+/// so the metric impls don't allocate per increment.
+pub mod phase {
+    pub const PROPOSE: &str = "propose";
+    pub const PREVOTE: &str = "prevote";
+    pub const PRECOMMIT: &str = "precommit";
+}
+
+/// Reason label values used by the jail counter.
+pub mod jail_reason {
+    pub const LIVENESS: &str = "liveness";
+    pub const DOUBLE_SIGN: &str = "double_sign";
+    pub const MANUAL: &str = "manual";
+}
+
+/// All BFT consensus metrics. Cheap to clone via [`Arc`]; engine holds an
+/// [`Option<Arc<BftMetrics>>`] so test paths can pass `None` and skip the
+/// metric calls entirely.
+#[derive(Clone, Debug)]
+pub struct BftMetrics {
+    /// Distribution of round wall-clock durations (start of round to next-round
+    /// advance or successful commit). Buckets cover sub-second to a full minute
+    /// — anything past that is a real consensus stall, captured as +Inf.
+    pub round_duration: Histogram,
+
+    /// Per-phase timeout counter. Increments every time a phase times out
+    /// without progress. Sustained non-zero rate on any phase = consensus
+    /// liveness pressure.
+    pub timeouts: IntCounterVec,
+
+    /// Per-phase votes-received counter. Increments on every `on_proposal` /
+    /// `on_prevote` / `on_precommit` accept. Useful for vote-loss detection
+    /// (compare to expected `active_count - 1` per round).
+    pub votes_received: IntCounterVec,
+
+    /// Total round advances at the current height. Reset implicit via
+    /// `new_height` — read via Prometheus delta over a window, not absolute.
+    pub rounds_total: IntCounter,
+
+    /// Jail events keyed by reason (`liveness` / `double_sign` / `manual`).
+    /// Increment is operator-driven (BFT engine doesn't enforce slashing
+    /// directly — slashing module signals; engine surfaces the count).
+    pub jail_events: IntCounterVec,
+
+    /// Current BFT round at the active height. Useful for "round stuck >0"
+    /// alerts and per-validator round-skew diagnostics.
+    pub current_round: IntGauge,
+
+    /// Current BFT height. Mirrors chain.height + 1 when proposing.
+    pub current_height: IntGauge,
+}
+
+impl BftMetrics {
+    /// Construct and register all metrics against the given registry.
+    ///
+    /// Returns an [`Arc`] so the engine can hold a cheap clone and call
+    /// sites stay one-liners.
+    pub fn new(registry: &Registry) -> Result<Arc<Self>, prometheus::Error> {
+        let round_duration = Histogram::with_opts(
+            HistogramOpts::new(
+                "bft_round_duration_seconds",
+                "Wall-clock duration of each BFT round (propose-to-commit or propose-to-next-round).",
+            )
+            .buckets(vec![
+                0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0,
+            ]),
+        )?;
+        registry.register(Box::new(round_duration.clone()))?;
+
+        let timeouts = IntCounterVec::new(
+            Opts::new(
+                "bft_timeout_total",
+                "BFT phase-timeout count, labeled by phase.",
+            ),
+            &["phase"],
+        )?;
+        registry.register(Box::new(timeouts.clone()))?;
+
+        let votes_received = IntCounterVec::new(
+            Opts::new(
+                "bft_votes_received_total",
+                "BFT votes received and accepted by the local engine, labeled by phase.",
+            ),
+            &["phase"],
+        )?;
+        registry.register(Box::new(votes_received.clone()))?;
+
+        let rounds_total = IntCounter::with_opts(Opts::new(
+            "bft_rounds_total",
+            "Cumulative BFT round advances since process start (any height).",
+        ))?;
+        registry.register(Box::new(rounds_total.clone()))?;
+
+        let jail_events = IntCounterVec::new(
+            Opts::new(
+                "bft_jail_events_total",
+                "Jail events observed by the consensus path, labeled by reason.",
+            ),
+            &["reason"],
+        )?;
+        registry.register(Box::new(jail_events.clone()))?;
+
+        let current_round = IntGauge::with_opts(Opts::new(
+            "bft_current_round",
+            "Current BFT round at the active consensus height.",
+        ))?;
+        registry.register(Box::new(current_round.clone()))?;
+
+        let current_height = IntGauge::with_opts(Opts::new(
+            "bft_current_height",
+            "Current BFT height (= chain.height + 1 while proposing).",
+        ))?;
+        registry.register(Box::new(current_height.clone()))?;
+
+        Ok(Arc::new(Self {
+            round_duration,
+            timeouts,
+            votes_received,
+            rounds_total,
+            jail_events,
+            current_round,
+            current_height,
+        }))
+    }
+
+    /// Convenience: instantiate against a fresh private registry. Useful in
+    /// tests so each test gets isolated counters.
+    pub fn for_test() -> Arc<Self> {
+        let registry = Registry::new();
+        Self::new(&registry).expect("test metrics registration cannot fail")
+    }
+
+    // ── Hot-path one-liners ───────────────────────────────────────────────
+
+    /// Increment per-phase timeout counter.
+    #[inline]
+    pub fn inc_timeout(&self, phase_label: &str) {
+        self.timeouts.with_label_values(&[phase_label]).inc();
+    }
+
+    /// Increment per-phase vote-received counter.
+    #[inline]
+    pub fn inc_vote(&self, phase_label: &str) {
+        self.votes_received.with_label_values(&[phase_label]).inc();
+    }
+
+    /// Increment round-advance counter.
+    #[inline]
+    pub fn inc_round(&self) {
+        self.rounds_total.inc();
+    }
+
+    /// Increment jail-event counter for a given reason.
+    #[inline]
+    pub fn inc_jail(&self, reason: &str) {
+        self.jail_events.with_label_values(&[reason]).inc();
+    }
+
+    /// Observe a completed round's wall-clock duration.
+    #[inline]
+    pub fn observe_round_duration(&self, seconds: f64) {
+        self.round_duration.observe(seconds);
+    }
+
+    /// Set current round gauge.
+    #[inline]
+    pub fn set_round(&self, round: u32) {
+        self.current_round.set(round as i64);
+    }
+
+    /// Set current height gauge.
+    #[inline]
+    pub fn set_height(&self, height: u64) {
+        self.current_height.set(height as i64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_against_fresh_registry() {
+        let registry = Registry::new();
+        let m = BftMetrics::new(&registry).unwrap();
+        // Smoke-check: all increments work without panic.
+        m.inc_timeout(phase::PROPOSE);
+        m.inc_vote(phase::PREVOTE);
+        m.inc_round();
+        m.inc_jail(jail_reason::LIVENESS);
+        m.observe_round_duration(0.5);
+        m.set_round(7);
+        m.set_height(12345);
+    }
+
+    #[test]
+    fn test_double_register_errors_cleanly() {
+        let registry = Registry::new();
+        let _ok = BftMetrics::new(&registry).unwrap();
+        // Must be a clean Err, not a panic. The exact error string varies
+        // across prometheus crate versions; the contract we care about is
+        // "second registration returns Err".
+        assert!(BftMetrics::new(&registry).is_err());
+    }
+
+    #[test]
+    fn test_for_test_helper_isolates() {
+        let m1 = BftMetrics::for_test();
+        let m2 = BftMetrics::for_test();
+        m1.inc_round();
+        assert_eq!(m1.rounds_total.get(), 1);
+        // m2 is on its own registry, so m1's increment doesn't bleed.
+        assert_eq!(m2.rounds_total.get(), 0);
+    }
+}


### PR DESCRIPTION
## Why

BFT consensus on Sentrix has been observable only through ad-hoc tracing logs scattered across `engine.rs`. Round stalls, phase timeouts, vote loss, and jail events have no Prometheus surface — operators have to grep journal to detect them, and dashboard-based alerts are impossible. This blocks public-validator scaling.

## What

New `crates/sentrix-bft/src/metrics.rs` defines `BftMetrics` — a struct holding `prometheus::{Histogram, IntCounter, IntCounterVec, IntGauge}` handles registered against any `prometheus::Registry`. Injected into `BftEngine` via `Option<Arc<BftMetrics>>` so:

- Validator binary path: `BftEngine::new_with_metrics(..., metrics)` wires observability
- Tests + bench: `BftEngine::new(...)` skips metrics via `None` → zero overhead

### Metrics shipped

| Name | Type | Labels | Use |
|---|---|---|---|
| `bft_round_duration_seconds` | Histogram | — | Round wall-clock distribution; buckets `0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60` |
| `bft_timeout_total` | IntCounterVec | `phase` | Per-phase timeout count (propose / prevote / precommit) |
| `bft_votes_received_total` | IntCounterVec | `phase` | Per-phase accepted-vote count |
| `bft_rounds_total` | IntCounter | — | Cumulative round advances since process start |
| `bft_jail_events_total` | IntCounterVec | `reason` | Jail events by reason (liveness / double_sign / manual) |
| `bft_current_round` | IntGauge | — | Current BFT round |
| `bft_current_height` | IntGauge | — | Current BFT height (= chain.height + 1 when proposing) |

Phase + jail-reason labels live as `pub const &'static str` in `phase::` and `jail_reason::` submodules — no per-increment allocation.

### Engine integration

Hot paths instrumented (every state transition gets one metric op + one tracing event):

- `new_height`: set_height + set_round(0) + info log
- `advance_round`: inc_round + observe_round_duration + set_round + info log
- `on_proposal` (post-proposer-verify): inc_vote[propose] + debug log
- `on_prevote_weighted` (post-dedup): inc_vote[prevote] + trace log
- `on_precommit_weighted` (post-dedup): inc_vote[precommit] + trace log
- `on_timeout`: inc_timeout[phase] + warn log

All metric ops guarded behind `if let Some(m) = &self.metrics` — when metrics is `None` the cost is one branch + no atomic, so the legacy hot path is unchanged.

### Wiring to sentrix-prom-exporter

`sentrix-prom-exporter` is a separate process that scrapes validator RPC. To surface `bft_*` metrics, the validator binary needs a `/metrics` endpoint returning `prometheus::default_registry().gather()`. **That wiring is the follow-up PR** — landing the bft-side surface alone keeps review clean.

After follow-up lands, exporter config gains:

```yaml
scrape_configs:
  - job_name: sentrix-validator
    static_configs:
      - targets: ['validator-host:8545']
```

## Test plan

- [x] 3 new unit tests in `metrics.rs` (registration smoke, double-register Err contract, per-test isolation)
- [x] Existing 125 sentrix-bft unit tests still pass
- [x] `cargo check --release --all-targets` clean with `RUSTFLAGS="-D warnings"`
- [x] `cargo fmt --check` clean
- [x] Follow-up PR: wire BftMetrics in `bin/sentrix/src/main.rs` + add `/metrics` axum route
- [x] After deploy: verify `curl http://validator:8545/metrics | grep bft_` returns counters

## Version

Workspace 2.2.19 → 2.2.21 (skips 2.2.20, reserved for #742 guard-resume fix; either PR can land first, the other rebases).