### PR TITLE
docs: fix broken UPPERCASE doc URLs to canonical lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ After the node is healthy: bond ≥ 15,000 SRX and submit `StakingOp::RegisterVa
 
 For incident coordination + ops support (not registration), contact **`validators@sentrixchain.com`**.
 
-Full operator guide: **[docs.sentrixchain.com/operations/VALIDATOR_ONBOARDING](https://docs.sentrixchain.com/operations/VALIDATOR_ONBOARDING)** (hardware, security, monitoring, recovery paths).
+Full operator guide: **[docs.sentrixchain.com/operations/validator-onboarding](https://docs.sentrixchain.com/operations/validator-onboarding)** (hardware, security, monitoring, recovery paths).
 
 ## Connect MetaMask (Testnet)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,8 +69,8 @@ Conceptual, no timeline commitments:
 
 ## Where to plug in
 
-- **Validator**: see [Validator Onboarding](https://docs.sentrixchain.com/docs/operations/VALIDATOR_ONBOARDING)
-- **dApp dev**: [Integration Cookbook](https://docs.sentrixchain.com/docs/operations/INTEGRATION_COOKBOOK)
+- **Validator**: see [Validator Onboarding](https://docs.sentrixchain.com/operations/validator-onboarding)
+- **dApp dev**: [Integration Cookbook](https://docs.sentrixchain.com/operations/integration-cookbook)
 - **Bug reports**: [GitHub issues](https://github.com/sentrix-labs/sentrix/issues)
 - **Protocol proposals**: [SIPs repo](https://github.com/sentrix-labs/SIPs)
 - **Security disclosures**: see [SECURITY.md](https://github.com/sentrix-labs/sentrix/blob/main/SECURITY.md)


### PR DESCRIPTION
## Summary

- README and ROADMAP linked to `docs.sentrixchain.com/operations/VALIDATOR_ONBOARDING` (uppercase) — Docusaurus returns HTTP 200 but the body is the 404 \"Page Not Found\" page, so it looks live to status-code checks but breaks for actual readers.
- ROADMAP also had a stale `/docs/` path prefix (Docusaurus removed it when the site was rebased to root).

Both fixed to the canonical lowercase kebab URLs: `/operations/validator-onboarding` and `/operations/integration-cookbook`.

## Test plan

- [x] curl `https://docs.sentrixchain.com/operations/validator-onboarding` → 200 with the real onboarding page body
- [x] curl `https://docs.sentrixchain.com/operations/integration-cookbook` → 200 with the cookbook
- [x] grep across repo confirms no remaining UPPERCASE doc URL refs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated validator operator guide link in README with standardized path formatting.
  * Updated documentation links in ROADMAP to reference new domain structure for Validator Onboarding and dApp Integration Cookbook resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->