### PR TITLE
test(core): serialize c03 rollback test against reward-env race (CI flake fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "aes-gcm",
  "alloy-consensus",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-bft"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "bincode",
  "hex",
@@ -5254,7 +5254,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-core"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5286,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-evm"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-faucet"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "anyhow",
  "axum",
@@ -5325,14 +5325,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-fork-heights"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "sentrix-grpc"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "async-stream",
  "bincode",
@@ -5351,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-network"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-nft"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "hex",
  "serde",
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-node"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "anyhow",
  "axum",
@@ -5406,14 +5406,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-precompiles"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "sentrix-primitives"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "hex",
  "proptest",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-prom-exporter"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5490,14 +5490,14 @@ dependencies = [
 
 [[package]]
 name = "sentrix-rpc-types"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "sentrix-staking"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "sentrix-primitives",
  "serde",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-storage"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "bincode",
  "libmdbx",
@@ -5522,7 +5522,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-trie"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "bincode",
  "blake3",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wallet"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5559,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "sentrix-wire"
-version = "2.2.41"
+version = "2.2.42"
 dependencies = [
  "bincode",
  "secp256k1 0.31.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [".", "crates/sentrix-primitives", "crates/sentrix-wallet", "crates/se
 # `version.workspace = true`. Same goes for edition/license/repository so
 # they can't drift across crates.
 [workspace.package]
-version = "2.2.41"
+version = "2.2.42"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/sentrix-labs/sentrix"

--- a/crates/sentrix-core/src/block_executor.rs
+++ b/crates/sentrix-core/src/block_executor.rs
@@ -2703,6 +2703,14 @@ mod tests {
     fn test_c03_pass2_failure_rolls_back_state() {
         use sentrix_primitives::block::Block;
 
+        // Serialize against env-mutating tests: this test credits v1 to
+        // u64::MAX - reward and relies on the coinbase credit overflowing, so
+        // the reward value must be stable. `get_block_reward()` reads the
+        // reward-fork env vars that other tests set under this same lock; without
+        // it, a concurrent mutation changes `reward` mid-test → no overflow →
+        // spurious failure (the recurring CI flake, 2026-06-06).
+        let _env_guard = crate::test_util::env_test_lock();
+
         let mut bc = setup();
         let reward = bc.get_block_reward();
         // Credit the validator to the ceiling so the next reward credit


### PR DESCRIPTION
Fixes the recurring CI flake (re-runs needed on #795/#798/#800/#801).

**Root cause:** `test_c03_pass2_failure_rolls_back_state` credits v1 to `u64::MAX - reward` and relies on the Pass-2 coinbase credit **overflowing**. It read `get_block_reward()` — which depends on reward-fork env vars (`VOYAGER_REWARD_V2_HEIGHT` / `TOKENOMICS_V2_HEIGHT` / halving) — **without holding `env_test_lock`**, while sibling tests mutate those vars under that lock. In the parallel `cargo test` run (notably the report-only coverage job) a concurrent env mutation changed `reward` mid-test → overflow didn't trigger → `add_block` returned `Ok` → `unwrap_err()` panicked.

**Fix:** acquire `env_test_lock` at the top of the test so it serializes against the env-mutating tests (same pattern they already use). Test-only.

`cargo test -p sentrix-core` green; `cargo clippy --workspace --all-targets -D warnings` clean.