### PR TITLE
feat(state): canonical fingerprint commitment for native module state (SRC-20 + NFT)

### DIFF
--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -1817,6 +1817,34 @@ fn emit_state_fingerprint(bc: &Blockchain, height: u64) {
     if std::env::var_os("SENTRIX_STATE_FINGERPRINT").is_none() {
         return;
     }
+    let (acc_fp, fp) = compute_state_fingerprint(bc);
+    // eprintln! matches the existing `[V2-DBG]` trace pattern in
+    // `update_trie_for_block` — guaranteed journalctl visibility
+    // regardless of RUST_LOG / tracing subscriber filter config.
+    eprintln!(
+        "[STATE-FP] h={} acc={} fp={}",
+        height,
+        hex::encode(&acc_fp[..8]),
+        hex::encode(&fp[..8]),
+    );
+}
+
+/// Compute `(account_fingerprint, combined_fingerprint)` for the current
+/// state. Split out of `emit_state_fingerprint` so it's testable without the
+/// `SENTRIX_STATE_FINGERPRINT` env gate or stderr capture.
+///
+/// The combined fingerprint folds, in fixed order:
+///   account state · total_minted · SRC-20 ContractRegistry · NFT NftRegistry
+///
+/// Native-module state commitment (2026-06-03): before this, the fingerprint
+/// hashed only accounts + total_minted + EVM code/storage, so two validators
+/// could diverge purely in SRC-20 or NFT state and still print identical
+/// `[STATE-FP]` lines — the incident tool was blind on those paths. Both
+/// registries now contribute via their `canonical_hash()` (sorted, HashMap-
+/// order-independent). Consensus-enforced trie/state_root commitment of the
+/// same state is the fork-gated follow-up; this closes the debug-visibility
+/// gap without a consensus change.
+fn compute_state_fingerprint(bc: &Blockchain) -> ([u8; 32], [u8; 32]) {
     use sha2::{Digest, Sha256};
 
     let mut acc_hasher = Sha256::new();
@@ -1851,17 +1879,12 @@ fn emit_state_fingerprint(bc: &Blockchain, height: u64) {
     let mut combined = Sha256::new();
     combined.update(acc_fp);
     combined.update(bc.total_minted.to_be_bytes());
+    // Native-module state: SRC-20 then NFT, each canonical (sorted) so
+    // HashMap iteration order can't move the fingerprint.
+    combined.update(bc.contracts.canonical_hash());
+    combined.update(bc.nft_registry.canonical_hash());
     let fp: [u8; 32] = combined.finalize().into();
-
-    // eprintln! matches the existing `[V2-DBG]` trace pattern in
-    // `update_trie_for_block` — guaranteed journalctl visibility
-    // regardless of RUST_LOG / tracing subscriber filter config.
-    eprintln!(
-        "[STATE-FP] h={} acc={} fp={}",
-        height,
-        hex::encode(&acc_fp[..8]),
-        hex::encode(&fp[..8]),
-    );
+    (acc_fp, fp)
 }
 
 // ── Tests ─────────────────────────────────────────────────
@@ -2082,6 +2105,149 @@ mod tests {
             format!("{err:?}").contains("coinbase recipient"),
             "expected recipient-mismatch rejection, got: {err:?}"
         );
+    }
+
+    // ── Native module state commitment (fingerprint) ─────────
+    //
+    // compute_state_fingerprint folds account state + total_minted + the
+    // SRC-20 ContractRegistry + the NFT NftRegistry (the last two via their
+    // canonical_hash). These tests prove the fingerprint moves on native-state
+    // changes, is replay-deterministic, and is HashMap-order-independent.
+
+    const NFT_ADDR_A: &str = "0x1111111111111111111111111111111111111111";
+    const NFT_ADDR_B: &str = "0x2222222222222222222222222222222222222222";
+
+    /// 1. SRC-20 state changes move the fingerprint.
+    #[test]
+    fn fingerprint_tracks_src20_state() {
+        let mut bc = setup();
+        let (_, fp_empty) = super::compute_state_fingerprint(&bc);
+        bc.contracts
+            .deploy("0xowner", "Tok", "TOK", 8, 1000, 0, "seed1")
+            .unwrap();
+        let (_, fp_deploy) = super::compute_state_fingerprint(&bc);
+        assert_ne!(fp_empty, fp_deploy, "SRC-20 deploy must move fingerprint");
+    }
+
+    /// 2. NFT state changes move the fingerprint.
+    #[test]
+    fn fingerprint_tracks_nft_state() {
+        let mut bc = setup();
+        let (_, fp_empty) = super::compute_state_fingerprint(&bc);
+        bc.nft_registry
+            .deploy_collection(NFT_ADDR_A, "C", "C", "u", None, true, true, "seed")
+            .unwrap();
+        let (_, fp_deploy) = super::compute_state_fingerprint(&bc);
+        assert_ne!(fp_empty, fp_deploy, "NFT deploy must move fingerprint");
+    }
+
+    /// 3. Same native-op sequence on fresh state ⇒ identical fingerprint.
+    #[test]
+    fn fingerprint_replay_deterministic() {
+        let build = || {
+            let mut bc = setup();
+            bc.contracts
+                .deploy("0xowner", "Tok", "TOK", 8, 1000, 0, "seed1")
+                .unwrap();
+            let (cid, _) = bc
+                .nft_registry
+                .deploy_collection(NFT_ADDR_A, "C", "C", "u", None, true, true, "ns")
+                .unwrap();
+            bc.nft_registry
+                .get_collection_mut(&cid)
+                .unwrap()
+                .mint(NFT_ADDR_A, NFT_ADDR_B, 7, "", None)
+                .unwrap();
+            super::compute_state_fingerprint(&bc).1
+        };
+        assert_eq!(build(), build(), "replayed native state must match");
+    }
+
+    /// 4. Different SRC-20 supply ⇒ different fingerprint.
+    #[test]
+    fn fingerprint_distinguishes_src20_supply() {
+        let make = |supply: u64| {
+            let mut bc = setup();
+            bc.contracts
+                .deploy("0xowner", "Tok", "TOK", 8, supply, 0, "seed1")
+                .unwrap();
+            super::compute_state_fingerprint(&bc).1
+        };
+        assert_ne!(make(1000), make(2000));
+    }
+
+    /// 5. Different NFT owner ⇒ different fingerprint.
+    #[test]
+    fn fingerprint_distinguishes_nft_owner() {
+        let make = |owner: &str| {
+            let mut bc = setup();
+            let (cid, _) = bc
+                .nft_registry
+                .deploy_collection(NFT_ADDR_A, "C", "C", "u", None, true, true, "ns")
+                .unwrap();
+            bc.nft_registry
+                .get_collection_mut(&cid)
+                .unwrap()
+                .mint(NFT_ADDR_A, owner, 1, "", None)
+                .unwrap();
+            super::compute_state_fingerprint(&bc).1
+        };
+        assert_ne!(make(NFT_ADDR_A), make(NFT_ADDR_B));
+    }
+
+    /// 6. SRC-20 contract insertion order does not change the fingerprint.
+    #[test]
+    fn fingerprint_src20_order_independent() {
+        let mut a = setup();
+        a.contracts
+            .deploy("0xowner", "A", "AAA", 8, 1, 0, "s1")
+            .unwrap();
+        a.contracts
+            .deploy("0xowner", "B", "BBB", 8, 1, 0, "s2")
+            .unwrap();
+        let mut b = setup();
+        b.contracts
+            .deploy("0xowner", "B", "BBB", 8, 1, 0, "s2")
+            .unwrap();
+        b.contracts
+            .deploy("0xowner", "A", "AAA", 8, 1, 0, "s1")
+            .unwrap();
+        assert_eq!(
+            super::compute_state_fingerprint(&a).1,
+            super::compute_state_fingerprint(&b).1,
+            "deploy order must not affect fingerprint"
+        );
+    }
+
+    /// 7. Invalid addresses are rejected at the NFT apply boundary.
+    #[test]
+    fn apply_rejects_invalid_nft_addresses() {
+        let mut reg = sentrix_nft::NftRegistry::new();
+        let (cid, _) = reg
+            .deploy_collection(NFT_ADDR_A, "C", "C", "u", None, true, true, "ns")
+            .unwrap();
+        // mint to a malformed address
+        let bad_mint = TokenOp::MintNft {
+            contract: cid.clone(),
+            to: "0xnothex".into(),
+            token_id: 1,
+            metadata_uri: String::new(),
+        };
+        let err =
+            crate::nft::apply_nft_token_op(&mut reg, &bad_mint, NFT_ADDR_A, "tx").unwrap_err();
+        assert!(
+            matches!(err, SentrixError::InvalidTransaction(ref m) if m.contains("invalid NFT"))
+        );
+        // mint to the zero address (valid format, not spendable)
+        let zero_mint = TokenOp::MintNft {
+            contract: cid,
+            to: "0x0000000000000000000000000000000000000000".into(),
+            token_id: 1,
+            metadata_uri: String::new(),
+        };
+        let err =
+            crate::nft::apply_nft_token_op(&mut reg, &zero_mint, NFT_ADDR_A, "tx").unwrap_err();
+        assert!(matches!(err, SentrixError::InvalidTransaction(_)));
     }
 
     // ── Native NFT apply-path E2E (through add_block) ─────────

