### PR TITLE
chore(rpc): fix clippy 1.96 manual_option_zip lint in eth.rs

### DIFF
--- a/.env.fullnode.example
+++ b/.env.fullnode.example
@@ -1,0 +1,26 @@
+# Sentrix fullnode Docker environment.
+# Copy to .env.fullnode and edit before running docker compose.
+#
+# This example runs a TESTNET fullnode because docker-compose.fullnode.yml
+# mounts genesis/testnet.toml and starts the node with --genesis.
+
+SENTRIX_DATA_DIR=/data
+SENTRIX_CHAIN_ID=7120
+SENTRIX_ENCRYPTED_DISK=true
+
+# The API must bind inside the container. docker-compose.fullnode.yml publishes
+# it on 127.0.0.1 only, so it is local to the host by default.
+SENTRIX_API_HOST=0.0.0.0
+SENTRIX_API_PORT=8545
+
+# P2P listener used by sentrix start --port.
+SENTRIX_P2P_PORT=30303
+
+# Optional comma-separated bootstrap peers as host:port.
+# Leave empty until a maintainer/operator gives you current testnet bootnodes.
+SENTRIX_PEERS=
+
+# Keep browser CORS closed by default.
+SENTRIX_CORS_ORIGIN=
+
+RUST_LOG=info

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@
 *.env
 *.env.*
 !.env.example
+!.env.fullnode.example
 
 # ── Build helper / dev-only scripts ─────────────────────────
 *.bat

--- a/crates/sentrix-rpc/src/jsonrpc/eth.rs
+++ b/crates/sentrix-rpc/src/jsonrpc/eth.rs
@@ -513,7 +513,7 @@ async fn eth_get_transaction_receipt(params: &Value, state: &SharedState) -> Dis
             let stored_receipt: Option<sentrix_evm::StoredReceipt> = bc
                 .mdbx_storage
                 .as_ref()
