### PR TITLE
feat(faucet): integrate reliakit-primitives + reliakit-validate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,10 +4550,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reliakit-primitives"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b320cee5e0da720c8254daed83dacf78e1aa5d52d1771760ad268c85251988f"
+
+[[package]]
 name = "reliakit-secret"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fc95b189ee53987da09d1e42fe985c458f0fce63b435fd7a907b9c4d921e19"
+
+[[package]]
+name = "reliakit-validate"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bfe73bc05eca3fc925280d4348d3d1eb91633d75fa927d85eec7b3da6fa9ae"
 
 [[package]]
 name = "reqwest"
@@ -5288,6 +5300,8 @@ dependencies = [
  "clap",
  "dashmap",
  "hex",
+ "reliakit-primitives",
+ "reliakit-validate",
  "reqwest",
  "secp256k1 0.31.1",
  "sentrix-primitives",

--- a/bin/sentrix-faucet/Cargo.toml
+++ b/bin/sentrix-faucet/Cargo.toml
@@ -12,6 +12,8 @@ path = "src/main.rs"
 [dependencies]
 sentrix-primitives = { path = "../../crates/sentrix-primitives" }
 sentrix-wallet     = { path = "../../crates/sentrix-wallet" }
+reliakit-primitives = "0.2"
+reliakit-validate   = "0.1"
 
 axum         = "0.8"
 tokio        = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }

--- a/bin/sentrix-faucet/src/main.rs
+++ b/bin/sentrix-faucet/src/main.rs
@@ -30,6 +30,8 @@ use axum::{
 };
 use clap::Parser;
 use dashmap::{DashMap, mapref::entry::Entry};
+use reliakit_primitives::{HexString, NonEmptyStr, PositiveInt};
+use reliakit_validate::{Valid, Validate, ValidationError};
 use secp256k1::{PublicKey, SecretKey};
 use sentrix_primitives::transaction::{MIN_TX_FEE, Transaction};
 use sentrix_wallet::{Keystore, Wallet};
@@ -121,6 +123,21 @@ struct DripRequest {
     to: String,
 }
 
+impl Validate for DripRequest {
+    type Error = ValidationError;
+
+    fn validate(&self) -> Result<(), Self::Error> {
+        let lower = self.to.to_lowercase();
+        let without_prefix = lower.strip_prefix("0x").unwrap_or(&lower);
+        if without_prefix.len() != 40 {
+            return Err(ValidationError::new("address must be 0x + 40 hex chars"));
+        }
+        HexString::new(without_prefix)
+            .map_err(|_| ValidationError::new("address contains invalid hex characters"))?;
+        Ok(())
+    }
+}
+
 #[derive(Serialize)]
 struct DripResponse {
     txid: String,
@@ -162,9 +179,8 @@ fn validate_address(addr: &str) -> Result<String> {
     if without_prefix.len() != 40 {
         bail!("address must be 0x + 40 hex chars");
     }
-    if !without_prefix.chars().all(|c| c.is_ascii_hexdigit()) {
-        bail!("address must be 0x + 40 hex chars");
-    }
+    // HexString validates that all chars are valid hex digits (0-9, a-f, A-F).
+    HexString::new(without_prefix).map_err(|_| anyhow!("address must be 0x + 40 hex chars"))?;
     Ok(format!("0x{}", without_prefix))
 }
 
@@ -249,16 +265,12 @@ async fn handle_drip(
     ConnectInfo(client): ConnectInfo<SocketAddr>,
     Json(req): Json<DripRequest>,
 ) -> Result<Json<DripResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let recipient = match validate_address(&req.to) {
-        Ok(a) => a,
-        Err(e) => {
-            return Err(err_with(
-                StatusCode::BAD_REQUEST,
-                "bad address",
-                e.to_string(),
-            ));
-        }
-    };
+    // Valid::new runs DripRequest::validate() — rejects bad addresses before
+    // any state mutation or RPC call.
+    let req = Valid::new(req)
+        .map_err(|e| err_with(StatusCode::BAD_REQUEST, "bad address", e.to_string()))?;
+    // validate_address already ran inside Validate; safe to unwrap the Ok.
+    let recipient = validate_address(&req.to).expect("already validated");
 
     if recipient == state.address {
         return Err(err(StatusCode::BAD_REQUEST, "cannot drip to self"));
@@ -361,6 +373,12 @@ async fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+
+    // Reject invalid config values early — before any I/O — using reliakit-primitives.
+    PositiveInt::new(cli.drip_amount)
+        .map_err(|_| anyhow!("SENTRIX_FAUCET_DRIP_AMOUNT must be > 0"))?;
+    NonEmptyStr::new(&cli.rpc_url)
+        .map_err(|_| anyhow!("SENTRIX_FAUCET_RPC_URL must not be empty"))?;
 
     info!(keystore = %cli.keystore, "loading keystore");
     let keystore = Keystore::load(&cli.keystore).context("load keystore")?;


### PR DESCRIPTION
Integrates two published Rust crates from the same author into the testnet faucet.

## What changed

**`reliakit-primitives = "0.2"` (crates.io)**

- `validate_address()`: replaced manual `.chars().all(|c| c.is_ascii_hexdigit())` with `HexString::new()` — same semantics, uses the typed primitive.
- `main()`: `PositiveInt::new(cli.drip_amount)` rejects drip_amount=0 at startup before any I/O. `NonEmptyStr::new(&cli.rpc_url)` rejects empty RPC URL.

**`reliakit-validate = "0.1"` (crates.io)**

- `DripRequest` now implements `Validate` — address format rules are expressed once at the type level.
- `handle_drip()` calls `Valid::new(req)` as the first operation, rejecting invalid addresses before any rate-limit state mutation or RPC call.

## No behavior change

The same address format is accepted/rejected. The change is structural: validation is now in one place (the `Validate` impl) and enforced at the type boundary rather than scattered through the handler.