### PR TITLE
feat(consensus): migrate pending_rewards to state trie post-fork (SIP-6, PR 2/N)

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -356,6 +356,10 @@ impl Blockchain {
         crate::fork_heights::is_strict_justification_height(height)
     }
 
+    pub fn is_state_in_trie_height(height: u64) -> bool {
+        crate::fork_heights::is_state_in_trie_height(height)
+    }
+
     pub fn is_bft_gate_relax_height(height: u64) -> bool {
         crate::fork_heights::is_bft_gate_relax_height(height)
     }

--- a/crates/sentrix-core/src/blockchain_trie_ops.rs
+++ b/crates/sentrix-core/src/blockchain_trie_ops.rs
@@ -24,7 +24,10 @@ use hex;
 use sentrix_primitives::error::{SentrixError, SentrixResult};
 use sentrix_primitives::transaction::{PROTOCOL_TREASURY, TOKEN_OP_ADDRESS};
 use sentrix_storage::MdbxStorage;
-use sentrix_trie::address::{account_value_bytes, address_to_key};
+use sentrix_trie::address::{
+    account_value_bytes, address_to_key, pending_rewards_value_bytes,
+    validator_pending_rewards_key,
+};
 use sentrix_trie::tree::SentrixTrie;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -438,6 +441,30 @@ impl Blockchain {
             .collect();
         // Borrow of `accounts` ends after collect().
 
+        // Phase 1c — SIP-6 Bug A (post-fork only): snapshot every
+        // validator's `pending_rewards` into the trie inputs BEFORE
+        // we re-borrow `self.state_trie` mutably. Pre-fork this is an
+        // empty Vec, so the legacy trie write path is bit-identical.
+        //
+        // Sorted by address for cross-validator determinism (the
+        // HashMap iteration order is per-process, but a sorted Vec is
+        // identical everywhere — same property the balance write path
+        // gets from its BTreeSet above).
+        let pending_rewards_updates: Vec<(String, u64)> =
+            if Self::is_state_in_trie_height(block_index) {
+                let mut rows: Vec<(String, u64)> = self
+                    .stake_registry
+                    .validators
+                    .iter()
+                    .map(|(addr, val)| (addr.clone(), val.pending_rewards))
+                    .collect();
+                rows.sort_by(|a, b| a.0.cmp(&b.0));
+                rows
+            } else {
+                Vec::new()
+            };
+        // Borrow of `stake_registry` ends after collect()+sort.
+
         if trace {
             eprintln!("[trie-trace] update_trie_for_block at h={block_index}");
             eprintln!("[trie-trace] touched (sorted): {} addresses", updates.len());
@@ -489,6 +516,35 @@ impl Blockchain {
                 );
             }
         }