--- a/crates/sentrix-core/src/nft.rs
+++ b/crates/sentrix-core/src/nft.rs
@@ -70,6 +70,32 @@ pub fn apply_nft_token_op(
             .ok_or_else(|| SentrixError::NotFound(format!("nft collection {contract}")))
     }
 
+    // Address-format validation at the apply boundary, mirroring the SRC-20
+    // path (M-02 validates token recipients via is_spendable_sentrix_address).
+    // The domain layer only rejects empty strings; this rejects malformed /
+    // zero addresses before they enter the registry, so an NFT can't be
+    // minted/transferred to an unspendable (lost) address. `sender` is already
+    // cryptographically valid (tx.verify binds it to the pubkey-derived addr).
+    use crate::address::{is_spendable_sentrix_address, is_valid_sentrix_address};
+    let recipient = |label: &str, a: &str| -> Result<(), SentrixError> {
+        if is_spendable_sentrix_address(a) {
+            Ok(())
+        } else {
+            Err(SentrixError::InvalidTransaction(format!(
+                "invalid NFT {label} address: {a}"
+            )))
+        }
+    };
+    let party = |label: &str, a: &str| -> Result<(), SentrixError> {
+        if is_valid_sentrix_address(a) {
+            Ok(())
+        } else {
+            Err(SentrixError::InvalidTransaction(format!(
+                "invalid NFT {label} address: {a}"
+            )))
+        }
+    };
+
     let event = match op {
         TokenOp::DeployNft {
             name,
@@ -97,20 +123,27 @@ pub fn apply_nft_token_op(
             to,
             token_id,
             metadata_uri,
-        } => collection_mut(registry, contract)?
-            // transferable = None → use the collection default.
-            .mint(sender, to, *token_id, metadata_uri, None)
-            .map_err(nft_err_to_sentrix)?,
+        } => {
+            recipient("mint to", to)?;
+            collection_mut(registry, contract)?
+                // transferable = None → use the collection default.
+                .mint(sender, to, *token_id, metadata_uri, None)
+                .map_err(nft_err_to_sentrix)?
+        }
         TokenOp::TransferNft {
             contract,
             from,
             to,
             token_id,
-        } => collection_mut(registry, contract)?
-            // `from` is untrusted claimed data; the domain checks it against
-            // the real owner. Authority is `sender` (caller).
-            .transfer(sender, from, to, *token_id)
-            .map_err(nft_err_to_sentrix)?,
+        } => {
+            party("transfer from", from)?;
+            recipient("transfer to", to)?;
+            collection_mut(registry, contract)?
+                // `from` is untrusted claimed data; the domain checks it
+                // against the real owner. Authority is `sender` (caller).
+                .transfer(sender, from, to, *token_id)
+                .map_err(nft_err_to_sentrix)?
+        }
         TokenOp::BurnNft { contract, token_id } => collection_mut(registry, contract)?
             // Domain clears the token's approval as part of the burn.
             .burn(sender, *token_id)
