### PR TITLE
feat(cli): v2.2.22 sentrix staking — TX-based unjail/stake/claim helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "bincode",
  "hex",
@@ -5262,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5307,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "anyhow",
  "axum",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5347,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "anyhow",
  "axum",
@@ -5391,14 +5391,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "hex",
  "proptest",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5472,14 +5472,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "bincode",
  "blake3",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5540,7 +5540,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.21"
+version = "2.2.22"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/bin/sentrix/src/commands/mod.rs
+++ b/bin/sentrix/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod chain;
 pub mod init;
 pub mod mempool;
 pub mod misc;
+pub mod staking;
 pub mod state;
 pub mod token;
 pub mod validator;

--- a/bin/sentrix/src/commands/staking.rs
+++ b/bin/sentrix/src/commands/staking.rs
@@ -1,0 +1,284 @@
+//! `sentrix staking …` subcommands — proper TX-based staking ops.
+//!
+//! Each command crafts a signed `StakingOp` transaction targeted at
+//! `PROTOCOL_TREASURY` and injects it into the local mempool. The chain's
+//! normal apply path picks it up at the next block, runs the dispatcher
+//! at `block_executor::apply_block` (which mutates `stake_registry` AND
+//! recomputes `state_trie`), and the change propagates via the standard
+//! block-sync route. No direct DB edits, no trie drift.
+//!
+//! This module exists because `sentrix validator unjail` and
+//! `sentrix validator force-unjail` mutate `stake_registry` directly in
+//! MDBX `TABLE_STATE` without touching `state_trie` — those commands
+//! create a one-way trap requiring a cluster-wide trie reconciliation
+//! to recover. The TX path here goes through apply_block so the trie
+//! stays consistent on every peer that re-executes the block.
+//!
+//! Pattern mirrors `commands::token::cli_create_token_tx` — load
+//! blockchain, build StakingOp, sign, add to mempool, save. Operator
+//! runs against any node's chain.db (typically the validator's own,
+//! while it's stopped); on next start the mempool gossips the tx out
+//! and an active proposer includes it.
+//!
+//! Fork notes:
+//!   - `RegisterValidator`, `Unjail`, `ClaimRewards`: gated by
+//!     `VOYAGER_REWARD_V2_HEIGHT` (activated mainnet h=590100 / testnet
+//!     long ago) — usable now.
+//!   - `AddSelfStake`: additionally gated by `ADD_SELF_STAKE_HEIGHT`,
+//!     which defaults to `u64::MAX` (dispatch dormant). Operator must
+//!     set the env var on every validator and halt-all + simul-start
+//!     before AddSelfStake will pass apply.
+
+use anyhow::Context;
+
+use sentrix::core::blockchain::Blockchain;
+use sentrix::core::transaction::{PROTOCOL_TREASURY, StakingOp, Transaction};
+use sentrix::storage::db::Storage;
+use sentrix::wallet::keystore::Keystore;
+use sentrix::wallet::wallet::Wallet;
+
+use crate::get_db_path;
+
+/// 1 SRX = 100,000,000 sentri (8 decimal places).
+const SENTRI_PER_SRX: u64 = 100_000_000;
+
+/// Shared helper: build + sign a StakingOp tx and queue it in mempool.
+///
+/// `tx_amount` is the value moved from the sender's balance to
+/// `PROTOCOL_TREASURY` (in sentri). For:
+///   - RegisterValidator / AddSelfStake: must equal the staked amount
+///   - Unjail / ClaimRewards: must be 0
+fn cli_create_staking_tx(
+    bc: &mut Blockchain,
+    wallet: &Wallet,
+    op: StakingOp,
+    tx_amount: u64,
+    fee: u64,
+) -> anyhow::Result<String> {
+    let sk = wallet.get_secret_key()?;
+    let pk = wallet.get_public_key()?;
+    let nonce = bc.accounts.get_nonce(&wallet.address);
+    let data = op
+        .encode()
+        .map_err(|e| anyhow::anyhow!("StakingOp encode failed: {}", e))?;
+    let tx = Transaction::new(
+        wallet.address.clone(),
+        PROTOCOL_TREASURY.to_string(),
+        tx_amount,
+        fee,
+        nonce,
+        data,
+        bc.chain_id,
+        &sk,
+        &pk,
+    )
+    .map_err(|e| anyhow::anyhow!("Transaction::new failed: {}", e))?;
+    let txid = tx.txid.clone();
+    bc.add_to_mempool(tx)
+        .map_err(|e| anyhow::anyhow!("add_to_mempool failed: {}", e))?;
+    Ok(txid)
+}
+
+/// Load a wallet from a keystore file. Password comes from the
+/// `SENTRIX_WALLET_PASSWORD` env var; if unset, prompts on stdin via
+/// rpassword so the password never lands in shell history.
+fn load_wallet(keystore_path: &str) -> anyhow::Result<Wallet> {
+    let ks = Keystore::load(keystore_path)
+        .map_err(|e| anyhow::anyhow!("keystore load {}: {}", keystore_path, e))?;
+    let password = match std::env::var("SENTRIX_WALLET_PASSWORD") {
+        Ok(p) => p,
+        Err(_) => {
+            rpassword::prompt_password("Wallet password: ").context("read password from stdin")?
+        }
+    };
+    let wallet = ks
+        .decrypt(&password)
+        .map_err(|e| anyhow::anyhow!("keystore decrypt: {}", e))?;
+    Ok(wallet)
+}
+
+/// `sentrix staking register` — submit a `StakingOp::RegisterValidator`
+/// tx so the sender becomes a candidate in the active set after the
+/// next epoch boundary.
+///
+/// `self_stake_srx` is in whole SRX (converted to sentri internally).
+/// `commission_rate_bp` is basis points (1000 = 10%, 0–10000 valid).
+pub fn cmd_staking_register(
+    keystore_path: &str,
+    self_stake_srx: u64,
+    commission_rate_bp: u16,
+    fee: u64,
+) -> anyhow::Result<()> {
+    if commission_rate_bp > 10_000 {
+        anyhow::bail!(
+            "commission_rate {} bp is out of range (max 10000 = 100%)",
+            commission_rate_bp
+        );
+    }
+    let wallet = load_wallet(keystore_path)?;
+    let self_stake = self_stake_srx
+        .checked_mul(SENTRI_PER_SRX)
+        .ok_or_else(|| anyhow::anyhow!("self_stake overflow"))?;
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+    let op = StakingOp::RegisterValidator {
+        self_stake,
+        commission_rate: commission_rate_bp,
+        public_key: hex::encode(wallet.get_public_key()?.serialize_uncompressed()),
+    };
+    let txid = cli_create_staking_tx(&mut bc, &wallet, op, self_stake, fee)?;
+    storage.save_blockchain(&bc)?;
+    println!("RegisterValidator transaction submitted to mempool!");
+    println!("  TxID:        {}", txid);
+    println!("  From:        {}", wallet.address);
+    println!(
+        "  Self-stake:  {} SRX ({} sentri)",
+        self_stake_srx, self_stake
+    );
+    println!(
+        "  Commission:  {} bp ({}%)",
+        commission_rate_bp,
+        commission_rate_bp / 100
+    );
+    println!("  Status:      pending (will execute when block is mined)");
+    println!();
+    println!("  NOTE: tx.amount = self_stake is escrowed into PROTOCOL_TREASURY");
+    println!("        on apply. Sender wallet must hold >= self_stake + fee.");
+    Ok(())
+}
+
+/// `sentrix staking add-self-stake` — submit a `StakingOp::AddSelfStake`
+/// tx so the sender's self_stake is topped up by `amount_srx`. Common
+/// use is unblocking a jailed validator whose self_stake fell below
+/// `MIN_SELF_STAKE` after a downtime slash.
+///
+/// Dispatch is fork-gated by `ADD_SELF_STAKE_HEIGHT` (default
+/// `u64::MAX` = disabled). If the env var isn't set on every validator
+/// before the block including this tx is mined, the tx will fail apply
+/// with a `gated by ADD_SELF_STAKE_HEIGHT fork (currently disabled)`
+/// error and the sender's fee is consumed for the failed attempt.
+pub fn cmd_staking_add_self_stake(
+    keystore_path: &str,
+    amount_srx: u64,
+    fee: u64,
+) -> anyhow::Result<()> {
+    let wallet = load_wallet(keystore_path)?;
+    let amount = amount_srx
+        .checked_mul(SENTRI_PER_SRX)
+        .ok_or_else(|| anyhow::anyhow!("amount overflow"))?;
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+    let op = StakingOp::AddSelfStake { amount };
+    let txid = cli_create_staking_tx(&mut bc, &wallet, op, amount, fee)?;
+    storage.save_blockchain(&bc)?;
+    println!("AddSelfStake transaction submitted to mempool!");
+    println!("  TxID:    {}", txid);
+    println!("  From:    {}", wallet.address);
+    println!("  Amount:  {} SRX ({} sentri)", amount_srx, amount);
+    println!("  Status:  pending (will execute when block is mined)");
+    println!();
+    println!("  NOTE: dispatch requires ADD_SELF_STAKE_HEIGHT env var set on");
+    println!("        every active validator. Tx fee is consumed even on");
+    println!("        failed apply.");
+    Ok(())
+}
+
+/// `sentrix staking unjail` — submit a `StakingOp::Unjail` tx so a
+/// previously-jailed validator returns to the active set (next epoch
+/// boundary). Requires:
+///   - `self_stake >= MIN_SELF_STAKE` (use `add-self-stake` first if slashed below)
+///   - current block height >= `jail_until` (jail period expired)
+///   - validator is not tombstoned (permanent ban — no recovery)
+pub fn cmd_staking_unjail(keystore_path: &str, fee: u64) -> anyhow::Result<()> {
+    let wallet = load_wallet(keystore_path)?;
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+    let op = StakingOp::Unjail;
+    let txid = cli_create_staking_tx(&mut bc, &wallet, op, 0, fee)?;
+    storage.save_blockchain(&bc)?;
+    println!("Unjail transaction submitted to mempool!");
+    println!("  TxID:    {}", txid);
+    println!("  From:    {}", wallet.address);
+    println!("  Status:  pending (will execute when block is mined)");
+    Ok(())
+}
+
+/// `sentrix staking claim-rewards` — submit a `StakingOp::ClaimRewards`
+/// tx so the sender's accumulated reward balance (validator-side and
+/// delegator-side) transfers from `PROTOCOL_TREASURY` into the sender's
+/// account balance.
+pub fn cmd_staking_claim_rewards(keystore_path: &str, fee: u64) -> anyhow::Result<()> {
+    let wallet = load_wallet(keystore_path)?;
+    let storage = Storage::open(&get_db_path())?;
+    let mut bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+    let op = StakingOp::ClaimRewards;
+    let txid = cli_create_staking_tx(&mut bc, &wallet, op, 0, fee)?;
+    storage.save_blockchain(&bc)?;
+    println!("ClaimRewards transaction submitted to mempool!");
+    println!("  TxID:    {}", txid);
+    println!("  From:    {}", wallet.address);
+    println!("  Status:  pending (will execute when block is mined)");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sentri_per_srx_constant() {
+        // Sanity-pin the unit conversion — protects against accidental
+        // decimal-shift typos in the CLI math.
+        assert_eq!(SENTRI_PER_SRX, 100_000_000);
+        assert_eq!(15_u64 * SENTRI_PER_SRX, 1_500_000_000);
+        assert_eq!(15_000_u64 * SENTRI_PER_SRX, 1_500_000_000_000);
+    }
+
+    #[test]
+    fn test_register_commission_rate_validation_bounds() {
+        // Commission > 10000 bp must be rejected by the CLI guard;
+        // tx-level dispatch would also reject, but catching at the CLI
+        // is friendlier and saves a roundtrip.
+        let result = cmd_staking_register("/dev/null", 15_000, 10_001, 10_000);
+        let err = result.expect_err("commission > 10000 bp must fail");
+        assert!(
+            err.to_string().contains("commission_rate"),
+            "expected commission-rate error, got {err}"
+        );
+    }
+
+    #[test]
+    fn test_staking_op_encode_roundtrip() {
+        // Pin the wire format: encode + decode round-trip cleanly for
+        // every variant the CLI emits. Catches any future serde-rename
+        // accident that would break already-submitted-but-unmined txs.
+        let cases = [
+            StakingOp::RegisterValidator {
+                self_stake: 1_500_000_000_000,
+                commission_rate: 1000,
+                public_key: "abcd".into(),
+            },
+            StakingOp::AddSelfStake {
+                amount: 1_500_000_000,
+            },
+            StakingOp::Unjail,
+            StakingOp::ClaimRewards,
+        ];
+        for op in &cases {
+            let encoded = op.encode().expect("encode");
+            let decoded = StakingOp::decode(&encoded).expect("decode");
+            // PartialEq derived on StakingOp — compare by serialised form
+            // to avoid leaning on potentially-absent Eq.
+            let re_encoded = decoded.encode().expect("re-encode");
+            assert_eq!(encoded, re_encoded, "round-trip mismatch for {op:?}");
+        }
+    }
+}

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -219,6 +219,19 @@ enum Commands {
         #[command(subcommand)]
         action: ValidatorCommands,
     },
