### PR TITLE
chore(ci): report-only coverage job for sentrix-core (non-blocking)

### DIFF
--- a/.github/workflows/coverage-sentrix-core.yml
+++ b/.github/workflows/coverage-sentrix-core.yml
@@ -1,0 +1,87 @@
+name: Coverage (sentrix-core, report-only)
+
+# Report-only coverage for sentrix-core. sentrix-core is deliberately excluded
+# from the required `cargo-llvm-cov` job (see coverage.yml) because llvm-cov
+# instrumentation of the revm dependency tree has been brittle on CI runners.
+#
+# This job exists so we still get a coverage number for sentrix-core's own
+# logic (apply paths, fingerprint, native-module commitment, etc.) WITHOUT any
+# of the risk:
+#   - it is NOT in the branch ruleset's required status checks, so it can never
+#     block a merge;
+#   - `continue-on-error: true` means a flaky/failed instrumentation run is a
+#     soft failure, not a red gate;
+#   - it does NOT run codecov/codecov-action, so it cannot change Codecov
+#     project/patch coverage for the repo.
+#
+# Output is an lcov + text summary published as a downloadable CI artifact for
+# manual inspection. Promote sentrix-core into the main coverage upload only
+# once revm instrumentation is proven reliable on CI runners.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/sentrix-core/**"
+      - ".github/workflows/coverage-sentrix-core.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  sentrix-core-coverage:
+    name: sentrix-core coverage (report-only, non-blocking)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    # Soft failure: never gate a merge on this, even if revm instrumentation
+    # is unstable on the runner.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable + llvm-tools-preview
+        run: |
+          rustup default stable
+          rustup component add llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cov-core-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cov-core-${{ runner.os }}-
+
+      - name: Coverage (sentrix-core) — report only, never uploaded to Codecov
+        run: |
+          cargo llvm-cov \
+            --package sentrix-core \
+            --lcov --output-path sentrix-core-lcov.info \
+            --ignore-filename-regex '/(tests|benches)/'
+          cargo llvm-cov report \
+            --package sentrix-core \
+            --ignore-filename-regex '/(tests|benches)/' \
+            --summary-only | tee sentrix-core-coverage-summary.txt
+
+      - name: Upload coverage report as artifact (NOT Codecov)
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: sentrix-core-coverage
+          path: |
+            sentrix-core-lcov.info
+            sentrix-core-coverage-summary.txt
+          retention-days: 30


### PR DESCRIPTION
Follow-up to #777. Adds a sentrix-core coverage number **without any risk** to the required gate or to Codecov.

## Why
`sentrix-core` is excluded from the required `cargo-llvm-cov` job (coverage.yml) because llvm-cov instrumentation of the revm dep tree is brittle on CI runners. So the new apply-path / fingerprint / native-module logic from #775/#776 has no coverage number in CI.

## What
A standalone `coverage-sentrix-core.yml`:
- **Not required** — its job name isn't in the branch ruleset's required checks (`Test`, `cargo audit`, `gitleaks`, `cargo-llvm-cov`, `Dependency review`, `commitlint`), so it can never block a merge.
- **`continue-on-error: true`** — if revm instrumentation flakes on the runner, it's a soft failure, not a red gate.
- **No Codecov upload** — no `codecov/codecov-action` step, so it cannot move project/patch coverage.
- **Artifact only** — publishes `sentrix-core-lcov.info` + a text summary as a downloadable CI artifact.
- Triggers only on PRs touching `crates/sentrix-core/**` + `workflow_dispatch`.

Does **not** modify `coverage.yml` or `codecov.yml`.

## Local verification
- `cargo test -p sentrix-core` ✅ (clean, ~37s, no flakiness)
- `cargo llvm-cov -p sentrix-core --summary-only` ✅ ~49s warm → **82.5% regions / 77.9% lines** (incl. the new vm.rs 86.7%, nft.rs apply path)

## Risk
Low. Worst case = the report-only job is slow or flakes on CI; because it's non-required + continue-on-error + artifact-only, that has zero impact on merges or the codecov number. Promoting sentrix-core into the *required* coverage upload stays deferred until revm instrumentation is proven reliable on CI.

No protocol logic, RPC, explorer, wallet, marketplace, or bridge changes. No deploy.