### PR TITLE
fix(faucet): close per-recipient cooldown TOCTOU bypass via Entry guard

### DIFF
--- a/bin/sentrix-faucet/src/main.rs
+++ b/bin/sentrix-faucet/src/main.rs
@@ -29,7 +29,7 @@ use axum::{
     routing::{get, post},
 };
 use clap::Parser;
-use dashmap::DashMap;
+use dashmap::{DashMap, mapref::entry::Entry};
 use secp256k1::{PublicKey, SecretKey};
 use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
 use sentrix_wallet::{Keystore, Wallet};
@@ -218,17 +218,28 @@ fn check_rate_limits(state: &AppState, ip: IpAddr, recipient: &str) -> Result<()
         entry.push(now);
     }
 
-    // Per-recipient: cooldown check
-    if let Some(last) = state.addr_last_drip.get(recipient)
-        && now.duration_since(*last) < state.addr_cooldown
-    {
-        let remaining = state.addr_cooldown - now.duration_since(*last);
-        return Err(format!(
-            "address cooldown: try again in {} seconds",
-            remaining.as_secs()
-        ));
+    // Per-recipient cooldown — atomic via Entry guard. The old
+    // `get` + check + `insert` pattern released the lock between
+    // read and write, so two parallel requests for the same address
+    // could each see "no prior drip" and both proceed → cooldown
+    // bypass. Matching on `Entry` holds the per-key lock for the
+    // entire check + update so concurrent callers serialize cleanly.
+    match state.addr_last_drip.entry(recipient.to_string()) {
+        Entry::Occupied(mut o) => {
+            let last = *o.get();
+            if now.duration_since(last) < state.addr_cooldown {
+                let remaining = state.addr_cooldown - now.duration_since(last);
+                return Err(format!(
+                    "address cooldown: try again in {} seconds",
+                    remaining.as_secs()
+                ));
+            }
+            o.insert(now);
+        }
+        Entry::Vacant(v) => {
+            v.insert(now);
+        }
     }
-    state.addr_last_drip.insert(recipient.to_string(), now);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`check_rate_limits` in \`bin/sentrix-faucet/src/main.rs\` had a TOCTOU race on the per-recipient cooldown check. The old code:

\`\`\`rust
if let Some(last) = state.addr_last_drip.get(recipient)
    && now.duration_since(*last) < state.addr_cooldown
{
    return Err(...);
}
state.addr_last_drip.insert(recipient.to_string(), now);
\`\`\`

\`DashMap::get\` returns a \`Ref\` that releases the lock as soon as it drops. Between the read+check and the subsequent \`insert\`, another concurrent request for the same recipient address can interleave its own \`get\` and see the same \"no prior drip\" or \"prior drip stale enough\" outcome — both requests pass the check, both insert \`now\`, and both proceed to drip. Net effect: one address can receive multiple drips inside what was supposed to be a single cooldown window. The per-IP rate limit (above) already uses \`entry()\` which holds the per-key write lock for the whole closure, so it's atomic; the per-recipient block was the only async bypass.

## Fix

Replace the get + insert pair with a \`match entry()\` block:

\`\`\`rust
match state.addr_last_drip.entry(recipient.to_string()) {
    Entry::Occupied(mut o) => {
        let last = *o.get();
        if now.duration_since(last) < state.addr_cooldown { return Err(...); }
        o.insert(now);
    }
    Entry::Vacant(v) => { v.insert(now); }
}
\`\`\`

\`Entry\` holds the per-key write lock for the entire check + update, so concurrent callers serialize cleanly. Same pattern as the per-IP block.

## Test plan

- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean (matches CI).
- [x] Manual reasoning above: only path now mutating \`addr_last_drip\` is inside an \`Entry\` arm holding the lock.

A focused integration test that spawns N parallel drips against a mock RPC would be valuable but is out of scope for the minimal fix.

## How I found it

Audit pass against all workspace crates one-by-one (operator request). \`sentrix-faucet\` was the 5th crate reviewed; this was the first real bug — earlier crates (\`sentrix-proto\`, \`sentrix-precompiles\`, \`sentrix-rpc-types\`, \`sentrix-codec\`) had only minor style notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a race condition in the faucet's per-recipient cooldown system that could allow concurrent requests to bypass rate limits. Cooldown enforcement is now properly serialized across simultaneous requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->