### PR TITLE
fix(consensus): v2.2.23 reject block where block.hash != justification.block_hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "bincode",
  "hex",
@@ -5262,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5307,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "anyhow",
  "axum",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5347,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "anyhow",
  "axum",
@@ -5391,14 +5391,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "hex",
  "proptest",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -5472,14 +5472,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "bincode",
  "blake3",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5540,7 +5540,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.22"
+version = "2.2.23"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.22"
+version = "2.2.23"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -239,6 +239,33 @@ impl Blockchain {
             // reject if threshold not met.
             if Self::is_strict_justification_height(expected_index) {
                 use sentrix_bft::messages::{Precommit, recover_signer};
+                // 2026-05-31 add: block ↔ justification hash consistency.
+                // A block with `block.hash=X, justification.block_hash=Y`
+                // and precommits validly signed for Y passes signature
+                // recovery + threshold checks because every check below
+                // uses `j.block_hash` as the signing payload. But the
+                // STORED block has hash X, so the chain accumulates
+                // internally-inconsistent blocks. Discovered live on
+                // 2026-05-31 testnet h=5817132: val4's self-produced
+                // block had hash=H2 (post-state_root recompute) while
+                // its embedded justification still referenced H1
+                // (pre-recompute hash collected by engine). Strictly
+                // gate so legacy blocks pre-fork stay accepted, and
+                // the consensus stack must produce hash-consistent
+                // blocks going forward. The producer-side architectural
+                // fix (block.hash committed BEFORE state_root stamp,
+                // OR speculative apply at propose time) ships separately;
+                // this check stops the bad block from being accepted
+                // by receivers in the meantime.
+                if j.block_hash != block.hash {
+                    return Err(SentrixError::InvalidBlock(format!(
+                        "block {} hash mismatch: block.hash={} != \
+                         justification.block_hash={} — peer block has \
+                         inconsistent block/justification refs, refusing \
+                         to apply",
+                        expected_index, block.hash, j.block_hash,
+                    )));
+                }
                 let mut verified_stake: u64 = 0;
                 let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
                 for p in &j.precommits {


### PR DESCRIPTION
Defense-in-depth fix for the **2026-05-31 testnet h=5817132 stall**.

## What happened

val4 stored block at h=5817132 with internal inconsistency:
- \`block.hash = 3c424952f541659ac597dbd54114d7414b1b85fee004e01085a30f8e5f0b99b6\`
- \`justification.block_hash = 2a5ad622d8a9ebb6b8c77302ac10f58112ffeb37025c65d7a1a510a7ca671e74\`
- All 3 precommits signed for \`2a5ad622...\`

val1 received + applied the bad block (same hash mismatch stored). val2 rejected via state_root mismatch and stayed at h=5817131. Cluster forked.

## Root cause (chain of bugs)

Investigation in handoff notes identified 3 bugs:

| # | Bug | Tracked |
|---|---|---|
| **A** | \`pending_rewards\` + similar off-trie state drifts silently between vals (not in state_root) | #750 |
| **B** | \`block.hash\` recomputed post-state_root-stamp doesn't update embedded justification refs | #(this issue's sibling) |
| **C** | \`add_block_impl\` missing \`block.hash == j.block_hash\` check | **this PR** |

The cascade: A → state divergence at h=5817131 (val3 claim-rewards) → vals try h=5817132 with different state → B causes proposer to produce hash-inconsistent block → C lets receivers accept it → split storage state.

## What this PR does

Adds explicit \`block.hash == j.block_hash\` check inside the existing \`strict_justification\` fork gate (default \`u64::MAX\` so legacy blocks unaffected; activation requires operator decision per chain).

```rust
if j.block_hash != block.hash {
    return Err(SentrixError::InvalidBlock(format!(
        "block {} hash mismatch: block.hash={} != \
         justification.block_hash={} — peer block has \
         inconsistent block/justification refs, refusing to apply",
        expected_index, block.hash, j.block_hash,
    )));
}
```

Stops bug C from compounding once strict_justification activates. Does NOT fix bugs A or B — those need architectural work (see linked issues).

## Test plan

- [x] \`cargo check --release --all-targets\` clean with \`RUSTFLAGS=-D warnings\`
- [x] \`cargo fmt --check\` clean
- [ ] Unit test: synthetic block with mismatched hash rejects under strict_justification fork
- [ ] Mainnet/testnet rollout requires strict_justification activation first

## Follow-up

- #750 Bug A: off-trie state drift (architectural fix needed before re-enabling staking ops cluster-wide)
- #(sibling) Bug B: producer-side hash recompute bug (B1 speculative-apply or B4 fork-rule change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 2.2.23.

* **Bug Fixes**
  * Enhanced block verification to enforce stricter validation checks during the verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->