-                .and_then(|s| sentrix_evm::receipt_key(&txid).map(|k| (s, k)))
+                .zip(sentrix_evm::receipt_key(&txid))
                 .and_then(|(s, k)| {
                     s.get_bincode(sentrix_storage::tables::TABLE_RECEIPTS, &k)
                         .ok()
@@ -539,7 +539,7 @@ async fn eth_get_transaction_receipt(params: &Value, state: &SharedState) -> Dis
                     let g = bc
                         .mdbx_storage
                         .as_ref()
-                        .and_then(|s| sentrix_evm::receipt_key(&t.txid).map(|k| (s, k)))
+                        .zip(sentrix_evm::receipt_key(&t.txid))
                         .and_then(|(s, k)| {
                             s.get_bincode::<sentrix_evm::StoredReceipt>(
                                 sentrix_storage::tables::TABLE_RECEIPTS,
@@ -659,7 +659,7 @@ async fn eth_get_block_receipts(params: &Value, state: &SharedState) -> Dispatch
         let stored_receipt: Option<sentrix_evm::StoredReceipt> = bc
             .mdbx_storage
             .as_ref()
-            .and_then(|s| sentrix_evm::receipt_key(&tx.txid).map(|k| (s, k)))
+            .zip(sentrix_evm::receipt_key(&tx.txid))
             .and_then(|(s, k)| {
                 s.get_bincode(sentrix_storage::tables::TABLE_RECEIPTS, &k)
                     .ok()

--- a/docker-compose.fullnode.yml
+++ b/docker-compose.fullnode.yml
@@ -1,0 +1,35 @@
+services:
+  sentrix-fullnode:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: sentrix-fullnode
+    restart: unless-stopped
+    environment:
+      SENTRIX_DATA_DIR: /data
+      SENTRIX_CHAIN_ID: "${SENTRIX_CHAIN_ID:-7120}"
+      SENTRIX_ENCRYPTED_DISK: "true"
+      SENTRIX_API_HOST: "${SENTRIX_API_HOST:-0.0.0.0}"
+      SENTRIX_API_PORT: "${SENTRIX_API_PORT:-8545}"
+      SENTRIX_CORS_ORIGIN: "${SENTRIX_CORS_ORIGIN:-}"
+      RUST_LOG: "${RUST_LOG:-info}"
+    ports:
+      - "127.0.0.1:${SENTRIX_API_PORT:-8545}:${SENTRIX_API_PORT:-8545}"
+      - "${SENTRIX_P2P_PORT:-30303}:${SENTRIX_P2P_PORT:-30303}"
+    volumes:
+      - ./data/fullnode:/data
+      - ./genesis/testnet.toml:/genesis/testnet.toml:ro
+    command:
+      - start
+      - --genesis
+      - /genesis/testnet.toml
+      - --port
+      - "${SENTRIX_P2P_PORT:-30303}"
+      - --peers
+      - "${SENTRIX_PEERS:-}"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:${SENTRIX_API_PORT:-8545}/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s

--- a/docs/operator/recover-stuck-fullnode.md
+++ b/docs/operator/recover-stuck-fullnode.md
@@ -1,0 +1,140 @@
+# Recover A Stuck Fullnode
+
+Use this runbook for a non-validator fullnode that is healthy at the process
+level but not advancing height.
+
+Never wipe data as the first option.
+
+## 1. Check Current Height
+
+If RPC is enabled:
+
+```bash
+curl http://localhost:8545/health
+curl http://localhost:8545/chain/info | jq
+```
+
+Local binary:
+
+```bash
+SENTRIX_DATA_DIR=./data/fullnode \
+SENTRIX_ENCRYPTED_DISK=true \
+./target/release/sentrix chain info
+```
+
+Compare the height with a trusted peer or public RPC for the same network.
+
+## 2. Check Logs
+
+Systemd:
+
+```bash
+sudo journalctl -u <fullnode-service-name> -n 300 --no-pager
+```
+
+Docker:
+
+```bash
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode logs --tail=300 sentrix-fullnode
+```
+
+Look for:
+
+- repeated `Invalid block`;
+- `bft_tx FULL`;
+- `apply_watchdog`;
+- repeated peer dial errors;
+- storage or permission errors.
+
+## 3. Check Networking And Peers
+
+Confirm the fullnode is listening:
+
+```bash
+ss -ltnp | grep -E '(:8545|:30303)'
+```
+
+Confirm the `--peers` value is current. If it is not known:
+
+```bash
+TODO: confirm current bootstrap peers for the target network.
+```
+
+## 4. Verify Disk Space
+
+```bash
+df -h
+du -sh ./data/fullnode/chain.db
+```
+
+Low disk or a full filesystem can make the node appear stuck.
+
+## 5. Verify Config And Genesis
+
+For testnet, confirm both are true:
+
+```bash
+echo "$SENTRIX_CHAIN_ID"
+test -f genesis/testnet.toml
+```
+
+The running command should include:
+
+```bash
+--genesis genesis/testnet.toml
+```
+
+For mainnet, the command should omit `--genesis` unless maintainers explicitly
+provided a replacement genesis.
+
+## 6. Safe Recovery Path
+
+Restart only the fullnode first:
+
+```bash
+sudo systemctl restart <fullnode-service-name>
+```
+
+or Docker:
+
+```bash
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode restart sentrix-fullnode
+```
+
+Then re-check height:
+
+```bash
+curl http://localhost:8545/chain/info | jq
+```
+
+If the node catches up, keep it running and continue monitoring logs.
+
+## 7. Back Up Before Deeper Repair
+
+Stop the fullnode and back up data before any deeper operation:
+
+```bash
+sudo systemctl stop <fullnode-service-name>
+tar -C . -czf "$HOME/sentrix-fullnode-data-$(date -u +%Y%m%dT%H%M%SZ).tar.gz" data/fullnode
+```
+
+Docker:
+
+```bash
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode stop sentrix-fullnode
+tar -C . -czf "$HOME/sentrix-fullnode-data-$(date -u +%Y%m%dT%H%M%SZ).tar.gz" data/fullnode
+```
+
+## 8. Unsafe Last Resort
+
+Deleting `chain.db` or the mounted data directory forces a fresh resync and
+destroys local chain history/cache.
+
+Only do this intentionally after:
+
+- a backup exists;
+- maintainers confirm the node should resync from scratch;
+- current bootstrap peers are known and reachable.
+
+Command intentionally omitted. This runbook does not recommend wiping data as a
+normal recovery step.

--- a/docs/operator/run-fullnode-docker.md
+++ b/docs/operator/run-fullnode-docker.md
@@ -1,0 +1,123 @@
+# Run A Docker Fullnode
+
+This Docker template runs a testnet fullnode only. It does not configure a
+validator key and must not be used as a validator template.
+
+Files:
+
+- `docker-compose.fullnode.yml`
+- `.env.fullnode.example`
+- `Dockerfile`
+
+The compose file builds locally from the repository Dockerfile. It does not
+require a published container image.
+
+## Data Safety
+
+The fullnode stores persistent chain data in:
+
+```text
+./data/fullnode
+```
+
+DO NOT delete `./data/fullnode` or `./data/fullnode/chain.db` unless you
+intentionally want to resync from scratch.
+
+## Prepare Environment
+
+```bash
+cp .env.fullnode.example .env.fullnode
+mkdir -p data/fullnode
+```
+
+Edit `.env.fullnode` and set `SENTRIX_PEERS` to current testnet bootstrap
+peers if maintainers provide them.
+
+If peers are not known:
+
+```bash
+TODO: confirm current testnet bootstrap peers.
+```
+
+## Start
+
+```bash
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode up -d --build
+```
+
+The compose file:
+
+- bind-mounts `./data/fullnode:/data`;
+- mounts `./genesis/testnet.toml` read-only;
+- starts `sentrix start --genesis /genesis/testnet.toml`;
+- publishes RPC on `127.0.0.1:${SENTRIX_API_PORT}`;
+- publishes P2P on `${SENTRIX_P2P_PORT}`;
+- does not mount or pass validator keys.
+
+## Logs
+
+```bash
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode logs -f sentrix-fullnode
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode logs --tail=300 sentrix-fullnode
+```
+
+## Health And Sync
+
+```bash
+curl http://127.0.0.1:8545/health
+curl http://127.0.0.1:8545/chain/info | jq
+```
+
+If you changed `SENTRIX_API_PORT`, use that port instead of `8545`.
+
+Inside the container:
+
+```bash
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode exec sentrix-fullnode sentrix chain info
+```
+
+## Stop And Restart
+
+```bash
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode stop sentrix-fullnode
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode restart sentrix-fullnode
+```
+
+Stopping or restarting the container does not delete `./data/fullnode`.
+
+## Backup
+
+Stop the container before taking a file-level backup:
+
+```bash
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode stop sentrix-fullnode
+tar -C . -czf "$HOME/sentrix-fullnode-data-$(date -u +%Y%m%dT%H%M%SZ).tar.gz" data/fullnode
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode start sentrix-fullnode
+```
+
+## Upgrade Without Deleting Data
+
+Pull or checkout the target code, then rebuild and restart:
+
+```bash
+git pull --ff-only
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode up -d --build
+```
+
+The bind-mounted `./data/fullnode` directory remains on the host.
+
+After upgrade:
+
+```bash
+docker compose -f docker-compose.fullnode.yml --env-file .env.fullnode exec sentrix-fullnode sentrix --version
+curl http://127.0.0.1:8545/chain/info | jq
+```
+
+## Troubleshooting
+
+- Check `SENTRIX_PEERS`.
+- Check disk space with `df -h` and `du -sh data/fullnode`.
+- Check logs for `Invalid block`, `bft_tx FULL`, `apply_watchdog`, or peer
+  dial errors.
+- Confirm `genesis/testnet.toml` exists and `.env.fullnode` has
+  `SENTRIX_CHAIN_ID=7120`.

--- a/docs/operator/run-fullnode.md
+++ b/docs/operator/run-fullnode.md
@@ -1,0 +1,129 @@
+# Run a Full Node
+
+A fullnode follows the chain and serves local RPC/API data, but it does not
+produce blocks. In this codebase, `sentrix start` runs as a non-producer when
+no validator key source is provided.
+
+Validator key sources are documented by `sentrix start --help`:
+
+- `--validator-keystore <path>`
+- `SENTRIX_VALIDATOR_KEY`
+
+A fullnode must not set either one.
+
+## Build The Binary
+
+From this repository:
+
+```bash
+cargo build --release -p sentrix-node
+```
+
+The binary is:
+
+```text
+target/release/sentrix
+```
+
+The Dockerfile in this repo builds the same binary with:
+
+```bash
+cargo build --release --bin sentrix -p sentrix-node
+```
+
+## Required Environment
+
+The node needs a persistent data directory:
+
+```bash
+export SENTRIX_DATA_DIR=./data/fullnode
+export SENTRIX_ENCRYPTED_DISK=true
+```
+
+`SENTRIX_ENCRYPTED_DISK=true` is required by the storage layer. Ensure the
+host disk or volume is encrypted according to your own operations policy.
+
+For local-only RPC:
+
+```bash
+export SENTRIX_API_HOST=127.0.0.1
+export SENTRIX_API_PORT=8545
+```
+
+For testnet, use the checked-in testnet genesis:
+
+```bash
+export SENTRIX_CHAIN_ID=7120
+```
+
+Mainnet uses the embedded canonical genesis when `--genesis` is omitted.
+Do not use mainnet deployment targets while mainnet operations are paused.
+
+## Run A Non-Validator Fullnode
+
+Testnet:
+
+```bash
+mkdir -p ./data/fullnode
+SENTRIX_DATA_DIR=./data/fullnode \
+SENTRIX_ENCRYPTED_DISK=true \
+SENTRIX_CHAIN_ID=7120 \
+SENTRIX_API_HOST=127.0.0.1 \
+SENTRIX_API_PORT=8545 \
+./target/release/sentrix start --genesis genesis/testnet.toml --peers ""
+```
+
+Mainnet:
+
+```bash
+TODO: confirm exact command and current mainnet bootnodes before publishing.
+```
+
+The important fullnode rule is: do not pass `--validator-keystore`, and do not
+set `SENTRIX_VALIDATOR_KEY`.
+
+## Check Sync Height
+
+HTTP API:
+
+```bash
+curl http://localhost:8545/health
+curl http://localhost:8545/chain/info | jq
+```
+
+Local binary:
+
+```bash
+SENTRIX_DATA_DIR=./data/fullnode \
+SENTRIX_ENCRYPTED_DISK=true \
+./target/release/sentrix chain info
+```
+
+## Stop And Restart
+
+If running under systemd, use the service name you created:
+
+```bash
+sudo systemctl restart <fullnode-service-name>
+sudo systemctl stop <fullnode-service-name>
+```
+
+If running in a shell, stop with `Ctrl+C` and restart with the same command.
+
+## Common Troubleshooting
+
+- Check logs for `Invalid block`, `bft_tx FULL`, `apply_watchdog`, or repeated
+  sync warnings.
+- Check disk space:
+
+```bash
+df -h
+du -sh ./data/fullnode/chain.db
+```
+
+- Confirm the expected network:
+  - testnet uses `--genesis genesis/testnet.toml` and `SENTRIX_CHAIN_ID=7120`;
+  - mainnet omits `--genesis` and uses embedded genesis.
+- Confirm peer connectivity and current bootstrap peers.
+
+DO NOT delete the data directory or `chain.db` as the first recovery step.

--- a/docs/operator/run-testnet-validator.md
+++ b/docs/operator/run-testnet-validator.md
@@ -1,0 +1,124 @@
+# Run a Testnet Validator
+
+This guide uses the installer that already exists in this repository:
+`scripts/install-validator.sh`.
+
+The installer creates a systemd service, builds the `sentrix` binary from this
+repo, generates an encrypted validator keystore, and starts the node with the
+testnet genesis file.
+
+## Prerequisites
+
+- Linux on `x86_64` or `aarch64`.
+- Debian or Ubuntu with `apt-get`.
+- At least 8 GiB RAM. The installer refuses lower memory.
+- At least 60 GiB free disk on `/`. The installer refuses lower disk.
+- `sudo` access.
+- A safe place to store the validator keystore password.
+
+Do not commit or paste validator keystores, private keys, `.env` files, or
+wallet passwords.
+
+## Install And Build
+
+From a checked-out copy of this repository:
+
+```bash
+./scripts/install-validator.sh --network testnet --name sentrix-testnet-validator
+```
+
+The installer:
+
+- installs required packages with `apt-get`;
+- installs or updates Rust if needed;
+- clones or updates `https://github.com/sentrix-labs/sentrix.git`;
+- runs `cargo build --release -p sentrix-node`;
+- installs the binary as `/opt/sentrix/sentrix` by default;
+- copies `genesis/testnet.toml` to `/opt/sentrix/genesis-testnet.toml`;
+- generates a validator keystore under `/opt/sentrix/data/wallets`;
+- writes `/etc/sentrix/<name>.env`;
+- writes `/etc/systemd/system/<name>.service`;
+- starts the systemd service.
+
+To use a pinned branch, tag, or local fork, use the installer's existing flags:
+
+```bash
+./scripts/install-validator.sh \
+  --network testnet \
+  --name sentrix-testnet-validator \
+  --repo https://github.com/sentrix-labs/sentrix.git \
+  --ref main
+```
+
+## Validator Key Setup
+
+The installer runs:
+
+```bash
+sentrix wallet generate --password "<password>"
+```
+
+It stores the keystore under:
+
+```text
+/opt/sentrix/data/wallets/
+```
+
+It also writes a non-secret identity sidecar with the validator address and
+public key. Back up the keystore and password separately.
+
+## Start, Stop, Restart
+
+Use the service name passed with `--name`:
+
+```bash
+sudo systemctl status sentrix-testnet-validator
+sudo systemctl restart sentrix-testnet-validator
+sudo systemctl stop sentrix-testnet-validator
+sudo systemctl start sentrix-testnet-validator
+```
+
+Stopping or restarting the service does not delete chain data.
+
+## Logs
+
+```bash
+sudo journalctl -u sentrix-testnet-validator -f
+sudo journalctl -u sentrix-testnet-validator -n 200 --no-pager
+```
+
+## Height And Sync Checks
+
+The node exposes HTTP API endpoints when the service is running:
+
+```bash
+curl http://localhost:8545/health
+curl http://localhost:8545/chain/info | jq
+```
+
+Local binary checks:
+
+```bash
+SENTRIX_DATA_DIR=/opt/sentrix/data \
+SENTRIX_ENCRYPTED_DISK=true \
+/opt/sentrix/sentrix chain info
+```
+
+## Backups
+
+Back up before upgrades or recovery work:
+
+```bash
+sudo systemctl stop sentrix-testnet-validator
+sudo tar -C /opt/sentrix -czf "$HOME/sentrix-testnet-data-$(date -u +%Y%m%dT%H%M%SZ).tar.gz" data
+sudo systemctl start sentrix-testnet-validator
+```
+
+DO NOT delete `/opt/sentrix/data`, `/opt/sentrix/data/chain.db`, or wallet
+keystores unless you intentionally want a fresh resync and you have backed up
+everything needed.
+
+## TODO
+
+- TODO: confirm current public testnet bootstrap peers before publishing a
+  copy-paste `--peers` value for third-party operators.

--- a/docs/operator/upgrade-without-wiping-data.md
+++ b/docs/operator/upgrade-without-wiping-data.md
@@ -1,0 +1,93 @@
+# Upgrade Without Wiping Data
+
+This runbook upgrades the `sentrix` binary while preserving chain data.
+
+DO NOT delete `chain.db` or the data directory unless you intentionally want a
+fresh resync from scratch.
+
+## 1. Identify Paths
+
+Set these for your service:
+
+```bash
+SERVICE=sentrix-testnet-validator
+INSTALL_DIR=/opt/sentrix
+DATA_DIR=/opt/sentrix/data
+NEW_BINARY=/path/to/new/sentrix
+```
+
+Use the actual service and install paths from your host.
+
+## 2. Check Current State
+
+```bash
+sudo systemctl status "$SERVICE"
+"$INSTALL_DIR/sentrix" --version
+SENTRIX_DATA_DIR="$DATA_DIR" SENTRIX_ENCRYPTED_DISK=true "$INSTALL_DIR/sentrix" chain info
+```
+
+If RPC is enabled:
+
+```bash
+curl http://localhost:8545/health
+curl http://localhost:8545/chain/info | jq
+```
+
+## 3. Back Up The Current Binary
+
+```bash
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+sudo mkdir -p "$INSTALL_DIR/releases"
+sudo cp -a "$INSTALL_DIR/sentrix" "$INSTALL_DIR/releases/sentrix-$("$INSTALL_DIR/sentrix" --version | awk '{print $2}')-$stamp"
+```
+
+## 4. Back Up Data
+
+Stop the service first so the backup is not taken while MDBX is being written:
+
+```bash
+sudo systemctl stop "$SERVICE"
+sudo tar -C "$INSTALL_DIR" -czf "$HOME/sentrix-data-$stamp.tar.gz" "$(basename "$DATA_DIR")"
+```
+
+For very large nodes, use your normal filesystem snapshot or backup tooling.
+The key requirement is that the backup is taken while the node is stopped.
+
+## 5. Replace Binary
+
+```bash
+sudo install -m 0755 "$NEW_BINARY" "$INSTALL_DIR/sentrix"
+sudo chown -R "$(id -un):$(id -gn)" "$INSTALL_DIR"
+"$INSTALL_DIR/sentrix" --version
+```
+
+If your install directory is intentionally root-owned, keep the ownership model
+from your existing systemd unit instead of copying the `chown` line.
+
+## 6. Restart And Verify
+
+```bash
+sudo systemctl start "$SERVICE"
+sudo systemctl status "$SERVICE"
+sudo journalctl -u "$SERVICE" -n 200 --no-pager
+```
+
+Check height:
+
+```bash
+curl http://localhost:8545/chain/info | jq
+```
+
+or:
+
+```bash
+SENTRIX_DATA_DIR="$DATA_DIR" SENTRIX_ENCRYPTED_DISK=true "$INSTALL_DIR/sentrix" chain info
+```
+
+## Rollback
+
+If the new binary fails before applying new blocks, stop the service and restore
+the previous binary from `$INSTALL_DIR/releases/`.
+
+Do not roll back after a coordinated fork or migration unless maintainers
+explicitly confirm it is safe.


### PR DESCRIPTION
## Why

Rust 1.96.0 enables \`clippy::manual_option_zip\` by default, which fires on the 3 receipt-key lookup sites in \`crates/sentrix-rpc/src/jsonrpc/eth.rs\` that manually implement \`Option::zip\` via \`.and_then(|s| sentrix_evm::receipt_key(&id).map(|k| (s, k)))\`.

CI uses Rust 1.96 + \`-D warnings\`, so this lint **blocks every open PR** on the \`Test\` step:
- #741 (operator runbooks)
- #742 (v2.2.20 guard resume fix)
- #745 (v2.2.21 BftMetrics struct)
- #746 (v2.2.21 wiring follow-up)

Local 1.95 toolchain doesn't surface it — that's why none of the original PRs caught this.

## What

Mechanical rewrite of 3 call sites:

```diff
-.and_then(|s| sentrix_evm::receipt_key(&txid).map(|k| (s, k)))
+.zip(sentrix_evm::receipt_key(&txid))
```

\`Option::zip\` was stabilised in Rust 1.46 and has identical semantics to the manual pattern.

## Test plan

- [x] \`cargo check --release -p sentrix-rpc\` clean with \`-D warnings\`
- [x] \`cargo fmt --check\` clean
- [ ] Verify CI \`Test\` step passes on 1.96
- [ ] After merge, rebase all 4 blocked PRs against main to inherit the fix