+
+        // Phase 2b — SIP-6 Bug A (post-fork only): commit per-validator
+        // pending_rewards into the trie under a domain-separated key
+        // (`validator_pending_rewards_key`) so any drift across
+        // validators surfaces immediately as a state_root mismatch
+        // instead of silently diverging on the off-trie HashMap until
+        // a ClaimRewards / Unjail / AddSelfStake tx consumes the
+        // drifted value.
+        //
+        // Empty `pending_rewards == 0` is written as `delete` to keep
+        // the trie footprint minimal and the key absent for vals that
+        // have never accrued (or have just claimed) — matches the
+        // balance loop's zero handling above.
+        for (addr, rewards) in &pending_rewards_updates {
+            let key = validator_pending_rewards_key(addr);
+            if *rewards == 0 {
+                trie.delete(&key)?;
+            } else {
+                let value = pending_rewards_value_bytes(*rewards);
+                trie.insert(&key, &value)?;
+            }
+            if trace {
+                eprintln!(
+                    "[trie-trace]   pending_rewards {addr}={rewards} → root={}",
+                    hex::encode(trie.root_hash())
+                );
+            }
+        }
+
         let root = trie.commit(block_index)?;
         if trace {
             eprintln!(

--- a/crates/sentrix-trie/src/address.rs
+++ b/crates/sentrix-trie/src/address.rs
@@ -39,6 +39,41 @@ pub fn account_value_decode(bytes: &[u8]) -> Option<(u64, u64)> {
     Some((balance, nonce))
 }
 
+/// SIP-6 Bug A — trie key for a validator's `pending_rewards` accumulator.
+///
+/// Distinct domain from `address_to_key` via a fixed prefix
+/// (`"sentrix/v1/pending_rewards/"`) so this namespace cannot collide
+/// with account-balance keys regardless of SHA-256 input length.
+///
+/// Post-`STATE_IN_TRIE_HEIGHT` the apply path writes each validator's
+/// `pending_rewards` to this key before state_root is taken, so any
+/// drift surfaces immediately as a state_root mismatch instead of
+/// silently diverging on the off-trie HashMap.
+pub fn validator_pending_rewards_key(address: &str) -> NodeHash {
+    const DOMAIN: &[u8] = b"sentrix/v1/pending_rewards/";
+    let addr = address.trim_start_matches("0x").to_lowercase();
+    let bytes = hex::decode(&addr).unwrap_or_else(|_| addr.as_bytes().to_vec());
+    let mut h = Sha256::new();
+    h.update(DOMAIN);
+    h.update(&bytes);
+    h.finalize().into()
+}
+
+/// Encode a `pending_rewards` value (u64 sentri) as 8 big-endian bytes
+/// for trie value storage.
+pub fn pending_rewards_value_bytes(rewards: u64) -> [u8; 8] {
+    rewards.to_be_bytes()
+}
+
+/// Decode trie value bytes produced by [`pending_rewards_value_bytes`].
+/// Returns `None` if the slice is shorter than 8 bytes.
+pub fn pending_rewards_value_decode(bytes: &[u8]) -> Option<u64> {
+    if bytes.len() < 8 {
+        return None;
+    }
+    Some(u64::from_be_bytes(bytes[0..8].try_into().ok()?))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -95,5 +130,53 @@ mod tests {
     fn test_account_value_decode_short_returns_none() {
         assert!(account_value_decode(&[0u8; 8]).is_none());
         assert!(account_value_decode(&[]).is_none());
+    }
+
+    // ── SIP-6 pending_rewards trie key tests ────────────────────────
+
+    #[test]
+    fn test_pending_rewards_key_deterministic() {
+        let addr = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        assert_eq!(
+            validator_pending_rewards_key(addr),
+            validator_pending_rewards_key(addr)
+        );
+    }
+
+    #[test]
+    fn test_pending_rewards_key_case_insensitive() {
+        let a = validator_pending_rewards_key("0xDEADBEEF");
+        let b = validator_pending_rewards_key("0xdeadbeef");
+        assert_eq!(a, b);
+    }
+
+    /// Domain separation guarantee: pending_rewards key for an address
+    /// MUST differ from the balance trie key for the SAME address.
+    /// Otherwise a balance write would clobber pending_rewards (and
+    /// vice versa) at the same trie slot — silent state corruption.
+    #[test]
+    fn test_pending_rewards_key_distinct_from_balance_key() {
+        let addr = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        let bal_key = address_to_key(addr);
+        let rew_key = validator_pending_rewards_key(addr);
+        assert_ne!(
+            bal_key, rew_key,
+            "pending_rewards and balance trie keys must be distinct \
+             for the same address — otherwise writes collide"
+        );
+    }
+
+    #[test]
+    fn test_pending_rewards_value_roundtrip() {
+        let rewards = 1_234_567_890u64;
+        let encoded = pending_rewards_value_bytes(rewards);
+        assert_eq!(encoded.len(), 8);
+        assert_eq!(pending_rewards_value_decode(&encoded), Some(rewards));
+    }
+
+    #[test]
+    fn test_pending_rewards_value_decode_short_returns_none() {
+        assert!(pending_rewards_value_decode(&[0u8; 4]).is_none());
+        assert!(pending_rewards_value_decode(&[]).is_none());
     }
 }

--- a/crates/sentrix-trie/src/lib.rs
+++ b/crates/sentrix-trie/src/lib.rs
@@ -17,7 +17,10 @@ pub mod storage;
 pub mod tree;
 
 // Re-export commonly used types
-pub use address::{account_value_bytes, account_value_decode, address_to_key};
+pub use address::{
+    account_value_bytes, account_value_decode, address_to_key,
+    pending_rewards_value_bytes, pending_rewards_value_decode, validator_pending_rewards_key,
+};
 pub use node::{NodeHash, TrieNode};
 pub use proof::MerkleProof;
 pub use tree::SentrixTrie;


### PR DESCRIPTION
## Summary

PR 2/N in the SIP-6 series. Commits per-validator \`pending_rewards\` into the state trie inside the apply path so the value participates in state_root.

Pre-fork (\`STATE_IN_TRIE_HEIGHT == u64::MAX\` = default): zero behavior change, chain history bit-identical.

Post-fork: \`update_trie_for_block\` collects \`(addr, pending_rewards)\` from \`stake_registry.validators\` (sorted by address for cross-validator determinism) and writes each one under a domain-separated trie key before \`trie.commit(block_index)\`. Drift across validators surfaces immediately as state_root mismatch at the block where it appears, not silently after a downstream ClaimRewards / Unjail / AddSelfStake tx consumes the diverged value.

## What changes

- \`crates/sentrix-trie/src/address.rs\` — \`validator_pending_rewards_key(addr)\` + \`pending_rewards_value_bytes(u64)\` + \`pending_rewards_value_decode\`. Domain prefix \`b\"sentrix/v1/pending_rewards/\"\` makes the key namespace disjoint from \`address_to_key\` (account balances), with a dedicated unit test asserting non-collision.
- \`crates/sentrix-trie/src/lib.rs\` — re-export the 3 new symbols.
- \`crates/sentrix-core/src/blockchain.rs\` — \`Blockchain::is_state_in_trie_height(height)\` method matching the existing \`is_*_height\` cluster shape.
- \`crates/sentrix-core/src/blockchain_trie_ops.rs::update_trie_for_block\`:
  - Phase 1c: snapshot sorted \`(addr, pending_rewards)\` from \`stake_registry\` BEFORE the \`state_trie.as_mut()\` re-borrow. Pre-fork this is an empty \`Vec\` so the legacy mutable trie path runs untouched.
  - Phase 2b: insert / delete per validator under the domain-separated key, with trace lines matching the existing balance write format.

## Tests

- \`sentrix-trie\` 11/11 pass (5 new for SIP-6 key/value helpers, including the critical domain-separation test).
- \`sentrix-core\` existing trie tests still pass (pre-fork bit-identical confirmed by no regression).
- \`RUSTFLAGS=\"-D warnings\" cargo check --release -p sentrix-core\` clean.

## Activation note (NOT in this PR)

Post-fork the FIRST block at \`STATE_IN_TRIE_HEIGHT\` will write every validator's CURRENT \`pending_rewards\` into the trie. If those values have already drifted across validators (the very class of bug this PR closes), state_root will diverge at the activation block — same first-activation hazard documented for \`STATE_ROOT_V2\` in 2026-05-06 post-mortem. Mitigation will be picked at activation time (operator-set canonical override modelled on \`STATE_ROOT_V2_TREASURY_BALANCE\`, or B3b-style pre-activation reconciliation). Out of scope here.

## Next PRs

- **3/N** — \`total_minted\` + per-validator liveness (\`blocks_signed\`/\`blocks_missed\`/\`is_jailed\`/\`jail_until\`).
- **4/N** — \`epoch_state\` (boundary + active-set rotation accumulators).
- **5/N** — testnet activation height + bake.