### PR TITLE
feat(nft): wire native NFT apply path (SRC-721) via sentrix-nft

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,12 +9,18 @@ name: Coverage
 # direct Codecov upload via lcov.
 #
 # Scope: EVM-free crates only for now (primitives, bft, staking,
-# trie, codec, wallet). The EVM-touching set (sentrix-evm, sentrix-
+# trie, codec, wallet, nft). The EVM-touching set (sentrix-evm, sentrix-
 # precompiles, sentrix-core, sentrix-rpc, sentrix-network, sentrix-
 # grpc, sentrix-storage, bin/sentrix) compiles and tests fine but
 # llvm-cov instrumentation against the revm dep tree is brittle on
 # CI runners; revisit when we drop a revm version that ships
 # explicit const-eval guard.
+#
+# sentrix-nft (pure Proof Asset domain crate, no revm) is in-scope. Note
+# the native-NFT *apply path* (dispatch + block wiring) lives in
+# sentrix-core, which is in the EVM-excluded set — those tests still run
+# in ci.yml's `cargo test`, they're just not in this coverage upload
+# until the EVM crates can be instrumented on CI.
 
 on:
   push:
@@ -67,6 +73,7 @@ jobs:
             --package sentrix-trie \
             --package sentrix-codec \
             --package sentrix-wallet \
+            --package sentrix-nft \
             --package sentrix-prom-exporter \
             --lcov --output-path lcov.info \
             --ignore-filename-regex '/(tests|benches)/'
@@ -80,6 +87,7 @@ jobs:
             --package sentrix-trie \
             --package sentrix-codec \
             --package sentrix-wallet \
