### PR TITLE
fix(network): pin verified peers as gossipsub explicit peers (mesh-death fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,31 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.2.28] — 2026-06-04 — Pin validators as gossipsub explicit peers
+
+### Networking — silent mesh-death fix
+
+On the 4-validator testnet we kept hitting a stall where peers stayed
+TCP-connected but `apply_watchdog` reported `rx_gossip=0` ("PEER-MESH
+IDLE") — gossip stopped flowing, BFT couldn't gather precommits, and only
+a restart recovered it (which then recurred). Root cause: on a mesh this
+small, gossipsub's graft/prune heartbeat is fragile. Once a validator gets
+pruned (mesh_n_high overshoot, a transient score dip, a brief disconnect)
+it can fail to re-graft and the topic mesh collapses to zero, while the
+connection itself looks healthy.
+
+Fix: pin every chain_id-verified peer into the gossipsub **explicit-peers**
+set (`add_explicit_peer` on verified handshake — inbound and outbound —
+`remove_explicit_peer` once all connections to the peer close). Explicit
+peers receive every published *and* forwarded message directly, bypassing
+mesh graft/prune, so validator↔validator propagation is robust by
+construction instead of depending on the heartbeat keeping the mesh full.
+Complementary to `flood_publish` (which only covers the originator's first
+hop, not relays or subscription-tracking gaps).
+
+Non-consensus: this changes only message propagation, not block validation
+or state — no fork gate needed. Applies to validators and fullnodes alike.
+
 ## [2.2.27] — 2026-06-04 — Deterministic per-block bookkeeping (fork-gated)
 
 ### Consensus — reward/epoch bookkeeping moved to the apply path

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "bincode",
  "hex",
@@ -5248,7 +5248,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-nft"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "hex",
  "serde",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -5391,14 +5391,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "hex",
  "proptest",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5475,14 +5475,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5492,7 +5492,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "bincode",
  "blake3",
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.27"
+version = "2.2.28"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/crates/sentrix-network/src/behaviour.rs
+++ b/crates/sentrix-network/src/behaviour.rs
@@ -445,6 +445,32 @@ impl SentrixBehaviour {
             connection_limits,
         }
     }
+
+    /// Pin a verified peer into the gossipsub explicit-peers set.
+    ///
+    /// Why we need this on top of normal mesh management: on a tiny
+    /// 4-validator mesh, gossipsub's graft/prune heartbeat is fragile —
+    /// once a validator gets pruned (mesh_n_high overshoot, a transient
+    /// score dip, a brief disconnect) it can fail to re-graft, and the
+    /// mesh for a topic drops to zero. The TCP connection stays up, so
+    /// nothing looks broken, but `rx_gossip` goes to 0 and BFT can't
+    /// gather precommits → the silent mesh-death stall we kept hitting
+    /// (apply_watchdog "PEER-MESH IDLE"). Explicit peers bypass mesh
+    /// selection entirely: every published message is forwarded to them
+    /// directly regardless of mesh state, so validator↔validator gossip
+    /// is robust by construction instead of depending on the heartbeat
+    /// keeping the mesh full. Called once per peer when its chain_id-
+    /// verified handshake completes; idempotent in libp2p if re-called.
+    pub fn add_gossip_explicit_peer(&mut self, peer: &PeerId) {
+        self.gossipsub.add_explicit_peer(peer);
+    }
+
+    /// Drop a peer from the gossipsub explicit-peers set once all its
+    /// connections are gone (paired with `add_gossip_explicit_peer`).
+    /// No-op if the peer was never explicit.
+    pub fn remove_gossip_explicit_peer(&mut self, peer: &PeerId) {
+        self.gossipsub.remove_explicit_peer(peer);
+    }
 }
 
 // ── Gossipsub message types ─────────────────────────────
@@ -631,6 +657,25 @@ mod tests {
         let kp = make_keypair();
         let pid = libp2p::PeerId::from_public_key(&kp.public());
         let _behaviour = SentrixBehaviour::new_with_keypair(pid, &kp);
+    }
+
+    #[test]
+    fn test_gossip_explicit_peer_add_remove() {
+        // Pins the libp2p 0.56 gossipsub explicit-peer API used by the
+        // mesh-death fix: add on verified handshake, remove on full
+        // disconnect. add/remove return () — we assert the wiring builds
+        // and runs (idempotent re-add, remove-unknown no-op) without panic.
+        let kp = make_keypair();
+        let pid = libp2p::PeerId::from_public_key(&kp.public());
+        let mut behaviour = SentrixBehaviour::new_with_keypair(pid, &kp);
+
+        let peer_kp = make_keypair();
+        let peer = libp2p::PeerId::from_public_key(&peer_kp.public());
+
+        behaviour.add_gossip_explicit_peer(&peer);
+        behaviour.add_gossip_explicit_peer(&peer); // idempotent re-add
+        behaviour.remove_gossip_explicit_peer(&peer);
+        behaviour.remove_gossip_explicit_peer(&peer); // remove-unknown no-op
     }
 
     #[test]

