### PR TITLE
refactor(core): extract fork-heights into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "bincode",
  "hex",
@@ -5254,7 +5254,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5267,6 +5267,7 @@ dependencies = [
  "secp256k1 0.31.1",
  "sentrix-bft",
  "sentrix-evm",
+ "sentrix-fork-heights",
  "sentrix-nft",
  "sentrix-primitives",
  "sentrix-staking",
@@ -5285,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5300,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "anyhow",
  "axum",
@@ -5323,8 +5324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentrix-fork-heights"
+version = "2.2.37"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
 name = "sentrix-grpc"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5343,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5361,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-nft"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "hex",
  "serde",
@@ -5372,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "anyhow",
  "axum",
@@ -5398,14 +5406,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "hex",
  "proptest",
@@ -5420,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5449,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5482,14 +5490,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5499,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5514,7 +5522,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "bincode",
  "blake3",
@@ -5531,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5551,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
 resolver = "2"
-members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-nft", "crates/sentrix-core", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "crates/sentrix-wire", "crates/sentrix-proto", "crates/sentrix-grpc", "crates/sentrix-prom-exporter", "bin/sentrix", "bin/sentrix-faucet"]
+members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/sentrix-trie", "crates/sentrix-staking", "crates/sentrix-evm", "crates/sentrix-bft", "crates/sentrix-codec", "crates/sentrix-nft", "crates/sentrix-core", "crates/sentrix-fork-heights", "crates/sentrix-network", "crates/sentrix-precompiles", "crates/sentrix-rpc", "crates/sentrix-rpc-types", "crates/sentrix-storage", "crates/sentrix-wire", "crates/sentrix-proto", "crates/sentrix-grpc", "crates/sentrix-prom-exporter", "bin/sentrix", "bin/sentrix-faucet"]
 
 # Single source of truth for fields every workspace member shares.
 # Future version bumps = edit `version` here only; each member inherits via
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.36"
+version = "2.2.37"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/crates/sentrix-core/Cargo.toml
+++ b/crates/sentrix-core/Cargo.toml
@@ -14,6 +14,7 @@ sentrix-staking = { path = "../sentrix-staking" }
 sentrix-evm = { path = "../sentrix-evm" }
 sentrix-bft = { path = "../sentrix-bft" }
 sentrix-nft = { path = "../sentrix-nft" }
+sentrix-fork-heights = { path = "../sentrix-fork-heights" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/sentrix-core/src/lib.rs
+++ b/crates/sentrix-core/src/lib.rs
@@ -17,7 +17,11 @@ pub mod blockchain_trie_ops;
 pub mod chain_params;
 pub mod chain_queries;
 pub(crate) mod divergence;
-pub mod fork_heights;
+// Fork-activation heights live in their own crate now (pure consts + env +
+// chain-id selection, no consensus-state coupling). Re-exported so the
+// fleet-wide `sentrix_core::fork_heights::*` / `crate::fork_heights::*` call
+// sites keep resolving unchanged.
+pub use sentrix_fork_heights as fork_heights;
 pub mod genesis;
 pub mod mempool;
 pub mod nft;

--- a/crates/sentrix-fork-heights/Cargo.toml
+++ b/crates/sentrix-fork-heights/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sentrix-fork-heights"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Sentrix fork-activation heights — chain-id-aware fork schedule (consts + env overrides) shared across the node"
+publish = false
+
+[dependencies]
+tracing = "0.1"

--- a/crates/sentrix-fork-heights/src/lib.rs
+++ b/crates/sentrix-fork-heights/src/lib.rs
@@ -462,7 +462,7 @@ pub fn get_reward_apply_path_height() -> u64 {
 /// Default `u64::MAX` makes this return false for all heights —
 /// the mainnet-safe-default-pre-activation pattern.
 ///
-/// **Use [`crate::Blockchain::voyager_mode_for`] in consensus paths** —
+/// **Use `Blockchain::voyager_mode_for` (sentrix-core) in consensus paths** —
 /// it ORs this check with the runtime persisted `voyager_activated`
 /// flag, so post-activation chains don't depend on the env var being
 /// set correctly. The 2026-04-26 mainnet stall happened because
@@ -609,7 +609,17 @@ pub fn is_bft_gate_relax_height(height: u64) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::env_test_lock;
+
+    /// Serialises env-var-mutating tests within this crate (env is
+    /// process-global). Inlined on extraction — was `crate::test_util`
+    /// back when these lived in sentrix-core.
+    fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
 
     /// Each fork-height reader is `env::var` parse → fallback. We
     /// exercise the env-set + env-unset paths once for one


### PR DESCRIPTION
Step 2 of breaking up the sentrix-core monolith. A **pure, peripheral crate extraction**: `fork_heights` is consts + env reads + chain-id selection with no consensus-state coupling, so it lifts out cleanly.

## What moved
`crates/sentrix-core/src/fork_heights.rs` → new crate `sentrix-fork-heights` (`crates/sentrix-fork-heights/src/lib.rs`, via `git mv` so history follows). sentrix-core re-exports it:
```rust
pub use sentrix_fork_heights as fork_heights;
```
so every fleet-wide `sentrix_core::fork_heights::*` / `crate::fork_heights::*` call site (37 across core/network/bin) resolves **unchanged** — zero call-site edits.

## Why
Separate compile unit (faster incremental builds when iterating fork schedule), clearer boundary, independently auditable/publishable. BUSL-1.1 + `publish = false` like the rest of the consensus crates.

## Safety (pure motion)
- Fork-schedule consts + selection logic are **byte-identical**.
- Only deltas: the in-crate env-test lock is inlined (was `crate::test_util`), and one intra-doc-link to a sentrix-core type is plain-texted (would be circular: core depends on this crate, not vice versa).
- New crate's only dep is `tracing` (one `warn!`).

## Verification
- `cargo check --workspace -D warnings` clean (all 37 call sites resolve via the re-export).
- Tests conserved: sentrix-core **263** + sentrix-fork-heights **10** = **273** (was 273), 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped workspace version from 2.2.35 to 2.2.37.
  * Reorganized internal crate dependencies for improved modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->