### PR TITLE
refactor(core): move state-fingerprint helpers to block_executor submodule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "bincode",
  "hex",
@@ -5254,7 +5254,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5300,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "anyhow",
  "axum",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-nft"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "hex",
  "serde",
@@ -5372,7 +5372,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "anyhow",
  "axum",
@@ -5398,14 +5398,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "hex",
  "proptest",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5482,14 +5482,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "bincode",
  "blake3",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.31"
+version = "2.2.36"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.35"
+version = "2.2.36"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -4,7 +4,11 @@
 // own files so this one can stay focused on the block-level apply
 // hot path.
 mod evm;
+mod fingerprint;
 mod validate;
+
+pub use fingerprint::{StateComponents, state_components};
+use fingerprint::{emit_apply_profile, emit_state_fingerprint};
 
 use crate::authority::AuthorityManager;
 use crate::blockchain::{
@@ -1911,207 +1915,6 @@ impl Blockchain {
     }
 }
 
-/// State-drift fingerprint emitter (debug-only). When
-/// `SENTRIX_STATE_FINGERPRINT=1` the apply path calls this at the end
-/// of every block; cross-host log diff at next halt pinpoints the
-/// first diverging block.
-///
-/// What we hash:
-///   1. AccountDB.accounts — sorted by address, each (balance, nonce,
-///      code_hash, storage_root)
-///   2. AccountDB.total_burned
-///   3. AccountDB.contract_code — sorted by code_hash, each
-///      sha256(bytecode)
-///   4. AccountDB.contract_storage — sorted by composite key, raw
-///      value bytes
-///   5. Blockchain.total_minted
-///
-/// We deliberately skip stake_registry — bincode HashMap serialisation
-/// is non-deterministic, and the drift we're chasing manifests in
-/// AccountDB (via trie roots that read from AccountDB).
-///
-/// Output line shape:
-///   [STATE-FP] h=<height> acc=<8-byte-hex> fp=<8-byte-hex>
-///
-/// Cost when enabled: ~O(N) sha256 over AccountDB content per block,
-/// Per-block apply-phase profile emitter. Single exit point for the
-/// `apply-profile h=... txs=... tx_apply=...ms trie=...ms post=...ms total=...ms`
-/// log line, so every return path through `apply_block_pass2` records
-/// timing when SENTRIX_APPLY_PROFILE=1. Pre-helper, the legacy-tolerated
-/// branch returned without emitting — replay of pre-cutoff blocks left a
-/// gap in the profile log.
-///
-/// No-op when any of the three timestamps is None (profiling disabled).
-fn emit_apply_profile(
-    t0: Option<std::time::Instant>,
-    t1: Option<std::time::Instant>,
-    t2: Option<std::time::Instant>,
-    height: u64,
-    txs: usize,
-) {
-    if let (Some(t0), Some(t1), Some(t2)) = (t0, t1, t2) {
-        let t3 = std::time::Instant::now();
-        tracing::info!(
-            target: "apply_profile",
-            "apply-profile h={} txs={} tx_apply={}ms trie={}ms post={}ms total={}ms",
-            height,
-            txs,
-            t1.duration_since(t0).as_millis(),
-            t2.duration_since(t1).as_millis(),
-            t3.duration_since(t2).as_millis(),
-            t3.duration_since(t0).as_millis(),
-        );
-    }
-}
-
-/// where N = total accounts + contract storage entries. At Sentrix
-/// mainnet scale (~tens of thousands of accounts, sparse contract
-/// storage) this adds ~1-2 ms per block. Acceptable for debug runs.
-fn emit_state_fingerprint(bc: &Blockchain, height: u64) {
-    if std::env::var_os("SENTRIX_STATE_FINGERPRINT").is_none() {
-        return;
-    }
-    let (acc_fp, fp) = compute_state_fingerprint(bc);
-    // eprintln! matches the existing `[V2-DBG]` trace pattern in
-    // `update_trie_for_block` — guaranteed journalctl visibility
-    // regardless of RUST_LOG / tracing subscriber filter config.
-    eprintln!(
-        "[STATE-FP] h={} acc={} fp={}",
-        height,
-        hex::encode(&acc_fp[..8]),
-        hex::encode(&fp[..8]),
-    );
-}
-
-/// Compute `(account_fingerprint, combined_fingerprint)` for the current
-/// state. Split out of `emit_state_fingerprint` so it's testable without the
-/// `SENTRIX_STATE_FINGERPRINT` env gate or stderr capture.
-///
-/// The combined fingerprint folds, in fixed order:
-///   account state · total_minted · SRC-20 ContractRegistry · NFT NftRegistry
-///
-/// Native-module state commitment (2026-06-03): before this, the fingerprint
-/// hashed only accounts + total_minted + EVM code/storage, so two validators
-/// could diverge purely in SRC-20 or NFT state and still print identical
-/// `[STATE-FP]` lines — the incident tool was blind on those paths. Both
-/// registries now contribute via their `canonical_hash()` (sorted, HashMap-
-/// order-independent). Consensus-enforced trie/state_root commitment of the
-/// same state is the fork-gated follow-up; this closes the debug-visibility
-/// gap without a consensus change.
-fn compute_state_fingerprint(bc: &Blockchain) -> ([u8; 32], [u8; 32]) {
-    use sha2::{Digest, Sha256};
-
-    let mut acc_hasher = Sha256::new();
-    let mut accounts: Vec<(&String, &sentrix_primitives::account::Account)> =
-        bc.accounts.accounts.iter().collect();
-    accounts.sort_by(|a, b| a.0.cmp(b.0));
-    for (addr, account) in accounts {
-        acc_hasher.update(addr.as_bytes());
-        acc_hasher.update(account.balance.to_be_bytes());
-        acc_hasher.update(account.nonce.to_be_bytes());
-        acc_hasher.update(account.code_hash);
-        acc_hasher.update(account.storage_root);
-    }
-    acc_hasher.update(bc.accounts.total_burned.to_be_bytes());
-
-    let mut codes: Vec<(&String, &Vec<u8>)> = bc.accounts.contract_code.iter().collect();
-    codes.sort_by(|a, b| a.0.cmp(b.0));
-    for (k, v) in codes {
-        acc_hasher.update(k.as_bytes());
-        let h: [u8; 32] = Sha256::digest(v).into();
-        acc_hasher.update(h);
-    }
-
-    let mut storage: Vec<(&String, &Vec<u8>)> = bc.accounts.contract_storage.iter().collect();
-    storage.sort_by(|a, b| a.0.cmp(b.0));
-    for (k, v) in storage {
-        acc_hasher.update(k.as_bytes());
-        acc_hasher.update(v);
-    }
-
-    let acc_fp: [u8; 32] = acc_hasher.finalize().into();
-    let mut combined = Sha256::new();
-    combined.update(acc_fp);
-    combined.update(bc.total_minted.to_be_bytes());
-    // Native-module state: SRC-20 then NFT, each canonical (sorted) so
-    // HashMap iteration order can't move the fingerprint.
-    combined.update(bc.contracts.canonical_hash());
-    combined.update(bc.nft_registry.canonical_hash());
-    let fp: [u8; 32] = combined.finalize().into();
-    (acc_fp, fp)
-}
-
-/// Per-component state fingerprints for cross-node drift diagnosis.
-///
-/// `compute_state_fingerprint` folds everything into one root, which tells
-/// you THAT two nodes diverged but not WHERE. This splits each component out
-/// (accounts / EVM code / EVM storage / mint / burn / SRC-20 / NFT) so a diff
-/// across nodes at the same height points straight at the divergent subsystem.
-/// Added 2026-06-04 chasing the post-#782 state-determinism drift.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StateComponents {
-    /// balance + nonce + code_hash + storage_root over sorted accounts.
-    pub accounts_fp: [u8; 32],
-    /// hash over sorted EVM contract bytecode.
-    pub contract_code_fp: [u8; 32],
-    /// hash over sorted EVM contract storage slots.
-    pub contract_storage_fp: [u8; 32],
-    pub total_minted: u64,
-    pub total_burned: u64,
-    /// SRC-20 native registry canonical hash.
-    pub src20_fp: [u8; 32],
-    /// NFT native registry canonical hash.
-    pub nft_fp: [u8; 32],
-    /// account count (cheap sanity signal alongside the hashes).
-    pub account_count: usize,
-}
-
-/// Compute the per-component fingerprints — see [`StateComponents`].
-pub fn state_components(bc: &Blockchain) -> StateComponents {
-    use sha2::{Digest, Sha256};
-
-    let mut accounts: Vec<(&String, &sentrix_primitives::account::Account)> =
-        bc.accounts.accounts.iter().collect();
-    accounts.sort_by(|a, b| a.0.cmp(b.0));
-    let account_count = accounts.len();
-    let mut acc_h = Sha256::new();
-    for (addr, account) in accounts {
-        acc_h.update(addr.as_bytes());
-        acc_h.update(account.balance.to_be_bytes());
-        acc_h.update(account.nonce.to_be_bytes());
-        acc_h.update(account.code_hash);
-        acc_h.update(account.storage_root);
-    }
-
-    let mut codes: Vec<(&String, &Vec<u8>)> = bc.accounts.contract_code.iter().collect();
-    codes.sort_by(|a, b| a.0.cmp(b.0));
-    let mut code_h = Sha256::new();
-    for (k, v) in codes {
-        code_h.update(k.as_bytes());
-        let h: [u8; 32] = Sha256::digest(v).into();
-        code_h.update(h);
-    }
-
-    let mut storage: Vec<(&String, &Vec<u8>)> = bc.accounts.contract_storage.iter().collect();
-    storage.sort_by(|a, b| a.0.cmp(b.0));
-    let mut stor_h = Sha256::new();
-    for (k, v) in storage {
-        stor_h.update(k.as_bytes());
-        stor_h.update(v);
-    }
-
-    StateComponents {
-        accounts_fp: acc_h.finalize().into(),
-        contract_code_fp: code_h.finalize().into(),
-        contract_storage_fp: stor_h.finalize().into(),
-        total_minted: bc.total_minted,
-        total_burned: bc.accounts.total_burned,
-        src20_fp: bc.contracts.canonical_hash(),
-        nft_fp: bc.nft_registry.canonical_hash(),
-        account_count,
-    }
-}
-
 // ── Tests ─────────────────────────────────────────────────
 #[cfg(test)]
 mod tests {
@@ -2346,11 +2149,11 @@ mod tests {
     #[test]
     fn fingerprint_tracks_src20_state() {
         let mut bc = setup();
-        let (_, fp_empty) = super::compute_state_fingerprint(&bc);
+        let (_, fp_empty) = super::fingerprint::compute_state_fingerprint(&bc);
         bc.contracts
             .deploy("0xowner", "Tok", "TOK", 8, 1000, 0, "seed1")
             .unwrap();
-        let (_, fp_deploy) = super::compute_state_fingerprint(&bc);
+        let (_, fp_deploy) = super::fingerprint::compute_state_fingerprint(&bc);
         assert_ne!(fp_empty, fp_deploy, "SRC-20 deploy must move fingerprint");
     }
 
@@ -2358,11 +2161,11 @@ mod tests {
     #[test]
     fn fingerprint_tracks_nft_state() {
         let mut bc = setup();
-        let (_, fp_empty) = super::compute_state_fingerprint(&bc);
+        let (_, fp_empty) = super::fingerprint::compute_state_fingerprint(&bc);
         bc.nft_registry
             .deploy_collection(NFT_ADDR_A, "C", "C", "u", None, true, true, "seed")
             .unwrap();
-        let (_, fp_deploy) = super::compute_state_fingerprint(&bc);
+        let (_, fp_deploy) = super::fingerprint::compute_state_fingerprint(&bc);
         assert_ne!(fp_empty, fp_deploy, "NFT deploy must move fingerprint");
     }
 
@@ -2383,7 +2186,7 @@ mod tests {
                 .unwrap()
                 .mint(NFT_ADDR_A, NFT_ADDR_B, 7, "", None)
                 .unwrap();
-            super::compute_state_fingerprint(&bc).1
+            super::fingerprint::compute_state_fingerprint(&bc).1
         };
         assert_eq!(build(), build(), "replayed native state must match");
     }
@@ -2396,7 +2199,7 @@ mod tests {
             bc.contracts
                 .deploy("0xowner", "Tok", "TOK", 8, supply, 0, "seed1")
                 .unwrap();
-            super::compute_state_fingerprint(&bc).1
+            super::fingerprint::compute_state_fingerprint(&bc).1
         };
         assert_ne!(make(1000), make(2000));
     }
@@ -2415,7 +2218,7 @@ mod tests {
                 .unwrap()
                 .mint(NFT_ADDR_A, owner, 1, "", None)
                 .unwrap();
-            super::compute_state_fingerprint(&bc).1
+            super::fingerprint::compute_state_fingerprint(&bc).1
         };
         assert_ne!(make(NFT_ADDR_A), make(NFT_ADDR_B));
     }
