### PR TITLE
feat(cli): read-only native-state activation preflight command

### DIFF
--- a/bin/sentrix/src/commands/state.rs
+++ b/bin/sentrix/src/commands/state.rs
@@ -148,3 +148,312 @@ pub fn cmd_state_verify(input: &str) -> anyhow::Result<()> {
     println!("{}", summary);
     Ok(())
 }
+
+// ── Native-module state-root activation preflight (read-only) ──────────
+//
+// `sentrix state preflight` reports whether THIS node looks ready for a
+// native-module state_root activation (see
+// `audits/native-state-in-trie-activation-playbook.md`). It is strictly
+// read-only: it opens the existing DB, loads the persisted Blockchain, reads
+// fields, and prints. It never writes, never inits/resets the trie, never sets
+// env, never enables a fork, and makes no network calls.
+//
+// A single node cannot prove cross-validator agreement — the operator must
+// compare the reported `src20_canonical_hash` / `nft_canonical_hash` /
+// `state_root` across ALL validators (per the playbook). This tool surfaces the
+// per-node values + a local verdict to make that comparison possible.
+
+/// One fork gate's status.
+struct GateStatus {
+    enabled: bool,
+    /// Activation height when enabled; `None` when disabled (`u64::MAX`).
+    activation_height: Option<u64>,
+}
+
+impl GateStatus {
+    fn read(height: u64) -> Self {
+        if height == u64::MAX {
+            GateStatus {
+                enabled: false,
+                activation_height: None,
+            }
+        } else {
+            GateStatus {
+                enabled: true,
+                activation_height: Some(height),
+            }
+        }
+    }
+}
+
+/// Read-only preflight snapshot for a single node.
+struct PreflightReport {
+    version: String,
+    height: u64,
+    tip_hash: String,
+    state_root: Option<String>,
+    src20_canonical_hash: String,
+    nft_canonical_hash: String,
+    native_state_in_trie_gate: GateStatus,
+    nft_tokenop_gate: GateStatus,
+    verdict: &'static str,
+    notes: Vec<String>,
+}
+
+/// Build the preflight report from an already-loaded chain. Pure (no I/O), so
+/// it is unit-testable without a DB. `native_gate_height` / `nft_gate_height`
+/// are the configured fork heights (passed in so the caller owns the env read).
+fn build_preflight_report(
+    bc: &Blockchain,
+    native_gate_height: u64,
+    nft_gate_height: u64,
+) -> PreflightReport {
+    let height = bc.height();
+    let tip = bc.latest_block().ok();
+    let tip_hash = tip.map(|b| b.hash.clone()).unwrap_or_default();
+    let state_root = tip.and_then(|b| b.state_root).map(hex::encode);
+
+    let src20_canonical_hash = hex::encode(bc.contracts.canonical_hash());
+    let nft_canonical_hash = hex::encode(bc.nft_registry.canonical_hash());
+
+    let native = GateStatus::read(native_gate_height);
+    let nft = GateStatus::read(nft_gate_height);
+
+    // Verdict: NOT_READY for hard problems (unreadable tip), WARNING for things
+    // the operator must notice, READY for a clean pre-activation baseline.
+    let mut notes: Vec<String> = Vec::new();
+    let mut warn = false;
+    let mut not_ready = false;
+
+    if tip.is_none() {
+        notes.push("chain not initialized / tip block unreadable".into());
+        not_ready = true;
+    }
+    if height == 0 {
+        notes.push("chain at genesis height 0 — nothing committed yet".into());
+        warn = true;
+    }
+    if state_root.is_none() && tip.is_some() {
+        notes.push(
+            "tip block has no state_root (pre-trie block) — STATE_IN_TRIE may not be active on this node".into(),
+        );
+        warn = true;
+    }
+    if native.enabled {
+        notes.push(format!(
+            "native state-trie gate ALREADY pinned at height {} — activation already scheduled/done; do not re-pin",
+            native.activation_height.unwrap_or_default()
+        ));
+        warn = true;
+    }
+    if nft.enabled {
+        notes.push(
+            "NFT TokenOp gate is ENABLED — per the playbook it must NOT be activated together with native state-trie".into(),
+        );
+        warn = true;
+    }
+    if !not_ready && !warn {
+        notes.push(
+            "clean pre-activation baseline — compare src20_canonical_hash, nft_canonical_hash and state_root across ALL validators before pinning a height (see activation playbook)".into(),
+        );
+    }
+
+    let verdict = if not_ready {
+        "NOT_READY"
+    } else if warn {
+        "WARNING"
+    } else {
+        "READY"
+    };
+
+    PreflightReport {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        height,
+        tip_hash,
+        state_root,
+        src20_canonical_hash,
+        nft_canonical_hash,
+        native_state_in_trie_gate: native,
+        nft_tokenop_gate: nft,
+        verdict,
+        notes,
+    }
+}
+
+fn gate_str(g: &GateStatus) -> String {
+    match g.activation_height {
+        Some(h) => format!("ENABLED (activation height {h})"),
+        None => "DISABLED (u64::MAX)".to_string(),
+    }
+}
+
+fn render_text(r: &PreflightReport) -> String {
+    let mut out = String::new();
+    out.push_str("Native-module state-root activation preflight (read-only)\n");
+    out.push_str("=========================================================\n");
+    out.push_str(&format!("binary version         : {}\n", r.version));
+    out.push_str(&format!("chain height           : {}\n", r.height));
+    out.push_str(&format!("tip hash               : {}\n", r.tip_hash));
+    out.push_str(&format!(
+        "state_root (tip)       : {}\n",
+        r.state_root.as_deref().unwrap_or("<none>")
+    ));
+    out.push_str(&format!(
+        "SRC-20 canonical hash  : {}\n",
+        r.src20_canonical_hash
+    ));
+    out.push_str(&format!(
+        "NFT canonical hash     : {}\n",
+        r.nft_canonical_hash
+    ));
+    out.push_str(&format!(
+        "NATIVE_STATE_IN_TRIE   : {}\n",
+        gate_str(&r.native_state_in_trie_gate)
+    ));
+    out.push_str(&format!(
+        "NFT_TOKENOP            : {}\n",
+        gate_str(&r.nft_tokenop_gate)
+    ));
+    out.push_str(&format!("\nVERDICT: {}\n", r.verdict));
+    for n in &r.notes {
+        out.push_str(&format!("  - {n}\n"));
+    }
+    out.push_str(
+        "\nNote: this reports THIS node only. Activation requires the SAME hashes\n\
+         and state_root across ALL validators — compare before pinning a height.\n",
+    );
+    out
+}
+
+fn render_json(r: &PreflightReport) -> String {
+    let v = serde_json::json!({
+        "version": r.version,
+        "height": r.height,
+        "tip_hash": r.tip_hash,
+        "state_root": r.state_root,
+        "src20_canonical_hash": r.src20_canonical_hash,
+        "nft_canonical_hash": r.nft_canonical_hash,
+        "native_state_in_trie_gate": {
+            "enabled": r.native_state_in_trie_gate.enabled,
+            "activation_height": r.native_state_in_trie_gate.activation_height,
+        },
+        "nft_tokenop_gate": {
+            "enabled": r.nft_tokenop_gate.enabled,
+            "activation_height": r.nft_tokenop_gate.activation_height,
+        },
+        "verdict": r.verdict,
+        "notes": r.notes,
+    });
+    // serde_json::Value serializes object keys in sorted order (BTreeMap), so
+    // this is deterministic across runs.
+    serde_json::to_string_pretty(&v).unwrap_or_else(|_| "{}".to_string())
+}
+
+/// `sentrix state preflight [--json]` — read-only activation readiness report.
+pub fn cmd_state_preflight(json: bool) -> anyhow::Result<()> {
+    let storage = Storage::open(&get_db_path())?;
+    let bc = storage
+        .load_blockchain()?
+        .ok_or_else(|| anyhow::anyhow!("Chain not initialized."))?;
+
+    let native = sentrix::core::fork_heights::get_native_state_in_trie_height();
+    let nft = sentrix::core::fork_heights::get_nft_tokenop_height();
+    let report = build_preflight_report(&bc, native, nft);
+
+    if json {
+        println!("{}", render_json(&report));
+    } else {
+        print!("{}", render_text(&report));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DISABLED: u64 = u64::MAX;
+
+    fn fresh() -> Blockchain {
+        Blockchain::new("admin".to_string())
+    }
+
+    // 1. Empty registries → stable report (same twice, hashes present).
+    #[test]
+    fn empty_registry_preflight_stable() {
+        let bc = fresh();
+        let a = build_preflight_report(&bc, DISABLED, DISABLED);
+        let b = build_preflight_report(&bc, DISABLED, DISABLED);
+        assert_eq!(a.src20_canonical_hash, b.src20_canonical_hash);
+        assert_eq!(a.nft_canonical_hash, b.nft_canonical_hash);
+        assert!(!a.src20_canonical_hash.is_empty());
+        assert!(!a.nft_canonical_hash.is_empty());
+        assert_eq!(render_json(&a), render_json(&b));
+    }
+
+    // 2. Populated SRC-20 registry changes the reported hash.
+    #[test]
+    fn populated_src20_changes_hash() {
+        let empty = build_preflight_report(&fresh(), DISABLED, DISABLED);
+        let mut bc = fresh();
+        bc.contracts
+            .deploy("0xdeployer", "Tok", "TOK", 8, 1_000, 0, "seed")
+            .unwrap();
+        let populated = build_preflight_report(&bc, DISABLED, DISABLED);
+        assert_ne!(
+            empty.src20_canonical_hash, populated.src20_canonical_hash,
+            "SRC-20 deploy must change the reported canonical hash"
+        );
+    }
+
+    // 3. Populated NFT registry changes the reported hash.
+    #[test]
+    fn populated_nft_changes_hash() {
+        let empty = build_preflight_report(&fresh(), DISABLED, DISABLED);
+        let mut bc = fresh();
+        bc.nft_registry
+            .deploy_collection("0xcreator", "C", "C", "u", None, true, true, "seed")
+            .unwrap();
+        let populated = build_preflight_report(&bc, DISABLED, DISABLED);
+        assert_ne!(
+            empty.nft_canonical_hash, populated.nft_canonical_hash,
+            "NFT deploy must change the reported canonical hash"
+        );
+    }
+
+    // 4. Disabled gates are reported clearly.
+    #[test]
+    fn disabled_gates_reported() {
+        let r = build_preflight_report(&fresh(), DISABLED, DISABLED);
+        assert!(!r.native_state_in_trie_gate.enabled);
+        assert!(r.native_state_in_trie_gate.activation_height.is_none());
+        assert!(!r.nft_tokenop_gate.enabled);
+        assert!(r.nft_tokenop_gate.activation_height.is_none());
+        assert!(render_text(&r).contains("DISABLED (u64::MAX)"));
+    }
+
+    // Enabled native gate surfaces a WARNING + the pinned height.
+    #[test]
+    fn enabled_native_gate_warns() {
+        let r = build_preflight_report(&fresh(), 1_000, DISABLED);
+        assert!(r.native_state_in_trie_gate.enabled);
+        assert_eq!(r.native_state_in_trie_gate.activation_height, Some(1_000));
+        assert_eq!(r.verdict, "WARNING");
+        assert!(r.notes.iter().any(|n| n.contains("pinned at height")));
+    }
+
+    // 5. JSON output is deterministic for identical state.
+    #[test]
+    fn json_output_deterministic() {
+        let mut bc = fresh();
+        bc.contracts
+            .deploy("0xdeployer", "Tok", "TOK", 8, 1_000, 0, "seed")
+            .unwrap();
+        let r1 = build_preflight_report(&bc, DISABLED, DISABLED);
+        let r2 = build_preflight_report(&bc, DISABLED, DISABLED);
+        assert_eq!(render_json(&r1), render_json(&r2));
+        let parsed: serde_json::Value = serde_json::from_str(&render_json(&r1)).unwrap();
+        assert!(parsed.get("verdict").is_some());
+        assert!(parsed.get("src20_canonical_hash").is_some());
+    }
+}

--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -614,6 +614,17 @@ enum StateCommands {
         /// Snapshot file to verify
         input: String,
     },
+    /// Read-only preflight for native-module state_root activation readiness.
+    /// Reports chain height/tip, state_root, SRC-20 + NFT canonical hashes,
+    /// fork-gate status, and a local READY/WARNING/NOT_READY verdict. Does not
+    /// mutate state, touch the trie, set env, or enable any fork. Compare the
+    /// reported hashes across ALL validators before activating (see
+    /// audits/native-state-in-trie-activation-playbook.md).
+    Preflight {
+        /// Emit JSON instead of human-readable text.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -882,6 +893,7 @@ async fn main() -> anyhow::Result<()> {
                 commands::state::cmd_state_import(&input, force)?
             }
             StateCommands::Verify { input } => commands::state::cmd_state_verify(&input)?,
+            StateCommands::Preflight { json } => commands::state::cmd_state_preflight(json)?,
         },
 
         Commands::Mempool { action } => match action {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -27,6 +27,7 @@ pub use sentrix_core::block_executor;
 pub use sentrix_core::block_producer;
 pub use sentrix_core::blockchain;
 pub use sentrix_core::chain_queries;
+pub use sentrix_core::fork_heights;
 pub use sentrix_core::genesis;
 pub use sentrix_core::mempool;
 pub use sentrix_core::state_export;


### PR DESCRIPTION
**Draft — do not merge; for review.** Read-only admin tooling; no protocol/consensus change, no fork enabled.

Adds `sentrix state preflight [--json]` to support the activation playbook (#780) pre-flight for the native-module state_root commitment (#779), which remains gated off (`NATIVE_STATE_IN_TRIE_HEIGHT = u64::MAX`).

## What it reports (per node)
1. binary version
2. chain height
3. tip hash
4. `state_root` (from the tip block header — no trie init needed)
5. SRC-20 `ContractRegistry` canonical hash
6. NFT `NftRegistry` canonical hash
7. `NATIVE_STATE_IN_TRIE` gate state (enabled + activation height)
8. `NFT_TOKENOP` gate state
9. verdict: **READY / WARNING / NOT_READY** + notes

Text by default; `--json` for deterministic machine output (sorted keys).

## Read-only by construction
Same `Storage::open` + `load_blockchain` pattern as the existing `state export`. It does **not**: write/mutate state, init or reset the trie, set env, enable any fork, or make network calls. The report-builder (`build_preflight_report`) is a pure function over an in-memory `Blockchain`, so it's unit-tested without a DB.

## Single-node scope (called out in the output)
A node can't prove cross-validator agreement. The verdict is local; the operator must compare `src20_canonical_hash` / `nft_canonical_hash` / `state_root` across **all** validators before pinning a height (per the playbook). The tool prints that reminder.

## Files
- `bin/sentrix/src/commands/state.rs` — `cmd_state_preflight` + pure builder + renderers + tests
- `bin/sentrix/src/main.rs` — `StateCommands::Preflight { json }` + dispatch
- `src/core/mod.rs` — re-export `sentrix_core::fork_heights` through the facade (one line)

## Tests (6)
empty-registry stable + deterministic JSON · populated SRC-20 changes hash · populated NFT changes hash · disabled gates reported · enabled native gate → WARNING with pinned height.

## Commands
- `cargo test --workspace` ✅ (67 suites, 0 fail) · `cargo fmt --check` ✅ · `cargo clippy --workspace --all-targets -D warnings` ✅

## Remaining manual activation risks (unchanged; tool surfaces, doesn't remove)
- Cross-validator agreement is still a manual comparison (run preflight on every node, diff the hashes/state_root).
- Hash-commitment, not reconstruction — divergence recovery is resync-from-canonical.
- Coordinated halt-all/simul-start with an identical pinned height remains an operator step.

No deploy, no validators touched, no RPC/explorer/wallet/marketplace/bridge, no fork enabled.