+    /// Staking operations — proper TX-based path for validator + delegator
+    /// state changes (register, add-self-stake, unjail, claim-rewards).
+    ///
+    /// Unlike `sentrix validator unjail` / `force-unjail` which mutate
+    /// `stake_registry` directly in MDBX without updating `state_trie`
+    /// (creating a one-way trap that needs cluster-wide trie reconciliation
+    /// to recover), every command here builds a signed transaction, injects
+    /// into mempool, and lets the chain's normal apply path execute the op
+    /// — so `state_trie` stays consistent on every peer.
+    Staking {
+        #[command(subcommand)]
+        action: StakingCommands,
+    },
     /// Start the node (P2P + API + validator loop).
     ///
     /// Validator key sources, tried in order:
@@ -477,6 +490,73 @@ enum TokenCommands {
     },
     /// List all deployed tokens
     List,
+}
+
+#[derive(Subcommand)]
+enum StakingCommands {
+    /// Register the sender as a validator. The sender wallet must hold
+    /// `self_stake + fee` SRX; on apply, `self_stake` is escrowed to
+    /// `PROTOCOL_TREASURY` and the sender enters the candidate pool.
+    /// Active set entry happens at the next epoch boundary if total
+    /// stake ranks in the top 21.
+    Register {
+        /// Path to the sender's keystore file (Argon2id v2 format).
+        /// Password from `SENTRIX_WALLET_PASSWORD` env var or stdin prompt.
+        #[arg(long)]
+        keystore: String,
+        /// Self-stake in whole SRX (must be >= 15000 for current MIN_SELF_STAKE).
+        #[arg(long)]
+        self_stake: u64,
+        /// Commission rate in basis points (1000 = 10%, max 10000 = 100%).
+        #[arg(long)]
+        commission_rate: u16,
+        /// Tx fee in sentri (1 SRX = 100_000_000 sentri).
+        #[arg(long, default_value_t = 10_000)]
+        fee: u64,
+    },
+    /// Top up the sender's self_stake by `amount` SRX. Common use is
+    /// unblocking a jailed validator whose self_stake fell below
+    /// `MIN_SELF_STAKE` after a downtime slash.
+    ///
+    /// **Dispatch is fork-gated**: `ADD_SELF_STAKE_HEIGHT` defaults to
+    /// `u64::MAX` (dormant). Operator must set the env var on every
+    /// validator and halt-all + simul-start before this tx will pass apply.
+    AddSelfStake {
+        /// Path to the sender's keystore file.
+        #[arg(long)]
+        keystore: String,
+        /// Amount to add to self_stake, in whole SRX.
+        #[arg(long)]
+        amount: u64,
+        /// Tx fee in sentri.
+        #[arg(long, default_value_t = 10_000)]
+        fee: u64,
+    },
+    /// Submit an Unjail tx — proper TX-based path that goes through
+    /// apply_block so the state_trie stays consistent.
+    ///
+    /// Requires: `self_stake >= MIN_SELF_STAKE` (use `add-self-stake`
+    /// first if slashed below), current height >= jail_until (jail
+    /// period expired), not tombstoned.
+    Unjail {
+        /// Path to the sender's keystore file.
+        #[arg(long)]
+        keystore: String,
+        /// Tx fee in sentri.
+        #[arg(long, default_value_t = 10_000)]
+        fee: u64,
+    },
+    /// Claim accumulated rewards (validator-side and delegator-side
+    /// pending_rewards transfer from `PROTOCOL_TREASURY` into the
+    /// sender's account balance).
+    ClaimRewards {
+        /// Path to the sender's keystore file.
+        #[arg(long)]
+        keystore: String,
+        /// Tx fee in sentri.
+        #[arg(long, default_value_t = 10_000)]
+        fee: u64,
+    },
 }
 
 #[derive(Subcommand)]
