### PR TITLE
docs: add ROADMAP.md at repo root (closes #626)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,14 @@ bin/
 
 ## Roadmap
 
+See **[ROADMAP.md](ROADMAP.md)** for current focus, recently shipped work, and direction.
+
+Phase history:
+
 | Phase | Status | Focus |
 |-------|--------|-------|
 | **Pioneer** | Completed (mainnet h=0…579,046) | PoA round-robin, MDBX storage, 1s blocks, SRC-20 tokens — succeeded by Voyager 2026-04-25 |
-| **Voyager** | **Live on mainnet** | DPoS proposer rotation + BFT finality, EVM (revm 38), V4 reward distribution v2 (treasury escrow + ClaimRewards), tokenomics v2 (315M cap + 4-year halving), `StakingOp::AddSelfStake`, side-car gRPC + gRPC-Web |
+| **Voyager** | **Live on mainnet** | DPoS proposer rotation + BFT finality, EVM (revm 40), V4 reward distribution v2 (treasury escrow + ClaimRewards), tokenomics v2 (315M cap + 4-year halving), `StakingOp::AddSelfStake`, side-car gRPC + gRPC-Web |
 | **Frontier** | Phase F-1 scaffold landed; F-2…F-10 planned | Parallel transaction execution, sub-1s block time, mainnet hard fork |
 | **Odyssey** | Future | Cross-chain bridges, mature ecosystem, light clients |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,76 @@
+# Sentrix Chain Roadmap
+
+> Last updated 2026-05-31. Subject to change via the [SIP process](https://github.com/sentrix-labs/SIPs).
+>
+> Current focus: **consensus-stability fixes** ([SIP-5](https://github.com/sentrix-labs/SIPs/pull/2), [SIP-6](https://github.com/sentrix-labs/SIPs/pull/3)) before the next feature wave.
+
+## Status
+
+- 🔴 **Mainnet**: temporarily off pending architectural fixes (SIPs #5 + #6 in review)
+- 🟢 **Testnet**: running 3-of-4 BFT at v2.2.23. Chain producing blocks normally. One validator (val3) jailed since 2026-05-30 — recovery blocked by Bug A fix
+- 🟢 **Bridges**: Hyperlane v3 functional testnet → Sepolia (testnet-grade security, production hardening in progress)
+- 🟢 **Tooling**: explorer, faucet, RPC, gRPC, dashboards all live
+
+---
+
+## Recently shipped
+
+Past 30 days (mainnet + testnet):
+
+- **Tokenomics v2** activated mainnet — 315 M cap, 4-year halving (BTC-parity), 63 M premine ratio improves to 20% ([SIP-3](https://github.com/sentrix-labs/SIPs/blob/main/sips/sip-3.md))
+- **v2.2.19** apply-path observability — `apply_watchdog` instrumentation surfaces silent-stall classes before they cascade
+- **v2.2.20** BFT engine self-heal — engine resume from persisted last-sign at restart, closes round-0-step-2 stuck pattern
+- **v2.2.21** `BftMetrics` + `/metrics` endpoint — Prometheus surface for round duration, vote tally, phase timeouts, jail events
+- **v2.2.22** `sentrix staking` CLI — TX-based `register` / `add-self-stake` / `unjail` / `claim-rewards` via `apply_block` (no DB-edit trap)
+- **v2.2.23** receiver-side `block.hash == justification.block_hash` consistency check (gated by strict-justification fork)
+- **revm 40** EVM engine upgrade
+- **Hyperlane v3 testnet bridge** — Sentrix Testnet ↔ Sepolia, manual relay, NoopIsm (production hardening pending)
+- **Signed releases**: cosign keyless OIDC + SLSA L3 provenance on every release tag
+- **Docs consolidation**: [docs.sentrixchain.com](https://docs.sentrixchain.com) as single source of truth — validator onboarding runbooks, slashing parameters synced to code
+
+## Current focus
+
+Q2 2026 priority order:
+
+1. **Bug A fix** — off-trie consensus state (pending_rewards, total_minted, liveness, epoch) moved into state trie. Eliminates silent drift class. ([SIP-6](https://github.com/sentrix-labs/SIPs/pull/3))
+2. **Bug B fix** — block hash + state_root commitment consistency via speculative apply. ([SIP-5](https://github.com/sentrix-labs/SIPs/pull/2))
+3. **Mainnet restart** — coordinated halt-all + simul-start window after Bug A + Bug B activate on testnet + bake clean ≥1 week
+4. **Multi-key validator separation** — signer / operator / stash key split, replaces current one-key model
+5. **Public validator onboarding** — externalize the runbook + UX once consensus-stability fixes ship and slashing economics are bake-tested
+
+## Planned next
+
+After Q2 stability sprint:
+
+- **Validator monitoring templates** — public Grafana dashboards for `bft_*` and `apply_*` series
+- **DEX subgraph** — UniV2-fork subgraph for `sentrix-dex` pools + swaps
+- **NFT primitive** — Seaport-compatible marketplace on top of EVM
+- **LayerZero V2** — production DVN + Executor wiring after Labs assignment
+- **Slashing bake** — testnet validator misbehavior testing against live slashing rates
+
+## Long-term direction
+
+Conceptual, no timeline commitments:
+
+- **Parallel apply** — block-level parallelism via read-write set scheduler
+- **DAG consensus exploration** — Narwhal/Bullshark-style mempool dissemination + commit
+- **Cross-chain liquidity** — Cosmos IBC integration evaluated if Cosmos-side demand emerges
+- **Validator set scaling** — 1000+ validators (BFT message O(N²) reduction, gossipsub fanout tuning)
+- **Bug bounty program** — public Immunefi-style after architectural fixes land
+
+---
+
+## How decisions are made
+
+- **Code changes**: PR review on [sentrix-labs/sentrix](https://github.com/sentrix-labs/sentrix)
+- **Consensus rule changes**: [SIP process](https://github.com/sentrix-labs/SIPs/blob/main/sips/sip-1.md) — design doc → review → testnet bake → mainnet activation height
+- **Economic parameters**: SIP track with tokenomics rationale
+- **No on-chain governance** today. SIP process is documentation + review; final acceptance via maintainers + validators
+
+## Where to plug in
+
+- **Validator**: see [Validator Onboarding](https://docs.sentrixchain.com/docs/operations/VALIDATOR_ONBOARDING)
+- **dApp dev**: [Integration Cookbook](https://docs.sentrixchain.com/docs/operations/INTEGRATION_COOKBOOK)
+- **Bug reports**: [GitHub issues](https://github.com/sentrix-labs/sentrix/issues)
+- **Protocol proposals**: [SIPs repo](https://github.com/sentrix-labs/SIPs)
+- **Security disclosures**: see [SECURITY.md](https://github.com/sentrix-labs/sentrix/blob/main/SECURITY.md)


### PR DESCRIPTION
Closes #626.

## Summary

Public-facing roadmap at \`ROADMAP.md\`. Honest about current state — mainnet temporarily off pending Bug A + Bug B fixes (in review as SIPs #5/#6 in sentrix-labs/SIPs).

## Sections

- **Status banner**: 🔴 mainnet off, 🟢 testnet running 3-of-4, bridges, tooling
- **Recently shipped** (past 30 days): tokenomics v2, v2.2.19-23 observability, revm 40, Hyperlane testnet, signed releases
- **Current focus** (Q2 2026): Bug A/B fixes → mainnet restart → multi-key → public validator onboarding
- **Planned next**: Grafana templates, DEX subgraph, NFT primitive, LayerZero V2, slashing bake
- **Long-term direction**: parallel apply, DAG consensus, cross-chain liquidity, validator set scaling, bug bounty
- **How decisions are made**: link to SIP process
- **Where to plug in**: validator/dapp/security/proposal entry points

## README change

Updated Roadmap section to link \`ROADMAP.md\` first (current direction), keeps the phase-history table (Pioneer/Voyager/Frontier/Odyssey) for context. Bumped revm reference 38 → 40 in Voyager row.

## Honest design choices

- No fabricated dates for future work — \`long-term\` items explicitly say "no timeline commitments"
- Bug A/B status surfaced at top — readers should know mainnet is on hold
- Internal bug numbers in footnote-style links, not in body prose
- "How decisions are made" section sets expectations: no on-chain governance, SIP process is documentation + review