### PR TITLE
fix: stabilize BFT block application and sync

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -1264,7 +1264,29 @@ async fn cmd_start(
                     }
                 }
                 match bc.create_block_voyager(wallet_address) {
-                    Ok(block) => {
+                    Ok(raw_block) => {
+                        // BFT votes must commit to the same hash that will be
+                        // stored after execution. Past STATE_ROOT_FORK_HEIGHT
+                        // add_block stamps state_root into the header hash, so
+                        // pre-apply on a scratch clone before signing proposal.
+                        let mut scratch = bc.clone();
+                        if let Err(e) = scratch.add_block(raw_block.clone()) {
+                            tracing::warn!(
+                                "create_block_voyager pre-apply failed at h={} r={}: {}",
+                                height,
+                                bft.round(),
+                                e
+                            );
+                            return None;
+                        }
+                        let Some(block) = scratch.latest_block().ok().cloned() else {
+                            tracing::warn!(
+                                "create_block_voyager pre-apply produced no latest block at h={} r={}",
+                                height,
+                                bft.round(),
+                            );
+                            return None;
+                        };
                         let block_hash = block.hash.clone();
                         let block_data = bincode::serialize(&block).unwrap_or_default();
                         let cur_round = bft.round();
@@ -2371,7 +2393,29 @@ async fn cmd_start(
                                                             match bc.create_block_voyager(
                                                                 &wallet.address,
                                                             ) {
-                                                                Ok(block) => {
+                                                                Ok(raw_block) => {
+                                                                    let mut scratch = bc.clone();
+                                                                    let block = match scratch
+                                                                        .add_block(
+                                                                            raw_block.clone(),
+                                                                        ) {
+                                                                        Ok(()) => scratch
+                                                                            .latest_block()
+                                                                            .ok()
+                                                                            .cloned(),
+                                                                        Err(e) => {
+                                                                            tracing::warn!(
+                                                                                "speculative pre-apply for h={} failed: {}",
+                                                                                next_h,
+                                                                                e,
+                                                                            );
+                                                                            None
+                                                                        }
+                                                                    };
+                                                                    let Some(block) = block else {
+                                                                        speculative_proposal = None;
+                                                                        break;
+                                                                    };
                                                                     let block_hash =
                                                                         block.hash.clone();
                                                                     let block_data =
@@ -2554,8 +2598,12 @@ async fn cmd_start(
                                             }
                                             break;
                                         }
-                                        BftAction::SyncNeeded { .. } => {
-                                            tracing::info!("BFT: peer ahead, need block sync");
+                                        BftAction::SyncNeeded { peer_height } => {
+                                            tracing::info!(
+                                                "BFT: peer at height {}, triggering block sync",
+                                                peer_height
+                                            );
+                                            lp2p_clone.trigger_sync().await;
                                             break;
                                         }
                                         BftAction::Wait | BftAction::ProposeBlock => break,
@@ -2837,6 +2885,23 @@ async fn cmd_start(
                                     }
 
                                     if let Some(mut blk) = proposed_block.take() {
+                                        if blk.validator != wallet.address {
+                                            tracing::info!(
+                                                target: "finalize_trace",
+                                                "BFT finalize peer-propose: h={} round={} block={:.16}… \
+                                                 proposer={} is not local validator {}; waiting for \
+                                                 libp2p NewBlock/sync instead of executing peer block \
+                                                 in the BFT loop",
+                                                height,
+                                                round,
+                                                block_hash,
+                                                blk.validator,
+                                                wallet.address,
+                                            );
+                                            lp2p_clone.trigger_sync().await;
+                                            break;
+                                        }
+
                                         blk.round = round;
                                         blk.justification = Some(justification.clone());
                                         let proposer = blk.validator.clone();
@@ -2915,7 +2980,28 @@ async fn cmd_start(
                                                     == Some(wallet.address.as_str());
                                                 if we_next_pf {
                                                     match bc.create_block_voyager(&wallet.address) {
-                                                        Ok(block) => {
+                                                        Ok(raw_block) => {
+                                                            let mut scratch = bc.clone();
+                                                            let block = match scratch
+                                                                .add_block(raw_block.clone())
+                                                            {
+                                                                Ok(()) => scratch
+                                                                    .latest_block()
+                                                                    .ok()
+                                                                    .cloned(),
+                                                                Err(e) => {
+                                                                    tracing::warn!(
+                                                                        "speculative pre-apply for h={} failed: {}",
+                                                                        next_h_pf,
+                                                                        e,
+                                                                    );
+                                                                    None
+                                                                }
+                                                            };
+                                                            let Some(block) = block else {
+                                                                speculative_proposal = None;
+                                                                break;
+                                                            };
                                                             let block_hash = block.hash.clone();
                                                             let block_data =
                                                                 bincode::serialize(&block)
@@ -3076,9 +3162,10 @@ async fn cmd_start(
                                 }
                                 BftAction::SyncNeeded { peer_height } => {
                                     tracing::info!(
-                                        "BFT: peer at height {}, need block sync",
+                                        "BFT: peer at height {}, triggering block sync",
                                         peer_height
                                     );
+                                    lp2p_clone.trigger_sync().await;
                                     break;
                                 }
                                 BftAction::Wait | BftAction::ProposeBlock => break,

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -1087,6 +1087,15 @@ async fn on_swarm_event(
                         let peer = propagation_source;
                         tokio::spawn(async move {
                             let mut chain = bc.write().await;
+                            if gossip.block.index <= chain.height() {
+                                tracing::debug!(
+                                    "gossip: skipping stale block {} from {} (local height {})",
+                                    gossip.block.index,
+                                    peer,
+                                    chain.height()
+                                );
+                                return;
+                            }
                             match chain.add_block_from_peer(gossip.block.clone()) {
                                 Ok(()) => {
                                     APPLY_OK.fetch_add(1, Ordering::Relaxed);
@@ -1702,6 +1711,15 @@ async fn on_inbound_request(
                 let block_idx = block.index;
                 let block_validator = block.validator.clone();
                 let block_justification = block.justification.clone();
+                if block_idx <= chain.height() {
+                    tracing::debug!(
+                        "libp2p: skipping stale block {} from {} (local height {})",
+                        block_idx,
+                        peer,
+                        chain.height()
+                    );
+                    return;
+                }
                 match chain.add_block_from_peer(*block.clone()) {
                     Ok(()) => {
                         APPLY_OK.fetch_add(1, Ordering::Relaxed);
@@ -1733,6 +1751,7 @@ async fn on_inbound_request(
                                 0,
                             );
                             chain.epoch_manager.record_block(reward);
+                            chain.run_epoch_bookkeeping(block_idx);
                         }
                         tracing::info!("libp2p: applied block {} from {}", block_idx, peer);
                         // Capture H2 (with state_root + recomputed hash) before releasing


### PR DESCRIPTION
<!--
Thanks for the PR. Fill in the relevant sections + check the boxes that apply.
The risk-tier checklist below is the gate — it codifies discipline rules that
existed in `feedback_*.md` memory but kept getting skipped under time pressure.
-->

## Summary

<!-- 1-3 lines: what changed and why. Link the issue if applicable. -->

## Risk tier

Check ONE:

- [ ] **🟢 Low** — docs, tools/, tests/, CI configs, dependency patch bumps in dev-only crates, comments
- [ ] **🟡 Medium** — non-consensus production code (RPC handlers, network plumbing, observability, ops scripts)
- [ ] **🟠 High** — consensus-critical crates (`sentrix-core`, `sentrix-trie`, `sentrix-staking`, `sentrix-bft`), `block_executor`, `apply_block_*`, `state_root` path
- [ ] **🔴 Critical** — Voyager activation, fork-height changes, hard-fork rollouts, anything that flips env vars on mainnet

## Required by tier

### 🟢 Low — minimum bar
- [ ] CI green (tests + clippy + audit + gitleaks)

### 🟡 Medium — adds
- [ ] New public function or behavioural change has at least one corresponding `#[test]` in same PR
- [ ] Brief description of how this was tested (manual run, integration test, etc.)

### 🟠 High — adds
- [ ] Regression test that **fails on main** and **passes with this change** — paste test name in PR body
- [ ] Designed against documented invariant (link the audit/runbook/design doc)
- [ ] Fresh-brain review by someone other than the author (per the consensus-change review checklist)
- [ ] Single conceptual unit per PR (no bundling — bundling consensus changes burned us on v2.1.12 → 2026-04-25 livelock)

### 🔴 Critical — adds
- [ ] **Testnet rehearsal completed** with success criteria + log evidence linked here
- [ ] **Bake window** observed: minimum 2h on testnet at the same configuration before mainnet
- [ ] **Coordinated rollback plan** documented in PR body — exact commands operator runs if it fails
- [ ] **Operator sign-off** at activation moment (not just PR approval — separate moment for the actual flip)

## Test plan

<!-- Bullet list. For 🟠 / 🔴 PRs the regression test must be specific. -->

-

## Rollback plan

<!-- Required for 🔴 PRs. Recommended for 🟠. The exact commands an on-call operator would run if this PR causes incidents post-deploy. -->

## Related

<!-- Issue numbers, prior PRs, design docs in internal operator docs, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block validation in the consensus loop to prevent applying stale or redundant blocks.
  * Fixed missing epoch bookkeeping in certain block processing paths to ensure consistency across the network.
  * Enhanced synchronization trigger behavior for better peer communication and block recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->