### PR TITLE
fix: audit follow-up — keystore 0600 + key_bytes zeroize + prom-exporter doc/warn

### DIFF
--- a/crates/sentrix-prom-exporter/src/main.rs
+++ b/crates/sentrix-prom-exporter/src/main.rs
@@ -12,7 +12,7 @@
 //! Metrics:
 //!   sentrix_chain_height{validator,network}             — per-validator tip height
 //!   sentrix_block_age_seconds{validator,network}        — now() - latest_block_time
-//!   sentrix_chain_tip_hash_short{validator,network}     — first 4 hex of latest_block_hash as u32 (lets PromQL count distinct values for divergence alert)
+//!   sentrix_chain_tip_hash_short{validator,network}     — first 8 hex of latest_block_hash as u32 (lets PromQL count distinct values for divergence alert)
 //!   sentrix_active_validators{network}                  — chain-wide count
 //!   sentrix_mempool_size{validator,network}             — mempool entries
 //!   sentrix_uptime_seconds{validator,network}
@@ -246,6 +246,15 @@ fn parse_targets() -> Vec<Target> {
                     url: parts[2].into(),
                 })
             } else {
+                // Don't silently drop malformed entries — operator that
+                // misconfigured SENTRIX_TARGETS would otherwise see the
+                // exporter run with fewer (or zero) targets and no log
+                // hint why the dashboard went dark.
+                warn!(
+                    item = %item,
+                    "SENTRIX_TARGETS entry skipped — expected 'name:network:url', got {} parts",
+                    parts.len()
+                );
                 None
             }
         })

--- a/crates/sentrix-wallet/src/keystore.rs
+++ b/crates/sentrix-wallet/src/keystore.rs
@@ -11,6 +11,7 @@ use rand::RngCore;
 use sentrix_primitives::{SentrixError, SentrixResult};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
+use zeroize::Zeroize;
 
 #[cfg(test)]
 const PBKDF2_ITERATIONS: u32 = 600_000; // NIST SP 800-132 recommended minimum (v1, tests only)
