### PR TITLE
fix: fork detection + /health hardening (forked node now returns 503)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ bin/
 **Verifier:** [verify.sentrixchain.com](https://verify.sentrixchain.com) (Sourcify)
 **gRPC + gRPC-Web:** [grpc.sentrixchain.com](https://grpc.sentrixchain.com) · [grpc-testnet.sentrixchain.com](https://grpc-testnet.sentrixchain.com)
 **WebSocket:** `wss://api.sentrixchain.com/ws` (mainnet) · `wss://testnet-api.sentrixchain.com/ws` (testnet)
-**Telegram:** [t.me/SentrixChain](https://t.me/SentrixChain) (announcements) · [t.me/SentrixCommunity](https://t.me/SentrixCommunity) (community chat)
+**Telegram:** [t.me/SentrixChain](https://t.me/SentrixChain) (announcements) · [t.me/Sentrix_Chain](https://t.me/Sentrix_Chain) (current community chat)
 
 ## Roadmap
 

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -3310,7 +3310,49 @@ async fn cmd_start(
             match event {
                 NodeEvent::PeerConnected(addr) => tracing::info!("Peer connected: {}", addr),
                 NodeEvent::PeerDisconnected(addr) => tracing::info!("Peer disconnected: {}", addr),
+                NodeEvent::SyncForkDetected {
+                    height,
+                    local_head_hash,
+                } => {
+                    use std::sync::atomic::Ordering;
+                    let already =
+                        sentrix::api::routes::ops::FORK_DETECTED.swap(true, Ordering::Relaxed);
+                    if !already {
+                        // First detection — record height + timestamp + local hash.
+                        sentrix::api::routes::ops::FORK_DETECTED_HEIGHT
+                            .store(height, Ordering::Relaxed);
+                        let now = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs())
+                            .unwrap_or(0);
+                        sentrix::api::routes::ops::FORK_DETECTED_AT_UNIX
+                            .store(now, Ordering::Relaxed);
+                        if let Ok(mut g) = sentrix::api::routes::ops::FORK_LOCAL_HEAD.lock() {
+                            *g = local_head_hash.clone();
+                        }
+                        tracing::error!(
+                            "FORK: node is on a divergent branch (local head {} cannot \
+                             attach canonical block {}). Health endpoint now returns 503. \
+                             Stop this node and copy chain.db from a healthy validator to recover.",
+                            local_head_hash,
+                            height
+                        );
+                    }
+                }
                 NodeEvent::NewBlock(block) => {
+                    // Clear fork state if it was set — a successful block arrival
+                    // means sync recovered (or the fork was transient / false alarm).
+                    if sentrix::api::routes::ops::FORK_DETECTED
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                    {
+                        sentrix::api::routes::ops::FORK_DETECTED
+                            .store(false, std::sync::atomic::Ordering::Relaxed);
+                        tracing::info!(
+                            "FORK cleared: block {} applied successfully after fork detection; \
+                             node is back on canonical chain.",
+                            block.index
+                        );
+                    }
                     // 2026-05-05 v2.1.63: explicit log for the libp2p-applied
                     // path so the BFT-engine vs chain.height race we hit on
                     // 2026-05-04 is greppable in journalctl. Pair this with

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -3315,21 +3315,28 @@ async fn cmd_start(
                     local_head_hash,
                 } => {
                     use std::sync::atomic::Ordering;
-                    let already =
-                        sentrix::api::routes::ops::FORK_DETECTED.swap(true, Ordering::Relaxed);
-                    if !already {
-                        // First detection — record height + timestamp + local hash.
-                        sentrix::api::routes::ops::FORK_DETECTED_HEIGHT
-                            .store(height, Ordering::Relaxed);
-                        let now = std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .map(|d| d.as_secs())
-                            .unwrap_or(0);
-                        sentrix::api::routes::ops::FORK_DETECTED_AT_UNIX
-                            .store(now, Ordering::Relaxed);
-                        if let Ok(mut g) = sentrix::api::routes::ops::FORK_LOCAL_HEAD.lock() {
+                    // Store metadata before setting the flag so readers that
+                    // observe FORK_DETECTED=true (with Acquire) are guaranteed
+                    // to also see the up-to-date height/timestamp (Release).
+                    sentrix::api::routes::ops::FORK_DETECTED_HEIGHT
+                        .store(height, Ordering::Relaxed);
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0);
+                    sentrix::api::routes::ops::FORK_DETECTED_AT_UNIX.store(now, Ordering::Relaxed);
+                    if let Ok(mut g) = sentrix::api::routes::ops::FORK_LOCAL_HEAD.lock() {
+                        // lock() provides the Release/Acquire fence for FORK_LOCAL_HEAD;
+                        // only write if not already set (first detection wins).
+                        if g.is_empty() {
                             *g = local_head_hash.clone();
                         }
+                    }
+                    // Release fence: HEIGHT/AT_UNIX stores above are visible to
+                    // any thread that observes FORK_DETECTED=true with Acquire.
+                    let already =
+                        sentrix::api::routes::ops::FORK_DETECTED.swap(true, Ordering::Release);
+                    if !already {
                         tracing::error!(
                             "FORK: node is on a divergent branch (local head {} cannot \
                              attach canonical block {}). Health endpoint now returns 503. \
@@ -3340,17 +3347,25 @@ async fn cmd_start(
                     }
                 }
                 NodeEvent::NewBlock(block) => {
-                    // Clear fork state if it was set — a successful block arrival
-                    // means sync recovered (or the fork was transient / false alarm).
-                    if sentrix::api::routes::ops::FORK_DETECTED
-                        .load(std::sync::atomic::Ordering::Relaxed)
+                    // Clear fork state only if the new block is at or beyond the
+                    // height where the fork was detected — a block below the fork
+                    // point cannot prove we're back on the canonical chain.
+                    use std::sync::atomic::Ordering;
+                    let fork_h =
+                        sentrix::api::routes::ops::FORK_DETECTED_HEIGHT.load(Ordering::Acquire);
+                    if sentrix::api::routes::ops::FORK_DETECTED.load(Ordering::Acquire)
+                        && block.index >= fork_h
                     {
-                        sentrix::api::routes::ops::FORK_DETECTED
-                            .store(false, std::sync::atomic::Ordering::Relaxed);
+                        sentrix::api::routes::ops::FORK_DETECTED.store(false, Ordering::Release);
+                        // Also clear the stored local hash so it's accurate on re-detection.
+                        if let Ok(mut g) = sentrix::api::routes::ops::FORK_LOCAL_HEAD.lock() {
+                            g.clear();
+                        }
                         tracing::info!(
-                            "FORK cleared: block {} applied successfully after fork detection; \
+                            "FORK cleared: block {} (>= fork h={}) applied successfully; \
                              node is back on canonical chain.",
-                            block.index
+                            block.index,
+                            fork_h
                         );
                     }
                     // 2026-05-05 v2.1.63: explicit log for the libp2p-applied

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -530,7 +530,7 @@ impl Blockchain {
     /// an epoch boundary.
     pub fn run_epoch_bookkeeping(&mut self, height: u64) {
         use sentrix_primitives::transaction::PROTOCOL_TREASURY;
-        use sentrix_staking::epoch::{EpochInfo, EpochManager, EPOCH_LENGTH};
+        use sentrix_staking::epoch::{EPOCH_LENGTH, EpochInfo, EpochManager};
 
         if !EpochManager::is_epoch_boundary(height) {
             return;
@@ -540,7 +540,8 @@ impl Blockchain {
         let released = self.stake_registry.process_unbonding(height);
         for (delegator, amount) in &released {
             let r = if Self::is_reward_v2_height(height) {
-                self.accounts.transfer(PROTOCOL_TREASURY, delegator, *amount, 0)
+                self.accounts
+                    .transfer(PROTOCOL_TREASURY, delegator, *amount, 0)
             } else {
                 self.accounts.credit(delegator, *amount)
             };

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -1143,9 +1143,31 @@ async fn on_swarm_event(
                                     drop(chain);
                                     let _ = etx.send(NodeEvent::NewBlock(updated)).await;
                                 }
+                                Err(SentrixError::InvalidBlock(ref msg))
+                                    if msg.contains("invalid previous hash") =>
+                                {
+                                    APPLY_ERR.fetch_add(1, Ordering::Relaxed);
+                                    let local_hash = chain
+                                        .latest_block()
+                                        .ok()
+                                        .map(|b| b.hash.clone())
+                                        .unwrap_or_default();
+                                    tracing::error!(
+                                        target: "sentrix::fork",
+                                        "FORK DETECTED (gossip): block {} from {:?} — \
+                                         local head {} on divergent branch.",
+                                        gossip.block.index, peer, local_hash
+                                    );
+                                    let _ = etx
+                                        .send(NodeEvent::SyncForkDetected {
+                                            height: gossip.block.index,
+                                            local_head_hash: local_hash,
+                                        })
+                                        .await;
+                                }
                                 Err(e) => {
                                     APPLY_ERR.fetch_add(1, Ordering::Relaxed);
-                                    tracing::debug!("gossip block from {} rejected: {}", peer, e);
+                                    tracing::debug!("gossip block from {:?} rejected: {}", peer, e);
                                 }
                             }
                         });
@@ -1719,6 +1741,28 @@ async fn on_inbound_request(
                         drop(chain);
                         let _ = etx.send(NodeEvent::NewBlock(updated)).await;
                     }
+                    Err(SentrixError::InvalidBlock(ref msg))
+                        if msg.contains("invalid previous hash") =>
+                    {
+                        APPLY_ERR.fetch_add(1, Ordering::Relaxed);
+                        let local_hash = chain
+                            .latest_block()
+                            .ok()
+                            .map(|b| b.hash.clone())
+                            .unwrap_or_default();
+                        tracing::error!(
+                            target: "sentrix::fork",
+                            "FORK DETECTED (direct): block {} from {} — \
+                             local head {} on divergent branch.",
+                            block_idx, peer, local_hash
+                        );
+                        let _ = etx
+                            .send(NodeEvent::SyncForkDetected {
+                                height: block_idx,
+                                local_head_hash: local_hash,
+                            })
+                            .await;
+                    }
                     Err(e) => {
                         APPLY_ERR.fetch_add(1, Ordering::Relaxed);
                         tracing::warn!("libp2p: rejected block from {}: {}", peer, e);
@@ -2037,6 +2081,31 @@ async fn on_inbound_response(
                             .unwrap_or_else(|| block.clone());
                         let _ = etx.send(NodeEvent::NewBlock(updated)).await;
                         synced += 1;
+                    }
+                    Err(SentrixError::InvalidBlock(ref msg))
+                        if msg.contains("invalid previous hash") =>
+                    {
+                        APPLY_ERR.fetch_add(1, Ordering::Relaxed);
+                        let local_hash = chain
+                            .latest_block()
+                            .ok()
+                            .map(|b| b.hash.clone())
+                            .unwrap_or_default();
+                        tracing::error!(
+                            target: "sentrix::fork",
+                            "FORK DETECTED: block {} from {} cannot attach — \
+                             local head {} is on a divergent branch. \
+                             Node marked unhealthy. Operator must copy canonical \
+                             chain.db from a healthy validator to recover.",
+                            block.index, peer_str, local_hash
+                        );
+                        let _ = etx
+                            .send(NodeEvent::SyncForkDetected {
+                                height: block.index,
+                                local_head_hash: local_hash,
+                            })
+                            .await;
+                        break;
                     }
                     Err(e) => {
                         APPLY_ERR.fetch_add(1, Ordering::Relaxed);

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -1154,7 +1154,7 @@ async fn on_swarm_event(
                                         .unwrap_or_default();
                                     tracing::error!(
                                         target: "sentrix::fork",
-                                        "FORK DETECTED (gossip): block {} from {:?} — \
+                                        "FORK DETECTED (gossip): block {} from {} — \
                                          local head {} on divergent branch.",
                                         gossip.block.index, peer, local_hash
                                     );
@@ -1167,7 +1167,7 @@ async fn on_swarm_event(
                                 }
                                 Err(e) => {
                                     APPLY_ERR.fetch_add(1, Ordering::Relaxed);
-                                    tracing::debug!("gossip block from {:?} rejected: {}", peer, e);
+                                    tracing::debug!("gossip block from {} rejected: {}", peer, e);
                                 }
                             }
                         });

--- a/crates/sentrix-network/src/node.rs
+++ b/crates/sentrix-network/src/node.rs
@@ -25,7 +25,22 @@ pub enum NodeEvent {
     NewTransaction(Transaction),
     PeerConnected(String),
     PeerDisconnected(String),
-    SyncNeeded { peer_addr: String, peer_height: u64 },
+    SyncNeeded {
+        peer_addr: String,
+        peer_height: u64,
+    },
+    /// Emitted when a block import fails because the incoming block's
+    /// `previous_hash` doesn't match our local head hash. This means
+    /// the local chain is on a divergent branch from the canonical
+    /// network. Automatic recovery is not possible without a storage
+    /// rollback primitive; the health endpoint marks the node unhealthy
+    /// until the operator copies a canonical chain.db.
+    SyncForkDetected {
+        /// Height of the incoming canonical block that couldn't be applied.
+        height: u64,
+        /// Our local head hash at the time of the mismatch.
+        local_head_hash: String,
+    },
     BftProposal(sentrix_bft::messages::Proposal),
     BftPrevote(sentrix_bft::messages::Prevote),
     BftPrecommit(sentrix_bft::messages::Precommit),

--- a/crates/sentrix-primitives/src/block.rs
+++ b/crates/sentrix-primitives/src/block.rs
@@ -396,4 +396,20 @@ mod tests {
             "is_valid_hash must fail when state_root changed after hash was set"
         );
     }
+
+    /// Pins the exact error string produced on a prev-hash mismatch.
+    /// The fork detection in libp2p_node.rs matches on "invalid previous hash"
+    /// inside the `InvalidBlock` payload — this test ensures the string stays
+    /// stable so fork detection never silently stops working after a refactor.
+    #[test]
+    fn test_invalid_previous_hash_error_string_is_stable() {
+        let genesis = Block::genesis();
+        let wrong_prev = "a".repeat(64);
+        let err = genesis.validate_structure(0, &wrong_prev).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("invalid previous hash"),
+            "fork detection relies on this exact substring; got: {msg}"
+        );
+    }
 }

--- a/crates/sentrix-rpc/src/routes/ops.rs
+++ b/crates/sentrix-rpc/src/routes/ops.rs
@@ -7,7 +7,7 @@
 // `create_router` so the first /sentrix_status call after boot sees a
 // non-zero value.
 
-use axum::{Json, extract::State, response::IntoResponse};
+use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
 
 use super::{ApiKey, SharedState};
 
@@ -20,6 +20,29 @@ pub(super) static START_TIME: std::sync::OnceLock<std::time::Instant> = std::syn
 /// disk persistence fails, CHAIN_WINDOW_SIZE rolls → permanent gap).
 pub static PEER_BLOCK_SAVE_FAILS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
+
+/// Set by main.rs when a `NodeEvent::SyncForkDetected` is received —
+/// meaning a block import failed because our local chain head has a
+/// different hash than the canonical network expects. Cleared when a
+/// new block is successfully applied (sync recovered).
+///
+/// While true, `/health` returns HTTP 503 so the Docker healthcheck
+/// fails and operators are alerted. Automatic recovery is not possible
+/// without a storage rollback API; the operator must copy a canonical
+/// `chain.db` from a healthy validator.
+pub static FORK_DETECTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Block height at which the fork was first detected.
+pub static FORK_DETECTED_HEIGHT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Unix timestamp (seconds) when fork was first detected.
+pub static FORK_DETECTED_AT_UNIX: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Our local head hash at the time fork was detected, stored as a
+/// newline-terminated string in an atomic-compatible slot via a Mutex.
+pub static FORK_LOCAL_HEAD: std::sync::Mutex<String> = std::sync::Mutex::new(String::new());
 
 pub(super) async fn root(State(state): State<SharedState>) -> Json<serde_json::Value> {
     // Read the runtime consensus state from chain.db's persistent
@@ -85,8 +108,89 @@ pub(super) async fn root(State(state): State<SharedState>) -> Json<serde_json::V
     }))
 }
 
-pub(super) async fn health() -> Json<serde_json::Value> {
-    Json(serde_json::json!({ "status": "ok", "node": "sentrix-chain" }))
+/// Node health check. Returns HTTP 200 when healthy, HTTP 503 when the
+/// node is forked or stale. The Docker healthcheck hits this endpoint;
+/// a 503 causes the container to be marked unhealthy, surfacing the
+/// condition to operators via `docker ps` and alerting pipelines.
+///
+/// Unhealthy conditions:
+/// - `FORK_DETECTED`: local chain head doesn't match canonical network.
+///   Requires operator intervention (copy canonical chain.db).
+/// - Chain stale: latest block timestamp > `STALE_THRESHOLD_SECS` ago.
+///   Indicates the node has stopped receiving/finalising blocks.
+pub(super) async fn health(State(state): State<SharedState>) -> impl IntoResponse {
+    use std::sync::atomic::Ordering;
+
+    const STALE_THRESHOLD_SECS: u64 = 120;
+
+    let fork = FORK_DETECTED.load(Ordering::Relaxed);
+    let fork_height = FORK_DETECTED_HEIGHT.load(Ordering::Relaxed);
+    let fork_at_unix = FORK_DETECTED_AT_UNIX.load(Ordering::Relaxed);
+    let fork_local_head = FORK_LOCAL_HEAD
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or_default();
+
+    let bc = state.read().await;
+    let (height, head_hash, last_block_ts) = bc
+        .latest_block()
+        .ok()
+        .map(|b| (b.index, b.hash.clone(), b.timestamp))
+        .unwrap_or((0, String::new(), 0));
+    drop(bc);
+
+    let now_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Only flag stale if the node has been running longer than the threshold.
+    // A fresh start (or a node catching up from a cold chain.db) shouldn't
+    // appear stale during the initial boot window — the old chain.db timestamp
+    // predates the current run.
+    let uptime_secs = START_TIME.get().map(|t| t.elapsed().as_secs()).unwrap_or(0);
+    let stale = uptime_secs > STALE_THRESHOLD_SECS
+        && last_block_ts > 0
+        && now_unix.saturating_sub(last_block_ts) > STALE_THRESHOLD_SECS;
+
+    if fork {
+        let body = serde_json::json!({
+            "status": "fork_detected",
+            "node": "sentrix-chain",
+            "height": height,
+            "head_hash": head_hash,
+            "fork_detected": true,
+            "fork_at_height": fork_height,
+            "fork_detected_at_unix": fork_at_unix,
+            "fork_local_head_at_detection": fork_local_head,
+            "stale": stale,
+            "recovery": "Copy canonical chain.db from a healthy validator and restart."
+        });
+        return (StatusCode::SERVICE_UNAVAILABLE, Json(body));
+    }
+
+    if stale {
+        let body = serde_json::json!({
+            "status": "stale",
+            "node": "sentrix-chain",
+            "height": height,
+            "head_hash": head_hash,
+            "fork_detected": false,
+            "stale": true,
+            "last_block_unix": last_block_ts,
+            "stale_for_secs": now_unix.saturating_sub(last_block_ts),
+        });
+        return (StatusCode::SERVICE_UNAVAILABLE, Json(body));
+    }
+
+    let body = serde_json::json!({
+        "status": "ok",
+        "node": "sentrix-chain",
+        "height": height,
+        "head_hash": head_hash,
+        "fork_detected": false,
+        "stale": false,
+    });
+    (StatusCode::OK, Json(body))
 }
 
 /// Structured node status (NEAR-style).
@@ -439,4 +543,93 @@ pub(super) async fn get_admin_log(
         "log": bc.authority.admin_log,
         "count": bc.authority.admin_log.len(),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::to_bytes, http::StatusCode};
+    use sentrix_core::blockchain::Blockchain;
+    use std::sync::{Arc, Mutex, atomic::Ordering};
+    use tokio::sync::RwLock;
+
+    // Tests that touch process-level atomics must run sequentially to
+    // avoid races between parallel test threads.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn make_state() -> SharedState {
+        Arc::new(RwLock::new(Blockchain::new(
+            "0x0000000000000000000000000000000000000001".into(),
+        )))
+    }
+
+    fn reset_fork_state() {
+        FORK_DETECTED.store(false, Ordering::SeqCst);
+        FORK_DETECTED_HEIGHT.store(0, Ordering::SeqCst);
+        FORK_DETECTED_AT_UNIX.store(0, Ordering::SeqCst);
+        if let Ok(mut g) = FORK_LOCAL_HEAD.lock() {
+            g.clear();
+        }
+    }
+
+    /// Health returns 200 + `status: ok` when no fork is detected and chain
+    /// is fresh. (The genesis block has no blocks so last_block_ts=0 and
+    /// the stale guard `last_block_ts > 0` prevents a false stale alarm.)
+    #[tokio::test]
+    async fn test_health_ok_when_no_fork() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_fork_state();
+
+        let state = make_state();
+        let resp = health(State(state)).await.into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["fork_detected"], false);
+    }
+
+    /// Health returns 503 + `status: fork_detected` when FORK_DETECTED is set.
+    /// This is what the Docker healthcheck sees when the node is on a
+    /// divergent branch.
+    #[tokio::test]
+    async fn test_health_503_when_fork_detected() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_fork_state();
+
+        FORK_DETECTED.store(true, Ordering::SeqCst);
+        FORK_DETECTED_HEIGHT.store(6_132_038, Ordering::SeqCst);
+        FORK_DETECTED_AT_UNIX.store(1_748_000_000, Ordering::SeqCst);
+        if let Ok(mut g) = FORK_LOCAL_HEAD.lock() {
+            *g = "deadbeef01234567".to_string();
+        }
+
+        let state = make_state();
+        let resp = health(State(state)).await.into_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "fork_detected");
+        assert_eq!(json["fork_detected"], true);
+        assert_eq!(json["fork_at_height"], 6_132_038u64);
+        assert_eq!(json["fork_local_head_at_detection"], "deadbeef01234567");
+
+        reset_fork_state();
+    }
+
+    /// Clearing FORK_DETECTED (as the NewBlock handler does) switches health
+    /// back to 200. This simulates a transient fork that resolved after sync.
+    #[tokio::test]
+    async fn test_health_recovers_when_fork_cleared() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_fork_state();
+
+        // Simulate: fork detected, then NewBlock clears the flag.
+        FORK_DETECTED.store(true, Ordering::SeqCst);
+        FORK_DETECTED.store(false, Ordering::SeqCst);
+
+        let state = make_state();
+        let resp = health(State(state)).await.into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
 }

--- a/crates/sentrix-rpc/src/routes/ops.rs
+++ b/crates/sentrix-rpc/src/routes/ops.rs
@@ -123,13 +123,22 @@ pub(super) async fn health(State(state): State<SharedState>) -> impl IntoRespons
 
     const STALE_THRESHOLD_SECS: u64 = 120;
 
-    let fork = FORK_DETECTED.load(Ordering::Relaxed);
-    let fork_height = FORK_DETECTED_HEIGHT.load(Ordering::Relaxed);
-    let fork_at_unix = FORK_DETECTED_AT_UNIX.load(Ordering::Relaxed);
+    // Acquire loads: pairs with the Release swap in main.rs so that when we
+    // observe FORK_DETECTED=true we are guaranteed to see the up-to-date
+    // HEIGHT/AT_UNIX values written before the swap.
+    let fork = FORK_DETECTED.load(Ordering::Acquire);
+    let fork_height = FORK_DETECTED_HEIGHT.load(Ordering::Acquire);
+    let fork_at_unix = FORK_DETECTED_AT_UNIX.load(Ordering::Acquire);
+    // Mutex::lock() provides its own Acquire fence for the string content.
+    // Clone inside the closure so the MutexGuard is dropped before any await.
+    // On poisoning: recover the inner value so diagnostic info is not lost.
     let fork_local_head = FORK_LOCAL_HEAD
         .lock()
         .map(|g| g.clone())
-        .unwrap_or_default();
+        .unwrap_or_else(|e| {
+            tracing::warn!("FORK_LOCAL_HEAD mutex poisoned — recovering inner value");
+            e.into_inner().clone()
+        });
 
     let bc = state.read().await;
     let (height, head_hash, last_block_ts) = bc
@@ -550,12 +559,18 @@ mod tests {
     use super::*;
     use axum::{body::to_bytes, http::StatusCode};
     use sentrix_core::blockchain::Blockchain;
-    use std::sync::{Arc, Mutex, atomic::Ordering};
+    use std::sync::{Arc, atomic::Ordering};
     use tokio::sync::RwLock;
 
-    // Tests that touch process-level atomics must run sequentially to
-    // avoid races between parallel test threads.
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
+    // Tests that touch process-level atomics must run sequentially to avoid
+    // races between parallel test threads. Using tokio::sync::Mutex so the
+    // guard can be held across .await points without triggering the
+    // `clippy::await_holding_lock` lint.
+    static TEST_LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+
+    fn test_lock() -> &'static tokio::sync::Mutex<()> {
+        TEST_LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+    }
 
     fn make_state() -> SharedState {
         Arc::new(RwLock::new(Blockchain::new(
@@ -577,7 +592,7 @@ mod tests {
     /// the stale guard `last_block_ts > 0` prevents a false stale alarm.)
     #[tokio::test]
     async fn test_health_ok_when_no_fork() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = test_lock().lock().await;
         reset_fork_state();
 
         let state = make_state();
@@ -594,7 +609,7 @@ mod tests {
     /// divergent branch.
     #[tokio::test]
     async fn test_health_503_when_fork_detected() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = test_lock().lock().await;
         reset_fork_state();
 
         FORK_DETECTED.store(true, Ordering::SeqCst);
@@ -621,7 +636,7 @@ mod tests {
     /// back to 200. This simulates a transient fork that resolved after sync.
     #[tokio::test]
     async fn test_health_recovers_when_fork_cleared() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = test_lock().lock().await;
         reset_fork_state();
 
         // Simulate: fork detected, then NewBlock clears the flag.

--- a/crates/sentrix-trie/src/address.rs
+++ b/crates/sentrix-trie/src/address.rs
@@ -479,23 +479,20 @@ mod tests {
     /// every post-SIP-6 block.
     #[test]
     fn test_epoch_state_value_validator_set_case_insensitive() {
-        let lower = vec![
-            "0xaaaa".to_string(),
-            "0xbbbb".to_string(),
-        ];
-        let upper = vec![
-            "0xAAAA".to_string(),
-            "0xBBBB".to_string(),
-        ];
-        let no_prefix = vec![
-            "aaaa".to_string(),
-            "bbbb".to_string(),
-        ];
+        let lower = vec!["0xaaaa".to_string(), "0xbbbb".to_string()];
+        let upper = vec!["0xAAAA".to_string(), "0xBBBB".to_string()];
+        let no_prefix = vec!["aaaa".to_string(), "bbbb".to_string()];
         let v_lower = epoch_state_value_bytes(1, 0, 0, 0, 0, 0, &lower);
         let v_upper = epoch_state_value_bytes(1, 0, 0, 0, 0, 0, &upper);
         let v_noprefix = epoch_state_value_bytes(1, 0, 0, 0, 0, 0, &no_prefix);
-        assert_eq!(v_lower, v_upper, "validator_set hash must be case-insensitive");
-        assert_eq!(v_lower, v_noprefix, "validator_set hash must strip 0x prefix");
+        assert_eq!(
+            v_lower, v_upper,
+            "validator_set hash must be case-insensitive"
+        );
+        assert_eq!(
+            v_lower, v_noprefix,
+            "validator_set hash must strip 0x prefix"
+        );
     }
 
     #[test]

--- a/crates/sentrix-wallet/src/keystore.rs
+++ b/crates/sentrix-wallet/src/keystore.rs
@@ -259,7 +259,10 @@ mod tests {
 
         assert_eq!(wallet.address, decrypted.address);
         assert_eq!(wallet.public_key, decrypted.public_key);
-        assert_eq!(wallet.secret_key_hex().expose_str(), decrypted.secret_key_hex().expose_str());
+        assert_eq!(
+            wallet.secret_key_hex().expose_str(),
+            decrypted.secret_key_hex().expose_str()
+        );
     }
 
     #[test]
@@ -303,7 +306,10 @@ mod tests {
         let decrypted = loaded.decrypt(password).unwrap();
 
         assert_eq!(wallet.address, decrypted.address);
-        assert_eq!(wallet.secret_key_hex().expose_str(), decrypted.secret_key_hex().expose_str());
+        assert_eq!(
+            wallet.secret_key_hex().expose_str(),
+            decrypted.secret_key_hex().expose_str()
+        );
 
         // Cleanup
         let _ = std::fs::remove_file(path_str);
@@ -318,10 +324,8 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         let wallet = Wallet::generate();
         let keystore = Keystore::encrypt(&wallet, "perm_test").unwrap();
-        let tmp_path = std::env::temp_dir().join(format!(
-            "sentrix_test_perms_{}.json",
-            std::process::id()
-        ));
+        let tmp_path =
+            std::env::temp_dir().join(format!("sentrix_test_perms_{}.json", std::process::id()));
         let path_str = tmp_path.to_str().unwrap();
         keystore.save(path_str).unwrap();
         let meta = std::fs::metadata(path_str).unwrap();
@@ -365,7 +369,10 @@ mod tests {
 
         let decrypted = ks.decrypt(password).unwrap();
         assert_eq!(wallet.address, decrypted.address);
-        assert_eq!(wallet.secret_key_hex().expose_str(), decrypted.secret_key_hex().expose_str());
+        assert_eq!(
+            wallet.secret_key_hex().expose_str(),
+            decrypted.secret_key_hex().expose_str()
+        );
     }
 
     #[test]
@@ -421,7 +428,10 @@ mod tests {
         // Must still decrypt correctly
         let decrypted = v1_ks.decrypt(password).unwrap();
         assert_eq!(wallet.address, decrypted.address);
-        assert_eq!(wallet.secret_key_hex().expose_str(), decrypted.secret_key_hex().expose_str());
+        assert_eq!(
+            wallet.secret_key_hex().expose_str(),
+            decrypted.secret_key_hex().expose_str()
+        );
     }
 
     #[test]
@@ -489,7 +499,10 @@ mod tests {
         // Decrypting the migrated keystore must yield the same key
         let decrypted = v2_ks.decrypt(password).unwrap();
         assert_eq!(wallet.address, decrypted.address);
-        assert_eq!(wallet.secret_key_hex().expose_str(), decrypted.secret_key_hex().expose_str());
+        assert_eq!(
+            wallet.secret_key_hex().expose_str(),
+            decrypted.secret_key_hex().expose_str()
+        );
     }
 
     #[test]

--- a/crates/sentrix-wallet/src/wallet.rs
+++ b/crates/sentrix-wallet/src/wallet.rs
@@ -136,7 +136,10 @@ mod tests {
         let w1 = Wallet::generate();
         let w2 = Wallet::generate();
         assert_ne!(w1.address, w2.address);
-        assert_ne!(w1.secret_key_hex().expose_str(), w2.secret_key_hex().expose_str());
+        assert_ne!(
+            w1.secret_key_hex().expose_str(),
+            w2.secret_key_hex().expose_str()
+        );
     }
 
     #[test]
@@ -155,7 +158,10 @@ mod tests {
         let wallet = Wallet::generate();
         let sk = wallet.get_secret_key().unwrap();
         let wallet2 = Wallet::from_keypair(&sk, &wallet.get_public_key().unwrap());
-        assert_eq!(wallet.secret_key_hex().expose_str(), wallet2.secret_key_hex().expose_str());
+        assert_eq!(
+            wallet.secret_key_hex().expose_str(),
+            wallet2.secret_key_hex().expose_str()
+        );
         assert_eq!(wallet.address, wallet2.address);
     }
 }


### PR DESCRIPTION
## Root Cause

Testnet val2 forked at h=6,132,038 but reported healthy to Docker because `/health` returned `{"status":"ok"}` unconditionally. The sync error `libp2p sync: block 6132039 failed: Invalid block: invalid previous hash` was logged and `APPLY_ERR` incremented, but no health state changed. The node kept attempting sync on every interval, kept failing, and kept serving as healthy.

No rollback/rewind API exists in the storage layer (`truncate_chain`, `rollback_to_height` — nothing). Automatic fork recovery is not implemented.

## What Changed

**`sentrix-network/src/node.rs`**
- New `NodeEvent::SyncForkDetected { height, local_head_hash }` — emitted when a block import fails with "invalid previous hash".

**`sentrix-network/src/libp2p_node.rs`**
- All three block-apply error paths (batch-sync GetBlocks, gossip, direct NewBlock) now pattern-match on `SentrixError::InvalidBlock` containing `"invalid previous hash"`. On match: read local head hash, log ERROR at `target: "sentrix::fork"`, emit `SyncForkDetected`.

**`sentrix-rpc/src/routes/ops.rs`**
- New atomics: `FORK_DETECTED`, `FORK_DETECTED_HEIGHT`, `FORK_DETECTED_AT_UNIX`, `FORK_LOCAL_HEAD`.
- `/health` now returns **HTTP 503** when forked or stale (stale check is uptime-gated to avoid false alarms during boot). Response body includes `fork_at_height`, `fork_local_head_at_detection`, and `recovery` instructions for the operator.
- Docker healthcheck now fails on a forked node.

**`bin/sentrix/src/main.rs`**
- `NodeEvent::SyncForkDetected` handler sets fork atomics on first detection; logs ERROR with operator recovery instruction.
- `NodeEvent::NewBlock` handler clears `FORK_DETECTED` if set (fork resolved via sync recovery).

## Limitations

- **No automatic recovery.** The storage layer has no `rollback_to(height)` or `rewind` API. The correct action remains: stop the node, copy `chain.db` from a healthy validator, restart.
- The `SyncForkDetected` event may clear if the canonical network somehow catches up to the local fork branch — but that scenario implies local state was actually canonical. The flag clears on any successful block apply, which is conservative.

## Tests

- `test_invalid_previous_hash_error_string_is_stable` — pins the exact `"invalid previous hash"` substring that fork detection matches on. Guards against silent breakage from error message changes.
- `test_health_503_when_fork_detected` — verifies HTTP 503 + structured body with correct fields.
- `test_health_ok_when_no_fork` — verifies HTTP 200 on clean state.
- `test_health_recovers_when_fork_cleared` — verifies recovery path.

`cargo check --workspace -D warnings`: clean. `cargo test --workspace`: all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Telegram community link in README.

* **New Features**
  * Added fork detection: nodes now detect and report when they diverge from the canonical blockchain.
  * Enhanced `/health` endpoint to return 503 SERVICE_UNAVAILABLE with diagnostic details when a fork is detected or node data is stale, including recovery guidance.

* **Tests**
  * Added test suite validating fork detection and health endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->