### PR TITLE
fix(consensus): restore staking state on Pass-2 rollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "bincode",
  "hex",
@@ -5254,7 +5254,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5300,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "anyhow",
  "axum",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-nft"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "hex",
  "serde",
@@ -5372,7 +5372,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "anyhow",
  "axum",
@@ -5398,14 +5398,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "hex",
  "proptest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5482,14 +5482,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "bincode",
  "blake3",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.30"
+version = "2.2.31"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -64,6 +64,17 @@ pub(crate) struct BlockchainSnapshot {
     /// Restored via `SentrixTrie::set_root` on Pass 2 failure so the
     /// next block's `update_trie_for_block` walks the correct state.
     trie_root: Option<[u8; 32]>,
+    /// Consensus/staking state. After STATE_IN_TRIE_HEIGHT these feed the
+    /// state_root, and the centralized reward bundle (apply_reward_bookkeeping)
+    /// mutates them inside `apply_block_pass2` BEFORE the #1e state_root
+    /// check. They were missing here, so a #1e reject left pending_rewards /
+    /// epoch / liveness incremented — that leak then diverged the next
+    /// block's computed root and crawled the chain once both forks were live.
+    /// Snapshot + restore them so the Pass-2 rollback is atomic over
+    /// everything the state_root now commits.
+    stake_registry: sentrix_staking::staking::StakeRegistry,
+    epoch_manager: sentrix_staking::epoch::EpochManager,
+    slashing: sentrix_staking::slashing::SlashingEngine,
 }
 
 /// Frontier Phase F-2 shadow observer. Calls into the F-1 scaffold's
@@ -606,6 +617,9 @@ impl Blockchain {
             total_minted: self.total_minted,
             chain_len: self.chain.len(),
             trie_root: self.state_trie.as_ref().map(|t| t.root_hash()),
+            stake_registry: self.stake_registry.clone(),
+            epoch_manager: self.epoch_manager.clone(),
+            slashing: self.slashing.clone(),
         };
 
         match self.apply_block_pass2(block) {
@@ -652,6 +666,13 @@ impl Blockchain {
                 self.rebuild_mempool_sidecars();
                 self.total_minted = snap.total_minted;
                 self.chain.truncate(snap.chain_len);
+                // Restore the consensus/staking state too — post STATE_IN_TRIE
+                // it's in the state_root and the reward bundle mutated it above,
+                // so leaving it dirty after a #1e reject leaks pending_rewards /
+                // epoch / liveness into the next block's root.
+                self.stake_registry = snap.stake_registry;
+                self.epoch_manager = snap.epoch_manager;
+                self.slashing = snap.slashing;
                 // Rewind trie to pre-Pass-2 root if one was captured.
                 // Orphan nodes from the failed block's partial inserts
                 // remain in MDBX but are unreachable from any committed


### PR DESCRIPTION
## Problem

Validators on the internal testnet computed different `state_root`s for the
same block+parent after both the state-in-trie and reward-in-apply forks
activated, producing a stream of `#1e` state_root mismatches and reducing
block production to a crawl. Committed history stayed consistent, but the
chain could not sustain finalization.

## Root cause

`apply_block_pass2` runs the centralized reward bundle
(`apply_reward_bookkeeping_for_latest_block`) **before** the `#1e`
state_root check. That bundle mutates `stake_registry` (pending_rewards),
`epoch_manager`, and `slashing` (liveness).

The C-03 Pass-2 rollback snapshot (`BlockchainSnapshot`) captured
`accounts / contracts / nft_registry / authority / mempool / total_minted /
chain_len / trie_root` — but **not** those three. Once `STATE_IN_TRIE`
activated, `pending_rewards / epoch / liveness` are committed into the
`state_root`. So every rejected (`#1e`) block left them incremented; the
leaked values then diverged the *next* block's computed root, compounding
per-node. This is the interaction of the state-in-trie fork, the
reward-in-apply fork, and the older (pre-both) rollback snapshot.

## Fix

Snapshot and restore `stake_registry`, `epoch_manager`, and `slashing` in
the Pass-2 rollback path, so the rollback is atomic over **every** input
the `state_root` now commits. Success path is unchanged; only the reject
path is made complete. No change to the committed-block root formula, so no
fork gate is required — deploy fleet-wide.

Verified every `state_root` input in `update_trie_for_block` is now covered:
accounts, per-validator pending_rewards, liveness, epoch_state, total_minted,
SRC-20 / NFT registry hashes.

## Validation

Deployed to the 4-validator internal testnet: `#1e` mismatches dropped from
~1/s to **0** across all validators, and committed `state_root` is identical
across all nodes at every height.

## Follow-up (this PR)

Regression test: a `#1e` reject after the reward bundle runs, asserting
`pending_rewards / epoch / liveness` are restored to their pre-block values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 2.2.31

* **Bug Fixes**
  * Enhanced state rollback mechanism to prevent staking state mutations (rewards, epochs, liveness, slashing) from persisting when block application fails, ensuring proper cleanup of failed blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->