@@ -119,19 +152,25 @@ pub fn apply_nft_token_op(
             contract,
             spender,
             token_id,
-        } => collection_mut(registry, contract)?
-            .approve(sender, spender, *token_id)
-            .map_err(nft_err_to_sentrix)?,
+        } => {
+            party("approve spender", spender)?;
+            collection_mut(registry, contract)?
+                .approve(sender, spender, *token_id)
+                .map_err(nft_err_to_sentrix)?
+        }
         TokenOp::SetApprovalForAll {
             contract,
             operator,
             approved,
-        } => collection_mut(registry, contract)?
-            // owner == sender: a caller may only manage operators for tokens
-            // it owns. The domain re-enforces caller == owner, so a payload
-            // can never set approvals on behalf of a different owner.
-            .set_approval_for_all(sender, sender, operator, *approved)
-            .map_err(nft_err_to_sentrix)?,
+        } => {
+            party("operator", operator)?;
+            collection_mut(registry, contract)?
+                // owner == sender: a caller may only manage operators for
+                // tokens it owns. The domain re-enforces caller == owner, so a
+                // payload can never set approvals on behalf of a different owner.
+                .set_approval_for_all(sender, sender, operator, *approved)
+                .map_err(nft_err_to_sentrix)?
+        }
         _ => {
             return Err(SentrixError::InvalidTransaction(
                 "unsupported NFT TokenOp in apply path \
@@ -299,9 +338,11 @@ mod tests {
     // snapshot rollback, cross-node determinism) is covered separately in
     // `block_executor.rs`.
 
-    const ADMIN: &str = "0xadmin";
-    const ALICE: &str = "0xalice";
-    const BOB: &str = "0xbob";
+    // Valid 42-char Sentrix addresses (apply path now validates address format).
+    const ADMIN: &str = "0x1111111111111111111111111111111111111111";
+    const ALICE: &str = "0x2222222222222222222222222222222222222222";
+    const BOB: &str = "0x3333333333333333333333333333333333333333";
+    const CAROL: &str = "0x4444444444444444444444444444444444444444";
 
     fn deploy(reg: &mut NftRegistry, seed: &str) -> String {
         let op = TokenOp::DeployNft {
@@ -450,13 +491,13 @@ mod tests {
         // pinned to the sender (BOB), so this grants BOB→operate-on-BOB only.
         let op = TokenOp::SetApprovalForAll {
             contract: cid.clone(),
-            operator: "0xcarol".into(),
+            operator: CAROL.into(),
             approved: true,
         };
         apply_nft_token_op(&mut reg, &op, BOB, "evilseed").expect("sets for BOB only");
         let c = reg.get_collection(&cid).unwrap();
         // Carol is NOT an operator over ALICE.
-        assert!(!c.is_approved_for_all(ALICE, "0xcarol"));
+        assert!(!c.is_approved_for_all(ALICE, CAROL));
         // BOB still cannot move ALICE's token.
         let err = transfer(&mut reg, &cid, ALICE, BOB, 1, BOB).unwrap_err();
         assert!(matches!(err, SentrixError::UnauthorizedValidator(_)));

--- a/crates/sentrix-core/src/vm.rs
+++ b/crates/sentrix-core/src/vm.rs
@@ -273,6 +273,52 @@ impl SRC20Contract {
         self.balances.values().filter(|&&b| b > 0).count()
     }
 
+    /// Canonical, deterministic hash of this contract's state. Fixed field
+    /// order; `balances` and `allowances` maps folded with keys sorted, so
+    /// the digest is independent of `HashMap` iteration order.
+    pub fn canonical_hash(&self) -> [u8; 32] {
+        let mut h = Sha256::new();
+        for s in [
+            self.contract_address.as_str(),
+            self.name.as_str(),
+            self.symbol.as_str(),
+            self.owner.as_str(),
+        ] {
+            h.update((s.len() as u64).to_be_bytes());
+            h.update(s.as_bytes());
+        }
+        h.update([self.decimals]);
+        h.update(self.total_supply.to_be_bytes());
+        h.update(self.max_supply.to_be_bytes());
+
+        // balances — sorted by address.
+        let mut bal: Vec<(&String, &u64)> = self.balances.iter().collect();
+        bal.sort_unstable_by(|a, b| a.0.cmp(b.0));
+        h.update((bal.len() as u64).to_be_bytes());
+        for (addr, n) in bal {
+            h.update((addr.len() as u64).to_be_bytes());
+            h.update(addr.as_bytes());
+            h.update(n.to_be_bytes());
+        }
+
+        // allowances — sorted by (owner, spender).
+        let mut allow: Vec<(&String, &String, &u64)> = self
+            .allowances
+            .iter()
+            .flat_map(|(owner, m)| m.iter().map(move |(sp, v)| (owner, sp, v)))
+            .collect();
+        allow.sort_unstable_by(|a, b| a.0.cmp(b.0).then(a.1.cmp(b.1)));
+        h.update((allow.len() as u64).to_be_bytes());
+        for (owner, sp, v) in allow {
+            h.update((owner.len() as u64).to_be_bytes());
+            h.update(owner.as_bytes());
+            h.update((sp.len() as u64).to_be_bytes());
+            h.update(sp.as_bytes());
+            h.update(v.to_be_bytes());
+        }
+        h.finalize().into()
+    }
+
     pub fn get_info(&self) -> serde_json::Value {
         serde_json::json!({
             "contract_address": self.contract_address,
@@ -386,6 +432,26 @@ impl ContractRegistry {
 
     pub fn exists(&self, address: &str) -> bool {
         self.contracts.contains_key(address)
+    }
+
+    /// Canonical, deterministic hash of every SRC-20 contract's state.
+    ///
+    /// Contracts are folded in sorted-address order, each via
+    /// [`SRC20Contract::canonical_hash`], so the digest is independent of
+    /// `HashMap` iteration order. This is the SRC-20 half of native-module
+    /// state commitment — today it feeds the STATE-FP fingerprint; the
+    /// fork-gated trie/state_root commitment is the documented follow-up.
+    pub fn canonical_hash(&self) -> [u8; 32] {
+        let mut addrs: Vec<&String> = self.contracts.keys().collect();
+        addrs.sort_unstable();
+        let mut h = Sha256::new();
+        h.update((addrs.len() as u64).to_be_bytes());
+        for addr in addrs {
+            h.update((addr.len() as u64).to_be_bytes());
+            h.update(addr.as_bytes());
+            h.update(self.contracts[addr].canonical_hash());
+        }
+        h.finalize().into()
     }
 
     pub fn get_token_balance(&self, contract: &str, address: &str) -> u64 {

--- a/crates/sentrix-nft/src/collection.rs
+++ b/crates/sentrix-nft/src/collection.rs
@@ -575,6 +575,110 @@ impl NftCollection {
         })
     }
 
+    /// Canonical, deterministic hash of this collection's full state.
+    ///
+    /// Every field and every map is folded in a fixed order with map keys
+    /// sorted, so the result is independent of `HashMap` iteration order and
+    /// identical across nodes/processes for the same logical state. This is
+    /// the building block for native-module state commitment (fingerprint
+    /// today; trie/state_root commitment is the fork-gated follow-up). The
+    /// domain owns its canonical form so encapsulation stays intact — this is
+    /// read-only and adds no mutable access to internals.
+    pub fn canonical_hash(&self) -> [u8; 32] {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        // Scalar / string fields, length-prefixed where ambiguous.
+        for s in [
+            self.id.as_str(),
+            self.creator.as_str(),
+            self.admin.as_str(),
+            self.name.as_str(),
+            self.symbol.as_str(),
+            self.description.as_str(),
+            self.base_uri.as_str(),
+            self.external_url.as_str(),
+        ] {
+            h.update((s.len() as u64).to_be_bytes());
+            h.update(s.as_bytes());
+        }
+        // Option<u64> max_supply: tag byte then value.
+        match self.max_supply {
+            Some(m) => {
+                h.update([1u8]);
+                h.update(m.to_be_bytes());
+            }
+            None => h.update([0u8]),
+        }
+        h.update(self.total_supply.to_be_bytes());
+        h.update(self.total_minted.to_be_bytes());
+        h.update([
+            self.default_transferable as u8,
+            self.metadata_mutable as u8,
+            self.frozen as u8,
+        ]);
+
+        // tokens — sorted by token_id.
+        let mut token_ids: Vec<&u64> = self.tokens.keys().collect();
+        token_ids.sort_unstable();
+        h.update((token_ids.len() as u64).to_be_bytes());
+        for tid in token_ids {
+            let t = &self.tokens[tid];
+            h.update(tid.to_be_bytes());
+            for s in [t.owner(), t.uri()] {
+                h.update((s.len() as u64).to_be_bytes());
+                h.update(s.as_bytes());
+            }
+            for opt in [t.uri_hash.as_deref(), t.metadata_hash.as_deref()] {
+                match opt {
+                    Some(s) => {
+                        h.update([1u8]);
+                        h.update((s.len() as u64).to_be_bytes());
+                        h.update(s.as_bytes());
+                    }
+                    None => h.update([0u8]),
+                }
+            }
+            h.update([t.transferable() as u8, t.frozen() as u8, t.burned() as u8]);
+        }
+
+        // balances — sorted by address.
+        let mut bal: Vec<(&String, &u64)> = self.balances.iter().collect();
+        bal.sort_unstable_by(|a, b| a.0.cmp(b.0));
+        h.update((bal.len() as u64).to_be_bytes());
+        for (addr, n) in bal {
+            h.update((addr.len() as u64).to_be_bytes());
+            h.update(addr.as_bytes());
+            h.update(n.to_be_bytes());
+        }
+
+        // token_approvals — sorted by token_id.
+        let mut appr: Vec<(&u64, &String)> = self.token_approvals.iter().collect();
+        appr.sort_unstable_by(|a, b| a.0.cmp(b.0));
+        h.update((appr.len() as u64).to_be_bytes());
+        for (tid, spender) in appr {
+            h.update(tid.to_be_bytes());
+            h.update((spender.len() as u64).to_be_bytes());
+            h.update(spender.as_bytes());
+        }
+
+        // operator_approvals — sorted by (owner, operator).
+        let mut ops: Vec<(&String, &String, &bool)> = self
+            .operator_approvals
+            .iter()
+            .flat_map(|(owner, m)| m.iter().map(move |(op, v)| (owner, op, v)))
+            .collect();
+        ops.sort_unstable_by(|a, b| a.0.cmp(b.0).then(a.1.cmp(b.1)));
+        h.update((ops.len() as u64).to_be_bytes());
+        for (owner, op, v) in ops {
+            h.update((owner.len() as u64).to_be_bytes());
+            h.update(owner.as_bytes());
+            h.update((op.len() as u64).to_be_bytes());
+            h.update(op.as_bytes());
+            h.update([*v as u8]);
+        }
+        h.finalize().into()
+    }
+
     /// Resolve the owner of a live token or error. Burned/absent → `TokenNotFound`.
     fn live_owner(&self, token_id: u64) -> NftResult<String> {
         match self.tokens.get(&token_id) {

--- a/crates/sentrix-nft/src/lib.rs
+++ b/crates/sentrix-nft/src/lib.rs
@@ -609,4 +609,90 @@ mod tests {
             NftEvent::TokenBurned { .. }
         ));
     }
+
+    // ── canonical_hash (native-module state commitment) ──────
+
+    /// Building the same logical state via a different mint order must yield
+    /// the same canonical hash — proves HashMap iteration order can't move it.
+    #[test]
+    fn canonical_hash_is_order_independent() {
+        let build = |order: &[u64]| -> [u8; 32] {
+            let mut r = NftRegistry::new();
+            let (id, _) = r
+                .deploy_collection(ADMIN, "C", "C", "u", None, true, true, "seed")
+                .unwrap();
+            let c = r.get_collection_mut(&id).unwrap();
+            for &t in order {
+                c.mint(ADMIN, ALICE, t, "", None).unwrap();
+            }
+            r.canonical_hash()
+        };
+        assert_eq!(build(&[1, 2, 3, 4, 5]), build(&[5, 4, 3, 2, 1]));
+        assert_eq!(build(&[3, 1, 4, 5, 2]), build(&[1, 2, 3, 4, 5]));
+    }
+
+    /// Every state transition must move the canonical hash.
+    #[test]
+    fn canonical_hash_tracks_state_changes() {
+        let mut r = NftRegistry::new();
+        let empty = r.canonical_hash();
+
+        let (id, _) = r
+            .deploy_collection(ADMIN, "C", "C", "u", None, true, true, "seed")
+            .unwrap();
+        let after_deploy = r.canonical_hash();
+        assert_ne!(empty, after_deploy, "deploy must change hash");
+
+        r.get_collection_mut(&id)
+            .unwrap()
+            .mint(ADMIN, ALICE, 1, "", None)
+            .unwrap();
+        let after_mint = r.canonical_hash();
+        assert_ne!(after_deploy, after_mint, "mint must change hash");
+
+        r.get_collection_mut(&id)
+            .unwrap()
+            .approve(ALICE, BOB, 1)
+            .unwrap();
+        let after_approve = r.canonical_hash();
+        assert_ne!(after_mint, after_approve, "approve must change hash");
+
+        r.get_collection_mut(&id)
+            .unwrap()
+            .transfer(ALICE, ALICE, CAROL, 1)
+            .unwrap();
+        let after_transfer = r.canonical_hash();
+        assert_ne!(after_approve, after_transfer, "transfer must change hash");
+
+        r.get_collection_mut(&id).unwrap().burn(CAROL, 1).unwrap();
+        assert_ne!(after_transfer, r.canonical_hash(), "burn must change hash");
+    }
+
+    /// Different owners ⇒ different hash; identical logical state ⇒ identical.
+    #[test]
+    fn canonical_hash_distinguishes_owners_and_is_deterministic() {
+        let make = |owner: &str| -> [u8; 32] {
+            let mut r = NftRegistry::new();
+            let (id, _) = r
+                .deploy_collection(ADMIN, "C", "C", "u", None, true, true, "seed")
+                .unwrap();
+            r.get_collection_mut(&id)
+                .unwrap()
+                .mint(ADMIN, owner, 1, "", None)
+                .unwrap();
+            r.canonical_hash()
+        };
+        assert_ne!(make(ALICE), make(BOB), "different owner ⇒ different hash");
+        assert_eq!(make(ALICE), make(ALICE), "same state ⇒ same hash");
+    }
+
+    /// Empty registry hashes to a stable, non-zero, distinct value.
+    #[test]
+    fn canonical_hash_empty_is_stable() {
+        assert_eq!(
+            NftRegistry::new().canonical_hash(),
+            NftRegistry::new().canonical_hash()
+        );
+        assert_ne!(NftRegistry::new().canonical_hash(), [0u8; 32]);
+    }
 }

--- a/crates/sentrix-nft/src/registry.rs
+++ b/crates/sentrix-nft/src/registry.rs
@@ -126,4 +126,24 @@ impl NftRegistry {
     pub fn collection_count(&self) -> usize {
         self.collections.len()
     }
+
+    /// Canonical, deterministic hash of the whole registry.
+    ///
+    /// Collections are folded in sorted-id order, each via
+    /// [`NftCollection::canonical_hash`], so the digest is independent of
+    /// `HashMap` iteration order. An empty registry hashes to a stable value
+    /// distinct from any populated one. Backs native-module state commitment.
+    pub fn canonical_hash(&self) -> [u8; 32] {
+        use sha2::{Digest, Sha256};
+        let mut ids: Vec<&String> = self.collections.keys().collect();
+        ids.sort_unstable();
+        let mut h = Sha256::new();
+        h.update((ids.len() as u64).to_be_bytes());
+        for id in ids {
+            h.update((id.len() as u64).to_be_bytes());
+            h.update(id.as_bytes());
+            h.update(self.collections[id].canonical_hash());
+        }
+        h.finalize().into()
+    }
 }


### PR DESCRIPTION
**Draft to prevent auto-merge** — do not merge; for review only.

Closes the native-module state-commitment gap for **both** SRC-20 `ContractRegistry` and NFT `NftRegistry`, and fixes 2 of the 3 CodeRabbit findings from #775.

## Problem
`SENTRIX_STATE_FINGERPRINT` (STATE-FP) hashed only accounts + total_minted + EVM code/storage. Native-module state (SRC-20 contracts, NFT registry) was invisible → two validators could diverge purely in token/NFT state and print identical `[STATE-FP]` lines (CodeRabbit #1).

## Change — canonical fingerprint commitment
- **`NftCollection`/`NftRegistry::canonical_hash()`** — fixed field order; all maps (tokens, balances, token_approvals, operator_approvals, collections) folded with keys **sorted** → HashMap-order-independent. Read-only; no new mutable surface on the domain crate.
- **`SRC20Contract`/`ContractRegistry::canonical_hash()`** — same approach (balances + allowances sorted).
- **`compute_state_fingerprint()`** — extracted from `emit_state_fingerprint` (testable, no env gate); folds `contracts.canonical_hash()` + `nft_registry.canonical_hash()` into the combined fingerprint.
- **Address validation** (CodeRabbit #3) — NFT apply path validates `to`/`from`/`spender`/`operator` via `is_spendable_/is_valid_sentrix_address` before mutating, mirroring SRC-20 M-02.

## Design decision (explicit)
Requirements allow "state_root **OR** fingerprint." I took the **fingerprint** arm:
- Consensus-enforced **trie/state_root** commitment of native state is a breaking change to live SRC-20 → needs a fork gate + deterministic migration at activation + testnet soak (the STATE_ROOT_V2 incident class). That's a soak-gated follow-up, not one safe PR.
- Fingerprint commitment is consensus-neutral, needs no fork gate/migration, satisfies all stated requirements + tests, and closes the debug-visibility gap now. The canonical serialization built here is the foundation for the heavier trie commitment.

## Deferred (documented)
- **Consensus-enforced trie/state_root commitment** of native-module state (fork-gated + migrated + soaked).
- **Event-staging** (CodeRabbit #2): NFT emits inline in Pass-2 exactly like SRC-20; fixing NFT alone would diverge from the precedent. Uniform repo-wide event-staging is a separate PR.

## Tests
- sentrix-nft: `canonical_hash` order-independence, state sensitivity (deploy/mint/approve/transfer/burn), owner distinction, empty stability.
- sentrix-core: fingerprint tracks SRC-20 + NFT changes, replay-deterministic, SRC-20 insertion-order-independent, distinct supply/owner differ, invalid-address rejection at the apply boundary.

## Commands
- `cargo test -p sentrix-nft` ✅ (43 + 2 doctests)
- `cargo test --workspace` ✅ (66 suites, 0 failures)
- `cargo fmt --check` ✅ · `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo llvm-cov -p sentrix-nft` ✅ 92.13% lines

No deploy. No RPC/explorer/wallet/marketplace/bridge/image-bytes. No state_root/trie/MDBX change, no fork gate.