+            --package sentrix-nft \
             --package sentrix-prom-exporter \
             --summary-only
 

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -52,6 +52,10 @@ pub enum BlockSource {
 pub(crate) struct BlockchainSnapshot {
     accounts: AccountDB,
     contracts: ContractRegistry,
+    /// Native NFT registry snapshot — restored alongside `contracts` on a
+    /// Pass-2 failure so a half-applied NFT op never survives a rolled-back
+    /// block (same atomicity contract as SRC-20 contract state).
+    nft_registry: sentrix_nft::NftRegistry,
     authority: AuthorityManager,
     mempool: VecDeque<Transaction>,
     total_minted: u64,
@@ -384,6 +388,12 @@ impl Blockchain {
         let mut working_balances: HashMap<String, u64> = HashMap::new();
         let mut working_nonces: HashMap<String, u64> = HashMap::new();
         let mut seen_sender_nonce: HashSet<(String, u64)> = HashSet::new();
+        // Pass-1 NFT dry-run state. Lazily cloned from `self.nft_registry`
+        // on the first NFT op so a deploy-then-mint within the same block
+        // validates against the in-block working registry, exactly mirroring
+        // what Pass-2 will mutate — without touching real state. Mirrors the
+        // working_balances / working_nonces clone pattern used for SRX.
+        let mut working_nft: Option<sentrix_nft::NftRegistry> = None;
 
         for tx in block.transactions.iter().skip(1) {
             // Phase D: system-emitted txs (JailEvidenceBundle from PROTOCOL_TREASURY)
@@ -536,6 +546,13 @@ impl Blockchain {
                                     .into(),
                             ));
                         }
+                        // Dry-run the op against a working clone so any
+                        // domain error (bad auth, unknown collection,
+                        // soulbound transfer, supply cap, id reuse) fails
+                        // here without mutating real state. Pass-2 re-applies
+                        // identically as the source of truth.
+                        let working = working_nft.get_or_insert_with(|| self.nft_registry.clone());
+                        crate::nft::apply_nft_token_op(working, op, &tx.from_address, &tx.txid)?;
                     }
                     // Audit L3 (2026-05-06): pre-fix this was
                     // `unreachable!("TokenOp variant handled above")`,
@@ -583,6 +600,7 @@ impl Blockchain {
         let snap = BlockchainSnapshot {
             accounts: self.accounts.clone(),
             contracts: self.contracts.clone(),
+            nft_registry: self.nft_registry.clone(),
             authority: self.authority.clone(),
             mempool: self.mempool.clone(),
             total_minted: self.total_minted,
@@ -625,6 +643,7 @@ impl Blockchain {
             Err(e) => {
                 self.accounts = snap.accounts;
                 self.contracts = snap.contracts;
+                self.nft_registry = snap.nft_registry;
                 self.authority = snap.authority;
                 self.mempool = snap.mempool;
                 // Audit M6: snapshot-restored `mempool` is the
@@ -907,11 +926,9 @@ impl Blockchain {
                         }
                     }
                     op if op.is_nft_family() => {
-                        // Pass-2 apply path: NFT TokenOp dispatch is
-                        // gated by NFT_TOKENOP_HEIGHT fork. Pre-fork:
-                        // reject (Pass-1 already rejected; this is
-                        // belt-and-suspenders). Storage layer handlers
-                        // land in the follow-up PR.
+                        // Pass-2 apply path: NFT TokenOp dispatch is gated by
+                        // NFT_TOKENOP_HEIGHT fork. Pre-fork: reject (Pass-1
+                        // already rejected; belt-and-suspenders).
                         if !Self::is_nft_tokenop_height(block.index) {
                             return Err(SentrixError::InvalidTransaction(
                                 "NFT TokenOp dispatch is gated by \
@@ -919,15 +936,26 @@ impl Blockchain {
                                     .into(),
                             ));
                         }
-                        // Post-fork dispatch land in follow-up PR; for
-                        // now reject explicitly so accidentally enabling
-                        // the fork doesn't silently apply non-existent
-                        // handlers.
-                        return Err(SentrixError::InvalidTransaction(
-                            "NFT TokenOp dispatch handlers not yet wired \
-                             (Phase B follow-up PR)"
-                                .into(),
-                        ));
+                        // Authority is the authenticated sender
+                        // (`tx.from_address`); the deterministic collection
+                        // seed is `tx.txid` (SRC-20 precedent). On Err the
+                        // Pass-2 snapshot restores `nft_registry`, so a
+                        // failed NFT op leaves no partial state.
+                        let events = crate::nft::apply_nft_token_op(
+                            &mut self.nft_registry,
+                            &op,
+                            &tx.from_address,
+                            &tx.txid,
+                        )?;
+                        if let Some(emitter) = &self.event_emitter {
+                            for ev in &events {
+                                emitter.emit_token_op(&crate::nft::nft_event_to_token_op_event(
+                                    ev,
+                                    &tx.txid,
+                                    block.index,
+                                ));
+                            }
+                        }
                     }
                     // Audit L3 sister site (Pass-2 dispatch). Same
                     // rationale as the Pass-1 fallthrough above — fail
@@ -1842,6 +1870,7 @@ mod tests {
     use crate::block_executor::BlockSource;
     use crate::blockchain::{Blockchain, CHAIN_ID};
     use secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use sentrix_primitives::error::{SentrixError, SentrixResult};
     use sentrix_primitives::transaction::{MIN_TX_FEE, TOKEN_OP_ADDRESS, TokenOp, Transaction};
 
     fn make_keypair() -> (SecretKey, PublicKey) {
@@ -2053,6 +2082,214 @@ mod tests {
             format!("{err:?}").contains("coinbase recipient"),
             "expected recipient-mismatch rejection, got: {err:?}"
         );
+    }
+
+    // ── Native NFT apply-path E2E (through add_block) ─────────
+    //
+    // These drive the full block path (mempool → create_block → add_block →
+    // Pass-1 dry-run → Pass-2 apply) to prove the wiring: the NFT_TOKENOP_HEIGHT
+    // fork gate, the `nft_registry` state field, and cross-node determinism.
+    // Behavioural depth (auth, soulbound, no-reuse, supply) is covered by the
+    // dispatch tests in `nft.rs`. NFT forks default to u64::MAX, so these set
+    // the height env var under the shared `env_test_lock` to avoid racing other
+    // env-touching tests.
+
+    fn nft_tx(op: &TokenOp, sk: &SecretKey, pk: &PublicKey, from: &str, nonce: u64) -> Transaction {
+        Transaction::new(
+            from.to_string(),
+            TOKEN_OP_ADDRESS.to_string(),
+            0,
+            MIN_TX_FEE,
+            nonce,
+            op.encode().unwrap(),
+            CHAIN_ID,
+            sk,
+            pk,
+        )
+        .unwrap()
+    }
+
+    /// Mine a single-tx block carrying `tx` onto `bc`.
+    fn mine(bc: &mut Blockchain, tx: Transaction) -> SentrixResult<()> {
+        bc.add_to_mempool(tx)?;
+        let block = bc.create_block("v1")?;
+        bc.add_block(block)
+    }
+
+    #[test]
+    fn nft_deploy_mint_transfer_through_add_block() {
+        let _guard = crate::test_util::env_test_lock();
+        unsafe {
+            std::env::set_var("NFT_TOKENOP_HEIGHT", "1");
+        }
+        let mut bc = setup();
+        let (sk, pk) = make_keypair();
+        let admin = derive_addr(&pk);
+        let (sk2, pk2) = make_keypair();
+        let bob = derive_addr(&pk2);
+        bc.accounts.credit(&admin, 10_000_000_000).unwrap();
+        bc.accounts.credit(&bob, 10_000_000_000).unwrap();
+
+        // Block 1: deploy.
+        let deploy = TokenOp::DeployNft {
+            name: "Validator Proof".into(),
+            symbol: "VPRF".into(),
+            base_uri: "ipfs://Q/".into(),
+            max_supply: 0,
+        };
+        let dtx = nft_tx(&deploy, &sk, &pk, &admin, 0);
+        let cid = crate::nft::compute_collection_id(&admin, &dtx.txid);
+        mine(&mut bc, dtx).expect("deploy block");
+        assert!(
+            bc.nft_registry.collection_exists(&cid),
+            "collection must exist after add_block"
+        );
+
+        // Block 2: mint token 1 to bob.
+        let mint = TokenOp::MintNft {
+            contract: cid.clone(),
+            to: bob.clone(),
+            token_id: 1,
+            metadata_uri: String::new(),
+        };
+        mine(&mut bc, nft_tx(&mint, &sk, &pk, &admin, 1)).expect("mint block");
+        assert_eq!(
+            bc.nft_registry.get_collection(&cid).unwrap().owner_of(1),
+            Some(bob.as_str())
+        );
+
+        // Block 3: bob transfers token 1 back to admin.
+        let xfer = TokenOp::TransferNft {
+            contract: cid.clone(),
+            from: bob.clone(),
+            to: admin.clone(),
+            token_id: 1,
+        };
+        mine(&mut bc, nft_tx(&xfer, &sk2, &pk2, &bob, 0)).expect("transfer block");
+        assert_eq!(
+            bc.nft_registry.get_collection(&cid).unwrap().owner_of(1),
+            Some(admin.as_str())
+        );
+
+        unsafe {
+            std::env::remove_var("NFT_TOKENOP_HEIGHT");
+        }
+    }
+
+    #[test]
+    fn nft_rejected_pre_fork_through_add_block() {
+        let _guard = crate::test_util::env_test_lock();
+        unsafe {
+            std::env::remove_var("NFT_TOKENOP_HEIGHT"); // default u64::MAX = disabled
+        }
+        let mut bc = setup();
+        let (sk, pk) = make_keypair();
+        let admin = derive_addr(&pk);
+        bc.accounts.credit(&admin, 10_000_000_000).unwrap();
+
+        let deploy = TokenOp::DeployNft {
+            name: "Too Early".into(),
+            symbol: "EARLY".into(),
+            base_uri: "u".into(),
+            max_supply: 0,
+        };
+        let err = mine(&mut bc, nft_tx(&deploy, &sk, &pk, &admin, 0)).unwrap_err();
+        assert!(
+            format!("{err:?}").contains("NFT_TOKENOP_HEIGHT"),
+            "pre-fork NFT op must be gated, got {err:?}"
+        );
+        assert_eq!(bc.nft_registry.collection_count(), 0);
+    }
+
+    #[test]
+    fn nft_collection_id_deterministic_across_nodes() {
+        let _guard = crate::test_util::env_test_lock();
+        unsafe {
+            std::env::set_var("NFT_TOKENOP_HEIGHT", "1");
+        }
+        let mut bc1 = setup();
+        let mut bc2 = setup();
+        let (sk, pk) = make_keypair();
+        let admin = derive_addr(&pk);
+        bc1.accounts.credit(&admin, 10_000_000_000).unwrap();
+        bc2.accounts.credit(&admin, 10_000_000_000).unwrap();
+
+        let deploy = TokenOp::DeployNft {
+            name: "Genesis Proof".into(),
+            symbol: "GEN".into(),
+            base_uri: "u".into(),
+            max_supply: 0,
+        };
+        // Same signed tx applied to both nodes → identical txid → identical id.
+        let tx = nft_tx(&deploy, &sk, &pk, &admin, 0);
+        let cid = crate::nft::compute_collection_id(&admin, &tx.txid);
+        mine(&mut bc1, tx.clone()).unwrap();
+        mine(&mut bc2, tx).unwrap();
+
+        assert_eq!(bc1.nft_registry.collection_count(), 1);
+        assert_eq!(bc2.nft_registry.collection_count(), 1);
+        // Compare by value (order-independent PartialEq), not serialized
+        // bytes — HashMap iteration order is per-process.
+        assert_eq!(
+            bc1.nft_registry.get_collection(&cid),
+            bc2.nft_registry.get_collection(&cid),
+            "both nodes must derive identical NFT state"
+        );
+
+        unsafe {
+            std::env::remove_var("NFT_TOKENOP_HEIGHT");
+        }
+    }
+
+    #[test]
+    fn nft_failed_block_leaves_registry_unchanged() {
+        let _guard = crate::test_util::env_test_lock();
+        unsafe {
+            std::env::set_var("NFT_TOKENOP_HEIGHT", "1");
+        }
+        let mut bc = setup();
+        let (sk, pk) = make_keypair();
+        let admin = derive_addr(&pk);
+        bc.accounts.credit(&admin, 10_000_000_000).unwrap();
+
+        // Deploy ok.
+        let deploy = TokenOp::DeployNft {
+            name: "Proof".into(),
+            symbol: "PRF".into(),
+            base_uri: "u".into(),
+            max_supply: 0,
+        };
+        let dtx = nft_tx(&deploy, &sk, &pk, &admin, 0);
+        let cid = crate::nft::compute_collection_id(&admin, &dtx.txid);
+        mine(&mut bc, dtx).unwrap();
+        let before = bc.nft_registry.get_collection(&cid).cloned();
+
+        // A block whose NFT op fails (mint by non-admin) must not mutate state.
+        let (sk2, pk2) = make_keypair();
+        let mallory = derive_addr(&pk2);
+        bc.accounts.credit(&mallory, 10_000_000_000).unwrap();
+        let mint = TokenOp::MintNft {
+            contract: cid.clone(),
+            to: mallory.clone(),
+            token_id: 1,
+            metadata_uri: String::new(),
+        };
+        let err = mine(&mut bc, nft_tx(&mint, &sk2, &pk2, &mallory, 0)).unwrap_err();
+        assert!(matches!(err, SentrixError::UnauthorizedValidator(_)));
+        // Registry unchanged (no token minted), compared by value.
+        assert_eq!(
+            bc.nft_registry.get_collection(&cid).cloned(),
+            before,
+            "failed block must leave nft_registry unchanged"
+        );
+        assert_eq!(
+            bc.nft_registry.get_collection(&cid).unwrap().owner_of(1),
+            None
+        );
+
+        unsafe {
+            std::env::remove_var("NFT_TOKENOP_HEIGHT");
+        }
     }
 
     // Contract address must be deterministic — same txid on any node produces the same address

--- a/crates/sentrix-core/src/block_executor/validate.rs
+++ b/crates/sentrix-core/src/block_executor/validate.rs
@@ -114,6 +114,11 @@ impl Blockchain {
         let mut working_balances: HashMap<String, u64> = HashMap::new();
         let mut working_nonces: HashMap<String, u64> = HashMap::new();
         let mut seen_sender_nonce: HashSet<(String, u64)> = HashSet::new();
+        // Read-only NFT pre-flight: lazily clone the registry and dry-run NFT
+        // ops so RPC/BFT readers reject obviously-broken NFT txs without the
+        // write lock. Optimisation only — Pass-1/Pass-2 in `add_block` re-run
+        // the same dispatch as the source of truth.
+        let mut working_nft: Option<sentrix_nft::NftRegistry> = None;
 
         for tx in block.transactions.iter().skip(1) {
             // Phase D: system-emitted txs (JailEvidenceBundle from PROTOCOL_TREASURY)
@@ -245,10 +250,8 @@ impl Blockchain {
                         }
                     }
                     op if op.is_nft_family() => {
-                        // SRC-721 + SRC-1155 dispatch is gated by
-                        // NFT_TOKENOP_HEIGHT fork. Pre-fork: reject. Wire
-                        // format stable from this PR; storage layer +
-                        // dispatch land in the follow-up PR.
+                        // SRC-721 dispatch is gated by NFT_TOKENOP_HEIGHT
+                        // fork. Pre-fork: reject.
                         if !Self::is_nft_tokenop_height(self.height() + 1) {
                             return Err(SentrixError::InvalidTransaction(
                                 "NFT TokenOp dispatch is gated by \
@@ -256,6 +259,10 @@ impl Blockchain {
                                     .into(),
                             ));
                         }
+                        // Post-fork read-only pre-flight: dry-run against a
+                        // working clone (same dispatch Pass-1/Pass-2 use).
+                        let working = working_nft.get_or_insert_with(|| self.nft_registry.clone());
+                        crate::nft::apply_nft_token_op(working, op, &tx.from_address, &tx.txid)?;
                     }
                     _ => unreachable!("TokenOp variant handled above"),
                 }

--- a/crates/sentrix-core/src/blockchain.rs
+++ b/crates/sentrix-core/src/blockchain.rs
@@ -68,6 +68,18 @@ pub struct Blockchain {
     pub accounts: AccountDB, // pub: main.rs uses accounts.get_balance() for CLI display
     pub authority: AuthorityManager, // pub: main.rs uses authority.* for validator management
     pub contracts: ContractRegistry,
+    /// Native NFT / Proof Asset registry (SRC-721). Follows the same
+    /// persistence model as `contracts`: serialized in the chain.db state
+    /// blob, NOT committed into the trie/state_root yet. `#[serde(default)]`
+    /// so pre-NFT chain.db blobs deserialize cleanly (empty registry).
+    ///
+    /// KNOWN GAP (deferred to `feat/native-module-state-commitment`): like
+    /// SRC-20 `contracts`, this state is reproduced by deterministic
+    /// re-execution + the blob cache, but a divergent registry is NOT caught
+    /// by a state_root mismatch. Not production/testnet-deploy ready until
+    /// native-module state is committed into the trie.
+    #[serde(default)]
+    pub nft_registry: sentrix_nft::NftRegistry,
     pub mempool: VecDeque<Transaction>,
     /// Audit M6 (2026-05-06): O(1) duplicate-txid check sidecar for
     /// `add_to_mempool`. Pre-fix the dup-scan was `mempool.iter().any(...)`
@@ -212,6 +224,7 @@ impl Blockchain {
             accounts: AccountDB::new(),
             authority: AuthorityManager::new(admin_address),
             contracts: ContractRegistry::new(),
+            nft_registry: sentrix_nft::NftRegistry::new(),
             mempool: VecDeque::new(),
             mempool_txids: std::collections::HashSet::new(),
             mempool_sender_count: std::collections::HashMap::new(),

--- a/crates/sentrix-core/src/nft.rs
+++ b/crates/sentrix-core/src/nft.rs
@@ -15,6 +15,8 @@ pub use sentrix_nft::{
 };
 
 use sentrix_primitives::error::SentrixError;
+use sentrix_primitives::events::TokenOpEvent;
+use sentrix_primitives::transaction::TokenOp;
 
 /// Map a pure NFT domain error onto the workspace error type at the
 /// sentrix-core boundary. Authorization failures become
@@ -29,6 +31,230 @@ pub fn nft_err_to_sentrix(e: NftError) -> SentrixError {
         NftError::Unauthorized(_) => SentrixError::UnauthorizedValidator(e.to_string()),
         NftError::Overflow(_) => SentrixError::Internal(e.to_string()),
         other => SentrixError::InvalidTransaction(other.to_string()),
+    }
+}
+
+/// Apply one SRC-721 NFT `TokenOp` against `registry`, returning the domain
+/// events it produced. This is the single dispatch point shared by all three
+/// block-execution layers (read-only validate, Pass-1 dry-run, Pass-2 apply):
+/// the caller passes `&mut self.nft_registry` to mutate real state, or a
+/// `&mut clone` to dry-run.
+///
+/// `sender` is the authenticated transaction sender (`tx.from_address`) — it
+/// is the ONLY authorization principal. NFT payloads never carry a `caller`
+/// field, and where a payload does carry an address (`TransferNft.from`) it is
+/// treated as untrusted claimed data that the domain checks against the real
+/// owner; authority always comes from `sender`. `seed` is `tx.txid`, matching
+/// the SRC-20 deterministic-address precedent (no wall-clock, no randomness).
+///
+/// Deterministic: the function only reads `op`, `sender`, `seed`, and the
+/// registry state, so two nodes applying the same block produce identical
+/// results and identical collection ids.
+///
+/// Scope (this PR): only the merged SRC-721 variants are wired. SRC-1155 and
+/// the metadata/freeze admin ops have no TokenOp variant yet and return an
+/// error here. Soulbound collections cannot yet be *deployed* via `DeployNft`
+/// (the wire format carries no transferability selector) — apply-path
+/// soulbound *enforcement* is fully wired and tested. See PR notes.
+pub fn apply_nft_token_op(
+    registry: &mut NftRegistry,
+    op: &TokenOp,
+    sender: &str,
+    seed: &str,
+) -> Result<Vec<NftEvent>, SentrixError> {
+    fn collection_mut<'a>(
+        reg: &'a mut NftRegistry,
+        contract: &str,
+    ) -> Result<&'a mut NftCollection, SentrixError> {
+        reg.get_collection_mut(contract)
+            .ok_or_else(|| SentrixError::NotFound(format!("nft collection {contract}")))
+    }
+
+    let event = match op {
+        TokenOp::DeployNft {
+            name,
+            symbol,
+            base_uri,
+            max_supply,
+        } => {
+            // SRC-20 precedent: max_supply == 0 means unlimited → None.
+            let max = if *max_supply == 0 {
+                None
+            } else {
+                Some(*max_supply)
+            };
+            // The merged DeployNft wire format carries no soulbound /
+            // metadata-mutability selector, so native collections default to
+            // transferable + mutable metadata. Deploying soulbound proof
+            // assets via tx needs a DeployNft field — deferred (see report).
+            let (_id, ev) = registry
+                .deploy_collection(sender, name, symbol, base_uri, max, true, true, seed)
+                .map_err(nft_err_to_sentrix)?;
+            ev
+        }
+        TokenOp::MintNft {
+            contract,
+            to,
+            token_id,
+            metadata_uri,
+        } => collection_mut(registry, contract)?
+            // transferable = None → use the collection default.
+            .mint(sender, to, *token_id, metadata_uri, None)
+            .map_err(nft_err_to_sentrix)?,
+        TokenOp::TransferNft {
+            contract,
+            from,
+            to,
+            token_id,
+        } => collection_mut(registry, contract)?
+            // `from` is untrusted claimed data; the domain checks it against
+            // the real owner. Authority is `sender` (caller).
+            .transfer(sender, from, to, *token_id)
+            .map_err(nft_err_to_sentrix)?,
+        TokenOp::BurnNft { contract, token_id } => collection_mut(registry, contract)?
+            // Domain clears the token's approval as part of the burn.
+            .burn(sender, *token_id)
+            .map_err(nft_err_to_sentrix)?,
+        TokenOp::ApproveNft {
+            contract,
+            spender,
+            token_id,
+        } => collection_mut(registry, contract)?
+            .approve(sender, spender, *token_id)
+            .map_err(nft_err_to_sentrix)?,
+        TokenOp::SetApprovalForAll {
+            contract,
+            operator,
+            approved,
+        } => collection_mut(registry, contract)?
+            // owner == sender: a caller may only manage operators for tokens
+            // it owns. The domain re-enforces caller == owner, so a payload
+            // can never set approvals on behalf of a different owner.
+            .set_approval_for_all(sender, sender, operator, *approved)
+            .map_err(nft_err_to_sentrix)?,
+        _ => {
+            return Err(SentrixError::InvalidTransaction(
+                "unsupported NFT TokenOp in apply path \
+                 (SRC-1155 / admin metadata ops deferred)"
+                    .into(),
+            ));
+        }
+    };
+    Ok(vec![event])
+}
+
+/// Map an [`NftEvent`] onto the existing [`TokenOpEvent`] WS/SSE channel.
+/// Lossy by design — it reuses the SRC-20 emitter rather than inventing a
+/// native NFT event subsystem (deferred). `amount` carries the `token_id`
+/// for token-level events (0 for collection-level).
+pub fn nft_event_to_token_op_event(ev: &NftEvent, txid: &str, block_height: u64) -> TokenOpEvent {
+    let (op, contract, from, to, amount) = match ev {
+        NftEvent::CollectionCreated {
+            collection_id,
+            creator,
+            ..
+        } => (
+            "deploy_nft",
+            collection_id,
+            creator.clone(),
+            String::new(),
+            0,
+        ),
+        NftEvent::TokenMinted {
+            collection_id,
+            token_id,
+            to,
+            ..
+        } => (
+            "mint_nft",
+            collection_id,
+            String::new(),
+            to.clone(),
+            *token_id,
+        ),
+        NftEvent::TokenTransferred {
+            collection_id,
+            token_id,
+            from,
+            to,
+        } => (
+            "transfer_nft",
+            collection_id,
+            from.clone(),
+            to.clone(),
+            *token_id,
+        ),
+        NftEvent::TokenBurned {
+            collection_id,
+            token_id,
+            owner,
+        } => (
+            "burn_nft",
+            collection_id,
+            owner.clone(),
+            String::new(),
+            *token_id,
+        ),
+        NftEvent::TokenApproved {
+            collection_id,
+            token_id,
+            owner,
+            approved,
+        } => (
+            "approve_nft",
+            collection_id,
+            owner.clone(),
+            approved.clone(),
+            *token_id,
+        ),
+        NftEvent::ApprovalForAll {
+            collection_id,
+            owner,
+            operator,
+            approved,
+        } => (
+            "set_approval_for_all",
+            collection_id,
+            owner.clone(),
+            operator.clone(),
+            u64::from(*approved),
+        ),
+        NftEvent::CollectionUpdated { collection_id }
+        | NftEvent::CollectionFrozen { collection_id }
+        | NftEvent::CollectionMetadataLocked { collection_id } => (
+            "nft_collection_update",
+            collection_id,
+            String::new(),
+            String::new(),
+            0,
+        ),
+        NftEvent::TokenUriUpdated {
+            collection_id,
+            token_id,
+        }
+        | NftEvent::TokenFrozen {
+            collection_id,
+            token_id,
+        }
+        | NftEvent::TokenUnfrozen {
+            collection_id,
+            token_id,
+        } => (
+            "nft_token_update",
+            collection_id,
+            String::new(),
+            String::new(),
+            *token_id,
+        ),
+    };
+    TokenOpEvent {
+        op: op.to_string(),
+        contract: contract.clone(),
+        from,
+        to,
+        amount,
+        txid: txid.to_string(),
+        block_height,
     }
 }
 
@@ -60,5 +286,308 @@ mod tests {
             .deploy_collection("0xa", "C", "C", "u", None, true, true, "tx")
             .unwrap();
         assert!(reg.collection_exists(&id));
+    }
+
+    // ── apply-path dispatch tests ────────────────────────────
+    //
+    // These exercise `apply_nft_token_op` directly — the exact function the
+    // read-only validate, Pass-1 dry-run, and Pass-2 apply layers all call.
+    // Testing it here covers the wired apply logic (sender authorization,
+    // deterministic seed, soulbound enforcement, strict no-reuse, supply
+    // accounting, typed-error mapping) deterministically and without the
+    // env-gated full block harness. End-to-end `add_block` wiring (fork gate,
+    // snapshot rollback, cross-node determinism) is covered separately in
+    // `block_executor.rs`.
+
+    const ADMIN: &str = "0xadmin";
+    const ALICE: &str = "0xalice";
+    const BOB: &str = "0xbob";
+
+    fn deploy(reg: &mut NftRegistry, seed: &str) -> String {
+        let op = TokenOp::DeployNft {
+            name: "Proof".into(),
+            symbol: "PRF".into(),
+            base_uri: "ipfs://Q/".into(),
+            max_supply: 0,
+        };
+        let evs = apply_nft_token_op(reg, &op, ADMIN, seed).expect("deploy");
+        match &evs[0] {
+            NftEvent::CollectionCreated { collection_id, .. } => collection_id.clone(),
+            other => panic!("expected CollectionCreated, got {other:?}"),
+        }
+    }
+
+    fn mint(
+        reg: &mut NftRegistry,
+        cid: &str,
+        to: &str,
+        token_id: u64,
+        caller: &str,
+    ) -> Result<Vec<NftEvent>, SentrixError> {
+        let op = TokenOp::MintNft {
+            contract: cid.into(),
+            to: to.into(),
+            token_id,
+            metadata_uri: String::new(),
+        };
+        apply_nft_token_op(reg, &op, caller, "mintseed")
+    }
+
+    fn transfer(
+        reg: &mut NftRegistry,
+        cid: &str,
+        from: &str,
+        to: &str,
+        id: u64,
+        caller: &str,
+    ) -> Result<Vec<NftEvent>, SentrixError> {
+        let op = TokenOp::TransferNft {
+            contract: cid.into(),
+            from: from.into(),
+            to: to.into(),
+            token_id: id,
+        };
+        apply_nft_token_op(reg, &op, caller, "xferseed")
+    }
+
+    // 1. DeployNft through the apply dispatch.
+    #[test]
+    fn apply_deploy_creates_collection() {
+        let mut reg = NftRegistry::new();
+        let cid = deploy(&mut reg, "tx1");
+        let c = reg.get_collection(&cid).expect("collection");
+        assert_eq!(c.creator(), ADMIN);
+        assert_eq!(c.admin(), ADMIN);
+        assert_eq!(c.name(), "Proof");
+        // max_supply 0 → unlimited (None), default transferable + mutable.
+        assert_eq!(c.max_supply(), None);
+        assert!(c.default_transferable());
+    }
+
+    // 2. MintNft through the apply dispatch.
+    #[test]
+    fn apply_mint_assigns_owner() {
+        let mut reg = NftRegistry::new();
+        let cid = deploy(&mut reg, "tx1");
+        mint(&mut reg, &cid, ALICE, 1, ADMIN).expect("mint");
+        assert_eq!(reg.get_collection(&cid).unwrap().owner_of(1), Some(ALICE));
+    }
+
+    // 3. TransferNft of a transferable token.
+    #[test]
+    fn apply_transfer_transferable_moves_owner() {
+        let mut reg = NftRegistry::new();
+        let cid = deploy(&mut reg, "tx1");
+        mint(&mut reg, &cid, ALICE, 1, ADMIN).unwrap();
+        transfer(&mut reg, &cid, ALICE, BOB, 1, ALICE).expect("transfer");
+        assert_eq!(reg.get_collection(&cid).unwrap().owner_of(1), Some(BOB));
+    }
+
+    // 4. Soulbound token cannot transfer through the apply path. The merged
+    //    DeployNft wire format can't request soulbound, so the collection is
+    //    seeded soulbound via the domain ctor; the mint + transfer still go
+    //    through the apply dispatch, proving apply-path enforcement.
+    #[test]
+    fn apply_transfer_soulbound_rejected() {
+        let mut reg = NftRegistry::new();
+        let (cid, _) = reg
+            .deploy_collection(ADMIN, "Soul", "SBT", "u", None, false, true, "seedsb")
+            .unwrap();
+        mint(&mut reg, &cid, ALICE, 1, ADMIN).unwrap();
+        let err = transfer(&mut reg, &cid, ALICE, BOB, 1, ALICE).unwrap_err();
+        assert!(
+            matches!(err, SentrixError::InvalidTransaction(ref m) if m.contains("not transferable") || m.contains("transferable")),
+            "soulbound transfer must map to a typed rejection, got {err:?}"
+        );
+        // Ownership unchanged.
+        assert_eq!(reg.get_collection(&cid).unwrap().owner_of(1), Some(ALICE));
+    }
+
+    // 5. Approved single-token spender can transfer a transferable NFT.
+    #[test]
+    fn apply_approved_spender_can_transfer() {
+        let mut reg = NftRegistry::new();
+        let cid = deploy(&mut reg, "tx1");
+        mint(&mut reg, &cid, ALICE, 1, ADMIN).unwrap();
+        // ALICE approves BOB for token 1.
+        let approve = TokenOp::ApproveNft {
+            contract: cid.clone(),
+            spender: BOB.into(),
+            token_id: 1,
+        };
+        apply_nft_token_op(&mut reg, &approve, ALICE, "aseed").unwrap();
+        // BOB (the approved spender) moves it to himself.
+        transfer(&mut reg, &cid, ALICE, BOB, 1, BOB).expect("approved transfer");
+        assert_eq!(reg.get_collection(&cid).unwrap().owner_of(1), Some(BOB));
+    }
+
+    // 6. Operator (approval-for-all) can transfer any of the owner's tokens.
+    #[test]
+    fn apply_operator_can_transfer() {
+        let mut reg = NftRegistry::new();
+        let cid = deploy(&mut reg, "tx1");
+        mint(&mut reg, &cid, ALICE, 1, ADMIN).unwrap();
+        // ALICE sets BOB as operator for all her tokens (owner == sender).
+        let op = TokenOp::SetApprovalForAll {
+            contract: cid.clone(),
+            operator: BOB.into(),
+            approved: true,
+        };
+        apply_nft_token_op(&mut reg, &op, ALICE, "opseed").unwrap();
+        transfer(&mut reg, &cid, ALICE, BOB, 1, BOB).expect("operator transfer");
+        assert_eq!(reg.get_collection(&cid).unwrap().owner_of(1), Some(BOB));
+    }
+
+    // 7. A caller cannot set operator approval on behalf of a different owner:
+    //    owner is forced to the sender, so the operator is set for the SENDER,
+    //    never for the impersonated victim.
+    #[test]
+    fn apply_set_approval_for_all_owner_is_sender() {
+        let mut reg = NftRegistry::new();
+        let cid = deploy(&mut reg, "tx1");
+        mint(&mut reg, &cid, ALICE, 1, ADMIN).unwrap();
+        // BOB tries to make himself operator of ALICE's tokens. owner is
+        // pinned to the sender (BOB), so this grants BOB→operate-on-BOB only.
+        let op = TokenOp::SetApprovalForAll {
+            contract: cid.clone(),
+            operator: "0xcarol".into(),
+            approved: true,
+        };
+        apply_nft_token_op(&mut reg, &op, BOB, "evilseed").expect("sets for BOB only");
+        let c = reg.get_collection(&cid).unwrap();
+        // Carol is NOT an operator over ALICE.
+        assert!(!c.is_approved_for_all(ALICE, "0xcarol"));
+        // BOB still cannot move ALICE's token.
+        let err = transfer(&mut reg, &cid, ALICE, BOB, 1, BOB).unwrap_err();
+        assert!(matches!(err, SentrixError::UnauthorizedValidator(_)));
+    }
+
+    // 8. BurnNft works and clears the token's single-token approval.
+    #[test]
+    fn apply_burn_works_and_clears_approval() {
+        let mut reg = NftRegistry::new();
+        let cid = deploy(&mut reg, "tx1");
+        mint(&mut reg, &cid, ALICE, 1, ADMIN).unwrap();
+        let approve = TokenOp::ApproveNft {
+            contract: cid.clone(),
+            spender: BOB.into(),
+            token_id: 1,
+        };
+        apply_nft_token_op(&mut reg, &approve, ALICE, "aseed").unwrap();
+        let burn = TokenOp::BurnNft {
+            contract: cid.clone(),
+            token_id: 1,
+        };
+        apply_nft_token_op(&mut reg, &burn, ALICE, "bseed").expect("burn");
+        let c = reg.get_collection(&cid).unwrap();
+        assert_eq!(c.owner_of(1), None, "burned token has no live owner");
+        assert_eq!(c.get_approved(1), None, "burn cleared approval");
+    }
+
+    // 9. A burned token id can never be reminted (strict no-reuse).
+    #[test]
+    fn apply_burned_id_not_reusable() {
+        let mut reg = NftRegistry::new();
+        let cid = deploy(&mut reg, "tx1");
+        mint(&mut reg, &cid, ALICE, 1, ADMIN).unwrap();
+        let burn = TokenOp::BurnNft {
+            contract: cid.clone(),
+            token_id: 1,
+        };
+        apply_nft_token_op(&mut reg, &burn, ALICE, "bseed").unwrap();
+        let err = mint(&mut reg, &cid, BOB, 1, ADMIN).unwrap_err();
+        assert!(
+            matches!(err, SentrixError::InvalidTransaction(ref m) if m.contains("already")),
+            "reusing a burned id must be rejected, got {err:?}"
+        );
+    }
+
+    // 10. max_supply counts ever-minted; a burn does NOT free a slot.
+    #[test]
+    fn apply_max_supply_counts_ever_minted() {
+        let mut reg = NftRegistry::new();
+        let (cid, _) = reg
+            .deploy_collection(ADMIN, "Cap", "CAP", "u", Some(1), true, true, "capseed")
+            .unwrap();
+        mint(&mut reg, &cid, ALICE, 1, ADMIN).unwrap();
+        // Burn the only token — supply drops but total_minted stays at the cap.
+        let burn = TokenOp::BurnNft {
+            contract: cid.clone(),
+            token_id: 1,
+        };
+        apply_nft_token_op(&mut reg, &burn, ALICE, "bseed").unwrap();
+        // A second mint must still be refused — the slot is not freed.
+        let err = mint(&mut reg, &cid, BOB, 2, ADMIN).unwrap_err();
+        assert!(
+            matches!(err, SentrixError::InvalidTransaction(ref m) if m.contains("supply") || m.contains("max")),
+            "max_supply must count ever-minted, got {err:?}"
+        );
+    }
+
+    // 11. Metadata-lock / collection-metadata ops are NOT exposed by the
+    //     wired SRC-721 TokenOp subset (no UpdateTokenUri / LockMetadata
+    //     variant), so the apply path cannot reach them in this PR. The
+    //     domain crate covers metadata-lock behavior in its own tests. Here
+    //     we assert the apply path refuses an out-of-scope NFT variant rather
+    //     than silently doing nothing.
+    #[test]
+    fn apply_unsupported_nft_variant_rejected() {
+        let mut reg = NftRegistry::new();
+        // SRC-1155 family is `is_nft_family()` but not wired here.
+        let op = TokenOp::DeployMulti {
+            name: "M".into(),
+            symbol: "M".into(),
+            base_uri: "u".into(),
+        };
+        let err = apply_nft_token_op(&mut reg, &op, ADMIN, "seed").unwrap_err();
+        assert!(
+            matches!(err, SentrixError::InvalidTransaction(ref m) if m.contains("unsupported"))
+        );
+    }
+
+    // 12. Deterministic replay: applying the same ops to two fresh registries
+    //     yields identical collection ids and identical resulting state.
+    #[test]
+    fn apply_deterministic_replay() {
+        let run = || {
+            let mut reg = NftRegistry::new();
+            let cid = deploy(&mut reg, "same-txid");
+            mint(&mut reg, &cid, ALICE, 7, ADMIN).unwrap();
+            transfer(&mut reg, &cid, ALICE, BOB, 7, ALICE).unwrap();
+            (cid, reg)
+        };
+        let (cid_a, reg_a) = run();
+        let (cid_b, reg_b) = run();
+        assert_eq!(cid_a, cid_b, "collection id must be deterministic");
+        // Logical state equality. NftCollection derives PartialEq, whose
+        // HashMap comparison is order-independent — the correct notion of
+        // determinism here. (Serialized-byte equality is NOT a valid check:
+        // HashMap iteration order is per-process; canonical ordering is the
+        // deferred state_root work's job, not the in-memory registry's.)
+        assert_eq!(
+            reg_a.get_collection(&cid_a),
+            reg_b.get_collection(&cid_b),
+            "replayed collections must be logically identical"
+        );
+    }
+
+    // 13. An unauthorized action maps to a typed SentrixError. Non-admin mint.
+    #[test]
+    fn apply_unauthorized_mint_typed_error() {
+        let mut reg = NftRegistry::new();
+        let cid = deploy(&mut reg, "tx1");
+        let err = mint(&mut reg, &cid, ALICE, 1, BOB).unwrap_err(); // BOB != admin
+        assert!(
+            matches!(err, SentrixError::UnauthorizedValidator(_)),
+            "non-admin mint must map to UnauthorizedValidator, got {err:?}"
+        );
+    }
+
+    // Unknown collection → NotFound (not a panic).
+    #[test]
+    fn apply_unknown_collection_not_found() {
+        let mut reg = NftRegistry::new();
+        let err = mint(&mut reg, "SRC721_deadbeef", ALICE, 1, ADMIN).unwrap_err();
+        assert!(matches!(err, SentrixError::NotFound(_)));
     }
 }


### PR DESCRIPTION
Wires the merged SRC-721 `TokenOp` variants into the existing block execution path using the `sentrix-nft` domain crate. Option A: follows the SRC-20 native-module precedent; state_root/trie commitment is **explicitly deferred**.

## What this does
Dispatches 6 SRC-721 ops through the existing 3-layer path:
- `DeployCollection` (DeployNft), `Mint` (MintNft), `Transfer` (TransferNft), `Burn` (BurnNft), `Approve` (ApproveNft), `SetApprovalForAll`

Layers wired (mirrors SRC-20):
1. read-only `validate_block` — lazy working-clone dry-run
2. Pass-1 dry-run — lazy working-clone dry-run (handles intra-block deploy→mint)
3. Pass-2 apply — mutates `Blockchain.nft_registry`, emits via existing `TokenOpEvent`

## Authorization
- Caller is **always** `tx.from_address` (authenticated sender). NFT payloads carry no `caller`.
- `TransferNft.from` is treated as untrusted claimed data; the domain cross-checks it against the real owner.
- `set_approval_for_all`: owner pinned to sender — a payload can't grant approvals for another owner.
- Deterministic collection seed = `tx.txid` (SRC-20 precedent; no wall-clock, no randomness).
- Gated by `NFT_TOKENOP_HEIGHT` (default `u64::MAX` = disabled).

## ⚠️ Deferred (NOT production/testnet-ready)
- **state_root/trie commitment**: `nft_registry` is serialized in the chain.db blob, NOT in the trie — identical to SRC-20 `contracts`. A divergent registry is NOT caught by a state_root mismatch. → next branch `feat/native-module-state-commitment`.
- **Soulbound deploy via tx**: `DeployNft` wire format has no transferability selector, so apply-path-deployed collections default to transferable. Soulbound *enforcement* is wired + tested; soulbound *deployment* via tx needs a `DeployNft` field (follow-up). This matters for the Proof Asset product goal (validator/builder/contributor/bug-hunter proofs are inherently soulbound).
- **Deferred ops** (no TokenOp variant yet): ClearApproval, UpdateTokenUri, UpdateCollectionMetadata, FreezeCollection, LockMetadata, SetTokenFrozen, and the entire SRC-1155 family (dispatch rejects them with a typed error).

## Tests (20)
16 dispatch + 4 E2E through `add_block`: deploy/mint/transfer, soulbound transfer rejected, approved spender, operator approval, owner-pinned set_approval_for_all, burn clears approval, strict no-reuse, max_supply counts ever-minted, deterministic replay, typed errors, pre-fork rejection, cross-node determinism, failed-block rollback.

## Coverage
`sentrix-nft` added to the `cargo-llvm-cov` package set (92.8% lines locally). The apply-path wiring itself lives in `sentrix-core`, which stays in the EVM-excluded coverage set (revm instrumentation brittleness) — its tests run in `ci.yml`'s `cargo test`.

## Commands
- `cargo test -p sentrix-nft` ✅ (39 + 2 doctests)
- `cargo test --workspace` ✅ (66 suites, 0 failures)
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅

Do not deploy. No RPC/explorer/wallet/marketplace/bridge/image-bytes. No trie/state-root/MDBX-table changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated NFT token operations (deploy, mint, transfer, burn, approvals) into block validation and execution pipeline.
  * NFT state is now properly validated during block processing and committed on success.
  * NFT events are now generated and emitted through the standard event system.

* **Tests**
  * Expanded test coverage for end-to-end NFT functionality including deploy, mint, transfer, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->