### PR TITLE
feat(nft): sentrix-nft crate — native Proof Asset NFT (pure domain logic)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5358,6 +5358,7 @@ version = "2.2.26"
 dependencies = [
  "hex",
  "serde",
+ "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5261,6 +5261,7 @@ dependencies = [
  "secp256k1 0.31.1",
  "sentrix-bft",
  "sentrix-evm",
+ "sentrix-nft",
  "sentrix-primitives",
  "sentrix-staking",
  "sentrix-storage",
@@ -5349,6 +5350,16 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "sentrix-nft"
+version = "2.2.26"
+dependencies = [
+ "hex",
+ "serde",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "crates/sentrix-wire", "crates/sentrix-proto", "crates/sentrix-grpc", "crates/sentrix-prom-exporter", "bin/sentrix", "bin/sentrix-faucet"]
+members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-nft", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "crates/sentrix-wire", "crates/sentrix-proto", "crates/sentrix-grpc", "crates/sentrix-prom-exporter", "bin/sentrix", "bin/sentrix-faucet"]
 
 # Single source of truth for fields every workspace member shares.
 # Future version bumps = edit `version` here only; each member inherits via

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -13,6 +13,7 @@ sentrix-trie = { path = "../sentrix-trie" }
 sentrix-staking = { path = "../sentrix-staking" }
 sentrix-evm = { path = "../sentrix-evm" }
 sentrix-bft = { path = "../sentrix-bft" }
+sentrix-nft = { path = "../sentrix-nft" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/sentrix-core/src/lib.rs
+++ b/crates/sentrix-core/src/lib.rs
@@ -20,6 +20,7 @@ pub(crate) mod divergence;
 pub mod fork_heights;
 pub mod genesis;
 pub mod mempool;
+pub mod nft;
 pub mod parallel;
 pub mod state_export;
 pub mod storage;

--- a/crates/sentrix-core/src/nft.rs
+++ b/crates/sentrix-core/src/nft.rs
@@ -1,0 +1,64 @@
+// nft.rs - Sentrix — native NFT facade.
+//
+// The NFT domain logic lives in the standalone `sentrix-nft` crate (pure,
+// no storage/consensus). This module re-exports it so existing
+// `crate::nft::*` paths keep resolving, and bridges `sentrix_nft::NftError`
+// into the workspace `SentrixError` so block-execution handlers (future
+// work) can use `?` on NFT operations.
+//
+// Pure NFT logic was moved out of sentrix-core into sentrix-nft on
+// 2026-06-03 so the Proof Asset layer is auditable in isolation and cannot
+// reach into block/state/consensus internals.
+
+pub use sentrix_nft::{
+    NftCollection, NftError, NftEvent, NftRegistry, NftResult, NftToken, compute_collection_id,
+};
+
+use sentrix_primitives::error::SentrixError;
+
+/// Map a pure NFT domain error onto the workspace error type at the
+/// sentrix-core boundary. Authorization failures become
+/// `UnauthorizedValidator`; arithmetic overflows become `Internal`;
+/// everything else is an `InvalidTransaction` carrying the typed message.
+///
+/// A free function rather than a `From` impl because both `NftError` and
+/// `SentrixError` are foreign to this crate (orphan rule). Future NFT
+/// block-execution handlers convert with `.map_err(nft_err_to_sentrix)`.
+pub fn nft_err_to_sentrix(e: NftError) -> SentrixError {
+    match e {
+        NftError::Unauthorized(_) => SentrixError::UnauthorizedValidator(e.to_string()),
+        NftError::Overflow(_) => SentrixError::Internal(e.to_string()),
+        other => SentrixError::InvalidTransaction(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nft_error_maps_to_sentrix_error() {
+        assert!(matches!(
+            nft_err_to_sentrix(NftError::Unauthorized("nope".into())),
+            SentrixError::UnauthorizedValidator(_)
+        ));
+        assert!(matches!(
+            nft_err_to_sentrix(NftError::Overflow("balance".into())),
+            SentrixError::Internal(_)
+        ));
+        assert!(matches!(
+            nft_err_to_sentrix(NftError::TokenNotFound(7)),
+            SentrixError::InvalidTransaction(_)
+        ));
+    }
+
+    #[test]
+    fn facade_reexports_usable() {
+        // The re-exported registry works through the facade path.
+        let mut reg = NftRegistry::new();
+        let (id, _) = reg
+            .deploy_collection("0xa", "C", "C", "u", None, true, true, "tx")
+            .unwrap();
+        assert!(reg.collection_exists(&id));
+    }
+}

--- a/crates/sentrix-nft/Cargo.toml
+++ b/crates/sentrix-nft/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sentrix-nft"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Sentrix Native NFT — Proof Asset layer (pure domain logic, no storage/consensus)"
+repository.workspace = true
+keywords = ["blockchain", "sentrix", "nft", "proof-asset"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.11"
+hex = "0.4"
+thiserror = "2.0"

--- a/crates/sentrix-nft/Cargo.toml
+++ b/crates/sentrix-nft/Cargo.toml
@@ -12,3 +12,6 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.11"
 hex = "0.4"
 thiserror = "2.0"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/crates/sentrix-nft/README.md
+++ b/crates/sentrix-nft/README.md
@@ -1,0 +1,91 @@
+# sentrix-nft
+
+**Sentrix Native NFT — a Proof Asset layer.**
+
+Pure NFT domain logic for Sentrix Chain. This crate is the native (SRC-721-style)
+NFT standard used for **proofs and reputation**, not a JPEG/PFP marketplace.
+
+## What it's for
+
+- validator proof
+- builder proof
+- testnet-participation proof
+- contributor proof
+- bug-hunter proof
+- genesis-supporter proof
+- community reputation
+- optional **soulbound** (non-transferable) assets
+
+## What it is and isn't
+
+- **Pure domain logic only.** Collections, tokens, ownership, approvals,
+  soulbound/freeze rules, metadata URIs, deterministic ids, and events. No MDBX,
+  no trie/state-root, no block execution, no RPC, no networking, no marketplace,
+  no bridge.
+- **Metadata lives off-chain.** Only URIs (`ipfs://`, `ar://`, `https://`, …)
+  and optional integrity hashes are stored. **Image/media bytes are never stored
+  in chain state.** No IPFS/Arweave upload logic lives here.
+- **EVM NFTs are separate.** ERC-721/ERC-1155 via `eth_sendRawTransaction`
+  remain a parallel path for public developers and normal collections. This
+  native rail does not replace them.
+
+## Determinism
+
+- Collection ids: `SRC721_<sha256(creator|seed)[..20]>`. No wall-clock time, no
+  randomness — every node derives the same id when applying the same block.
+- Token ids: deterministic `u64`, chosen by the minter.
+- **Strict no-reuse:** a burned token id is retired forever (kept as a
+  tombstone). History stays append-only and auditable — important for a
+  reputation layer.
+
+## Model
+
+- `NftRegistry` — holds every deployed collection.
+- `NftCollection` — one collection: tokens, balances, approvals, admin, freeze
+  and metadata-lock flags, `max_supply` (counts ever-minted).
+- `NftToken` — one token: owner, optional URI + integrity hashes, `transferable`
+  (false = soulbound), `frozen`, `burned`.
+- `NftEvent` — every state change returns a typed event.
+- `NftError` — typed errors (no stringly-typed failures).
+
+## Examples
+
+```rust
+use sentrix_nft::NftRegistry;
+
+let mut reg = NftRegistry::new();
+
+// 1. Create a soulbound Builder Badge collection (default_transferable = false).
+let (id, _) = reg
+    .deploy_collection(
+        "0xfoundation", "Builder Badge", "BUILD", "ipfs://badges/",
+        None,   // unlimited
+        false,  // soulbound by default
+        true,   // metadata mutable
+        "tx-001",
+    )
+    .unwrap();
+let col = reg.get_collection_mut(&id).unwrap();
+
+// 2. Mint a soulbound Builder Badge (admin = creator mints).
+col.mint("0xfoundation", "0xbuilder", 1, "", None).unwrap();
+assert_eq!(col.owner_of(1), Some(&"0xbuilder".to_string()));
+
+// 3. Mint a transferable token (override the collection default).
+col.mint("0xfoundation", "0xalice", 2, "", Some(true)).unwrap();
+
+// 4. Transfer the transferable token.
+col.transfer("0xalice", "0xalice", "0xbob", 2).unwrap();
+assert_eq!(col.owner_of(2), Some(&"0xbob".to_string()));
+
+// 5. Soulbound transfer fails.
+assert!(col.transfer("0xbuilder", "0xbuilder", "0xbob", 1).is_err());
+```
+
+## Future work (not in this crate)
+
+- MDBX / state integration and the storage-key scheme (documented in `lib.rs`).
+- Trie / state-root commitment of NFT state.
+- Native NFT transaction execution in `sentrix-core`'s block executor.
+- JSON-RPC methods, explorer indexing, wallet display.
+- ERC-721 compatibility adapter/precompile (EVM side).

--- a/crates/sentrix-nft/src/collection.rs
+++ b/crates/sentrix-nft/src/collection.rs
@@ -1,0 +1,524 @@
+//! The collection model and all token state transitions.
+//!
+//! A [`NftCollection`] owns its tokens, balances, and approvals. Every
+//! state-changing method returns an [`NftEvent`] describing what happened, so
+//! the integrating layer (`sentrix-core`) can emit it without re-deriving the
+//! effect.
+//!
+//! Determinism: state lives in `HashMap`s. In-memory order is per-process and
+//! is never hashed directly; when this state is committed to the state trie
+//! (future work in `sentrix-core`), maps are iterated in sorted order.
+
+use crate::error::{NftError, NftResult};
+use crate::events::NftEvent;
+use crate::token::NftToken;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A native NFT collection (the Proof Asset issuer unit).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NftCollection {
+    /// Collection id/address (deterministic; see [`crate::NftRegistry`]).
+    pub id: String,
+    /// Address that created the collection.
+    pub creator: String,
+    /// Address with administrative rights (mint, freeze, metadata). Defaults
+    /// to `creator` at creation.
+    pub admin: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Ticker symbol.
+    pub symbol: String,
+    /// Optional free-text description (empty = none).
+    pub description: String,
+    /// Metadata-URI prefix; per-token URI is `{base_uri}{token_id}` unless the
+    /// token carries an explicit override.
+    pub base_uri: String,
+    /// Optional external URL for the collection (empty = none).
+    pub external_url: String,
+    /// Maximum number of tokens that may ever be minted. `None` = unlimited.
+    /// Counted against ever-minted, so burning never frees a slot.
+    pub max_supply: Option<u64>,
+    /// Count of currently-live (non-burned) tokens.
+    pub total_supply: u64,
+    /// Monotonic count of tokens ever minted. Backs `max_supply` and the
+    /// no-reuse guarantee. Never decreases.
+    pub total_minted: u64,
+    /// Default transferability applied to mints that don't override it.
+    pub default_transferable: bool,
+    /// Whether token metadata URIs may be updated after mint.
+    pub metadata_mutable: bool,
+    /// Whether the whole collection is frozen (blocks all transfers).
+    pub frozen: bool,
+    /// token_id → token. Includes burned tombstones (never removed) so ids are
+    /// never reused.
+    pub tokens: HashMap<u64, NftToken>,
+    /// owner → count of live tokens held.
+    pub balances: HashMap<String, u64>,
+    /// token_id → approved spender (single-token approval).
+    pub token_approvals: HashMap<u64, String>,
+    /// owner → (operator → approved) for operator-for-all.
+    pub operator_approvals: HashMap<String, HashMap<String, bool>>,
+}
+
+impl NftCollection {
+    /// Create a new collection. `admin` defaults to `creator`.
+    pub fn new(
+        id: String,
+        creator: String,
+        name: String,
+        symbol: String,
+        base_uri: String,
+        max_supply: Option<u64>,
+        default_transferable: bool,
+        metadata_mutable: bool,
+    ) -> Self {
+        Self {
+            id,
+            admin: creator.clone(),
+            creator,
+            name,
+            symbol,
+            description: String::new(),
+            base_uri,
+            external_url: String::new(),
+            max_supply,
+            total_supply: 0,
+            total_minted: 0,
+            default_transferable,
+            metadata_mutable,
+            frozen: false,
+            tokens: HashMap::new(),
+            balances: HashMap::new(),
+            token_approvals: HashMap::new(),
+            operator_approvals: HashMap::new(),
+        }
+    }
+
+    // ── Reads ────────────────────────────────────────────
+
+    /// Current owner of a live token, or `None` if it doesn't exist or is burned.
+    pub fn owner_of(&self, token_id: u64) -> Option<&String> {
+        match self.tokens.get(&token_id) {
+            Some(t) if !t.burned => Some(&t.owner),
+            _ => None,
+        }
+    }
+
+    /// Number of live tokens `address` holds (0 if none).
+    pub fn balance_of(&self, address: &str) -> u64 {
+        self.balances.get(address).copied().unwrap_or(0)
+    }
+
+    /// Single approved spender for a token, or `None`.
+    pub fn get_approved(&self, token_id: u64) -> Option<&String> {
+        self.token_approvals.get(&token_id)
+    }
+
+    /// Whether `operator` may act on all of `owner`'s tokens.
+    pub fn is_approved_for_all(&self, owner: &str, operator: &str) -> bool {
+        self.operator_approvals
+            .get(owner)
+            .and_then(|m| m.get(operator))
+            .copied()
+            .unwrap_or(false)
+    }
+
+    /// Resolved metadata URI: explicit override if set, else the
+    /// `{base_uri}{token_id}` convention. Empty for nonexistent/burned tokens.
+    pub fn token_uri(&self, token_id: u64) -> String {
+        match self.tokens.get(&token_id) {
+            Some(t) if !t.burned => {
+                if t.uri.is_empty() {
+                    format!("{}{}", self.base_uri, token_id)
+                } else {
+                    t.uri.clone()
+                }
+            }
+            _ => String::new(),
+        }
+    }
+
+    /// Current live supply.
+    pub fn total_supply(&self) -> u64 {
+        self.total_supply
+    }
+
+    /// Configured maximum supply (`None` = unlimited).
+    pub fn max_supply(&self) -> Option<u64> {
+        self.max_supply
+    }
+
+    /// Borrow a token (including burned tombstones) for inspection.
+    pub fn get_token(&self, token_id: u64) -> Option<&NftToken> {
+        self.tokens.get(&token_id)
+    }
+
+    /// Authorization for transfer: owner, single-token approvee, or operator.
+    /// Does NOT consider transferability — soulbound is checked separately and
+    /// first, so approval can never bypass it.
+    fn transfer_authorized(&self, caller: &str, owner: &str, token_id: u64) -> bool {
+        caller == owner
+            || self.token_approvals.get(&token_id).map(String::as_str) == Some(caller)
+            || self.is_approved_for_all(owner, caller)
+    }
+
+    // ── Writes ───────────────────────────────────────────
+
+    /// Mint `token_id` to `to`. Admin-only. `token_id` must never have been
+    /// minted before (strict no-reuse). `transferable` overrides the
+    /// collection default; pass `None` to use the default.
+    pub fn mint(
+        &mut self,
+        caller: &str,
+        to: &str,
+        token_id: u64,
+        uri: &str,
+        transferable: Option<bool>,
+    ) -> NftResult<NftEvent> {
+        if caller != self.admin {
+            return Err(NftError::Unauthorized(
+                "only the collection admin can mint".into(),
+            ));
+        }
+        if to.is_empty() {
+            return Err(NftError::InvalidParams("empty recipient".into()));
+        }
+        // Strict no-reuse: any id ever minted (live OR burned tombstone) is taken.
+        if self.tokens.contains_key(&token_id) {
+            return Err(NftError::TokenAlreadyExists(token_id));
+        }
+        if let Some(max) = self.max_supply
+            && self.total_minted >= max
+        {
+            return Err(NftError::MaxSupplyReached {
+                minted: self.total_minted,
+                max,
+            });
+        }
+
+        let transferable = transferable.unwrap_or(self.default_transferable);
+        self.tokens.insert(
+            token_id,
+            NftToken::new(
+                self.id.clone(),
+                token_id,
+                to.to_string(),
+                uri.to_string(),
+                transferable,
+            ),
+        );
+        let bal = self.balances.entry(to.to_string()).or_insert(0);
+        *bal = bal
+            .checked_add(1)
+            .ok_or_else(|| NftError::Overflow("balance".into()))?;
+        self.total_supply = self
+            .total_supply
+            .checked_add(1)
+            .ok_or_else(|| NftError::Overflow("total_supply".into()))?;
+        self.total_minted = self
+            .total_minted
+            .checked_add(1)
+            .ok_or_else(|| NftError::Overflow("total_minted".into()))?;
+
+        Ok(NftEvent::TokenMinted {
+            collection_id: self.id.clone(),
+            token_id,
+            to: to.to_string(),
+            transferable,
+        })
+    }
+
+    /// Transfer a token. Order of checks matters: soulbound is rejected before
+    /// authorization so an approved spender cannot move a soulbound token.
+    pub fn transfer(
+        &mut self,
+        caller: &str,
+        from: &str,
+        to: &str,
+        token_id: u64,
+    ) -> NftResult<NftEvent> {
+        if from.is_empty() || to.is_empty() {
+            return Err(NftError::InvalidParams("empty address".into()));
+        }
+        if from == to {
+            return Err(NftError::InvalidParams("cannot transfer to self".into()));
+        }
+        // Existence (burned tokens read as not-found).
+        let token = self.tokens.get(&token_id).filter(|t| !t.burned);
+        let token = token.ok_or(NftError::TokenNotFound(token_id))?;
+        // Soulbound — checked first; no approval bypasses it.
+        if !token.transferable {
+            return Err(NftError::NotTransferable(token_id));
+        }
+        if token.frozen {
+            return Err(NftError::TokenFrozen(token_id));
+        }
+        if self.frozen {
+            return Err(NftError::CollectionFrozen);
+        }
+        if token.owner != from {
+            return Err(NftError::NotOwner {
+                token_id,
+                claimed: from.to_string(),
+            });
+        }
+        if !self.transfer_authorized(caller, from, token_id) {
+            return Err(NftError::Unauthorized(format!(
+                "{} cannot transfer token_id {}",
+                caller, token_id
+            )));
+        }
+
+        // Apply.
+        let from_bal = self.balances.entry(from.to_string()).or_insert(0);
+        *from_bal = from_bal
+            .checked_sub(1)
+            .ok_or_else(|| NftError::Overflow("transfer underflow".into()))?;
+        let to_bal = self.balances.entry(to.to_string()).or_insert(0);
+        *to_bal = to_bal
+            .checked_add(1)
+            .ok_or_else(|| NftError::Overflow("transfer overflow".into()))?;
+        // Owner update + approval clear.
+        if let Some(t) = self.tokens.get_mut(&token_id) {
+            t.owner = to.to_string();
+        }
+        self.token_approvals.remove(&token_id);
+
+        Ok(NftEvent::TokenTransferred {
+            collection_id: self.id.clone(),
+            token_id,
+            from: from.to_string(),
+            to: to.to_string(),
+        })
+    }
+
+    /// Approve a single `spender` for `token_id`. Caller must be the owner or
+    /// an operator-for-all. Use [`Self::clear_approval`] to revoke.
+    pub fn approve(&mut self, caller: &str, spender: &str, token_id: u64) -> NftResult<NftEvent> {
+        if spender.is_empty() {
+            return Err(NftError::InvalidParams(
+                "empty spender (use clear_approval)".into(),
+            ));
+        }
+        let owner = self.live_owner(token_id)?;
+        if caller != owner && !self.is_approved_for_all(&owner, caller) {
+            return Err(NftError::Unauthorized(format!(
+                "{} cannot approve token_id {}",
+                caller, token_id
+            )));
+        }
+        self.token_approvals.insert(token_id, spender.to_string());
+        Ok(NftEvent::TokenApproved {
+            collection_id: self.id.clone(),
+            token_id,
+            owner,
+            approved: spender.to_string(),
+        })
+    }
+
+    /// Clear the single-token approval for `token_id`. Caller must be the owner
+    /// or an operator-for-all.
+    pub fn clear_approval(&mut self, caller: &str, token_id: u64) -> NftResult<NftEvent> {
+        let owner = self.live_owner(token_id)?;
+        if caller != owner && !self.is_approved_for_all(&owner, caller) {
+            return Err(NftError::Unauthorized(format!(
+                "{} cannot clear approval on token_id {}",
+                caller, token_id
+            )));
+        }
+        self.token_approvals.remove(&token_id);
+        Ok(NftEvent::TokenApproved {
+            collection_id: self.id.clone(),
+            token_id,
+            owner,
+            approved: String::new(),
+        })
+    }
+
+    /// Grant or revoke `operator` over all of `owner`'s tokens.
+    pub fn set_approval_for_all(
+        &mut self,
+        owner: &str,
+        operator: &str,
+        approved: bool,
+    ) -> NftResult<NftEvent> {
+        if owner.is_empty() || operator.is_empty() {
+            return Err(NftError::InvalidParams("empty address".into()));
+        }
+        if owner == operator {
+            return Err(NftError::InvalidParams(
+                "cannot set operator for self".into(),
+            ));
+        }
+        self.operator_approvals
+            .entry(owner.to_string())
+            .or_default()
+            .insert(operator.to_string(), approved);
+        Ok(NftEvent::ApprovalForAll {
+            collection_id: self.id.clone(),
+            owner: owner.to_string(),
+            operator: operator.to_string(),
+            approved,
+        })
+    }
+
+    /// Burn a token. Caller must be the owner or the collection admin. The id
+    /// is retired permanently (tombstone) and can never be reminted.
+    pub fn burn(&mut self, caller: &str, token_id: u64) -> NftResult<NftEvent> {
+        let owner = self.live_owner(token_id)?;
+        if caller != owner && caller != self.admin {
+            return Err(NftError::Unauthorized(format!(
+                "only owner or admin can burn token_id {}",
+                token_id
+            )));
+        }
+        let bal = self.balances.entry(owner.clone()).or_insert(0);
+        *bal = bal
+            .checked_sub(1)
+            .ok_or_else(|| NftError::Overflow("burn underflow".into()))?;
+        self.total_supply = self
+            .total_supply
+            .checked_sub(1)
+            .ok_or_else(|| NftError::Overflow("total_supply underflow".into()))?;
+        self.token_approvals.remove(&token_id);
+        // Tombstone: keep the entry so the id is never reusable; record audit.
+        if let Some(t) = self.tokens.get_mut(&token_id) {
+            t.burned = true;
+            t.frozen = false;
+        }
+        Ok(NftEvent::TokenBurned {
+            collection_id: self.id.clone(),
+            token_id,
+            owner,
+        })
+    }
+
+    /// Update a token's metadata URI. Caller must be the admin or the current
+    /// owner. Fails if the collection is frozen, metadata is locked, or the
+    /// token is frozen.
+    pub fn update_token_uri(
+        &mut self,
+        caller: &str,
+        token_id: u64,
+        new_uri: &str,
+    ) -> NftResult<NftEvent> {
+        if self.frozen {
+            return Err(NftError::CollectionFrozen);
+        }
+        if !self.metadata_mutable {
+            return Err(NftError::MetadataLocked);
+        }
+        let owner = self.live_owner(token_id)?;
+        if caller != self.admin && caller != owner {
+            return Err(NftError::Unauthorized(format!(
+                "{} cannot update token_id {} uri",
+                caller, token_id
+            )));
+        }
+        // Safe: live_owner proved a live token exists.
+        if let Some(t) = self.tokens.get_mut(&token_id) {
+            if t.frozen {
+                return Err(NftError::TokenFrozen(token_id));
+            }
+            t.uri = new_uri.to_string();
+        }
+        Ok(NftEvent::TokenUriUpdated {
+            collection_id: self.id.clone(),
+            token_id,
+        })
+    }
+
+    /// Update collection-level metadata. Admin-only; fails if frozen.
+    pub fn update_collection_metadata(
+        &mut self,
+        caller: &str,
+        description: Option<String>,
+        base_uri: Option<String>,
+        external_url: Option<String>,
+    ) -> NftResult<NftEvent> {
+        if caller != self.admin {
+            return Err(NftError::Unauthorized(
+                "only admin can update metadata".into(),
+            ));
+        }
+        if self.frozen {
+            return Err(NftError::CollectionFrozen);
+        }
+        if let Some(d) = description {
+            self.description = d;
+        }
+        if let Some(b) = base_uri {
+            self.base_uri = b;
+        }
+        if let Some(e) = external_url {
+            self.external_url = e;
+        }
+        Ok(NftEvent::CollectionUpdated {
+            collection_id: self.id.clone(),
+        })
+    }
+
+    /// Freeze the whole collection (blocks all transfers). Admin-only.
+    pub fn freeze_collection(&mut self, caller: &str) -> NftResult<NftEvent> {
+        if caller != self.admin {
+            return Err(NftError::Unauthorized("only admin can freeze".into()));
+        }
+        self.frozen = true;
+        Ok(NftEvent::CollectionFrozen {
+            collection_id: self.id.clone(),
+        })
+    }
+
+    /// Lock collection metadata (token URIs become immutable). Admin-only.
+    pub fn lock_metadata(&mut self, caller: &str) -> NftResult<NftEvent> {
+        if caller != self.admin {
+            return Err(NftError::Unauthorized(
+                "only admin can lock metadata".into(),
+            ));
+        }
+        self.metadata_mutable = false;
+        Ok(NftEvent::CollectionMetadataLocked {
+            collection_id: self.id.clone(),
+        })
+    }
+
+    /// Freeze or unfreeze a single token. Admin-only.
+    pub fn set_token_frozen(
+        &mut self,
+        caller: &str,
+        token_id: u64,
+        frozen: bool,
+    ) -> NftResult<NftEvent> {
+        if caller != self.admin {
+            return Err(NftError::Unauthorized(
+                "only admin can freeze tokens".into(),
+            ));
+        }
+        // Must be a live token.
+        self.live_owner(token_id)?;
+        if let Some(t) = self.tokens.get_mut(&token_id) {
+            t.frozen = frozen;
+        }
+        let collection_id = self.id.clone();
+        Ok(if frozen {
+            NftEvent::TokenFrozen {
+                collection_id,
+                token_id,
+            }
+        } else {
+            NftEvent::TokenUnfrozen {
+                collection_id,
+                token_id,
+            }
+        })
+    }
+
+    /// Resolve the owner of a live token or error. Burned/absent → `TokenNotFound`.
+    fn live_owner(&self, token_id: u64) -> NftResult<String> {
+        match self.tokens.get(&token_id) {
+            Some(t) if !t.burned => Ok(t.owner.clone()),
+            _ => Err(NftError::TokenNotFound(token_id)),
+        }
+    }
+}

--- a/crates/sentrix-nft/src/collection.rs
+++ b/crates/sentrix-nft/src/collection.rs
@@ -5,9 +5,17 @@
 //! the integrating layer (`sentrix-core`) can emit it without re-deriving the
 //! effect.
 //!
+//! Invariant-carrying fields are private; read them through the getters. This
+//! prevents external code from mutating supply counters, balances, ownership,
+//! or approvals out from under the invariants the methods enforce.
+//!
 //! Determinism: state lives in `HashMap`s. In-memory order is per-process and
 //! is never hashed directly; when this state is committed to the state trie
 //! (future work in `sentrix-core`), maps are iterated in sorted order.
+//!
+//! Atomicity: every state-changing method performs all validation and checked
+//! arithmetic into locals first, and only commits mutations once every fallible
+//! step has succeeded — so a rejected operation never leaves partial state.
 
 use crate::error::{NftError, NftResult};
 use crate::events::NftEvent;
@@ -16,49 +24,30 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// A native NFT collection (the Proof Asset issuer unit).
+///
+/// Fields are private; construct via [`NftCollection::new`] and read via the
+/// getters. Mutate only through the methods, which enforce authorization,
+/// supply, soulbound, freeze, and metadata-lock invariants.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NftCollection {
-    /// Collection id/address (deterministic; see [`crate::NftRegistry`]).
-    pub id: String,
-    /// Address that created the collection.
-    pub creator: String,
-    /// Address with administrative rights (mint, freeze, metadata). Defaults
-    /// to `creator` at creation.
-    pub admin: String,
-    /// Human-readable name.
-    pub name: String,
-    /// Ticker symbol.
-    pub symbol: String,
-    /// Optional free-text description (empty = none).
-    pub description: String,
-    /// Metadata-URI prefix; per-token URI is `{base_uri}{token_id}` unless the
-    /// token carries an explicit override.
-    pub base_uri: String,
-    /// Optional external URL for the collection (empty = none).
-    pub external_url: String,
-    /// Maximum number of tokens that may ever be minted. `None` = unlimited.
-    /// Counted against ever-minted, so burning never frees a slot.
-    pub max_supply: Option<u64>,
-    /// Count of currently-live (non-burned) tokens.
-    pub total_supply: u64,
-    /// Monotonic count of tokens ever minted. Backs `max_supply` and the
-    /// no-reuse guarantee. Never decreases.
-    pub total_minted: u64,
-    /// Default transferability applied to mints that don't override it.
-    pub default_transferable: bool,
-    /// Whether token metadata URIs may be updated after mint.
-    pub metadata_mutable: bool,
-    /// Whether the whole collection is frozen (blocks all transfers).
-    pub frozen: bool,
-    /// token_id → token. Includes burned tombstones (never removed) so ids are
-    /// never reused.
-    pub tokens: HashMap<u64, NftToken>,
-    /// owner → count of live tokens held.
-    pub balances: HashMap<String, u64>,
-    /// token_id → approved spender (single-token approval).
-    pub token_approvals: HashMap<u64, String>,
-    /// owner → (operator → approved) for operator-for-all.
-    pub operator_approvals: HashMap<String, HashMap<String, bool>>,
+    id: String,
+    creator: String,
+    admin: String,
+    name: String,
+    symbol: String,
+    description: String,
+    base_uri: String,
+    external_url: String,
+    max_supply: Option<u64>,
+    total_supply: u64,
+    total_minted: u64,
+    default_transferable: bool,
+    metadata_mutable: bool,
+    frozen: bool,
+    tokens: HashMap<u64, NftToken>,
+    balances: HashMap<String, u64>,
+    token_approvals: HashMap<u64, String>,
+    operator_approvals: HashMap<String, HashMap<String, bool>>,
 }
 
 impl NftCollection {
@@ -95,12 +84,74 @@ impl NftCollection {
         }
     }
 
-    // ── Reads ────────────────────────────────────────────
+    // ── Getters (read-only) ──────────────────────────────
+
+    /// Collection id/address.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+    /// Address that created the collection.
+    pub fn creator(&self) -> &str {
+        &self.creator
+    }
+    /// Address with administrative rights.
+    pub fn admin(&self) -> &str {
+        &self.admin
+    }
+    /// Human-readable name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    /// Ticker symbol.
+    pub fn symbol(&self) -> &str {
+        &self.symbol
+    }
+    /// Free-text description (empty = none).
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+    /// Metadata-URI prefix.
+    pub fn base_uri(&self) -> &str {
+        &self.base_uri
+    }
+    /// External URL (empty = none).
+    pub fn external_url(&self) -> &str {
+        &self.external_url
+    }
+    /// Configured maximum supply (`None` = unlimited).
+    pub fn max_supply(&self) -> Option<u64> {
+        self.max_supply
+    }
+    /// Current live (non-burned) supply.
+    pub fn total_supply(&self) -> u64 {
+        self.total_supply
+    }
+    /// Monotonic count of tokens ever minted (backs `max_supply` + no-reuse).
+    pub fn total_minted(&self) -> u64 {
+        self.total_minted
+    }
+    /// Default transferability applied to mints that don't override it.
+    pub fn default_transferable(&self) -> bool {
+        self.default_transferable
+    }
+    /// Whether token metadata URIs may still be updated.
+    pub fn metadata_mutable(&self) -> bool {
+        self.metadata_mutable
+    }
+    /// Whether the whole collection is frozen.
+    pub fn frozen(&self) -> bool {
+        self.frozen
+    }
+
+    /// Borrow a token (including burned tombstones) for inspection.
+    pub fn token(&self, token_id: u64) -> Option<&NftToken> {
+        self.tokens.get(&token_id)
+    }
 
     /// Current owner of a live token, or `None` if it doesn't exist or is burned.
-    pub fn owner_of(&self, token_id: u64) -> Option<&String> {
+    pub fn owner_of(&self, token_id: u64) -> Option<&str> {
         match self.tokens.get(&token_id) {
-            Some(t) if !t.burned => Some(&t.owner),
+            Some(t) if !t.burned() => Some(t.owner()),
             _ => None,
         }
     }
@@ -128,30 +179,15 @@ impl NftCollection {
     /// `{base_uri}{token_id}` convention. Empty for nonexistent/burned tokens.
     pub fn token_uri(&self, token_id: u64) -> String {
         match self.tokens.get(&token_id) {
-            Some(t) if !t.burned => {
-                if t.uri.is_empty() {
+            Some(t) if !t.burned() => {
+                if t.uri().is_empty() {
                     format!("{}{}", self.base_uri, token_id)
                 } else {
-                    t.uri.clone()
+                    t.uri().to_string()
                 }
             }
             _ => String::new(),
         }
-    }
-
-    /// Current live supply.
-    pub fn total_supply(&self) -> u64 {
-        self.total_supply
-    }
-
-    /// Configured maximum supply (`None` = unlimited).
-    pub fn max_supply(&self) -> Option<u64> {
-        self.max_supply
-    }
-
-    /// Borrow a token (including burned tombstones) for inspection.
-    pub fn get_token(&self, token_id: u64) -> Option<&NftToken> {
-        self.tokens.get(&token_id)
     }
 
     /// Authorization for transfer: owner, single-token approvee, or operator.
@@ -176,6 +212,7 @@ impl NftCollection {
         uri: &str,
         transferable: Option<bool>,
     ) -> NftResult<NftEvent> {
+        // ── validate + compute (no mutation yet) ──
         if caller != self.admin {
             return Err(NftError::Unauthorized(
                 "only the collection admin can mint".into(),
@@ -196,8 +233,21 @@ impl NftCollection {
                 max,
             });
         }
-
         let transferable = transferable.unwrap_or(self.default_transferable);
+        let new_balance = self
+            .balance_of(to)
+            .checked_add(1)
+            .ok_or_else(|| NftError::Overflow("balance".into()))?;
+        let new_total_supply = self
+            .total_supply
+            .checked_add(1)
+            .ok_or_else(|| NftError::Overflow("total_supply".into()))?;
+        let new_total_minted = self
+            .total_minted
+            .checked_add(1)
+            .ok_or_else(|| NftError::Overflow("total_minted".into()))?;
+
+        // ── commit (all infallible) ──
         self.tokens.insert(
             token_id,
             NftToken::new(
@@ -208,18 +258,9 @@ impl NftCollection {
                 transferable,
             ),
         );
-        let bal = self.balances.entry(to.to_string()).or_insert(0);
-        *bal = bal
-            .checked_add(1)
-            .ok_or_else(|| NftError::Overflow("balance".into()))?;
-        self.total_supply = self
-            .total_supply
-            .checked_add(1)
-            .ok_or_else(|| NftError::Overflow("total_supply".into()))?;
-        self.total_minted = self
-            .total_minted
-            .checked_add(1)
-            .ok_or_else(|| NftError::Overflow("total_minted".into()))?;
+        self.balances.insert(to.to_string(), new_balance);
+        self.total_supply = new_total_supply;
+        self.total_minted = new_total_minted;
 
         Ok(NftEvent::TokenMinted {
             collection_id: self.id.clone(),
@@ -238,26 +279,29 @@ impl NftCollection {
         to: &str,
         token_id: u64,
     ) -> NftResult<NftEvent> {
+        // ── validate + compute (no mutation yet) ──
         if from.is_empty() || to.is_empty() {
             return Err(NftError::InvalidParams("empty address".into()));
         }
         if from == to {
             return Err(NftError::InvalidParams("cannot transfer to self".into()));
         }
-        // Existence (burned tokens read as not-found).
-        let token = self.tokens.get(&token_id).filter(|t| !t.burned);
-        let token = token.ok_or(NftError::TokenNotFound(token_id))?;
+        let token = self
+            .tokens
+            .get(&token_id)
+            .filter(|t| !t.burned())
+            .ok_or(NftError::TokenNotFound(token_id))?;
         // Soulbound — checked first; no approval bypasses it.
-        if !token.transferable {
+        if !token.transferable() {
             return Err(NftError::NotTransferable(token_id));
         }
-        if token.frozen {
+        if token.frozen() {
             return Err(NftError::TokenFrozen(token_id));
         }
         if self.frozen {
             return Err(NftError::CollectionFrozen);
         }
-        if token.owner != from {
+        if token.owner() != from {
             return Err(NftError::NotOwner {
                 token_id,
                 claimed: from.to_string(),
@@ -269,19 +313,20 @@ impl NftCollection {
                 caller, token_id
             )));
         }
-
-        // Apply.
-        let from_bal = self.balances.entry(from.to_string()).or_insert(0);
-        *from_bal = from_bal
+        let new_from = self
+            .balance_of(from)
             .checked_sub(1)
             .ok_or_else(|| NftError::Overflow("transfer underflow".into()))?;
-        let to_bal = self.balances.entry(to.to_string()).or_insert(0);
-        *to_bal = to_bal
+        let new_to = self
+            .balance_of(to)
             .checked_add(1)
             .ok_or_else(|| NftError::Overflow("transfer overflow".into()))?;
-        // Owner update + approval clear.
+
+        // ── commit (all infallible) ──
+        self.balances.insert(from.to_string(), new_from);
+        self.balances.insert(to.to_string(), new_to);
         if let Some(t) = self.tokens.get_mut(&token_id) {
-            t.owner = to.to_string();
+            t.set_owner(to.to_string());
         }
         self.token_approvals.remove(&token_id);
 
@@ -336,15 +381,22 @@ impl NftCollection {
         })
     }
 
-    /// Grant or revoke `operator` over all of `owner`'s tokens.
+    /// Grant or revoke `operator` over all of `owner`'s tokens. `caller` must be
+    /// `owner` — a caller can only manage operators for their own tokens.
     pub fn set_approval_for_all(
         &mut self,
+        caller: &str,
         owner: &str,
         operator: &str,
         approved: bool,
     ) -> NftResult<NftEvent> {
         if owner.is_empty() || operator.is_empty() {
             return Err(NftError::InvalidParams("empty address".into()));
+        }
+        if caller != owner {
+            return Err(NftError::Unauthorized(
+                "caller may only set operator approvals for itself".into(),
+            ));
         }
         if owner == operator {
             return Err(NftError::InvalidParams(
@@ -366,6 +418,7 @@ impl NftCollection {
     /// Burn a token. Caller must be the owner or the collection admin. The id
     /// is retired permanently (tombstone) and can never be reminted.
     pub fn burn(&mut self, caller: &str, token_id: u64) -> NftResult<NftEvent> {
+        // ── validate + compute (no mutation yet) ──
         let owner = self.live_owner(token_id)?;
         if caller != owner && caller != self.admin {
             return Err(NftError::Unauthorized(format!(
@@ -373,19 +426,22 @@ impl NftCollection {
                 token_id
             )));
         }
-        let bal = self.balances.entry(owner.clone()).or_insert(0);
-        *bal = bal
+        let new_balance = self
+            .balance_of(&owner)
             .checked_sub(1)
             .ok_or_else(|| NftError::Overflow("burn underflow".into()))?;
-        self.total_supply = self
+        let new_total_supply = self
             .total_supply
             .checked_sub(1)
             .ok_or_else(|| NftError::Overflow("total_supply underflow".into()))?;
+
+        // ── commit (all infallible) ──
+        self.balances.insert(owner.clone(), new_balance);
+        self.total_supply = new_total_supply;
         self.token_approvals.remove(&token_id);
         // Tombstone: keep the entry so the id is never reusable; record audit.
         if let Some(t) = self.tokens.get_mut(&token_id) {
-            t.burned = true;
-            t.frozen = false;
+            t.mark_burned();
         }
         Ok(NftEvent::TokenBurned {
             collection_id: self.id.clone(),
@@ -416,12 +472,12 @@ impl NftCollection {
                 caller, token_id
             )));
         }
-        // Safe: live_owner proved a live token exists.
+        // A live token frozen individually also blocks its URI update.
+        if self.tokens.get(&token_id).is_some_and(|t| t.frozen()) {
+            return Err(NftError::TokenFrozen(token_id));
+        }
         if let Some(t) = self.tokens.get_mut(&token_id) {
-            if t.frozen {
-                return Err(NftError::TokenFrozen(token_id));
-            }
-            t.uri = new_uri.to_string();
+            t.set_uri(new_uri.to_string());
         }
         Ok(NftEvent::TokenUriUpdated {
             collection_id: self.id.clone(),
@@ -429,7 +485,8 @@ impl NftCollection {
         })
     }
 
-    /// Update collection-level metadata. Admin-only; fails if frozen.
+    /// Update collection-level metadata. Admin-only; fails if the collection is
+    /// frozen or its metadata is locked.
     pub fn update_collection_metadata(
         &mut self,
         caller: &str,
@@ -444,6 +501,9 @@ impl NftCollection {
         }
         if self.frozen {
             return Err(NftError::CollectionFrozen);
+        }
+        if !self.metadata_mutable {
+            return Err(NftError::MetadataLocked);
         }
         if let Some(d) = description {
             self.description = d;
@@ -470,7 +530,8 @@ impl NftCollection {
         })
     }
 
-    /// Lock collection metadata (token URIs become immutable). Admin-only.
+    /// Lock collection metadata (collection + token URIs become immutable).
+    /// Admin-only.
     pub fn lock_metadata(&mut self, caller: &str) -> NftResult<NftEvent> {
         if caller != self.admin {
             return Err(NftError::Unauthorized(
@@ -498,7 +559,7 @@ impl NftCollection {
         // Must be a live token.
         self.live_owner(token_id)?;
         if let Some(t) = self.tokens.get_mut(&token_id) {
-            t.frozen = frozen;
+            t.set_frozen(frozen);
         }
         let collection_id = self.id.clone();
         Ok(if frozen {
@@ -517,7 +578,7 @@ impl NftCollection {
     /// Resolve the owner of a live token or error. Burned/absent → `TokenNotFound`.
     fn live_owner(&self, token_id: u64) -> NftResult<String> {
         match self.tokens.get(&token_id) {
-            Some(t) if !t.burned => Ok(t.owner.clone()),
+            Some(t) if !t.burned() => Ok(t.owner().to_string()),
             _ => Err(NftError::TokenNotFound(token_id)),
         }
     }

--- a/crates/sentrix-nft/src/error.rs
+++ b/crates/sentrix-nft/src/error.rs
@@ -1,0 +1,78 @@
+//! Typed errors for the Sentrix Native NFT domain.
+//!
+//! Pure domain errors — no I/O, no storage, no consensus. `sentrix-core`
+//! converts these into its own `SentrixError` at the integration boundary
+//! via a `From` impl on its side.
+
+use thiserror::Error;
+
+/// Result alias for NFT domain operations.
+pub type NftResult<T> = Result<T, NftError>;
+
+/// Every way an NFT domain operation can fail.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum NftError {
+    /// Caller is not permitted to perform the action.
+    #[error("unauthorized: {0}")]
+    Unauthorized(String),
+
+    /// A token with this id already exists (live or burned tombstone).
+    /// Burned ids are never reusable — strict no-reuse for a clean audit trail.
+    #[error("token_id {0} already exists (ids are never reused after burn)")]
+    TokenAlreadyExists(u64),
+
+    /// No live token with this id.
+    #[error("token_id {0} not found")]
+    TokenNotFound(u64),
+
+    /// The claimed `from` is not the current owner of the token.
+    #[error("token_id {token_id}: {claimed} is not the owner")]
+    NotOwner {
+        /// Token whose ownership was asserted.
+        token_id: u64,
+        /// The address the caller claimed owned it.
+        claimed: String,
+    },
+
+    /// Token is soulbound (non-transferable). No approval can bypass this.
+    #[error("token_id {0} is soulbound (non-transferable)")]
+    NotTransferable(u64),
+
+    /// Token is individually frozen.
+    #[error("token_id {0} is frozen")]
+    TokenFrozen(u64),
+
+    /// The whole collection is frozen.
+    #[error("collection is frozen")]
+    CollectionFrozen,
+
+    /// Collection metadata is locked (immutable).
+    #[error("collection metadata is locked")]
+    MetadataLocked,
+
+    /// Minting would exceed the collection's max supply (counts ever-minted,
+    /// so burning does not free a slot).
+    #[error("max supply reached: {minted} minted, max {max}")]
+    MaxSupplyReached {
+        /// Total ever minted in this collection.
+        minted: u64,
+        /// Configured maximum.
+        max: u64,
+    },
+
+    /// A parameter failed a basic validity check.
+    #[error("invalid params: {0}")]
+    InvalidParams(String),
+
+    /// A collection with this id/address already exists.
+    #[error("collection {0} already exists")]
+    CollectionExists(String),
+
+    /// No collection with this id/address.
+    #[error("collection {0} not found")]
+    CollectionNotFound(String),
+
+    /// A counter overflowed (supply or balance).
+    #[error("arithmetic overflow: {0}")]
+    Overflow(String),
+}

--- a/crates/sentrix-nft/src/events.rs
+++ b/crates/sentrix-nft/src/events.rs
@@ -1,0 +1,112 @@
+//! Pure NFT event types.
+//!
+//! Each state-changing operation returns one [`NftEvent`]. These are plain
+//! data — `sentrix-core` decides whether/how to emit them into block logs.
+//! Nothing here touches the event bus, RPC, or storage.
+
+use serde::{Deserialize, Serialize};
+
+/// Domain events emitted by NFT state transitions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NftEvent {
+    /// A new collection was created.
+    CollectionCreated {
+        /// Collection id/address.
+        collection_id: String,
+        /// Address that created (and by default administers) it.
+        creator: String,
+        /// Human-readable name.
+        name: String,
+        /// Ticker symbol.
+        symbol: String,
+    },
+    /// Collection-level metadata (description / base_uri / external_url) changed.
+    CollectionUpdated {
+        /// Collection id/address.
+        collection_id: String,
+    },
+    /// The collection was frozen (all transfers now fail).
+    CollectionFrozen {
+        /// Collection id/address.
+        collection_id: String,
+    },
+    /// Collection metadata was locked (token URIs can no longer change).
+    CollectionMetadataLocked {
+        /// Collection id/address.
+        collection_id: String,
+    },
+    /// A token was minted.
+    TokenMinted {
+        /// Collection id/address.
+        collection_id: String,
+        /// Minted token id.
+        token_id: u64,
+        /// Recipient / first owner.
+        to: String,
+        /// Whether the token can ever be transferred (`false` = soulbound).
+        transferable: bool,
+    },
+    /// A token changed owner.
+    TokenTransferred {
+        /// Collection id/address.
+        collection_id: String,
+        /// Token id.
+        token_id: u64,
+        /// Previous owner.
+        from: String,
+        /// New owner.
+        to: String,
+    },
+    /// A token was burned (tombstoned; its id is never reusable).
+    TokenBurned {
+        /// Collection id/address.
+        collection_id: String,
+        /// Token id.
+        token_id: u64,
+        /// Owner at burn time.
+        owner: String,
+    },
+    /// A single-token approval was set or cleared (`approved` empty = cleared).
+    TokenApproved {
+        /// Collection id/address.
+        collection_id: String,
+        /// Token id.
+        token_id: u64,
+        /// Owner granting the approval.
+        owner: String,
+        /// Approved spender (empty string means the approval was cleared).
+        approved: String,
+    },
+    /// An operator-for-all approval was set or revoked.
+    ApprovalForAll {
+        /// Collection id/address.
+        collection_id: String,
+        /// Token owner.
+        owner: String,
+        /// Operator.
+        operator: String,
+        /// Whether the operator is now approved.
+        approved: bool,
+    },
+    /// A token's metadata URI was updated.
+    TokenUriUpdated {
+        /// Collection id/address.
+        collection_id: String,
+        /// Token id.
+        token_id: u64,
+    },
+    /// A token was individually frozen.
+    TokenFrozen {
+        /// Collection id/address.
+        collection_id: String,
+        /// Token id.
+        token_id: u64,
+    },
+    /// A token was individually unfrozen.
+    TokenUnfrozen {
+        /// Collection id/address.
+        collection_id: String,
+        /// Token id.
+        token_id: u64,
+    },
+}

--- a/crates/sentrix-nft/src/lib.rs
+++ b/crates/sentrix-nft/src/lib.rs
@@ -1,0 +1,564 @@
+//! # Sentrix Native NFT — Proof Asset layer
+//!
+//! Pure domain logic for Sentrix's *native* NFT standard (SRC-721-style). This
+//! is a **Proof Asset / reputation layer**, not a JPEG/PFP marketplace:
+//!
+//! - validator proof, builder proof, testnet-participation proof, contributor
+//!   proof, bug-hunter proof, genesis-supporter proof, community reputation,
+//!   and optional **soulbound** (non-transferable) assets.
+//!
+//! What this crate is and isn't:
+//!
+//! - It contains **only** NFT domain logic: collections, tokens, ownership,
+//!   approvals, soulbound/freeze rules, metadata URIs, deterministic ids, and
+//!   events. No storage, no trie, no consensus, no RPC, no marketplace, no
+//!   bridge.
+//! - Metadata and media live **off-chain**; only URIs (and optional integrity
+//!   hashes) are kept. Image bytes are never stored in chain state.
+//! - EVM ERC-721/ERC-1155 remain a **separate**, parallel path for public
+//!   developers; this native rail does not replace them.
+//!
+//! Determinism: ids are derived from `sha256(creator|seed)` — no wall-clock
+//! time, no randomness. Burned token ids are **never reused** (tombstones),
+//! keeping the reputation history append-only and auditable.
+//!
+//! ## Future storage key design (NOT implemented here)
+//!
+//! Storage/MDBX integration is future work in `sentrix-core`. The intended key
+//! scheme, for reference only:
+//!
+//! ```text
+//! nft:collection:{collection_id}
+//! nft:token:{collection_id}:{token_id}
+//! nft:owner:{collection_id}:{token_id}
+//! nft:owner_index:{owner}:{collection_id}:{token_id}
+//! nft:approval:{collection_id}:{token_id}
+//! nft:operator:{owner}:{operator}
+//! nft:supply:{collection_id}
+//! ```
+//!
+//! A `NftStorage` trait is intentionally deferred until a real storage consumer
+//! exists — adding it now would be an unused abstraction.
+//!
+//! ## Examples
+//!
+//! Create a soulbound Builder Badge collection and mint a badge:
+//!
+//! ```
+//! use sentrix_nft::NftRegistry;
+//!
+//! let mut reg = NftRegistry::new();
+//! // default_transferable = false → badges are soulbound by default.
+//! let (id, _ev) = reg
+//!     .deploy_collection("0xfoundation", "Builder Badge", "BUILD", "ipfs://badges/", None, false, true, "tx-001")
+//!     .unwrap();
+//!
+//! let col = reg.get_collection_mut(&id).unwrap();
+//! // admin (= creator) mints a soulbound badge to a builder.
+//! col.mint("0xfoundation", "0xbuilder", 1, "", None).unwrap();
+//! assert_eq!(col.owner_of(1), Some(&"0xbuilder".to_string()));
+//! ```
+//!
+//! Soulbound transfer fails; a transferable token moves normally:
+//!
+//! ```
+//! use sentrix_nft::NftRegistry;
+//!
+//! let mut reg = NftRegistry::new();
+//! let (id, _) = reg
+//!     .deploy_collection("0xadmin", "Mixed", "MIX", "ipfs://", None, false, true, "seed")
+//!     .unwrap();
+//! let col = reg.get_collection_mut(&id).unwrap();
+//!
+//! // soulbound (uses the collection default false) → cannot move
+//! col.mint("0xadmin", "0xalice", 1, "", None).unwrap();
+//! assert!(col.transfer("0xalice", "0xalice", "0xbob", 1).is_err());
+//!
+//! // explicitly transferable → moves
+//! col.mint("0xadmin", "0xalice", 2, "", Some(true)).unwrap();
+//! col.transfer("0xalice", "0xalice", "0xbob", 2).unwrap();
+//! assert_eq!(col.owner_of(2), Some(&"0xbob".to_string()));
+//! ```
+
+pub mod collection;
+pub mod error;
+pub mod events;
+pub mod registry;
+pub mod token;
+
+pub use collection::NftCollection;
+pub use error::{NftError, NftResult};
+pub use events::NftEvent;
+pub use registry::{NftRegistry, compute_collection_id};
+pub use token::NftToken;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ADMIN: &str = "0xadmin";
+    const ALICE: &str = "0xalice";
+    const BOB: &str = "0xbob";
+    const CAROL: &str = "0xcarol";
+
+    /// Transferable-by-default collection for the common cases.
+    fn transferable_collection() -> NftCollection {
+        NftCollection::new(
+            "SRC721_test".into(),
+            ADMIN.into(),
+            "Test".into(),
+            "TEST".into(),
+            "https://meta/".into(),
+            None, // unlimited
+            true, // default_transferable
+            true, // metadata_mutable
+        )
+    }
+
+    /// Soulbound-by-default collection (Proof Asset style).
+    fn soulbound_collection() -> NftCollection {
+        NftCollection::new(
+            "SRC721_badge".into(),
+            ADMIN.into(),
+            "Badge".into(),
+            "BADGE".into(),
+            "ipfs://b/".into(),
+            None,
+            false, // default_transferable = false → soulbound
+            true,
+        )
+    }
+
+    // ── collection / registry ────────────────────────────
+
+    #[test]
+    fn registry_deploy_deterministic_and_prefixed() {
+        let mut a = NftRegistry::new();
+        let mut b = NftRegistry::new();
+        let (id_a, ev) = a
+            .deploy_collection(ADMIN, "C", "C", "u", None, true, true, "tx1")
+            .unwrap();
+        let (id_b, _) = b
+            .deploy_collection(ADMIN, "C", "C", "u", None, true, true, "tx1")
+            .unwrap();
+        assert_eq!(id_a, id_b);
+        assert!(id_a.starts_with("SRC721_"));
+        assert!(matches!(ev, NftEvent::CollectionCreated { .. }));
+    }
+
+    #[test]
+    fn registry_rejects_duplicate_collection() {
+        let mut r = NftRegistry::new();
+        r.deploy_collection(ADMIN, "C", "C", "u", None, true, true, "tx1")
+            .unwrap();
+        assert!(
+            r.deploy_collection(ADMIN, "C", "C", "u", None, true, true, "tx1")
+                .is_err()
+        );
+        assert_eq!(r.collection_count(), 1);
+    }
+
+    #[test]
+    fn registry_rejects_empty_name_symbol_and_zero_max_supply() {
+        let mut r = NftRegistry::new();
+        assert!(
+            r.deploy_collection(ADMIN, "", "C", "u", None, true, true, "t")
+                .is_err()
+        );
+        assert!(
+            r.deploy_collection(ADMIN, "C", "", "u", None, true, true, "t")
+                .is_err()
+        );
+        assert!(
+            r.deploy_collection(ADMIN, "C", "bad sym", "u", None, true, true, "t")
+                .is_err()
+        );
+        assert!(
+            r.deploy_collection(ADMIN, "C", "C", "u", Some(0), true, true, "t")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn registry_get_and_exists() {
+        let mut r = NftRegistry::new();
+        let (id, _) = r
+            .deploy_collection(ADMIN, "C", "C", "u", None, true, true, "t")
+            .unwrap();
+        assert!(r.collection_exists(&id));
+        assert!(!r.collection_exists("SRC721_nope"));
+        assert!(r.get_collection(&id).is_some());
+    }
+
+    // ── mint ─────────────────────────────────────────────
+
+    #[test]
+    fn mint_sets_owner_balance_supply_and_event() {
+        let mut c = transferable_collection();
+        let ev = c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        assert_eq!(c.owner_of(1), Some(&ALICE.to_string()));
+        assert_eq!(c.balance_of(ALICE), 1);
+        assert_eq!(c.total_supply(), 1);
+        assert!(matches!(ev, NftEvent::TokenMinted { token_id: 1, .. }));
+    }
+
+    #[test]
+    fn mint_only_admin() {
+        let mut c = transferable_collection();
+        assert!(c.mint(ALICE, ALICE, 1, "", None).is_err());
+        assert_eq!(c.total_supply(), 0);
+    }
+
+    #[test]
+    fn mint_rejects_duplicate_token_id() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        assert!(c.mint(ADMIN, BOB, 1, "", None).is_err());
+        assert_eq!(c.owner_of(1), Some(&ALICE.to_string()));
+    }
+
+    #[test]
+    fn mint_respects_max_supply_against_ever_minted() {
+        let mut c = NftCollection::new(
+            "SRC721_cap".into(),
+            ADMIN.into(),
+            "Cap".into(),
+            "CAP".into(),
+            "u".into(),
+            Some(2),
+            true,
+            true,
+        );
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.mint(ADMIN, ALICE, 2, "", None).unwrap();
+        assert!(c.mint(ADMIN, ALICE, 3, "", None).is_err());
+        // burning does NOT free a cap slot (counts ever-minted)
+        c.burn(ALICE, 1).unwrap();
+        assert!(c.mint(ADMIN, ALICE, 9, "", None).is_err());
+    }
+
+    #[test]
+    fn mint_soulbound_and_transferable() {
+        let mut c = soulbound_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap(); // default soulbound
+        assert!(!c.get_token(1).unwrap().transferable);
+        c.mint(ADMIN, ALICE, 2, "", Some(true)).unwrap(); // override
+        assert!(c.get_token(2).unwrap().transferable);
+    }
+
+    #[test]
+    fn mint_uri_override_and_base_convention() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 7, "ipfs://custom", None).unwrap();
+        assert_eq!(c.token_uri(7), "ipfs://custom");
+        c.mint(ADMIN, ALICE, 8, "", None).unwrap();
+        assert_eq!(c.token_uri(8), "https://meta/8");
+    }
+
+    // ── transfer ─────────────────────────────────────────
+
+    #[test]
+    fn owner_can_transfer_transferable() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        let ev = c.transfer(ALICE, ALICE, BOB, 1).unwrap();
+        assert_eq!(c.owner_of(1), Some(&BOB.to_string()));
+        assert_eq!(c.balance_of(ALICE), 0);
+        assert_eq!(c.balance_of(BOB), 1);
+        assert!(matches!(ev, NftEvent::TokenTransferred { .. }));
+    }
+
+    #[test]
+    fn soulbound_transfer_fails_typed() {
+        let mut c = soulbound_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        assert_eq!(
+            c.transfer(ALICE, ALICE, BOB, 1),
+            Err(NftError::NotTransferable(1))
+        );
+        assert_eq!(c.owner_of(1), Some(&ALICE.to_string()));
+    }
+
+    #[test]
+    fn approval_does_not_bypass_soulbound() {
+        let mut c = soulbound_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        // even if an operator is set, soulbound still can't move
+        c.set_approval_for_all(ALICE, BOB, true).unwrap();
+        assert_eq!(
+            c.transfer(BOB, ALICE, CAROL, 1),
+            Err(NftError::NotTransferable(1))
+        );
+    }
+
+    #[test]
+    fn transfer_unauthorized_fails() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        assert!(c.transfer(BOB, ALICE, BOB, 1).is_err());
+    }
+
+    #[test]
+    fn transfer_wrong_from_fails() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        assert!(matches!(
+            c.transfer(ALICE, BOB, CAROL, 1),
+            Err(NftError::NotOwner { token_id: 1, .. })
+        ));
+    }
+
+    #[test]
+    fn transfer_nonexistent_and_self_fail() {
+        let mut c = transferable_collection();
+        assert_eq!(
+            c.transfer(ALICE, ALICE, BOB, 99),
+            Err(NftError::TokenNotFound(99))
+        );
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        assert!(c.transfer(ALICE, ALICE, ALICE, 1).is_err());
+    }
+
+    #[test]
+    fn approved_spender_transfers_then_approval_clears() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.approve(ALICE, BOB, 1).unwrap();
+        assert_eq!(c.get_approved(1), Some(&BOB.to_string()));
+        c.transfer(BOB, ALICE, CAROL, 1).unwrap();
+        assert_eq!(c.owner_of(1), Some(&CAROL.to_string()));
+        assert_eq!(c.get_approved(1), None); // cleared by transfer
+    }
+
+    #[test]
+    fn operator_can_transfer_and_be_revoked() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.mint(ADMIN, ALICE, 2, "", None).unwrap();
+        c.set_approval_for_all(ALICE, BOB, true).unwrap();
+        c.transfer(BOB, ALICE, CAROL, 1).unwrap();
+        c.set_approval_for_all(ALICE, BOB, false).unwrap();
+        assert!(c.transfer(BOB, ALICE, CAROL, 2).is_err());
+    }
+
+    #[test]
+    fn frozen_token_and_collection_block_transfer() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.mint(ADMIN, ALICE, 2, "", None).unwrap();
+        // token freeze
+        c.set_token_frozen(ADMIN, 1, true).unwrap();
+        assert_eq!(
+            c.transfer(ALICE, ALICE, BOB, 1),
+            Err(NftError::TokenFrozen(1))
+        );
+        c.set_token_frozen(ADMIN, 1, false).unwrap();
+        c.transfer(ALICE, ALICE, BOB, 1).unwrap();
+        // collection freeze
+        c.freeze_collection(ADMIN).unwrap();
+        assert_eq!(
+            c.transfer(ALICE, ALICE, BOB, 2),
+            Err(NftError::CollectionFrozen)
+        );
+    }
+
+    // ── approval ─────────────────────────────────────────
+
+    #[test]
+    fn approve_requires_owner_or_operator() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        assert!(c.approve(BOB, BOB, 1).is_err());
+        // operator may approve on owner's behalf
+        c.set_approval_for_all(ALICE, BOB, true).unwrap();
+        c.approve(BOB, CAROL, 1).unwrap();
+        assert_eq!(c.get_approved(1), Some(&CAROL.to_string()));
+    }
+
+    #[test]
+    fn clear_approval_works() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.approve(ALICE, BOB, 1).unwrap();
+        c.clear_approval(ALICE, 1).unwrap();
+        assert_eq!(c.get_approved(1), None);
+    }
+
+    #[test]
+    fn approval_cleared_after_burn() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.approve(ALICE, BOB, 1).unwrap();
+        c.burn(ALICE, 1).unwrap();
+        assert_eq!(c.get_approved(1), None);
+    }
+
+    #[test]
+    fn set_approval_for_all_rejects_self() {
+        let mut c = transferable_collection();
+        assert!(c.set_approval_for_all(ALICE, ALICE, true).is_err());
+    }
+
+    // ── burn (strict no-reuse) ───────────────────────────
+
+    #[test]
+    fn owner_burn_works_balance_and_supply_drop() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "ipfs://x", None).unwrap();
+        let ev = c.burn(ALICE, 1).unwrap();
+        assert_eq!(c.owner_of(1), None);
+        assert_eq!(c.balance_of(ALICE), 0);
+        assert_eq!(c.total_supply(), 0);
+        assert_eq!(c.token_uri(1), "");
+        assert!(matches!(ev, NftEvent::TokenBurned { token_id: 1, .. }));
+    }
+
+    #[test]
+    fn admin_can_burn() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.burn(ADMIN, 1).unwrap();
+        assert_eq!(c.owner_of(1), None);
+    }
+
+    #[test]
+    fn unauthorized_burn_fails() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        assert!(c.burn(BOB, 1).is_err());
+        assert_eq!(c.owner_of(1), Some(&ALICE.to_string()));
+    }
+
+    #[test]
+    fn burn_nonexistent_and_double_burn_fail() {
+        let mut c = transferable_collection();
+        assert_eq!(c.burn(ALICE, 5), Err(NftError::TokenNotFound(5)));
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.burn(ALICE, 1).unwrap();
+        assert_eq!(c.burn(ALICE, 1), Err(NftError::TokenNotFound(1)));
+    }
+
+    #[test]
+    fn burned_token_id_strictly_not_reusable() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.burn(ALICE, 1).unwrap();
+        // strict no-reuse: id 1 is retired forever
+        assert_eq!(
+            c.mint(ADMIN, BOB, 1, "", None),
+            Err(NftError::TokenAlreadyExists(1))
+        );
+        // tombstone preserved for audit
+        assert!(c.get_token(1).unwrap().burned);
+    }
+
+    #[test]
+    fn transfer_burned_token_fails() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.burn(ALICE, 1).unwrap();
+        assert_eq!(
+            c.transfer(ALICE, ALICE, BOB, 1),
+            Err(NftError::TokenNotFound(1))
+        );
+    }
+
+    // ── metadata ─────────────────────────────────────────
+
+    #[test]
+    fn update_token_uri_by_owner_and_admin() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.update_token_uri(ALICE, 1, "ipfs://new").unwrap();
+        assert_eq!(c.token_uri(1), "ipfs://new");
+        c.update_token_uri(ADMIN, 1, "ipfs://admin").unwrap();
+        assert_eq!(c.token_uri(1), "ipfs://admin");
+    }
+
+    #[test]
+    fn update_token_uri_unauthorized_fails() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        assert!(c.update_token_uri(BOB, 1, "ipfs://x").is_err());
+    }
+
+    #[test]
+    fn update_token_uri_fails_when_locked() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.lock_metadata(ADMIN).unwrap();
+        assert_eq!(
+            c.update_token_uri(ALICE, 1, "ipfs://x"),
+            Err(NftError::MetadataLocked)
+        );
+    }
+
+    #[test]
+    fn update_collection_metadata_admin_only() {
+        let mut c = transferable_collection();
+        assert!(
+            c.update_collection_metadata(BOB, Some("d".into()), None, None)
+                .is_err()
+        );
+        c.update_collection_metadata(ADMIN, Some("desc".into()), Some("ipfs://b/".into()), None)
+            .unwrap();
+        assert_eq!(c.description, "desc");
+        assert_eq!(c.base_uri, "ipfs://b/");
+    }
+
+    #[test]
+    fn frozen_collection_blocks_metadata_update() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        c.freeze_collection(ADMIN).unwrap();
+        assert_eq!(
+            c.update_token_uri(ALICE, 1, "x"),
+            Err(NftError::CollectionFrozen)
+        );
+        assert!(
+            c.update_collection_metadata(ADMIN, Some("d".into()), None, None)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn uri_hash_field_round_trips() {
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "ipfs://x", None).unwrap();
+        // set integrity hashes directly on the token (no media bytes stored)
+        let t = c.tokens.get_mut(&1).unwrap();
+        t.uri_hash = Some("deadbeef".into());
+        t.metadata_hash = Some("cafebabe".into());
+        let got = c.get_token(1).unwrap();
+        assert_eq!(got.uri_hash.as_deref(), Some("deadbeef"));
+        assert_eq!(got.metadata_hash.as_deref(), Some("cafebabe"));
+    }
+
+    // ── events ───────────────────────────────────────────
+
+    #[test]
+    fn events_are_returned_for_each_op() {
+        let mut r = NftRegistry::new();
+        let (id, created) = r
+            .deploy_collection(ADMIN, "C", "C", "u", None, true, true, "t")
+            .unwrap();
+        assert!(matches!(created, NftEvent::CollectionCreated { .. }));
+        let c = r.get_collection_mut(&id).unwrap();
+        assert!(matches!(
+            c.mint(ADMIN, ALICE, 1, "", None).unwrap(),
+            NftEvent::TokenMinted { .. }
+        ));
+        assert!(matches!(
+            c.approve(ALICE, BOB, 1).unwrap(),
+            NftEvent::TokenApproved { .. }
+        ));
+        assert!(matches!(
+            c.transfer(BOB, ALICE, CAROL, 1).unwrap(),
+            NftEvent::TokenTransferred { .. }
+        ));
+        assert!(matches!(
+            c.burn(CAROL, 1).unwrap(),
+            NftEvent::TokenBurned { .. }
+        ));
+    }
+}

--- a/crates/sentrix-nft/src/lib.rs
+++ b/crates/sentrix-nft/src/lib.rs
@@ -56,7 +56,7 @@
 //! let col = reg.get_collection_mut(&id).unwrap();
 //! // admin (= creator) mints a soulbound badge to a builder.
 //! col.mint("0xfoundation", "0xbuilder", 1, "", None).unwrap();
-//! assert_eq!(col.owner_of(1), Some(&"0xbuilder".to_string()));
+//! assert_eq!(col.owner_of(1), Some("0xbuilder"));
 //! ```
 //!
 //! Soulbound transfer fails; a transferable token moves normally:
@@ -77,7 +77,7 @@
 //! // explicitly transferable → moves
 //! col.mint("0xadmin", "0xalice", 2, "", Some(true)).unwrap();
 //! col.transfer("0xalice", "0xalice", "0xbob", 2).unwrap();
-//! assert_eq!(col.owner_of(2), Some(&"0xbob".to_string()));
+//! assert_eq!(col.owner_of(2), Some("0xbob"));
 //! ```
 
 pub mod collection;
@@ -196,7 +196,7 @@ mod tests {
     fn mint_sets_owner_balance_supply_and_event() {
         let mut c = transferable_collection();
         let ev = c.mint(ADMIN, ALICE, 1, "", None).unwrap();
-        assert_eq!(c.owner_of(1), Some(&ALICE.to_string()));
+        assert_eq!(c.owner_of(1), Some(ALICE));
         assert_eq!(c.balance_of(ALICE), 1);
         assert_eq!(c.total_supply(), 1);
         assert!(matches!(ev, NftEvent::TokenMinted { token_id: 1, .. }));
@@ -214,7 +214,7 @@ mod tests {
         let mut c = transferable_collection();
         c.mint(ADMIN, ALICE, 1, "", None).unwrap();
         assert!(c.mint(ADMIN, BOB, 1, "", None).is_err());
-        assert_eq!(c.owner_of(1), Some(&ALICE.to_string()));
+        assert_eq!(c.owner_of(1), Some(ALICE));
     }
 
     #[test]
@@ -241,9 +241,9 @@ mod tests {
     fn mint_soulbound_and_transferable() {
         let mut c = soulbound_collection();
         c.mint(ADMIN, ALICE, 1, "", None).unwrap(); // default soulbound
-        assert!(!c.get_token(1).unwrap().transferable);
+        assert!(!c.token(1).unwrap().transferable());
         c.mint(ADMIN, ALICE, 2, "", Some(true)).unwrap(); // override
-        assert!(c.get_token(2).unwrap().transferable);
+        assert!(c.token(2).unwrap().transferable());
     }
 
     #[test]
@@ -262,7 +262,7 @@ mod tests {
         let mut c = transferable_collection();
         c.mint(ADMIN, ALICE, 1, "", None).unwrap();
         let ev = c.transfer(ALICE, ALICE, BOB, 1).unwrap();
-        assert_eq!(c.owner_of(1), Some(&BOB.to_string()));
+        assert_eq!(c.owner_of(1), Some(BOB));
         assert_eq!(c.balance_of(ALICE), 0);
         assert_eq!(c.balance_of(BOB), 1);
         assert!(matches!(ev, NftEvent::TokenTransferred { .. }));
@@ -276,7 +276,7 @@ mod tests {
             c.transfer(ALICE, ALICE, BOB, 1),
             Err(NftError::NotTransferable(1))
         );
-        assert_eq!(c.owner_of(1), Some(&ALICE.to_string()));
+        assert_eq!(c.owner_of(1), Some(ALICE));
     }
 
     #[test]
@@ -284,7 +284,7 @@ mod tests {
         let mut c = soulbound_collection();
         c.mint(ADMIN, ALICE, 1, "", None).unwrap();
         // even if an operator is set, soulbound still can't move
-        c.set_approval_for_all(ALICE, BOB, true).unwrap();
+        c.set_approval_for_all(ALICE, ALICE, BOB, true).unwrap();
         assert_eq!(
             c.transfer(BOB, ALICE, CAROL, 1),
             Err(NftError::NotTransferable(1))
@@ -326,7 +326,7 @@ mod tests {
         c.approve(ALICE, BOB, 1).unwrap();
         assert_eq!(c.get_approved(1), Some(&BOB.to_string()));
         c.transfer(BOB, ALICE, CAROL, 1).unwrap();
-        assert_eq!(c.owner_of(1), Some(&CAROL.to_string()));
+        assert_eq!(c.owner_of(1), Some(CAROL));
         assert_eq!(c.get_approved(1), None); // cleared by transfer
     }
 
@@ -335,9 +335,9 @@ mod tests {
         let mut c = transferable_collection();
         c.mint(ADMIN, ALICE, 1, "", None).unwrap();
         c.mint(ADMIN, ALICE, 2, "", None).unwrap();
-        c.set_approval_for_all(ALICE, BOB, true).unwrap();
+        c.set_approval_for_all(ALICE, ALICE, BOB, true).unwrap();
         c.transfer(BOB, ALICE, CAROL, 1).unwrap();
-        c.set_approval_for_all(ALICE, BOB, false).unwrap();
+        c.set_approval_for_all(ALICE, ALICE, BOB, false).unwrap();
         assert!(c.transfer(BOB, ALICE, CAROL, 2).is_err());
     }
 
@@ -370,7 +370,7 @@ mod tests {
         c.mint(ADMIN, ALICE, 1, "", None).unwrap();
         assert!(c.approve(BOB, BOB, 1).is_err());
         // operator may approve on owner's behalf
-        c.set_approval_for_all(ALICE, BOB, true).unwrap();
+        c.set_approval_for_all(ALICE, ALICE, BOB, true).unwrap();
         c.approve(BOB, CAROL, 1).unwrap();
         assert_eq!(c.get_approved(1), Some(&CAROL.to_string()));
     }
@@ -396,7 +396,7 @@ mod tests {
     #[test]
     fn set_approval_for_all_rejects_self() {
         let mut c = transferable_collection();
-        assert!(c.set_approval_for_all(ALICE, ALICE, true).is_err());
+        assert!(c.set_approval_for_all(ALICE, ALICE, ALICE, true).is_err());
     }
 
     // ── burn (strict no-reuse) ───────────────────────────
@@ -426,7 +426,7 @@ mod tests {
         let mut c = transferable_collection();
         c.mint(ADMIN, ALICE, 1, "", None).unwrap();
         assert!(c.burn(BOB, 1).is_err());
-        assert_eq!(c.owner_of(1), Some(&ALICE.to_string()));
+        assert_eq!(c.owner_of(1), Some(ALICE));
     }
 
     #[test]
@@ -449,7 +449,7 @@ mod tests {
             Err(NftError::TokenAlreadyExists(1))
         );
         // tombstone preserved for audit
-        assert!(c.get_token(1).unwrap().burned);
+        assert!(c.token(1).unwrap().burned());
     }
 
     #[test]
@@ -502,8 +502,8 @@ mod tests {
         );
         c.update_collection_metadata(ADMIN, Some("desc".into()), Some("ipfs://b/".into()), None)
             .unwrap();
-        assert_eq!(c.description, "desc");
-        assert_eq!(c.base_uri, "ipfs://b/");
+        assert_eq!(c.description(), "desc");
+        assert_eq!(c.base_uri(), "ipfs://b/");
     }
 
     #[test]
@@ -522,16 +522,64 @@ mod tests {
     }
 
     #[test]
-    fn uri_hash_field_round_trips() {
-        let mut c = transferable_collection();
-        c.mint(ADMIN, ALICE, 1, "ipfs://x", None).unwrap();
-        // set integrity hashes directly on the token (no media bytes stored)
-        let t = c.tokens.get_mut(&1).unwrap();
+    fn uri_hash_fields_serde_round_trip() {
+        // Integrity hashes are optional URI references (never media bytes) and
+        // survive serialization. Tested on NftToken directly — collection
+        // internals are sealed.
+        let mut t = NftToken::new("SRC721_c".into(), 1, ALICE.into(), "ipfs://x".into(), true);
         t.uri_hash = Some("deadbeef".into());
         t.metadata_hash = Some("cafebabe".into());
-        let got = c.get_token(1).unwrap();
-        assert_eq!(got.uri_hash.as_deref(), Some("deadbeef"));
-        assert_eq!(got.metadata_hash.as_deref(), Some("cafebabe"));
+        let json = serde_json::to_string(&t).unwrap();
+        let back: NftToken = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.uri_hash.as_deref(), Some("deadbeef"));
+        assert_eq!(back.metadata_hash.as_deref(), Some("cafebabe"));
+        assert!(!back.burned());
+    }
+
+    // ── CodeRabbit hardening regressions ─────────────────
+
+    #[test]
+    fn set_approval_for_all_non_owner_rejected() {
+        // F1: a caller cannot set operator approvals on someone else's behalf.
+        let mut c = transferable_collection();
+        c.mint(ADMIN, ALICE, 1, "", None).unwrap();
+        // BOB tries to make CAROL an operator over ALICE's tokens.
+        assert_eq!(
+            c.set_approval_for_all(BOB, ALICE, CAROL, true),
+            Err(NftError::Unauthorized(
+                "caller may only set operator approvals for itself".into()
+            ))
+        );
+        assert!(!c.is_approved_for_all(ALICE, CAROL));
+    }
+
+    #[test]
+    fn collection_id_no_separator_collision() {
+        // F2: ambiguous-separator inputs must NOT collide.
+        let a = compute_collection_id("alice|x", "1");
+        let b = compute_collection_id("alice", "x|1");
+        assert_ne!(a, b, "length-prefixing must disambiguate the preimage");
+        // determinism preserved for identical inputs
+        assert_eq!(
+            compute_collection_id("alice", "x|1"),
+            compute_collection_id("alice", "x|1")
+        );
+    }
+
+    #[test]
+    fn collection_metadata_update_fails_after_lock() {
+        // F5: lock must block collection-level metadata, not just token URIs.
+        let mut c = transferable_collection();
+        // works before lock
+        c.update_collection_metadata(ADMIN, Some("d1".into()), None, None)
+            .unwrap();
+        c.lock_metadata(ADMIN).unwrap();
+        assert_eq!(
+            c.update_collection_metadata(ADMIN, Some("d2".into()), None, None),
+            Err(NftError::MetadataLocked)
+        );
+        // collection-level field unchanged
+        assert_eq!(c.description(), "d1");
     }
 
     // ── events ───────────────────────────────────────────

--- a/crates/sentrix-nft/src/registry.rs
+++ b/crates/sentrix-nft/src/registry.rs
@@ -1,0 +1,115 @@
+//! The collection registry and deterministic collection-id derivation.
+//!
+//! Collection ids/addresses are derived as `SRC721_<sha256(creator|seed)[..20]>`.
+//! The `seed` is supplied by the caller (the transaction id at the integration
+//! site) so every node derives the same address when applying the same block —
+//! no wall-clock time, no randomness.
+
+use crate::collection::NftCollection;
+use crate::error::{NftError, NftResult};
+use crate::events::NftEvent;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+
+/// Derive a deterministic collection address from creator + seed.
+pub fn compute_collection_id(creator: &str, seed: &str) -> String {
+    let payload = format!("{}|{}", creator, seed);
+    let hash = Sha256::digest(payload.as_bytes());
+    format!("SRC721_{}", hex::encode(&hash[..20]))
+}
+
+/// Holds every deployed native NFT collection.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NftRegistry {
+    /// collection id → collection.
+    pub collections: HashMap<String, NftCollection>,
+}
+
+impl NftRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Deploy a new collection. Returns the derived id and the
+    /// `CollectionCreated` event. Errors on bad params or id collision.
+    ///
+    /// `max_supply` is optional; `Some(0)` is rejected (use `None` for
+    /// unlimited).
+    #[allow(clippy::too_many_arguments)]
+    pub fn deploy_collection(
+        &mut self,
+        creator: &str,
+        name: &str,
+        symbol: &str,
+        base_uri: &str,
+        max_supply: Option<u64>,
+        default_transferable: bool,
+        metadata_mutable: bool,
+        seed: &str,
+    ) -> NftResult<(String, NftEvent)> {
+        if creator.is_empty() {
+            return Err(NftError::InvalidParams("empty creator".into()));
+        }
+        if name.is_empty() || name.len() > 64 {
+            return Err(NftError::InvalidParams("name must be 1–64 bytes".into()));
+        }
+        if symbol.is_empty()
+            || symbol.len() > 10
+            || !symbol.chars().all(|c| c.is_ascii_alphanumeric())
+        {
+            return Err(NftError::InvalidParams(
+                "symbol must be 1–10 ASCII alphanumeric chars".into(),
+            ));
+        }
+        if max_supply == Some(0) {
+            return Err(NftError::InvalidParams(
+                "max_supply cannot be 0 (use None for unlimited)".into(),
+            ));
+        }
+
+        let id = compute_collection_id(creator, seed);
+        if self.collections.contains_key(&id) {
+            return Err(NftError::CollectionExists(id));
+        }
+        let collection = NftCollection::new(
+            id.clone(),
+            creator.to_string(),
+            name.to_string(),
+            symbol.to_string(),
+            base_uri.to_string(),
+            max_supply,
+            default_transferable,
+            metadata_mutable,
+        );
+        self.collections.insert(id.clone(), collection);
+        let event = NftEvent::CollectionCreated {
+            collection_id: id.clone(),
+            creator: creator.to_string(),
+            name: name.to_string(),
+            symbol: symbol.to_string(),
+        };
+        Ok((id, event))
+    }
+
+    /// Borrow a collection by id.
+    pub fn get_collection(&self, id: &str) -> Option<&NftCollection> {
+        self.collections.get(id)
+    }
+
+    /// Mutably borrow a collection by id (for applying token operations).
+    pub fn get_collection_mut(&mut self, id: &str) -> Option<&mut NftCollection> {
+        self.collections.get_mut(id)
+    }
+
+    /// Whether a collection with this id exists.
+    pub fn collection_exists(&self, id: &str) -> bool {
+        self.collections.contains_key(id)
+    }
+
+    /// Number of deployed collections.
+    pub fn collection_count(&self) -> usize {
+        self.collections.len()
+    }
+}

--- a/crates/sentrix-nft/src/registry.rs
+++ b/crates/sentrix-nft/src/registry.rs
@@ -13,17 +13,31 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
 /// Derive a deterministic collection address from creator + seed.
+///
+/// Uses length-prefixed encoding (`len(creator) ‖ creator ‖ len(seed) ‖ seed`,
+/// lengths as `u64` big-endian) rather than a separator string. A separator
+/// like `"{creator}|{seed}"` is ambiguous — `("a|b", "c")` and `("a", "b|c")`
+/// would hash identically and collide on the same collection id. Length
+/// prefixing makes the preimage unambiguous.
 pub fn compute_collection_id(creator: &str, seed: &str) -> String {
-    let payload = format!("{}|{}", creator, seed);
-    let hash = Sha256::digest(payload.as_bytes());
+    let mut h = Sha256::new();
+    h.update((creator.len() as u64).to_be_bytes());
+    h.update(creator.as_bytes());
+    h.update((seed.len() as u64).to_be_bytes());
+    h.update(seed.as_bytes());
+    let hash = h.finalize();
     format!("SRC721_{}", hex::encode(&hash[..20]))
 }
 
 /// Holds every deployed native NFT collection.
+///
+/// The `collections` map is private: collections are only ever created through
+/// [`NftRegistry::deploy_collection`] (which validates params and assigns the
+/// deterministic id), so external code cannot insert an unvalidated collection
+/// under an arbitrary id or delete one. serde still persists the field.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NftRegistry {
-    /// collection id → collection.
-    pub collections: HashMap<String, NftCollection>,
+    collections: HashMap<String, NftCollection>,
 }
 
 impl NftRegistry {

--- a/crates/sentrix-nft/src/token.rs
+++ b/crates/sentrix-nft/src/token.rs
@@ -1,0 +1,61 @@
+//! The per-token model.
+//!
+//! A token carries its own transferability and freeze flags so the Proof
+//! Asset layer can mint soulbound (non-transferable) badges alongside normal
+//! transferable assets in the same collection. Burned tokens are kept as
+//! tombstones (`burned = true`) so their ids can never be reused — this keeps
+//! the reputation/audit history append-only.
+
+use serde::{Deserialize, Serialize};
+
+/// A single native NFT.
+///
+/// `owner` holds the last owner even after burn (for audit); read ownership
+/// through [`crate::NftCollection::owner_of`], which returns `None` for burned
+/// tokens.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NftToken {
+    /// Collection this token belongs to.
+    pub collection_id: String,
+    /// Token id (deterministic integer; never reused after burn).
+    pub token_id: u64,
+    /// Current owner (or last owner if `burned`).
+    pub owner: String,
+    /// Explicit metadata URI override. Empty means "derive from the
+    /// collection's `base_uri`" (`{base_uri}{token_id}`).
+    pub uri: String,
+    /// Optional hash of the URI target (integrity pin). Metadata bytes
+    /// themselves are never stored on-chain.
+    pub uri_hash: Option<String>,
+    /// Optional hash of the off-chain metadata document.
+    pub metadata_hash: Option<String>,
+    /// Whether this token may be transferred. `false` = soulbound.
+    pub transferable: bool,
+    /// Whether this token is individually frozen (transfers temporarily halted).
+    pub frozen: bool,
+    /// Whether this token has been burned (tombstone; id permanently retired).
+    pub burned: bool,
+}
+
+impl NftToken {
+    /// Construct a fresh, live token.
+    pub fn new(
+        collection_id: String,
+        token_id: u64,
+        owner: String,
+        uri: String,
+        transferable: bool,
+    ) -> Self {
+        Self {
+            collection_id,
+            token_id,
+            owner,
+            uri,
+            uri_hash: None,
+            metadata_hash: None,
+            transferable,
+            frozen: false,
+            burned: false,
+        }
+    }
+}

--- a/crates/sentrix-nft/src/token.rs
+++ b/crates/sentrix-nft/src/token.rs
@@ -5,6 +5,11 @@
 //! transferable assets in the same collection. Burned tokens are kept as
 //! tombstones (`burned = true`) so their ids can never be reused — this keeps
 //! the reputation/audit history append-only.
+//!
+//! Fields are private: the transferability / freeze / burned / owner
+//! invariants are enforced by [`crate::NftCollection`]'s methods, so the type
+//! must not allow external code to flip them directly. Read via the getters;
+//! mutation is `pub(crate)` and only happens inside `collection.rs`.
 
 use serde::{Deserialize, Serialize};
 
@@ -15,26 +20,20 @@ use serde::{Deserialize, Serialize};
 /// tokens.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NftToken {
-    /// Collection this token belongs to.
-    pub collection_id: String,
-    /// Token id (deterministic integer; never reused after burn).
-    pub token_id: u64,
-    /// Current owner (or last owner if `burned`).
-    pub owner: String,
-    /// Explicit metadata URI override. Empty means "derive from the
-    /// collection's `base_uri`" (`{base_uri}{token_id}`).
-    pub uri: String,
-    /// Optional hash of the URI target (integrity pin). Metadata bytes
-    /// themselves are never stored on-chain.
+    collection_id: String,
+    token_id: u64,
+    owner: String,
+    uri: String,
+    /// Optional integrity hash of the URI target (never media bytes). No
+    /// behavioral invariant, so it stays public — unlike owner/transferable/
+    /// frozen/burned which gate state transitions and are private.
     pub uri_hash: Option<String>,
-    /// Optional hash of the off-chain metadata document.
+    /// Optional hash of the off-chain metadata document. No behavioral
+    /// invariant; public like `uri_hash`.
     pub metadata_hash: Option<String>,
-    /// Whether this token may be transferred. `false` = soulbound.
-    pub transferable: bool,
-    /// Whether this token is individually frozen (transfers temporarily halted).
-    pub frozen: bool,
-    /// Whether this token has been burned (tombstone; id permanently retired).
-    pub burned: bool,
+    transferable: bool,
+    frozen: bool,
+    burned: bool,
 }
 
 impl NftToken {
@@ -57,5 +56,53 @@ impl NftToken {
             frozen: false,
             burned: false,
         }
+    }
+
+    // ── Getters ──────────────────────────────────────────
+
+    /// Collection this token belongs to.
+    pub fn collection_id(&self) -> &str {
+        &self.collection_id
+    }
+    /// Token id.
+    pub fn token_id(&self) -> u64 {
+        self.token_id
+    }
+    /// Current owner (or last owner if burned).
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+    /// Explicit metadata URI override (empty = derive from collection base_uri).
+    pub fn uri(&self) -> &str {
+        &self.uri
+    }
+    /// Whether this token may be transferred (`false` = soulbound).
+    pub fn transferable(&self) -> bool {
+        self.transferable
+    }
+    /// Whether this token is individually frozen.
+    pub fn frozen(&self) -> bool {
+        self.frozen
+    }
+    /// Whether this token has been burned (tombstone; id permanently retired).
+    pub fn burned(&self) -> bool {
+        self.burned
+    }
+
+    // ── Crate-internal mutation (only NftCollection methods) ──
+
+    pub(crate) fn set_owner(&mut self, owner: String) {
+        self.owner = owner;
+    }
+    pub(crate) fn set_uri(&mut self, uri: String) {
+        self.uri = uri;
+    }
+    pub(crate) fn set_frozen(&mut self, frozen: bool) {
+        self.frozen = frozen;
+    }
+    /// Mark the token burned and clear its freeze flag (tombstone).
+    pub(crate) fn mark_burned(&mut self) {
+        self.burned = true;
+        self.frozen = false;
     }
 }


### PR DESCRIPTION
## Summary

New workspace crate **`sentrix-nft`** — native NFT as a **Proof Asset / reputation layer** (validator/builder/contributor/bug-hunter/genesis proofs, soulbound badges). Not a marketplace, not a JPEG/PFP collection tool. EVM ERC-721/1155 remain a separate path.

Pure domain logic only: **no MDBX, trie, block execution, RPC, networking, consensus, marketplace, or bridge.** Metadata is URI-only — no image bytes, no IPFS/Arweave upload logic.

## Crate layout
- `collection.rs` — `NftCollection` + all token state transitions
- `token.rs` — `NftToken` (`transferable`/`frozen`/`burned`, optional uri + integrity hashes)
- `registry.rs` — `NftRegistry`, deterministic `SRC721_<sha256(creator|seed)>` id
- `events.rs` — `NftEvent` (typed, returned by every state change)
- `error.rs` — `NftError` (typed)

## Design
- Collection-scoped; `String` addresses + `u64` token ids (matches the SRC-20 native rail).
- **Soulbound**: `transferable=false`; transfer fails with typed `NotTransferable` — **no approval bypasses it** (checked before authorization).
- Per-token + collection freeze; metadata lock.
- **Strict no-reuse**: a burned token id is retired forever (tombstone) — append-only audit trail for the reputation layer.
- `max_supply` counts ever-minted (burning never frees a slot).

## Intentional behavior changes vs the earlier in-core `nft.rs`
1. Errors: `SentrixError` → typed `NftError`.
2. Token model: parallel HashMaps → `NftToken` struct (enables per-token soulbound/freeze).
3. **Strict no-reuse** replaces the earlier allow-re-mint-after-burn behavior (and its test), per the audit-trail requirement.

## Integration (thin)
`sentrix-core` depends on `sentrix-nft`; `sentrix-core/src/nft.rs` is now a facade (`pub use sentrix_nft::*`) + `nft_err_to_sentrix()` to bridge errors at the core boundary. No block-execution/trie/RPC wiring yet (deferred). `sentrix-nft` has **zero sentrix-\* deps** → no cycle.

## Tests / gate
- 36 unit + 2 doctests in `sentrix-nft`; 2 facade tests in core. Earlier 21 in-core tests superseded (same behaviors + soulbound, freeze, metadata-lock, operator, strict-no-reuse).
- `cargo test` (workspace): pass · `cargo fmt --check`: clean · `cargo clippy --workspace --all-targets -- -D warnings`: clean

## Deferred
MDBX/state integration, trie/state-root commitment, native NFT tx execution, JSON-RPC, explorer/wallet, ERC-721 adapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native NFT (Proof Asset) system supporting collection deployment, token minting, transfers, approvals, burning, and metadata management with authorization and transfer restriction controls.

* **Documentation**
  * Added comprehensive documentation for NFT functionality including usage examples and feature scope.

* **Chores**
  * Extended workspace configuration with new NFT and supporting crates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sentrix-labs/sentrix/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->