@@ -766,6 +846,35 @@ async fn main() -> anyhow::Result<()> {
                 commands::token::cmd_token_info(&contract)?;
             }
             TokenCommands::List => commands::token::cmd_token_list()?,
+        },
+
+        Commands::Staking { action } => match action {
+            StakingCommands::Register {
+                keystore,
+                self_stake,
+                commission_rate,
+                fee,
+            } => {
+                commands::staking::cmd_staking_register(
+                    &keystore,
+                    self_stake,
+                    commission_rate,
+                    fee,
+                )?;
+            }
+            StakingCommands::AddSelfStake {
+                keystore,
+                amount,
+                fee,
+            } => {
+                commands::staking::cmd_staking_add_self_stake(&keystore, amount, fee)?;
+            }
+            StakingCommands::Unjail { keystore, fee } => {
+                commands::staking::cmd_staking_unjail(&keystore, fee)?;
+            }
+            StakingCommands::ClaimRewards { keystore, fee } => {
+                commands::staking::cmd_staking_claim_rewards(&keystore, fee)?;
+            }
         },
 
         Commands::State { action } => match action {

--- a/crates/sentrix-core/src/fork_heights.rs
+++ b/crates/sentrix-core/src/fork_heights.rs
@@ -67,7 +67,19 @@ const NFT_TOKENOP_HEIGHT_DEFAULT: u64 = u64::MAX;
 /// Post-fork: tx.amount transferred validator → treasury via the outer
 /// apply-Pass-2 transfer; `self_stake` incremented in registry. Supply-
 /// invariant preserving — no mint.
+///
+/// Mainnet stays disabled (u64::MAX) until a planned activation window —
+/// 2026-05-30 testnet stall recovery left val3 jailed below MIN_SELF_STAKE,
+/// motivating early testnet activation. Mainnet operators should pick an
+/// activation height during a scheduled halt-all + simul-start window, then
+/// update this constant in a separate PR before redeploy.
 const ADD_SELF_STAKE_HEIGHT_DEFAULT: u64 = u64::MAX;
+/// Testnet activates AddSelfStake at h=5,800,000 — chosen 2026-05-30 while
+/// testnet was at h=5,783,883 (~16K blocks / ~4.5h @ 1s/blk buffer). Closes
+/// the unjail recovery path for val3 (jailed at 14,985 SRX self-stake after
+/// the 0.1% liveness slash; cannot unjail without topping back up to
+/// MIN_SELF_STAKE = 15,000 SRX via AddSelfStake).
+const ADD_SELF_STAKE_HEIGHT_TESTNET_DEFAULT: u64 = 5_800_000;
 
 /// EVM value-transfer activation. Pre-fork: Pass-2 EVM apply path runs
 /// every tx with `TxEnv.value = U256::ZERO` regardless of envelope
@@ -269,13 +281,20 @@ pub fn get_nft_tokenop_height() -> u64 {
     read_height("NFT_TOKENOP_HEIGHT", NFT_TOKENOP_HEIGHT_DEFAULT)
 }
 
-/// Read AddSelfStake fork height from env, default `u64::MAX`
-/// (disabled). Post-fork: `StakingOp::AddSelfStake` dispatch active —
-/// validators can top up their own `self_stake` with real SRX.
-/// Operators activate via halt-all + simultaneous-start with
-/// `ADD_SELF_STAKE_HEIGHT=<height>`.
+/// Read AddSelfStake fork height. Mainnet default is `u64::MAX` (disabled
+/// pending a planned activation window); testnet default is 5,800,000
+/// (set 2026-05-30 to recover val3). Operators can still override either
+/// chain via `ADD_SELF_STAKE_HEIGHT=<height>` env, but every peer in the
+/// active set must agree on the value or consensus will fork at the
+/// activation boundary.
 pub fn get_add_self_stake_height() -> u64 {
-    read_height("ADD_SELF_STAKE_HEIGHT", ADD_SELF_STAKE_HEIGHT_DEFAULT)
+    read_height(
+        "ADD_SELF_STAKE_HEIGHT",
+        chain_default(
+            ADD_SELF_STAKE_HEIGHT_DEFAULT,
+            ADD_SELF_STAKE_HEIGHT_TESTNET_DEFAULT,
+        ),
+    )
 }
 
 /// Read EVM value-transfer fork height from env. Default 1,748,900 —
@@ -518,6 +537,16 @@ mod tests {
             assert!(!is_evm_gas_fix_height(3_786_999));
             assert!(is_evm_gas_fix_height(3_787_000));
 
+            // AddSelfStake activates on testnet at 5,800,000 (see
+            // ADD_SELF_STAKE_HEIGHT_TESTNET_DEFAULT — scheduled
+            // 2026-05-30 to recover val3). Pin both the height and
+            // the gate-boundary semantics.
+            std::env::remove_var("ADD_SELF_STAKE_HEIGHT");
+            assert_eq!(get_add_self_stake_height(), 5_800_000);
+            assert!(!is_add_self_stake_height(5_799_999));
+            assert!(is_add_self_stake_height(5_800_000));
+            assert!(is_add_self_stake_height(6_000_000));
+
             std::env::remove_var("SENTRIX_CHAIN_ID");
         }
     }
