### PR TITLE
fix(consensus): two SIP-6 pre-deploy blockers — address case normalization + epoch transition in libp2p sync

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -6,7 +6,6 @@ use libp2p::Multiaddr;
 use sentrix::api::events::EventBus;
 use sentrix::api::routes::{SharedState, create_router_with_bus};
 use sentrix::core::blockchain::{BLOCK_TIME_SECS, Blockchain};
-use sentrix::core::transaction::PROTOCOL_TREASURY;
 use sentrix::network::libp2p_node::{LibP2pNode, make_multiaddr};
 use sentrix::network::node::{DEFAULT_PORT, NodeEvent};
 use sentrix::storage::db::Storage;
@@ -2347,74 +2346,7 @@ async fn cmd_start(
                                                                 validator_fee,
                                                             );
 
-                                                        if sentrix::core::epoch::EpochManager::is_epoch_boundary(height) {
-                                                            tracing::info!("Epoch boundary at height {} — transitioning", height);
-                                                            let released = bc.stake_registry.process_unbonding(height);
-                                                            for (delegator, amount) in &released {
-                                                                // V4 Step 3: post-reward-v2 fork, unbonded
-                                                                // stake returns from treasury (where it
-                                                                // was escrowed on Delegate), not a fresh
-                                                                // mint. Pre-fork path keeps legacy credit
-                                                                // behaviour for existing chain.db state.
-                                                                let r = if Blockchain::is_reward_v2_height(height) {
-                                                                    bc.accounts.transfer(
-                                                                        PROTOCOL_TREASURY,
-                                                                        delegator,
-                                                                        *amount,
-                                                                        0,
-                                                                    )
-                                                                } else {
-                                                                    bc.accounts.credit(delegator, *amount)
-                                                                };
-                                                                r.unwrap_or_else(|e| tracing::warn!("unbonding release failed: {}", e));
-                                                            }
-                                                            if !released.is_empty() {
-                                                                tracing::info!("Released {} unbonding entries", released.len());
-                                                            }
-
-                                                            bc.stake_registry.update_active_set();
-                                                            let active_set = bc.stake_registry.active_set.clone();
-                                                            let total_staked: u64 = active_set.iter()
-                                                                .filter_map(|a| bc.stake_registry.get_validator(a))
-                                                                .map(|v| v.total_stake())
-                                                                .sum();
-                                                            bc.epoch_manager.record_block(0);
-                                                            let finished = bc.epoch_manager.current_epoch.clone();
-                                                            bc.epoch_manager.history.push(finished);
-                                                            if bc.epoch_manager.history.len() > bc.epoch_manager.max_history {
-                                                                bc.epoch_manager.history.remove(0);
-                                                            }
-                                                            let next_num = bc.epoch_manager.current_epoch.epoch_number + 1;
-                                                            let next_start = next_num * sentrix::core::epoch::EPOCH_LENGTH;
-                                                            bc.epoch_manager.current_epoch = sentrix::core::epoch::EpochInfo {
-                                                                epoch_number: next_num,
-                                                                start_height: next_start,
-                                                                end_height: next_start + sentrix::core::epoch::EPOCH_LENGTH - 1,
-                                                                validator_set: active_set.clone(),
-                                                                total_staked,
-                                                                total_rewards: 0,
-                                                                total_blocks_produced: 0,
-                                                            };
-                                                            // Phase 3 WS: notify sentrix_subscribe(validatorSet)
-                                                            // — full epoch-advance wire-up. Subscribers see
-                                                            // the new active set on every epoch boundary,
-                                                            // not just AddSelfStake re-entry.
-                                                            if let Some(emitter) = &bc.event_emitter {
-                                                                emitter.emit_validator_set(next_num, &active_set);
-                                                            }
-                                                            tracing::info!("Epoch {} started — {} validators, {} staked",
-                                                                next_num, active_set.len(), total_staked);
-
-                                                            let mut slashing = std::mem::take(&mut bc.slashing);
-                                                            let slashed = slashing.check_liveness(
-                                                                &mut bc.stake_registry, &active_set, height,
-                                                            );
-                                                            bc.slashing = slashing;
-                                                            for (val, amt) in &slashed {
-                                                                tracing::warn!("Slashed {} for {} sentri (downtime)", val, amt);
-                                                                bc.accounts.burn(*amt);
-                                                            }
-                                                        }
+                                                        bc.run_epoch_bookkeeping(height);
 
                                                         tracing::info!(
                                                             "BFT finalized height={} round={}",
@@ -2963,73 +2895,7 @@ async fn cmd_start(
                                                     validator_fee,
                                                 );
 
-                                                if sentrix::core::epoch::EpochManager::is_epoch_boundary(height) {
-                                                    tracing::info!("Epoch boundary at height {} — transitioning", height);
-                                                    let released = bc.stake_registry.process_unbonding(height);
-                                                    for (delegator, amount) in &released {
-                                                        // V4 Step 3 — mirror of the self-produced
-                                                        // finalize handler above; unbonded stake
-                                                        // returns from treasury post-fork.
-                                                        let r = if Blockchain::is_reward_v2_height(height) {
-                                                            bc.accounts.transfer(
-                                                                PROTOCOL_TREASURY,
-                                                                delegator,
-                                                                *amount,
-                                                                0,
-                                                            )
-                                                        } else {
-                                                            bc.accounts.credit(delegator, *amount)
-                                                        };
-                                                        r.unwrap_or_else(|e| tracing::warn!("unbonding release failed: {}", e));
-                                                    }
-                                                    if !released.is_empty() {
-                                                        tracing::info!("Released {} unbonding entries", released.len());
-                                                    }
-
-                                                    bc.stake_registry.update_active_set();
-                                                    let active_set = bc.stake_registry.active_set.clone();
-                                                    let total_staked: u64 = active_set.iter()
-                                                        .filter_map(|a| bc.stake_registry.get_validator(a))
-                                                        .map(|v| v.total_stake())
-                                                        .sum();
-                                                    bc.epoch_manager.record_block(0);
-                                                    let finished = bc.epoch_manager.current_epoch.clone();
-                                                    bc.epoch_manager.history.push(finished);
-                                                    if bc.epoch_manager.history.len() > bc.epoch_manager.max_history {
-                                                        bc.epoch_manager.history.remove(0);
-                                                    }
-                                                    let next_num = bc.epoch_manager.current_epoch.epoch_number + 1;
-                                                    let next_start = next_num * sentrix::core::epoch::EPOCH_LENGTH;
-                                                    bc.epoch_manager.current_epoch = sentrix::core::epoch::EpochInfo {
-                                                        epoch_number: next_num,
-                                                        start_height: next_start,
-                                                        end_height: next_start + sentrix::core::epoch::EPOCH_LENGTH - 1,
-                                                        validator_set: active_set.clone(),
-                                                        total_staked,
-                                                        total_rewards: 0,
-                                                        total_blocks_produced: 0,
-                                                    };
-                                                    // Phase 3 WS: notify sentrix_subscribe(validatorSet) —
-                                                    // libp2p-applied path mirror of the validator-finalize
-                                                    // emit above. Both call sites must emit so subscribers
-                                                    // see the rotation regardless of which path applied
-                                                    // the boundary block.
-                                                    if let Some(emitter) = &bc.event_emitter {
-                                                        emitter.emit_validator_set(next_num, &active_set);
-                                                    }
-                                                    tracing::info!("Epoch {} started — {} validators, {} staked",
-                                                        next_num, active_set.len(), total_staked);
-
-                                                    let mut slashing = std::mem::take(&mut bc.slashing);
-                                                    let slashed = slashing.check_liveness(
-                                                        &mut bc.stake_registry, &active_set, height,
-                                                    );
-                                                    bc.slashing = slashing;
-                                                    for (val, amt) in &slashed {
-                                                        tracing::warn!("Slashed {} for {} sentri (downtime)", val, amt);
-                                                        bc.accounts.burn(*amt);
-                                                    }
-                                                }
+                                                bc.run_epoch_bookkeeping(height);
 
                                                 tracing::info!(
                                                     "BFT finalized height={} round={}",

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -519,6 +519,82 @@ impl Blockchain {
         self.total_minted
     }
 
+    /// Run epoch-boundary bookkeeping for the block at `height` if it is
+    /// an epoch boundary. Encapsulates process_unbonding → unbond releases
+    /// → update_active_set → epoch rotation → slashing.check_liveness so
+    /// both the BFT-finalize path (main.rs) and the libp2p sync paths
+    /// (gossip + GetBlocks catch-up) run identical logic.
+    ///
+    /// Call AFTER record_block + distribute_reward have already run for
+    /// this block. Returns without doing anything if the height is not
+    /// an epoch boundary.
+    pub fn run_epoch_bookkeeping(&mut self, height: u64) {
+        use sentrix_primitives::transaction::PROTOCOL_TREASURY;
+        use sentrix_staking::epoch::{EpochInfo, EpochManager, EPOCH_LENGTH};
+
+        if !EpochManager::is_epoch_boundary(height) {
+            return;
+        }
+
+        tracing::info!("Epoch boundary at height {} — transitioning", height);
+        let released = self.stake_registry.process_unbonding(height);
+        for (delegator, amount) in &released {
+            let r = if Self::is_reward_v2_height(height) {
+                self.accounts.transfer(PROTOCOL_TREASURY, delegator, *amount, 0)
+            } else {
+                self.accounts.credit(delegator, *amount)
+            };
+            r.unwrap_or_else(|e| tracing::warn!("unbonding release failed: {}", e));
+        }
+        if !released.is_empty() {
+            tracing::info!("Released {} unbonding entries", released.len());
+        }
+
+        self.stake_registry.update_active_set();
+        let active_set = self.stake_registry.active_set.clone();
+        let total_staked: u64 = active_set
+            .iter()
+            .filter_map(|a| self.stake_registry.get_validator(a))
+            .map(|v| v.total_stake())
+            .sum();
+
+        self.epoch_manager.record_block(0);
+        let finished = self.epoch_manager.current_epoch.clone();
+        self.epoch_manager.history.push(finished);
+        if self.epoch_manager.history.len() > self.epoch_manager.max_history {
+            self.epoch_manager.history.remove(0);
+        }
+        let next_num = self.epoch_manager.current_epoch.epoch_number + 1;
+        let next_start = next_num * EPOCH_LENGTH;
+        self.epoch_manager.current_epoch = EpochInfo {
+            epoch_number: next_num,
+            start_height: next_start,
+            end_height: next_start + EPOCH_LENGTH - 1,
+            validator_set: active_set.clone(),
+            total_staked,
+            total_rewards: 0,
+            total_blocks_produced: 0,
+        };
+
+        if let Some(emitter) = &self.event_emitter {
+            emitter.emit_validator_set(next_num, &active_set);
+        }
+        tracing::info!(
+            "Epoch {} started — {} validators, {} staked",
+            next_num,
+            active_set.len(),
+            total_staked
+        );
+
+        let mut slashing = std::mem::take(&mut self.slashing);
+        let slashed = slashing.check_liveness(&mut self.stake_registry, &active_set, height);
+        self.slashing = slashing;
+        for (val, amt) in &slashed {
+            tracing::warn!("Slashed {} for {} sentri (downtime)", val, amt);
+            self.accounts.burn(*amt);
+        }
+    }
+
     // Memory estimate reflects the in-memory window, not the full historical chain
     pub fn get_memory_estimate(&self) -> String {
         let window_blocks = self.chain.len();

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -1132,6 +1132,11 @@ async fn on_swarm_event(
                                         );
                                         // Epoch tracking — mirror main.rs validator-finalize.
                                         chain.epoch_manager.record_block(reward);
+                                        // Epoch boundary transition — rotate active set,
+                                        // release unbonding, run liveness slashing.
+                                        // Previously missing here; libp2p-synced nodes
+                                        // diverged from BFT-finalize path at boundaries.
+                                        chain.run_epoch_bookkeeping(gossip.block.index);
                                     }
                                     let updated =
                                         chain.latest_block().ok().cloned().unwrap_or(gossip.block);
@@ -2018,6 +2023,11 @@ async fn on_inbound_response(
                                 0,
                             );
                             chain.epoch_manager.record_block(reward);
+                            // Epoch boundary transition — rotate active set,
+                            // release unbonding, run liveness slashing.
+                            // Previously missing here; batch-syncing nodes
+                            // diverged from BFT-finalize path at boundaries.
+                            chain.run_epoch_bookkeeping(block.index);
                         }
                         // Use H2 (post-add_block state_root hash) — not the raw peer block (PR #78).
                         let updated = chain

--- a/crates/sentrix-trie/src/address.rs
+++ b/crates/sentrix-trie/src/address.rs
@@ -188,10 +188,13 @@ pub fn epoch_state_value_bytes(
     v[32..40].copy_from_slice(&total_rewards.to_be_bytes());
     v[40..48].copy_from_slice(&total_blocks_produced.to_be_bytes());
 
-    let mut sorted: Vec<&String> = validator_set.iter().collect();
+    let mut sorted: Vec<String> = validator_set
+        .iter()
+        .map(|a| a.trim_start_matches("0x").to_lowercase())
+        .collect();
     sorted.sort();
     let mut h = Sha256::new();
-    for addr in sorted {
+    for addr in &sorted {
         h.update(addr.as_bytes());
         h.update(b"\n");
     }
@@ -468,6 +471,31 @@ mod tests {
             "validator_set hash must be order-independent — otherwise \
              HashMap-iteration drift forks the chain"
         );
+    }
+
+    /// validator_set hash must be case-insensitive and strip 0x prefix.
+    /// If one node stores addresses as "0xABCD" and another as "0xabcd",
+    /// both must hash to the same bytes — otherwise state_root forks at
+    /// every post-SIP-6 block.
+    #[test]
+    fn test_epoch_state_value_validator_set_case_insensitive() {
+        let lower = vec![
+            "0xaaaa".to_string(),
+            "0xbbbb".to_string(),
+        ];
+        let upper = vec![
+            "0xAAAA".to_string(),
+            "0xBBBB".to_string(),
+        ];
+        let no_prefix = vec![
+            "aaaa".to_string(),
+            "bbbb".to_string(),
+        ];
+        let v_lower = epoch_state_value_bytes(1, 0, 0, 0, 0, 0, &lower);
+        let v_upper = epoch_state_value_bytes(1, 0, 0, 0, 0, 0, &upper);
+        let v_noprefix = epoch_state_value_bytes(1, 0, 0, 0, 0, 0, &no_prefix);
+        assert_eq!(v_lower, v_upper, "validator_set hash must be case-insensitive");
+        assert_eq!(v_lower, v_noprefix, "validator_set hash must strip 0x prefix");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two bugs found during SIP-6 pre-deploy review that would cause immediate state_root forks on testnet.

**Fix 1 — `epoch_state_value_bytes` address case normalization** (`crates/sentrix-trie/src/address.rs`)

The validator_set hash was feeding raw address strings into SHA-256 without normalizing case or stripping the `0x` prefix. If any two validators stored the same address with different casing (e.g. `0xABCD` vs `0xabcd`), the 32-byte `validator_set_hash` at bytes 48..80 of the epoch state value would differ → `state_root` mismatch at every post-SIP-6 block. Fix: normalize each address with `trim_start_matches("0x").to_lowercase()` before hashing, matching the existing pattern in `address_to_key`. New test `test_epoch_state_value_validator_set_case_insensitive` pins the fix.

**Fix 2 — epoch boundary transition missing in libp2p sync paths** (`crates/sentrix-core/src/blockchain.rs`, `crates/sentrix-network/src/libp2p_node.rs`, `bin/sentrix/src/main.rs`)

The gossip and GetBlocks batch-sync paths in `libp2p_node.rs` applied `record_block_signatures + distribute_reward + epoch_manager.record_block` but skipped the full epoch boundary transition (`process_unbonding → unbond releases → update_active_set → epoch rotation → check_liveness`). Nodes catching up via these paths would have a stale `active_set` and wrong `epoch_state` after every epoch boundary — with SIP-6 active, this surfaces immediately as a `state_root` mismatch.

Fix: extract the epoch boundary block from the two duplicate `main.rs` FinalizeBlock arms into `Blockchain::run_epoch_bookkeeping(height)`, then call it from all three paths (both `main.rs` arms + both `libp2p_node.rs` paths).

## Test plan

- [x] `cargo check --workspace -D warnings` clean
- [x] 78 `sentrix-trie` tests pass (new case normalization test included)
- [x] 8 `sentrix-core` tests pass
- [x] 32 `sentrix-network` tests pass
- [x] Testnet bake post-merge before mainnet SIP-6 activation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed epoch-boundary state transitions during network synchronization, ensuring nodes properly handle unbonding releases, validator set updates, and liveness slashing when syncing blocks.
  * Improved validator address normalization to be case-insensitive and independent of address formatting prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->