### PR TITLE
feat: integrate reliakit (Secret + PositiveInt) in RPC auth, rate-limit, exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,9 +4551,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reliakit-primitives"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b320cee5e0da720c8254daed83dacf78e1aa5d52d1771760ad268c85251988f"
+checksum = "fdd920a56c8d9c7bb55fc8db757f8fc4e442f2ca029e9dabae5125f8fecc8d2b"
 
 [[package]]
 name = "reliakit-secret"
@@ -5407,6 +5407,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "prometheus",
+ "reliakit-primitives",
  "reqwest",
  "serde",
  "serde_json",
@@ -5440,6 +5441,8 @@ dependencies = [
  "futures-util",
  "hex",
  "prometheus",
+ "reliakit-primitives",
+ "reliakit-secret",
  "revm",
  "sentrix-codec",
  "sentrix-core",

--- a/crates/sentrix-prom-exporter/Cargo.toml
+++ b/crates/sentrix-prom-exporter/Cargo.toml
@@ -19,3 +19,4 @@ hyper-util = { version = "0.1", features = ["server", "tokio"] }
 http-body-util = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+reliakit-primitives = "0.2.5"

--- a/crates/sentrix-prom-exporter/src/main.rs
+++ b/crates/sentrix-prom-exporter/src/main.rs
@@ -272,9 +272,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let targets = parse_targets();
     info!(count = targets.len(), "starting prom-exporter");
 
+    // PositiveInt rejects 0 — a probe interval of 0s would turn poll_loop
+    // into a busy spin (Duration::from_secs(0) = no sleep between probes),
+    // hammering every target and pinning a core. Invalid / 0 / unparseable
+    // falls back to the 15s default.
     let interval = std::env::var("SENTRIX_PROBE_INTERVAL_SEC")
         .ok()
-        .and_then(|s| s.parse().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .and_then(|n| reliakit_primitives::PositiveInt::new(n).ok())
+        .map(|p| p.get())
         .unwrap_or(15u64);
 
     tokio::spawn(poll_loop(targets, Duration::from_secs(interval)));

--- a/crates/sentrix-rpc/Cargo.toml
+++ b/crates/sentrix-rpc/Cargo.toml
@@ -14,6 +14,8 @@ sentrix-evm = { path = "../sentrix-evm" }
 sentrix-rpc-types = { path = "../sentrix-rpc-types" }
 sentrix-trie = { path = "../sentrix-trie" }
 sentrix-storage = { path = "../sentrix-storage" }
+reliakit-primitives = "0.2.5"
+reliakit-secret = "0.1"
 
 axum = { version = "0.8", features = ["ws"] }
 futures-util = "0.3"

--- a/crates/sentrix-rpc/src/routes/auth.rs
+++ b/crates/sentrix-rpc/src/routes/auth.rs
@@ -3,6 +3,7 @@
 // refactor.
 
 use axum::{extract::FromRequestParts, http::StatusCode, http::request::Parts};
+use reliakit_secret::{ExposeSecret, SecretString};
 
 // ── API key extractor ─────────────────────────────────────
 /// Add `_auth: ApiKey` as the first parameter of any handler that needs
@@ -21,9 +22,14 @@ impl<S: Send + Sync> FromRequestParts<S> for ApiKey {
         // empty or too-short value now behaves as "not configured" —
         // endpoints stay open rather than silently trusting a
         // hopelessly weak secret.
+        //
+        // SecretString wraps the key so accidental Debug/Display of
+        // `required` prints `[REDACTED]` rather than the raw value.
+        // .expose_secret() is the only way to read it — every call
+        // site is auditable.
         const MIN_API_KEY_LEN: usize = 16;
-        let required = match std::env::var("SENTRIX_API_KEY") {
-            Ok(k) if k.len() >= MIN_API_KEY_LEN => k,
+        let required: SecretString = match std::env::var("SENTRIX_API_KEY") {
+            Ok(k) if k.len() >= MIN_API_KEY_LEN => SecretString::from_string(k),
             Ok(k) if !k.is_empty() => {
                 tracing::warn!(
                     "SENTRIX_API_KEY is set but too short ({} chars, need ≥ {}); \
@@ -40,7 +46,7 @@ impl<S: Send + Sync> FromRequestParts<S> for ApiKey {
             .get("X-API-Key")
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
-        if constant_time_eq(provided, &required) {
+        if constant_time_eq(provided, required.expose_secret()) {
             Ok(ApiKey)
         } else {
             Err(StatusCode::UNAUTHORIZED)

--- a/crates/sentrix-rpc/src/routes/ratelimit.rs
+++ b/crates/sentrix-rpc/src/routes/ratelimit.rs
@@ -17,6 +17,7 @@
 //   first while read traffic from the same IP keeps flowing.
 
 use axum::{Json, http::StatusCode, response::IntoResponse};
+use reliakit_primitives::PositiveInt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
@@ -25,15 +26,28 @@ use tokio::sync::Mutex;
 pub type IpRateLimiter = Arc<Mutex<HashMap<String, (u32, Instant)>>>;
 const RATE_LIMIT_WINDOW_SECS: u64 = 60;
 
+/// Parse a rate-limit env override into a positive u32.
+///
+/// `PositiveInt` rejects a value of `0` — without this guard, setting
+/// `SENTRIX_GLOBAL_RATE_LIMIT=0` (or the write equivalent) would cap the
+/// limiter at zero requests, silently locking every client out of the
+/// endpoint. A `0` or unparseable value now falls back to `default`.
+/// The `min(u32::MAX)` clamp keeps the u64 → u32 cast lossless.
+fn rate_limit_from_env(var: &str, default: u32) -> u32 {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .and_then(|n| PositiveInt::new(n).ok())
+        .map(|p| p.get().min(u32::MAX as u64) as u32)
+        .unwrap_or(default)
+}
+
 /// Override via `SENTRIX_GLOBAL_RATE_LIMIT` env var for benchmarking.
 /// Default raised from 60 to 300 on 2026-04-21 — block-explorer
 /// frontend polls ~8 stats endpoints per tick, single user on shared
 /// IP was hitting 60/min within seconds.
 pub(super) fn global_rate_limit_max() -> u32 {
-    std::env::var("SENTRIX_GLOBAL_RATE_LIMIT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(300)
+    rate_limit_from_env("SENTRIX_GLOBAL_RATE_LIMIT", 300)
 }
 
 /// A7: tighter per-IP cap applied only to write / expensive endpoints
@@ -43,10 +57,7 @@ pub(super) fn global_rate_limit_max() -> u32 {
 /// limit. Override via `SENTRIX_WRITE_RATE_LIMIT` env var for
 /// benchmarking (e.g. 10000).
 pub(super) fn write_rate_limit_max() -> u32 {
-    std::env::var("SENTRIX_WRITE_RATE_LIMIT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(10)
+    rate_limit_from_env("SENTRIX_WRITE_RATE_LIMIT", 10)
 }
 
 /// Comma-separated list of IPs that bypass both rate limiters. Set via
@@ -191,5 +202,43 @@ pub(super) async fn write_rate_limit_middleware(
         next.run(request).await
     } else {
         rate_limit_response(write_rate_limit_max(), RATE_LIMIT_WINDOW_SECS)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rate_limit_from_env;
+
+    // Each test uses a unique env var name so parallel test threads don't
+    // race on a shared key.
+
+    #[test]
+    fn zero_falls_back_to_default() {
+        // SAFETY: unique var, set+remove within this test.
+        unsafe { std::env::set_var("SENTRIX_TEST_RL_ZERO", "0") };
+        // PositiveInt rejects 0 → default returned, not 0 (which would lock
+        // every client out of the endpoint).
+        assert_eq!(rate_limit_from_env("SENTRIX_TEST_RL_ZERO", 300), 300);
+        unsafe { std::env::remove_var("SENTRIX_TEST_RL_ZERO") };
+    }
+
+    #[test]
+    fn unparseable_falls_back_to_default() {
+        unsafe { std::env::set_var("SENTRIX_TEST_RL_BAD", "not_a_number") };
+        assert_eq!(rate_limit_from_env("SENTRIX_TEST_RL_BAD", 10), 10);
+        unsafe { std::env::remove_var("SENTRIX_TEST_RL_BAD") };
+    }
+
+    #[test]
+    fn valid_positive_overrides_default() {
+        unsafe { std::env::set_var("SENTRIX_TEST_RL_OK", "5000") };
+        assert_eq!(rate_limit_from_env("SENTRIX_TEST_RL_OK", 10), 5000);
+        unsafe { std::env::remove_var("SENTRIX_TEST_RL_OK") };
+    }
+
+    #[test]
+    fn unset_returns_default() {
+        // A var name that is definitely not set.
+        assert_eq!(rate_limit_from_env("SENTRIX_TEST_RL_UNSET_XYZ", 42), 42);
     }
 }

--- a/crates/sentrix-rpc/src/routes/ratelimit.rs
+++ b/crates/sentrix-rpc/src/routes/ratelimit.rs
@@ -26,20 +26,30 @@ use tokio::sync::Mutex;
 pub type IpRateLimiter = Arc<Mutex<HashMap<String, (u32, Instant)>>>;
 const RATE_LIMIT_WINDOW_SECS: u64 = 60;
 
-/// Parse a rate-limit env override into a positive u32.
+/// Pure parse/validate of a rate-limit override string into a positive u32.
+///
+/// Split out from the env read so it can be unit-tested without touching
+/// the process environment — `std::env::set_var` is `unsafe` under edition
+/// 2024 and is not safe to call from parallel tests (the race is on the
+/// global env table, not key names, so unique keys don't help).
 ///
 /// `PositiveInt` rejects a value of `0` — without this guard, setting
 /// `SENTRIX_GLOBAL_RATE_LIMIT=0` (or the write equivalent) would cap the
 /// limiter at zero requests, silently locking every client out of the
-/// endpoint. A `0` or unparseable value now falls back to `default`.
+/// endpoint. A `0`, unparseable, or absent value falls back to `default`.
 /// The `min(u32::MAX)` clamp keeps the u64 → u32 cast lossless.
-fn rate_limit_from_env(var: &str, default: u32) -> u32 {
-    std::env::var(var)
-        .ok()
+fn rate_limit_from_str(value: Option<&str>, default: u32) -> u32 {
+    value
         .and_then(|v| v.parse::<u64>().ok())
         .and_then(|n| PositiveInt::new(n).ok())
         .map(|p| p.get().min(u32::MAX as u64) as u32)
         .unwrap_or(default)
+}
+
+/// Read a rate-limit override from `var` and parse it via
+/// [`rate_limit_from_str`].
+fn rate_limit_from_env(var: &str, default: u32) -> u32 {
+    rate_limit_from_str(std::env::var(var).ok().as_deref(), default)
 }
 
 /// Override via `SENTRIX_GLOBAL_RATE_LIMIT` env var for benchmarking.
@@ -207,38 +217,36 @@ pub(super) async fn write_rate_limit_middleware(
 
 #[cfg(test)]
 mod tests {
-    use super::rate_limit_from_env;
+    use super::rate_limit_from_str;
 
-    // Each test uses a unique env var name so parallel test threads don't
-    // race on a shared key.
+    // Tests target the pure `rate_limit_from_str` helper — no env mutation,
+    // so they are sound and parallel-safe (no `unsafe std::env::set_var`).
 
     #[test]
     fn zero_falls_back_to_default() {
-        // SAFETY: unique var, set+remove within this test.
-        unsafe { std::env::set_var("SENTRIX_TEST_RL_ZERO", "0") };
         // PositiveInt rejects 0 → default returned, not 0 (which would lock
         // every client out of the endpoint).
-        assert_eq!(rate_limit_from_env("SENTRIX_TEST_RL_ZERO", 300), 300);
-        unsafe { std::env::remove_var("SENTRIX_TEST_RL_ZERO") };
+        assert_eq!(rate_limit_from_str(Some("0"), 300), 300);
     }
 
     #[test]
     fn unparseable_falls_back_to_default() {
-        unsafe { std::env::set_var("SENTRIX_TEST_RL_BAD", "not_a_number") };
-        assert_eq!(rate_limit_from_env("SENTRIX_TEST_RL_BAD", 10), 10);
-        unsafe { std::env::remove_var("SENTRIX_TEST_RL_BAD") };
+        assert_eq!(rate_limit_from_str(Some("not_a_number"), 10), 10);
     }
 
     #[test]
     fn valid_positive_overrides_default() {
-        unsafe { std::env::set_var("SENTRIX_TEST_RL_OK", "5000") };
-        assert_eq!(rate_limit_from_env("SENTRIX_TEST_RL_OK", 10), 5000);
-        unsafe { std::env::remove_var("SENTRIX_TEST_RL_OK") };
+        assert_eq!(rate_limit_from_str(Some("5000"), 10), 5000);
     }
 
     #[test]
-    fn unset_returns_default() {
-        // A var name that is definitely not set.
-        assert_eq!(rate_limit_from_env("SENTRIX_TEST_RL_UNSET_XYZ", 42), 42);
+    fn absent_returns_default() {
+        assert_eq!(rate_limit_from_str(None, 42), 42);
+    }
+
+    #[test]
+    fn above_u32_max_clamps_not_truncates() {
+        // u64 value beyond u32::MAX clamps to u32::MAX rather than wrapping.
+        assert_eq!(rate_limit_from_str(Some("99999999999"), 10), u32::MAX);
     }
 }


### PR DESCRIPTION
Deeper integration of the reliakit crates (crates.io) into non-consensus boundaries, after verifying each candidate against real code rather than the audit summary.

## Shipped

**`reliakit-secret::SecretString` — API key (`routes/auth.rs`)**
`SENTRIX_API_KEY` is now held in `SecretString`. Debug/Display prints `[REDACTED]`; `.expose_secret()` is the only read path (used once, at the constant-time compare). Closes the accidental-key-in-logs class.

**`reliakit-primitives::PositiveInt` — rate-limit env (`routes/ratelimit.rs`)**
`SENTRIX_GLOBAL_RATE_LIMIT=0` / `SENTRIX_WRITE_RATE_LIMIT=0` previously capped the limiter at **zero requests**, silently locking every client out (self-DoS). `0`/unparseable now falls back to the default. 4 unit tests cover the guard.

**`reliakit-primitives::PositiveInt` — probe interval (`prom-exporter`)**
`SENTRIX_PROBE_INTERVAL_SEC=0` turned `poll_loop` into a busy-spin (`from_secs(0)` = no sleep), pinning a core and hammering every target. `0` now falls back to 15s.

## Deliberately rejected (verified against real code)

- **`BoundedStr` for token name/symbol** (`block_executor.rs`): `BoundedStr` measures `chars().count()`; the consensus rule uses byte length (`name.len()`) plus a different empty-check. Swapping it changes Pass-1 block-validity → chain fork. Consensus rule changes need a fork gate; left untouched.
- **`BoundedVec` for RPC batch** (`jsonrpc/mod.rs`): the current code checks `arr.len()` on the cheap `Value::Array` *before* the typed deserialize. Wrapping in `BoundedVec<JsonRpcRequest>` would force the expensive deserialize first — a regression. Current code is already optimal.

## Test plan
- [x] `cargo check --workspace -D warnings` clean
- [x] `cargo clippy -p sentrix-rpc -p sentrix-prom-exporter --all-targets -D warnings` clean
- [x] 4 new ratelimit tests pass (0→default, unparseable→default, valid→override, unset→default)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for startup probe interval and rate-limit configuration; invalid or zero inputs now fall back to safe defaults.

* **Security**
  * Enhanced API key handling to prevent accidental exposure in logs or error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->