### PR TITLE
fix(trie): fail-closed on malformed tombstone (CodeRabbit follow-up to #798)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "bincode",
  "hex",
@@ -5254,7 +5254,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5286,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "anyhow",
  "axum",
@@ -5325,14 +5325,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-fork-heights"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5351,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-nft"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "hex",
  "serde",
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "anyhow",
  "axum",
@@ -5406,14 +5406,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "hex",
  "proptest",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5490,14 +5490,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5522,7 +5522,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "bincode",
  "blake3",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5559,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.38"
+version = "2.2.39"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.38"
+version = "2.2.39"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/crates/sentrix-trie/src/storage.rs
+++ b/crates/sentrix-trie/src/storage.rs
@@ -388,6 +388,19 @@ impl TrieStorage {
     /// the tombstone instead of deleting it. Worst-case failure mode is benign:
     /// under-deletion (storage grows), never deletion of a live entry. Returns
     /// the count actually deleted this cycle.
+    ///
+    /// CALLER CONTRACT: `live_hashes` must be augmented to the latest committed
+    /// root IMMEDIATELY before this call (`tree.rs::prune` re-walks the on-disk
+    /// roots into `live` just before each gc pass). That collapses the reap-vs-
+    /// commit window to this method's own scan+delete duration (ms — the
+    /// tombstone table is small), versus the old immediate-delete that raced the
+    /// whole multi-minute walk. RESIDUAL (CodeRabbit, 2026-06-06): a
+    /// content-addressed hash re-committed inside that ms window can still be
+    /// reaped here; fully eliminating it needs the reap coupled to writer
+    /// synchronization (walk+delete in one RW txn) — the tracked complete fix
+    /// this PR deliberately defers to avoid a 10–20 min apply-blocking write
+    /// lock. This change strictly narrows the race; it does not pretend to close
+    /// it. Boot-time verify_integrity remains the backstop.
     fn gc_table_generational(
         &self,
         data_table: &str,
@@ -410,9 +423,23 @@ impl TrieStorage {
                     if live_hashes.contains(&h) {
                         clear.push(h);
                     } else {
-                        let tv = v.try_into().map(u64::from_be_bytes).unwrap_or(0);
-                        if tv < version {
-                            reap.push(h);
+                        // Fail closed: a malformed tombstone payload must NOT
+                        // authorise deleting trie data. Defaulting to tv=0 would
+                        // make a corrupt entry instantly reapable; instead keep
+                        // the entry (skip reaping) and surface the corruption.
+                        match <[u8; 8]>::try_from(v) {
+                            Ok(b) => {
+                                if u64::from_be_bytes(b) < version {
+                                    reap.push(h);
+                                }
+                            }
+                            Err(_) => {
+                                tracing::warn!(
+                                    "trie GC: malformed tombstone payload ({} bytes) — \
+                                     keeping entry (fail-closed)",
+                                    v.len()
+                                );
+                            }
                         }
                     }
                 }
@@ -694,6 +721,40 @@ mod tests {
         assert!(
             storage.load_node(&raced).unwrap().is_some(),
             "raced/live node survives — #791 race fixed"
+        );
+    }
+
+    #[test]
+    fn test_generational_gc_keeps_data_on_malformed_tombstone() {
+        // Fail closed: a corrupt (non-8-byte) tombstone payload must NOT
+        // authorise deleting trie data.
+        let (_dir, storage) = temp_storage();
+        let orphan = dummy_hash(0x05);
+        let node = TrieNode::Leaf {
+            key: [0u8; 32],
+            value_hash: empty_hash(0),
+        };
+        storage.store_node(&orphan, &node).unwrap();
+
+        // Plant a malformed (4-byte) tombstone for the orphan as if a prior cycle.
+        let mut tk = [0u8; 33];
+        tk[0] = b'n';
+        tk[1..].copy_from_slice(&orphan);
+        storage
+            .mdbx
+            .put(
+                sentrix_storage::tables::TABLE_TRIE_TOMBSTONES,
+                &tk,
+                &[0u8; 4],
+            )
+            .unwrap();
+
+        let empty: HashSet<NodeHash> = HashSet::new();
+        let deleted = storage.gc_nodes_generational(&empty, 999).unwrap();
+        assert_eq!(deleted, 0, "malformed tombstone must not authorise deletion");
+        assert!(
+            storage.load_node(&orphan).unwrap().is_some(),
+            "trie data must survive a malformed tombstone (fail-closed)"
         );
     }
 


### PR DESCRIPTION
Addresses the two CodeRabbit findings on #798's generational GC.

- **Major** — non-8-byte tombstone payload → `tv=0` → instantly reapable (could delete live trie data). Now **fail closed**: skip reaping malformed tombstones + warn, never default to 0.
- **Critical (doc)** — narrow content-addressed resurrection window remains inside the reap's own scan+delete. Documented the caller contract (`tree.rs` re-augments `live` to the latest root immediately before each gc pass → window collapses from the old multi-minute walk to ms) and that full elimination needs writer-coupling (single RW txn) — the deferred complete fix. Strictly narrows the race; `verify_integrity` is the backstop.

Regression test: malformed tombstone must not authorise deletion. `cargo test -p sentrix-trie`: 83 passed.