### PR TITLE
fix(consensus): remove double record_block(0) at epoch boundary

### DIFF
--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -558,7 +558,6 @@ impl Blockchain {
             .map(|v| v.total_stake())
             .sum();
 
-        self.epoch_manager.record_block(0);
         let finished = self.epoch_manager.current_epoch.clone();
         self.epoch_manager.history.push(finished);
         if self.epoch_manager.history.len() > self.epoch_manager.max_history {


### PR DESCRIPTION
## Summary

CodeRabbit finding on PR #763 — valid.

`run_epoch_bookkeeping` called `self.epoch_manager.record_block(0)` before pushing the finished epoch to history. But every call site already invoked `epoch_manager.record_block(reward)` before entering this method. The extra `record_block(0)` incremented `total_blocks_produced` twice for every boundary block, so epoch history carried an inflated block count (+1 per rollover).

Fix: remove the redundant call. The caller's `record_block(reward)` is sufficient.

## What's not fixed

The second CodeRabbit finding (`process_unbonding` drops releases on transfer failure) is pre-existing behavior, not introduced by PR #763. Fixing it requires changing `StakeRegistry::process_unbonding` return semantics — deferred to a dedicated PR.

## Test plan

- [x] `cargo check -p sentrix-core -D warnings` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized epoch bookkeeping process by removing an unnecessary operation during epoch finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->