### PR TITLE
test(nft): cover canonical_hash branches → patch coverage to 100%

### DIFF
--- a/crates/sentrix-nft/src/collection.rs
+++ b/crates/sentrix-nft/src/collection.rs
@@ -687,3 +687,44 @@ impl NftCollection {
         }
     }
 }
+
+#[cfg(test)]
+mod canonical_tests {
+    use super::*;
+
+    /// `uri_hash` / `metadata_hash` are optional integrity hashes with no
+    /// public setter yet (they're populated by a future update API), so the
+    /// `Some` arm of `canonical_hash` is only reachable white-box. Setting
+    /// them on a live token must move the canonical hash — proving the
+    /// integrity hashes are part of committed state.
+    #[test]
+    fn canonical_hash_includes_token_integrity_hashes() {
+        let mut c = NftCollection::new(
+            "SRC721_x".into(),
+            "0xadmin".into(),
+            "C".into(),
+            "C".into(),
+            "u".into(),
+            None,
+            true,
+            true,
+        );
+        c.mint("0xadmin", "0xowner", 1, "", None).unwrap();
+        let baseline = c.canonical_hash();
+
+        let t = c.tokens.get_mut(&1).expect("token 1");
+        t.uri_hash = Some("deadbeef".into());
+        let after_uri_hash = c.canonical_hash();
+        assert_ne!(
+            baseline, after_uri_hash,
+            "uri_hash must affect canonical hash"
+        );
+
+        c.tokens.get_mut(&1).unwrap().metadata_hash = Some("cafe".into());
+        assert_ne!(
+            after_uri_hash,
+            c.canonical_hash(),
+            "metadata_hash must affect canonical hash"
+        );
+    }
+}

--- a/crates/sentrix-nft/src/lib.rs
+++ b/crates/sentrix-nft/src/lib.rs
@@ -695,4 +695,27 @@ mod tests {
         );
         assert_ne!(NftRegistry::new().canonical_hash(), [0u8; 32]);
     }
+
+    /// Exercise the remaining canonical_hash branches: bounded `max_supply`
+    /// (the `Some` arm), a non-empty token URI, a single-token approval, and
+    /// an operator-for-all approval. Toggling the operator must move the hash.
+    #[test]
+    fn canonical_hash_covers_max_supply_uri_and_operator() {
+        let mut r = NftRegistry::new();
+        let (id, _) = r
+            .deploy_collection(ADMIN, "C", "C", "u", Some(100), true, true, "s")
+            .unwrap();
+        let c = r.get_collection_mut(&id).unwrap();
+        c.mint(ADMIN, ALICE, 1, "ipfs://token/1", None).unwrap();
+        c.approve(ALICE, BOB, 1).unwrap();
+        c.set_approval_for_all(ALICE, ALICE, CAROL, true).unwrap();
+        let with_operator = r.canonical_hash();
+
+        // Revoking the operator approval must change the canonical hash.
+        r.get_collection_mut(&id)
+            .unwrap()
+            .set_approval_for_all(ALICE, ALICE, CAROL, false)
+            .unwrap();
+        assert_ne!(with_operator, r.canonical_hash());
+    }
 }


### PR DESCRIPTION
Follow-up to #776. Codecov patch on #776 flagged **15 uncovered lines** in `sentrix-nft/src/collection.rs` `canonical_hash` (patch 90.38%, the file at 81%). These are the branches the original tests didn't exercise:

- bounded `max_supply` (the `Some` arm)
- token `uri_hash` / `metadata_hash` (the `Some` arm — no public setter yet)
- the operator-approvals loop

## Tests added
- **lib.rs** (black-box): collection with `Some(max_supply)`, non-empty token URI, single-token approval, and operator-for-all (toggling the operator moves the hash).
- **collection.rs** (white-box): `uri_hash`/`metadata_hash` integrity hashes have no public setter, so the `Some` arm is only reachable by setting the pub fields directly on a live token; verifies they're part of the committed canonical hash.

`canonical_hash` is now fully covered in both `collection.rs` and `registry.rs` (verified locally: 0 uncovered lines in the function).

## Note on scope
Only `sentrix-nft` is in the `cargo-llvm-cov` package set (the EVM-touching crates incl. `sentrix-core` are excluded due to revm instrumentation brittleness on CI), so the codecov patch % is computed over `sentrix-nft` only. The new `sentrix-core` logic from #775/#776 (apply path, fingerprint, address validation) is tested (verified 86%+ locally) but not in the codecov number until the EVM crates can be instrumented on CI — tracked as separate follow-up.

## Commands
- `cargo test -p sentrix-nft` ✅ (45 + 2 doctests)
- `cargo fmt --check` ✅
- `cargo llvm-cov -p sentrix-nft` ✅ canonical_hash 0 uncovered lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for canonical hash functionality, including scenarios for integrity field modifications and approval state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->