### PR TITLE
fix(consensus): apply finalized peer block from local stash

### DIFF
--- a/bin/sentrix/src/main.rs
+++ b/bin/sentrix/src/main.rs
@@ -2914,21 +2914,27 @@ async fn cmd_start(
                                     }
 
                                     if let Some(mut blk) = proposed_block.take() {
+                                        // Apply the finalized block we already hold, whoever proposed
+                                        // it. The hash-match guard above proved `blk` IS the
+                                        // FinalizeBlock action's block, and `justification` carries
+                                        // its 2/3 precommit certificate — so this is the canonical
+                                        // committed block. This previously broke out and waited for
+                                        // libp2p NewBlock/sync to re-deliver a peer's block; when
+                                        // gossip missed, the node sat in Finalize re-triggering sync
+                                        // while holding the block the whole time → chain crawl/stall.
+                                        // `validate_block` below still re-checks structure + the
+                                        // justification supermajority before we write.
                                         if blk.validator != wallet.address {
                                             tracing::info!(
                                                 target: "finalize_trace",
-                                                "BFT finalize peer-propose: h={} round={} block={:.16}… \
-                                                 proposer={} is not local validator {}; waiting for \
-                                                 libp2p NewBlock/sync instead of executing peer block \
-                                                 in the BFT loop",
+                                                "BFT finalize: applying peer-proposed finalized block \
+                                                 h={} round={} block={:.16}… proposer={} from local \
+                                                 stash (valid 2/3 justification)",
                                                 height,
                                                 round,
                                                 block_hash,
                                                 blk.validator,
-                                                wallet.address,
                                             );
-                                            lp2p_clone.trigger_sync().await;
-                                            break;
                                         }
 
                                         blk.round = round;


### PR DESCRIPTION
## Problem

After the Pass-2 rollback fix (#792) eliminated `#1e` state_root mismatches,
the testnet still crawled: blocks committed only via the slow `GetBlocks`
sync fallback, ~1 block per several seconds, with nodes frequently stuck in
the BFT `Finalize` phase.

## Root cause

In the peer-propose `FinalizeBlock` arm, the node **already held** the
finalized block — it had received the proposal and voted for it, the
hash-match guard confirmed `proposed_block.hash == action.block_hash`, and
`justification` carried the 2/3 precommit certificate. But the code applied
it only if the local node was the proposer; otherwise it logged
"waiting for libp2p NewBlock/sync instead of executing peer block",
triggered a sync, and broke. When NewBlock gossip missed (common after a
restart / on a small mesh), the node sat in `Finalize` re-requesting a block
it was holding the whole time → stall/crawl.

## Fix

Apply the held block locally regardless of proposer, mirroring the
self-propose arm. The hash-match guard already proved it is the canonical
finalized block, and `validate_block` still re-checks structure + the
justification supermajority before the write. No change to block content or
`state_root`, so no fork gate — deploy fleet-wide.

## Validation

Deployed to the 4-validator internal testnet alongside #792: block production
went from a crawl to **~3 blk/s** (catching up the backlog), all validators
converged to the same height, and the public RPC returned to 200.

## Note

Stacks on #792 (base set to that branch). A benign log artifact remains: the
redundant libp2p receive path can `#1e` on a block the finalize path already
committed — non-fatal (committed state_root is identical across nodes), to be
quieted as a follow-up.