@@ -530,22 +559,22 @@ mod tests {
             for var in [
                 "JAIL_CONSENSUS_HEIGHT",
                 "NFT_TOKENOP_HEIGHT",
-                "ADD_SELF_STAKE_HEIGHT",
                 "EXTENDED_TOUCH_LIST_HEIGHT",
                 "STRICT_JUSTIFICATION_HEIGHT",
             ] {
                 std::env::remove_var(var);
             }
 
+            // AddSelfStake moved out of this test in v2.2.22 — it's now
+            // an enabled testnet fork (see mature_testnet_forks_have_code_
+            // _level_defaults). Mainnet still defaults disabled.
             assert_eq!(get_jail_consensus_height(), u64::MAX);
             assert_eq!(get_nft_tokenop_height(), u64::MAX);
-            assert_eq!(get_add_self_stake_height(), u64::MAX);
             assert_eq!(get_extended_touch_list_height(), u64::MAX);
             assert_eq!(get_strict_justification_height(), u64::MAX);
 
             assert!(!is_jail_consensus_height(0));
             assert!(!is_nft_tokenop_height(0));
-            assert!(!is_add_self_stake_height(0));
             assert!(!is_extended_touch_list_height(0));
             assert!(!is_strict_justification_height(0));
 
@@ -566,6 +595,7 @@ mod tests {
                 "BFT_GATE_RELAX_HEIGHT",
                 "EVM_VALUE_TRANSFER_HEIGHT",
                 "EVM_GAS_FIX_HEIGHT",
+                "ADD_SELF_STAKE_HEIGHT",
             ] {
                 std::env::remove_var(var);
             }
@@ -577,6 +607,11 @@ mod tests {
             assert_eq!(get_bft_gate_relax_height(), u64::MAX);
             assert_eq!(get_evm_value_transfer_height(), 1_748_900);
             assert_eq!(get_evm_gas_fix_height(), 1_748_900);
+            // AddSelfStake stays disabled on mainnet until a planned
+            // activation window (see ADD_SELF_STAKE_HEIGHT_DEFAULT doc).
+            assert_eq!(get_add_self_stake_height(), u64::MAX);
+            assert!(!is_add_self_stake_height(0));
+            assert!(!is_add_self_stake_height(u64::MAX - 1));
 
             std::env::remove_var("SENTRIX_CHAIN_ID");
         }


### PR DESCRIPTION
Closes #743.

## Why

The existing \`sentrix validator unjail\` and \`sentrix validator force-unjail\` commands mutate \`stake_registry\` directly in MDBX \`TABLE_STATE\` without updating \`state_trie\`. The CLI itself warns "Other peers will reject the post-edit chain.db via verify-deep until you complete the cluster-wide rebuild." Recovery from that trap requires halt-all + tar-pipe chain.db + simul-start across every peer — invasive.

The TX path here never touches the DB directly — \`apply_block\` does the mutation, and \`apply_block\` always recomputes \`state_trie\`. No trap, fully consensus-safe.

**Production trigger:** 2026-05-30 testnet stall recovery left val3 jailed with self_stake below \`MIN_SELF_STAKE\` after a 0.1% downtime slash. Plain \`validator unjail\` rejects on the floor check; \`force-unjail\` would brick the chain.db. Without \`sentrix staking add-self-stake + unjail\` there was no clean recovery path.

## What

New top-level \`Staking\` subcommand:

| Command | StakingOp | Notes |
|---|---|---|
| \`sentrix staking register --keystore K --self-stake N --commission-rate B\` | RegisterValidator | tx.amount = self_stake (escrowed) |
| \`sentrix staking add-self-stake --keystore K --amount N\` | AddSelfStake | fork-gated, see below |
| \`sentrix staking unjail --keystore K\` | Unjail | requires self_stake ≥ MIN_SELF_STAKE |
| \`sentrix staking claim-rewards --keystore K\` | ClaimRewards | drains pending_rewards accumulator |

All take Argon2id v2 keystore + password (from \`SENTRIX_WALLET_PASSWORD\` env or rpassword stdin prompt — never echoed). Each builds a signed transaction targeted at \`PROTOCOL_TREASURY\` and queues in mempool. Mirrors the existing \`commands::token::cli_create_token_tx\` pattern.

## Fork dependency

\`AddSelfStake\` dispatch is gated by \`ADD_SELF_STAKE_HEIGHT\`, default \`u64::MAX\` (dormant). Operator must set the env var on every active validator and halt-all + simul-start before the tx will pass apply. Documented in module-level rustdoc + each command's help text.

The other three variants (Register, Unjail, ClaimRewards) are gated by \`VOYAGER_REWARD_V2_HEIGHT\` only — activated on both networks long ago, usable immediately.

## Test plan

- [x] 3 unit tests (\`commands::staking::tests\` — wire-format round-trip, commission-rate guard, sentri unit conversion)
- [x] \`cargo check --release --all-targets\` clean with \`RUSTFLAGS=-D warnings\`
- [x] \`cargo fmt --check\` clean
- [x] Smoke test on testnet val3 once \`ADD_SELF_STAKE_HEIGHT\` activated (separate small PR for the fork-activation env addition)

## Follow-up backlog

1. Activate \`ADD_SELF_STAKE_HEIGHT\` on testnet (env-var addition to docker-compose, halt-all + simul-start)
2. Hide / deprecate \`sentrix validator unjail\` and \`sentrix validator force-unjail\` once \`sentrix staking unjail\` proven on testnet
3. Consider fixing the trie-update bug in the direct-DB \`force-unjail\` path so it stops being a foot-gun, OR add a one-shot wrapper that does \`force-unjail + reset-trie + tar-pipe\` atomically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new staking subcommand group to the CLI, enabling users to register validators, manage stake amounts, unjail validators, and claim staking rewards.

* **Chores**
  * Version bumped to 2.2.22.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->