--- a/crates/sentrix-network/src/libp2p_node.rs
+++ b/crates/sentrix-network/src/libp2p_node.rs
@@ -1009,6 +1009,8 @@ async fn on_swarm_event(
             // Previously, we removed on ANY close, orphaning the surviving connection.
             if num_established == 0 {
                 verified_peers.remove(&peer_id);
+                // Drop the gossipsub explicit-peer pin we set on verify.
+                swarm.behaviour_mut().remove_gossip_explicit_peer(&peer_id);
                 let _ = event_tx
                     .send(NodeEvent::PeerDisconnected(peer_id.to_string()))
                     .await;
@@ -1458,6 +1460,7 @@ async fn on_rr_event(
             },
             ..
         } => {
+            let was_verified = verified_peers.contains(&peer);
             on_inbound_request(
                 peer,
                 request,
@@ -1469,6 +1472,18 @@ async fn on_rr_event(
                 our_chain_id,
             )
             .await;
+            // Newly chain_id-verified peer → pin it as a gossipsub
+            // explicit peer so block/BFT propagation doesn't depend on
+            // the mesh heartbeat keeping it grafted (see
+            // SentrixBehaviour::add_gossip_explicit_peer).
+            if !was_verified && verified_peers.contains(&peer) {
+                swarm.behaviour_mut().add_gossip_explicit_peer(&peer);
+                tracing::info!(
+                    target: "gossip_mesh",
+                    "pinned {} as gossipsub explicit peer (inbound handshake)",
+                    peer
+                );
+            }
         }
 
         // ── Inbound: peer replied to one of our requests ─
@@ -1487,6 +1502,7 @@ async fn on_rr_event(
             pending_variants.remove(&request_id);
 
             // Check if this response matches a pending GetBlocks sync request
+            let was_verified = verified_peers.contains(&peer);
             let followup = on_inbound_response(
                 peer,
                 request_id,
@@ -1499,6 +1515,16 @@ async fn on_rr_event(
                 our_chain_id,
             )
             .await;
+            // Newly chain_id-verified peer (outbound handshake replied) →
+            // pin as gossipsub explicit peer; mirrors the inbound path.
+            if !was_verified && verified_peers.contains(&peer) {
+                swarm.behaviour_mut().add_gossip_explicit_peer(&peer);
+                tracing::info!(
+                    target: "gossip_mesh",
+                    "pinned {} as gossipsub explicit peer (outbound handshake)",
+                    peer
+                );
+            }
             // If sync returned more blocks to fetch, send another GetBlocks
             if let Some((next_peer, from_height)) = followup {
                 let req = SentrixRequest::GetBlocks { from_height };


### PR DESCRIPTION
## Problem

On the 4-validator testnet we kept hitting a stall where peers stayed
TCP-connected but `apply_watchdog` reported `rx_gossip=0` ("PEER-MESH IDLE"):
gossip stopped flowing, BFT couldn't gather precommits, and only a restart
recovered it — which then recurred.

Root cause: on a mesh this small, gossipsub's graft/prune heartbeat is fragile.
Once a validator is pruned (mesh_n_high overshoot, a transient score dip, a
brief disconnect) it can fail to re-graft and the topic mesh collapses to zero,
while the TCP connection itself looks healthy.

## Fix

Pin every chain_id-verified peer into the gossipsub **explicit-peers** set:
- `add_explicit_peer` on verified handshake — both inbound (`on_inbound_request`)
  and outbound (`on_inbound_response`) paths.
- `remove_explicit_peer` once all connections to the peer close
  (`ConnectionClosed`, `num_established == 0`).

Explicit peers receive every published *and* forwarded message directly,
bypassing mesh graft/prune — so validator↔validator propagation is robust by
construction instead of depending on the heartbeat keeping the mesh full. This
is complementary to `flood_publish` (already on), which only covers the
originator's first hop, not relays or subscription-tracking gaps.

This is the right-altitude fix: the team deliberately removed in-process
restart watchdogs (restart authority belongs to the external supervisor), so
the fix belongs at the mesh layer, not in another watchdog.

## Blast radius

**Non-consensus.** Changes only message propagation, not block validation or
state — no two nodes can disagree on chain state because of it, so no fork gate
is needed. Applies to validators and fullnodes alike. Rollback = `git revert`.

## Tests

`test_gossip_explicit_peer_add_remove` pins the libp2p 0.56 explicit-peer API
(idempotent re-add, remove-unknown no-op). Full `sentrix-network` suite green
under `RUSTFLAGS="-D warnings"` (33 passed). Propagation behaviour to be
confirmed on testnet bake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peer management methods for network operations with test coverage.

* **Improvements**
  * Enhanced peer connection lifecycle by automatically managing peer pinning upon verification and removing peers when all connections close.

* **Chores**
  * Bumped workspace version to 2.2.28.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->