@@ -69,7 +70,7 @@ impl Keystore {
             .hash_password_into(password.as_bytes(), &salt, &mut key_bytes)
             .map_err(|e| SentrixError::KeystoreError(e.to_string()))?;
 
-        let private_key_bytes = hex::decode(wallet.secret_key_hex())
+        let mut private_key_bytes = hex::decode(wallet.secret_key_hex())
             .map_err(|_| SentrixError::KeystoreError("invalid private key".to_string()))?;
 
         let cipher_key = Key::<Aes256Gcm>::from_slice(&key_bytes);
@@ -85,6 +86,15 @@ impl Keystore {
         mac_input.extend_from_slice(&key_bytes[16..32]);
         mac_input.extend_from_slice(&ciphertext);
         let mac = Sha256Hasher::digest(&mac_input);
+
+        // Zero out the derived KDF key + raw private-key bytes before the
+        // stack frame unwinds. Defense in depth — limits the window where
+        // a core dump or post-free memory inspection could recover the
+        // AES-GCM key or the plaintext private key. The `zeroize` crate
+        // uses volatile writes the compiler can't optimise away.
+        key_bytes.zeroize();
+        private_key_bytes.zeroize();
+        mac_input.zeroize();
 
         Ok(Self {
             version: 2,
@@ -164,6 +174,12 @@ impl Keystore {
         // length leak here is negligible — stored MACs are always 64 hex
         // chars — but the explicit check keeps the invariant tight.
         if stored.len() != computed.len() || computed.ct_eq(stored).unwrap_u8() != 1 {
+            // Even on the wrong-password path, zero the derived KDF
+            // key + MAC input before unwinding — a core dump taken
+            // mid-MAC-failure would otherwise still contain the AES
+            // key derived from this attempt.
+            key_bytes.zeroize();
+            mac_input.zeroize();
             return Err(SentrixError::WrongPassword);
         }
 
@@ -172,12 +188,21 @@ impl Keystore {
         let cipher = Aes256Gcm::new(cipher_key);
         let nonce = Nonce::from_slice(&nonce_bytes);
 
-        let private_key_bytes = cipher
+        let mut private_key_bytes = cipher
             .decrypt(nonce, ciphertext.as_ref())
             .map_err(|_| SentrixError::WrongPassword)?;
 
-        let private_key_hex = hex::encode(private_key_bytes);
-        Wallet::from_private_key(&private_key_hex)
+        let mut private_key_hex = hex::encode(&private_key_bytes);
+        let wallet = Wallet::from_private_key(&private_key_hex);
+
+        // Defense in depth — zero the derived KDF key + raw + hex
+        // private-key bytes before the stack frame unwinds. Same
+        // rationale as `encrypt`.
+        key_bytes.zeroize();
+        private_key_bytes.zeroize();
+        mac_input.zeroize();
+        private_key_hex.zeroize();
+        wallet
     }
 
     // Migrate a v1 (PBKDF2) keystore to v2 (Argon2id) for stronger key derivation.
@@ -191,10 +216,23 @@ impl Keystore {
         Self::encrypt(&wallet, password)
     }
 
-    // Save keystore to JSON file
+    // Save keystore to JSON file with 0600 (owner-read/write only) on
+    // Unix. Default `std::fs::write` honours the process umask, which
+    // on most systems leaves the file world-readable (0644). Even
+    // though the contents are AES-GCM ciphertext over an Argon2id-
+    // derived key, leaking the file to a co-tenant user enables
+    // offline brute-force against the password — and the per-user
+    // bound is the strongest one we can set from this binary without
+    // mandating a specific filesystem layout. Windows keeps the
+    // default; ACL hardening there is the operator's responsibility.
     pub fn save(&self, path: &str) -> SentrixResult<()> {
         let json = serde_json::to_string_pretty(self)?;
         std::fs::write(path, json)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        }
         Ok(())
     }
 
@@ -269,6 +307,31 @@ mod tests {
 
         // Cleanup
         let _ = std::fs::remove_file(path_str);
+    }
+
+    /// Pin the file-mode contract: `save` writes 0600 (owner rw only) on
+    /// Unix. Leaking the keystore file to a co-tenant user would enable
+    /// offline brute-force against the password.
+    #[cfg(unix)]
+    #[test]
+    fn test_save_file_mode_is_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let wallet = Wallet::generate();
+        let keystore = Keystore::encrypt(&wallet, "perm_test").unwrap();
+        let tmp_path = std::env::temp_dir().join(format!(
+            "sentrix_test_perms_{}.json",
+            std::process::id()
+        ));
+        let path_str = tmp_path.to_str().unwrap();
+        keystore.save(path_str).unwrap();
+        let meta = std::fs::metadata(path_str).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        let _ = std::fs::remove_file(path_str);
+        assert_eq!(
+            mode, 0o600,
+            "keystore file must be 0600 (owner-only); got 0{:o}",
+            mode
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to the workspace-wide audit pass. Each finding here was re-verified against current code (per operator's \"yakin kan?\") before fixing. Four real defects, no theoretical ones.

## Findings + fixes

### sentrix-wallet (security — defense in depth)

**1. `Keystore::save` wrote keystore with default umask (0644 on most hosts) → world-readable file.**

Even with AES-GCM ciphertext over an Argon2id-derived key, leaking the file's ciphertext + salt + MAC to a co-tenant user enables offline brute-force against the password. Fix: explicit \`set_permissions(0o600)\` after the write on Unix. Windows keeps the default — ACL hardening is the operator's responsibility.

Added \`test_save_file_mode_is_0600\` so a future edit that drops the chmod fails CI.

**2. Derived KDF key + plaintext private key bytes were never zeroized.**

`encrypt` / `decrypt` / the wrong-password early-return path all allocated \`[u8; 32]\` for the Argon2id-derived AES-GCM key on stack and left it there until the frame unwound. A core dump or post-free memory inspection could still recover the AES key (and the second-half MAC key sliced from it). Fix: \`zeroize::Zeroize::zeroize()\` on:

- \`key_bytes\` — the derived AES-GCM key
- \`private_key_bytes\` — the raw secret-key bytes between hex-decode and AES encrypt (encrypt path) / between AES decrypt and re-encode (decrypt path)
- \`mac_input\` — contains a copy of the MAC half of \`key_bytes\`
- \`private_key_hex\` (decrypt path) — the hex-encoded private key

The \`zeroize\` crate was already in workspace deps (used by other crates).

### sentrix-prom-exporter (correctness + observability)

**3. Module doc said \"first 4 hex of latest_block_hash as u32\" — actual code consumes 8 hex chars.**

Code at line 222 (\`if h.len() < 8\`) + test asserting \`0xdeadbeef\` (8 chars → u32) + the metric-registration doc string at line 89 all agree on 8. Module doc line 15 was stale. Fix: update to \"first 8 hex\".

**4. \`parse_targets\` silently dropped malformed \`SENTRIX_TARGETS\` entries.**

Operator that misconfigured the env var would see the exporter run with fewer (or zero) targets and no log indication why the Grafana dashboard went dark. Fix: \`warn!\` on the dropped entry with the bad input + observed part count.

## Self-review (per `feedback_smoke_test_and_code_review_every_change`)

- ✅ Each finding re-verified by reading the exact source lines before fixing — no speculative changes.
- ✅ \`cargo clippy --workspace --tests -- -D warnings\` clean (matches CI Test workflow).
- ✅ 22/22 \`sentrix-wallet\` tests pass — includes the new \`test_save_file_mode_is_0600\` regression test.
- ✅ Existing roundtrip + wrong-password tests still pass — zeroize calls don't perturb the cryptographic contract.
- ✅ \`sentrix-prom-exporter\` builds clean.

## Downgraded / not in this PR

These were initially flagged in the audit but downgraded after re-verification:

- \`prom-exporter::metrics_handler\` \`.unwrap()\` on response builder — practically infallible (hardcoded headers, in-memory body), not a bug.
- \`grpc::marshal_block\` silent bincode-error fallback — owned-struct bincode serialize practically infallible, theoretical only.
- Argon2id parameters (m=64 MiB) — within RFC 9106 acceptable range, not a defect.

These are notes for a future hardening pass, not real defects today.

## Found via

Operator-requested audit pass against workspace crates one at a time. Faucet cooldown TOCTOU (separate PR #760) was the first real bug; these are the next four after re-verifying the rest.