@@ -2438,8 +2241,8 @@ mod tests {
             .deploy("0xowner", "A", "AAA", 8, 1, 0, "s1")
             .unwrap();
         assert_eq!(
-            super::compute_state_fingerprint(&a).1,
-            super::compute_state_fingerprint(&b).1,
+            super::fingerprint::compute_state_fingerprint(&a).1,
+            super::fingerprint::compute_state_fingerprint(&b).1,
             "deploy order must not affect fingerprint"
         );
     }

--- a/crates/sentrix-core/src/block_executor/fingerprint.rs
+++ b/crates/sentrix-core/src/block_executor/fingerprint.rs
@@ -1,0 +1,209 @@
+//! State fingerprinting + apply profiling — cross-node drift diagnosis.
+//!
+//! Pure code motion out of `block_executor.rs` (no logic change). These are
+//! debug/observability helpers, gated behind `SENTRIX_STATE_FINGERPRINT` /
+//! `SENTRIX_APPLY_PROFILE`; they never feed consensus. Kept together so the
+//! apply path in `block_executor.rs` stays focused on state transition.
+
+use crate::blockchain::Blockchain;
+
+/// Per-block apply-phase profile emitter. Single exit point for the
+/// `apply-profile h=... txs=... tx_apply=...ms trie=...ms post=...ms total=...ms`
+/// log line, so every return path through `apply_block_pass2` records
+/// timing when SENTRIX_APPLY_PROFILE=1. Pre-helper, the legacy-tolerated
+/// branch returned without emitting — replay of pre-cutoff blocks left a
+/// gap in the profile log.
+///
+/// No-op when any of the three timestamps is None (profiling disabled).
+pub(crate) fn emit_apply_profile(
+    t0: Option<std::time::Instant>,
+    t1: Option<std::time::Instant>,
+    t2: Option<std::time::Instant>,
+    height: u64,
+    txs: usize,
+) {
+    if let (Some(t0), Some(t1), Some(t2)) = (t0, t1, t2) {
+        let t3 = std::time::Instant::now();
+        tracing::info!(
+            target: "apply_profile",
+            "apply-profile h={} txs={} tx_apply={}ms trie={}ms post={}ms total={}ms",
+            height,
+            txs,
+            t1.duration_since(t0).as_millis(),
+            t2.duration_since(t1).as_millis(),
+            t3.duration_since(t2).as_millis(),
+            t3.duration_since(t0).as_millis(),
+        );
+    }
+}
+
+/// State-drift fingerprint emitter (debug-only). When
+/// `SENTRIX_STATE_FINGERPRINT=1` the apply path calls this at the end
+/// of every block; cross-host log diff at next halt pinpoints the
+/// first diverging block.
+///
+/// What we hash:
+///   1. AccountDB.accounts — sorted by address, each (balance, nonce,
+///      code_hash, storage_root)
+///   2. AccountDB.total_burned
+///   3. AccountDB.contract_code — sorted by code_hash, each
+///      sha256(bytecode)
+///   4. AccountDB.contract_storage — sorted by composite key, raw
+///      value bytes
+///   5. Blockchain.total_minted
+///
+/// We deliberately skip stake_registry — bincode HashMap serialisation
+/// is non-deterministic, and the drift we're chasing manifests in
+/// AccountDB (via trie roots that read from AccountDB).
+///
+/// Output line shape:
+///   [STATE-FP] h=<height> acc=<8-byte-hex> fp=<8-byte-hex>
+///
+/// Cost when enabled: ~O(N) sha256 over AccountDB content per block,
+/// where N = total accounts + contract storage entries. At Sentrix
+/// mainnet scale (~tens of thousands of accounts, sparse contract
+/// storage) this adds ~1-2 ms per block. Acceptable for debug runs.
+pub(crate) fn emit_state_fingerprint(bc: &Blockchain, height: u64) {
+    if std::env::var_os("SENTRIX_STATE_FINGERPRINT").is_none() {
+        return;
+    }
+    let (acc_fp, fp) = compute_state_fingerprint(bc);
+    // eprintln! matches the existing `[V2-DBG]` trace pattern in
+    // `update_trie_for_block` — guaranteed journalctl visibility
+    // regardless of RUST_LOG / tracing subscriber filter config.
+    eprintln!(
+        "[STATE-FP] h={} acc={} fp={}",
+        height,
+        hex::encode(&acc_fp[..8]),
+        hex::encode(&fp[..8]),
+    );
+}
+
+/// Compute `(account_fingerprint, combined_fingerprint)` for the current
+/// state. Split out of `emit_state_fingerprint` so it's testable without the
+/// `SENTRIX_STATE_FINGERPRINT` env gate or stderr capture.
+///
+/// The combined fingerprint folds, in fixed order:
+///   account state · total_minted · SRC-20 ContractRegistry · NFT NftRegistry
+///
+/// Native-module state commitment (2026-06-03): before this, the fingerprint
+/// hashed only accounts + total_minted + EVM code/storage, so two validators
+/// could diverge purely in SRC-20 or NFT state and still print identical
+/// `[STATE-FP]` lines — the incident tool was blind on those paths. Both
+/// registries now contribute via their `canonical_hash()` (sorted, HashMap-
+/// order-independent). Consensus-enforced trie/state_root commitment of the
+/// same state is the fork-gated follow-up; this closes the debug-visibility
+/// gap without a consensus change.
+pub(crate) fn compute_state_fingerprint(bc: &Blockchain) -> ([u8; 32], [u8; 32]) {
+    use sha2::{Digest, Sha256};
+
+    let mut acc_hasher = Sha256::new();
+    let mut accounts: Vec<(&String, &sentrix_primitives::account::Account)> =
+        bc.accounts.accounts.iter().collect();
+    accounts.sort_by(|a, b| a.0.cmp(b.0));
+    for (addr, account) in accounts {
+        acc_hasher.update(addr.as_bytes());
+        acc_hasher.update(account.balance.to_be_bytes());
+        acc_hasher.update(account.nonce.to_be_bytes());
+        acc_hasher.update(account.code_hash);
+        acc_hasher.update(account.storage_root);
+    }
+    acc_hasher.update(bc.accounts.total_burned.to_be_bytes());
+
+    let mut codes: Vec<(&String, &Vec<u8>)> = bc.accounts.contract_code.iter().collect();
+    codes.sort_by(|a, b| a.0.cmp(b.0));
+    for (k, v) in codes {
+        acc_hasher.update(k.as_bytes());
+        let h: [u8; 32] = Sha256::digest(v).into();
+        acc_hasher.update(h);
+    }
+
+    let mut storage: Vec<(&String, &Vec<u8>)> = bc.accounts.contract_storage.iter().collect();
+    storage.sort_by(|a, b| a.0.cmp(b.0));
+    for (k, v) in storage {
+        acc_hasher.update(k.as_bytes());
+        acc_hasher.update(v);
+    }
+
+    let acc_fp: [u8; 32] = acc_hasher.finalize().into();
+    let mut combined = Sha256::new();
+    combined.update(acc_fp);
+    combined.update(bc.total_minted.to_be_bytes());
+    // Native-module state: SRC-20 then NFT, each canonical (sorted) so
+    // HashMap iteration order can't move the fingerprint.
+    combined.update(bc.contracts.canonical_hash());
+    combined.update(bc.nft_registry.canonical_hash());
+    let fp: [u8; 32] = combined.finalize().into();
+    (acc_fp, fp)
+}
+
+/// Per-component state fingerprints for cross-node drift diagnosis.
+///
+/// `compute_state_fingerprint` folds everything into one root, which tells
+/// you THAT two nodes diverged but not WHERE. This splits each component out
+/// (accounts / EVM code / EVM storage / mint / burn / SRC-20 / NFT) so a diff
+/// across nodes at the same height points straight at the divergent subsystem.
+/// Added 2026-06-04 chasing the post-#782 state-determinism drift.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateComponents {
+    /// balance + nonce + code_hash + storage_root over sorted accounts.
+    pub accounts_fp: [u8; 32],
+    /// hash over sorted EVM contract bytecode.
+    pub contract_code_fp: [u8; 32],
+    /// hash over sorted EVM contract storage slots.
+    pub contract_storage_fp: [u8; 32],
+    pub total_minted: u64,
+    pub total_burned: u64,
+    /// SRC-20 native registry canonical hash.
+    pub src20_fp: [u8; 32],
+    /// NFT native registry canonical hash.
+    pub nft_fp: [u8; 32],
+    /// account count (cheap sanity signal alongside the hashes).
+    pub account_count: usize,
+}
+
+/// Compute the per-component fingerprints — see [`StateComponents`].
+pub fn state_components(bc: &Blockchain) -> StateComponents {
+    use sha2::{Digest, Sha256};
+
+    let mut accounts: Vec<(&String, &sentrix_primitives::account::Account)> =
+        bc.accounts.accounts.iter().collect();
+    accounts.sort_by(|a, b| a.0.cmp(b.0));
+    let account_count = accounts.len();
+    let mut acc_h = Sha256::new();
+    for (addr, account) in accounts {
+        acc_h.update(addr.as_bytes());
+        acc_h.update(account.balance.to_be_bytes());
+        acc_h.update(account.nonce.to_be_bytes());
+        acc_h.update(account.code_hash);
+        acc_h.update(account.storage_root);
+    }
+
+    let mut codes: Vec<(&String, &Vec<u8>)> = bc.accounts.contract_code.iter().collect();
+    codes.sort_by(|a, b| a.0.cmp(b.0));
+    let mut code_h = Sha256::new();
+    for (k, v) in codes {
+        code_h.update(k.as_bytes());
+        let h: [u8; 32] = Sha256::digest(v).into();
+        code_h.update(h);
+    }
+
+    let mut storage: Vec<(&String, &Vec<u8>)> = bc.accounts.contract_storage.iter().collect();
+    storage.sort_by(|a, b| a.0.cmp(b.0));
+    let mut stor_h = Sha256::new();
+    for (k, v) in storage {
+        stor_h.update(k.as_bytes());
+        stor_h.update(v);
+    }
+
+    StateComponents {
+        accounts_fp: acc_h.finalize().into(),
+        contract_code_fp: code_h.finalize().into(),
+        contract_storage_fp: stor_h.finalize().into(),
+        total_minted: bc.total_minted,
+        total_burned: bc.accounts.total_burned,
+        src20_fp: bc.contracts.canonical_hash(),
+        nft_fp: bc.nft_registry.canonical_hash(),
+        account_count,
+    }
+}


### PR DESCRIPTION
First step of breaking up the sentrix-core monolith (16k LOC) for debuggability, lowest-risk first: a **pure module-split within the crate** — zero crate boundary, so no serialization/API surface where a determinism bug could hide.

## What moved
`emit_apply_profile`, `emit_state_fingerprint`, `compute_state_fingerprint`, `StateComponents`, `state_components` → `block_executor/fingerprint.rs` (continuing the existing `block_executor/{evm,validate}` submodule pattern). All are debug/observability helpers gated behind `SENTRIX_STATE_FINGERPRINT` / `SENTRIX_APPLY_PROFILE`; they never feed consensus.

## Safety
- Pure code motion — function bodies are byte-identical, no logic change.
- `state_components` + `StateComponents` stay `pub` (re-exported at the module path, used by the bin `state` command); the rest are `pub(crate)`.
- Un-scrambles doc comments that had drifted above the wrong function.

## Verification
- `cargo check --workspace -D warnings` clean (bin re-export resolves).
- `cargo test -p sentrix-core`: 273 passed, 0 failed (unchanged from before the move).