### PR TITLE
fix(storage): save_block atomic — single MDBX write transaction

### DIFF
--- a/crates/sentrix-storage/src/chain.rs
+++ b/crates/sentrix-storage/src/chain.rs
@@ -159,16 +159,34 @@ impl ChainStorage {
 
     // ── Per-block operations ────────────────────────────────
 
+    /// Persist a single block atomically: block JSON + hash-to-height
+    /// index + tip-height key all land in one MDBX write transaction,
+    /// matching the atomic-write contract `save_blockchain` already
+    /// provides. A crash mid-transaction commits nothing; a crash after
+    /// `commit()` commits everything.
+    ///
+    /// Pre-fix the three puts ran as separate transactions, so a crash
+    /// between them could leave the block stored without its hash
+    /// index (recoverable by `ensure_hash_index` on next boot) or with
+    /// a stale `height` key (= orphaned block until the next save).
+    /// The atomic batch closes both windows.
     pub fn save_block(&self, block: &Block) -> StorageResult<()> {
         let key = format!("block:{}", block.index);
         let block_json = serde_json::to_vec(block)?;
-        self.mdbx.put(TABLE_META, key.as_bytes(), &block_json)?;
-        self.mdbx.put(
+        let height_bytes = serde_json::to_vec(&block.index)?;
+
+        let batch = self.mdbx.begin_write()?;
+        batch.put(TABLE_META, key.as_bytes(), &block_json)?;
+        batch.put(
             TABLE_BLOCK_HASHES,
             block.hash.as_bytes(),
             &height_key(block.index),
         )?;
-        self.save_height(block.index)?;
+        // Tip-height key — same TABLE_META as the per-block keys, written
+        // inside the same transaction so a torn write cannot leave the
+        // height key out of sync with the block JSON.
+        batch.put(TABLE_META, b"height", &height_bytes)?;
+        batch.commit()?;
         self.mdbx.sync()?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

\`ChainStorage::save_block\` was doing three separate \`mdbx.put\` calls
(block JSON → hash index → height key) followed by a \`sync()\`. Each
put is internally atomic in MDBX, but the trio is not — a crash
between them leaves on-disk state partially consistent:

| Crash window | On-disk state |
|---|---|
| After put #1, before put #2 | Block JSON stored, hash → height index missing |
| After put #2, before put #3 | Block + hash indexed, but \`height\` key still points at the previous tip |

The first is recoverable: \`ensure_hash_index\` walks every block on next boot and rebuilds the index. The second leaves the block orphaned until the next \`save_block\` call advances \`height\` past it, and any consumer that derives \"tip\" from the \`height\` key (the live chain extent) sees the old tip on restart even though the block JSON for \`tip + 1\` is persisted. Patch B1 (v2.1.90) added an atomic-write contract for the bulk \`save_blockchain\` path for exactly this reason; \`save_block\` was left on the pre-Patch-B1 sequential-put path.

This PR routes the same three puts through one \`begin_write\` + \`commit\` so MDBX either writes all three or none. Same mechanism, same tables, same encoded values — only the transactional grouping changes.

## What changes

\`crates/sentrix-storage/src/chain.rs\`:

- Replace the sequential \`mdbx.put\` × 2 + \`save_height\` sequence with \`mdbx.begin_write()\` → \`batch.put\` × 3 → \`batch.commit()\`.
- Keep the post-commit \`sync()\` (matches \`save_blockchain\` line 145).
- Add a doc comment naming the crash windows the fix closes.

Out of scope: the \`save_height\` standalone API is unchanged — other callers that need to update height without saving a block (initial chain bootstrap, test helpers) still work.

## Test plan

- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean (matches CI Test workflow).
- [x] \`cargo test --release -p sentrix-storage\` — 23/23 pass, including \`test_save_and_load_block\`, \`test_load_block_by_hash\`, \`test_persistence\`, \`test_height\` (all exercise the changed path).
- [x] Diff vs \`save_blockchain\` (chain.rs:108-147) confirms identical pattern (\`begin_write\` → \`batch.put\` → \`commit\` → \`sync\`).
- Crash-window verification can't be expressed as a unit test — MDBX's transactional guarantee is the contract that closes it. Same as the original \`save_blockchain\` Patch B1 had no crash-injection test either.

## How I found it

Audit pass against workspace crates one-by-one (operator request). \`sentrix-storage\` was the 9th crate reviewed. Earlier finds (faucet TOCTOU #760, wallet 0600 + zeroize + prom-exporter doc/warn #761) covered surface issues; this is the first transactional-correctness gap found in storage. Production callers verified in audit:

- \`crates/sentrix-core/src/storage.rs:344\` — chain-state save path
- \`bin/sentrix/src/main.rs:3104\` — validator-loop block-finalized save
- \`bin/sentrix/src/main.rs:3458\` — p2p block-arrival save

All three benefit identically.

## Related

Operator constraint for this audit pass: \"fix nya jangan buat tambah error, jangan typo, ada gap dan bug lagi\". Self-review pre-push confirms: no new error types, no new gaps, clippy clean, 23/23 existing tests pass.